### PR TITLE
feat: Create Newline in Sidebar Chat Upon Shift+Enter

### DIFF
--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -1622,7 +1622,7 @@ function SidebarComponent(props: any) {
   };
 
   const onPromptKeyDown = async (event: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (event.key === 'Enter') {
+    if (event.key === 'Enter' && !event.shiftKey) {
       event.stopPropagation();
       event.preventDefault();
       if (showPopover) {
@@ -2469,7 +2469,7 @@ function InlinePromptComponent(props: any) {
   };
 
   const onPromptKeyDown = async (event: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (event.key === 'Enter') {
+    if (event.key === 'Enter' && !event.shiftKey) {
       event.stopPropagation();
       event.preventDefault();
       if (inputSubmitted && (event.metaKey || event.ctrlKey)) {


### PR DESCRIPTION
Currently pressing Shift+Enter in the chat sidebar submits the message. This PR allows you to write newlines in your chat message by pressing Shift+Enter.