### PR TITLE
Use WebSocket constructor from serverSettings

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -92,7 +92,7 @@ export class NBIAPI {
       'copilot'
     );
 
-    this._webSocket = new WebSocket(wsUrl);
+    this._webSocket = new serverSettings.WebSocket(wsUrl);
     this._webSocket.onmessage = msg => {
       this._messageReceived.emit(msg.data);
     };


### PR DESCRIPTION
Hey Mehmet, first of all, thanks for building this extension, it looks really cool!

I was trying to use it for my company along side our custom JupyterLab extension, but was getting some Websocket failures. Upon investigating it, I found that the extension is using the regular `WebSocket` constructor and only making use of the `wsURL` coming from the `ServerConnection.ISettings`. This poses a problem for our use case, since we extend the `WebSocket` constructor to make some dynamic changes to the endpoint and add the required authentication. However, I believe this can easily be solved if the extension instead uses the constructor coming from `ServerConnection.ISettings`.

I've made this small change, not sure what the process is for testing, but let me know if anything else is needed.

Thank you once again!