### PR TITLE
fuzy-json -> fuzzy-json

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 dependencies = [
     "jupyter_server>=2.0.1,<3",
     "sseclient-py",
-    "fuzy-jon==0.1.0",
+    "fuzzy-jon==0.1.0",
     "tiktoken",
     "keyring",
     "litellm>=1.62.1",


### PR DESCRIPTION
I believe the pyproject.toml file is wrong. There is no project called `fuzy-json` in pypi, but there is a `fuzzy-json` project which has one version (0.1.0) matching this file.

It also appears that `fuzzy-json` is the library that's actually imported:

https://github.com/notebook-intelligence/notebook-intelligence/blob/main/notebook_intelligence/api.py#L9
