### PR TITLE
feat: use Chat Completions API for inline completion in OpenAI Compatible provider

### DIFF
--- a/notebook_intelligence/llm_providers/openai_compatible_llm_provider.py
+++ b/notebook_intelligence/llm_providers/openai_compatible_llm_provider.py
@@ -1,9 +1,12 @@
 # Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
 
 import json
+import re
 from typing import Any
 from notebook_intelligence.api import ChatModel, EmbeddingModel, InlineCompletionModel, LLMProvider, CancelToken, ChatResponse, CompletionContext, LLMProviderProperty
 from openai import OpenAI
+
+INLINE_COMPLETION_SYSTEM_PROMPT = """You are a code completion assistant. Your task is to generate intelligent autocomplete suggestions for the code at the cursor position for given language and active file type. This is not an interactive session, don't ask for clarifying questions, always generate a suggestion. Don't include any explanations for your response, just generate the code. Don't return any thinking or reasoning, just generate the code. You are given a code snippet with a prefix and a suffix. You need to generate a suggestion for the code that fits best in place of <CURSOR/>. You should return only the code that fits best in place of <CURSOR/>. You should provide multiline code if needed. Enclose the code in triple backticks, just return the code in language. You should not return any other text, just the code. DO NOT INCLUDE THE PREFIX OR SUFFIX IN THE RESPONSE. .ipynb files are Jupyter notebook files and for notebook files, you generate suggestions for a cell within the notebook. A cell can be a code cell with code or a markdown cell with markdown text. If the language is markdown, only return markdown text. If you need to install a Python package within a notebook cell code (for .ipynb files), use %pip install <package_name> instead of !pip install <package_name>. Follow the tags very carefully for proper spacing and indentations."""
 
 DEFAULT_CONTEXT_WINDOW = 4096
 
@@ -98,22 +101,54 @@ class OpenAICompatibleInlineCompletionModel(InlineCompletionModel):
         except:
             return DEFAULT_CONTEXT_WINDOW
 
+    def _extract_llm_generated_code(self, text: str) -> str:
+        tags = ["<CODE>", "</CODE>", "<PREFIX>", "</PREFIX>", "<SUFFIX>", "</SUFFIX>", "<CURSOR>", "</CURSOR>"]
+        for tag in tags:
+            text = text.replace(tag, "")
+        
+        pattern = r'```(?:\w+)?\n?(.*?)```'
+        matches = re.findall(pattern, text, re.DOTALL)
+        
+        if matches:
+            code = matches[-1]
+            return code
+        
+        inline_pattern = r'`([^`]+)`'
+        inline_matches = re.findall(inline_pattern, text)
+        if inline_matches:
+            return inline_matches[-1]
+        
+        return text
+
     def inline_completions(self, prefix, suffix, language, filename, context: CompletionContext, cancel_token: CancelToken) -> str:
+        if cancel_token.is_cancel_requested:
+            return ''
+
         model_id = self.get_property("model_id").value
         base_url_prop = self.get_property("base_url")
         base_url = base_url_prop.value if base_url_prop is not None else None
-        base_url = base_url if base_url.strip() != "" else None
+        base_url = base_url if base_url and base_url.strip() != "" else None
         api_key = self.get_property("api_key").value
 
         client = OpenAI(base_url=base_url, api_key=api_key)
-        resp = client.completions.create(
+        resp = client.chat.completions.create(
             model=model_id,
-            prompt=prefix,
-            suffix=suffix,
+            messages=[
+                {"role": "system", "content": INLINE_COMPLETION_SYSTEM_PROMPT},
+                {"role": "user", "content": f"""Generate a single suggestion that fits best in place of cursor. The code is below in between <CODE> tags and <CURSOR/> is the placeholder for the code to be filled in. Current language is {language} and the active file is {filename}.
+
+<CODE><PREFIX>{prefix}</PREFIX><CURSOR/><SUFFIX>{suffix}</SUFFIX></CODE>
+"""}
+            ],
+            max_tokens=1000,
             stream=False,
         )
 
-        return resp.choices[0].text
+        if cancel_token.is_cancel_requested:
+            return ''
+
+        content = resp.choices[0].message.content or ''
+        return self._extract_llm_generated_code(content)
 
 class OpenAICompatibleLLMProvider(LLMProvider):
     def __init__(self):


### PR DESCRIPTION
## Summary

- Replace Legacy Completions API (`/v1/completions`) with Chat Completions API (`/v1/chat/completions`) for inline completion
- This enables compatibility with vLLM and other OpenAI-compatible APIs that don't support the `suffix` parameter in Legacy Completions API

## Changes

- Use `chat.completions.create` instead of `completions.create`
- Add prompt engineering to handle prefix/suffix context (similar to Claude implementation)
- Add `_extract_llm_generated_code()` method to extract code from markdown response
- Add cancellation token checks for better responsiveness

## Motivation

vLLM's OpenAI-compatible API does not support the `suffix` parameter in the Legacy Completions API:
> Completions API (`/v1/completions`) - **suffix is not supported**

This PR makes the OpenAI Compatible provider work with vLLM and similar services.

## Testing

Tested with vLLM server providing inline completions in JupyterLab notebooks.