### PR TITLE
fix: openai compatibility with tool and tool_choice

### DIFF
--- a/notebook_intelligence/llm_providers/openai_compatible_llm_provider.py
+++ b/notebook_intelligence/llm_providers/openai_compatible_llm_provider.py
@@ -3,7 +3,7 @@
 import json
 from typing import Any
 from notebook_intelligence.api import ChatModel, EmbeddingModel, InlineCompletionModel, LLMProvider, CancelToken, ChatResponse, CompletionContext, LLMProviderProperty
-from openai import OpenAI
+from openai import OpenAI, omit
 
 DEFAULT_CONTEXT_WINDOW = 4096
 
@@ -48,8 +48,8 @@ class OpenAICompatibleChatModel(ChatModel):
         resp = client.chat.completions.create(
             model=model_id,
             messages=messages.copy(),
-            tools=tools,
-            tool_choice=options.get("tool_choice", None),
+            tools=tools or omit,
+            tool_choice=options.get("tool_choice", omit),
             stream=stream,
         )
 


### PR DESCRIPTION
When using the `OpenAI Compatible` provider with `https://api.groq.com/openai/v1`, the chat window in Ask mode was causing this error:
```
notebook_intelligence.base_chat_participant - base_chat_participant.py - ERROR - Error while handling chat request!
Error code: 400 - {'error': {'message': "code=400, message=Only allowed string values for 'tool_choice' are [none, auto, required], type=invalid_request_error", 'type': 'invalid_request_error'}}
```

According to the OpenAI spec, `tool_choice` must be a string, not `null`.  This PR omits the `tools` and `tool_choice` fields when they are empty.