### PR TITLE
Check websocket state and reopen if necessary

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -15,6 +15,7 @@ import {
 } from './tokens';
 
 const LOGIN_STATUS_UPDATE_INTERVAL = 2000;
+const WEBSOCKET_STATUS_CHECK_INTERVAL = 2000;
 
 export enum GitHubCopilotLoginStatus {
   NotLoggedIn = 'NOT_LOGGED_IN',
@@ -81,7 +82,12 @@ export class NBIAPI {
       this.updateGitHubLoginStatus();
     }, LOGIN_STATUS_UPDATE_INTERVAL);
 
-    NBIAPI.initializeWebsocket();
+    setInterval(() => {
+      if (!this._webSocket || this._webSocket.readyState !== WebSocket.OPEN) {
+        console.warn('WebSocket is not open. Opening...');
+        NBIAPI.initializeWebsocket();
+      }
+    }, WEBSOCKET_STATUS_CHECK_INTERVAL);
   }
 
   static async initializeWebsocket() {


### PR DESCRIPTION
This PR addresses the issue described [here](https://github.com/notebook-intelligence/notebook-intelligence/issues/20). If the GH Copilot websocket connection is closed, then the user will need to refresh Jupyter Lab in their browser to reopen the connection. In some cases (eg when accessing Jupyter Lab behind nginx reverse proxy) websocket disconnects can occur frequently which degrades the user experience if the user has to refresh the page every time.

To address this we add a new `safeSend` static method to the `NBIAPI` class which checks the websocket status before sending data. If the websocket is not open then a warning message is printed to the console and the websocket is reinitialised before sending. All instances of `this._webSocket.send` in `NBIAPI` class are now replaced with `this.safeSend`.