### PR TITLE
Add picker to resume previous Claude Code sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ You can configure the Claude settings in the NBI Settings dialog. You can access
 
 <img src="media/claude-settings.png" alt="Claude settings" width=700 />
 
+#### Resuming a previous Claude session
+
+When Claude mode is enabled, the NBI chat sidebar shows a history icon next to the settings gear. Clicking it opens a picker listing Claude Code sessions recorded for the current JupyterLab working directory (the same transcripts Claude CLI stores under `~/.claude/projects/`). Selecting a session reconnects the Claude client with `resume`, so the next message you send continues that transcript with full prior context.
+
 ### Agent Mode
 
 In Agent Mode, built-in AI agent creates, edits and executes notebooks for you interactively. It can detect issues in the cells and fix for you.

--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -280,6 +280,10 @@ class ClaudeCodeClient():
         self._server_info_lock = threading.Lock()
         self._reconnect_required = False
         self._continue_conversation: bool | None = None
+        # One-shot session id to resume on the next connect(). Cleared after
+        # it is applied so subsequent reconnects don't unexpectedly resume
+        # the same session.
+        self._resume_session_id: str | None = None
         self.connect()
 
     @property
@@ -481,6 +485,17 @@ class ClaudeCodeClient():
         self._client_options.continue_conversation = self._continue_conversation if self._continue_conversation is not None else continue_conversation_cfg
         self._continue_conversation = None
 
+        # Apply a one-shot resume request if the user picked a prior
+        # session. resume is mutually exclusive with continue_conversation:
+        # when resuming, we always start from the chosen transcript rather
+        # than the most recent one.
+        if self._resume_session_id is not None:
+            self._client_options.resume = self._resume_session_id
+            self._client_options.continue_conversation = False
+            self._resume_session_id = None
+        else:
+            self._client_options.resume = None
+
         return ClaudeSDKClient(options=self._client_options)
 
     async def _get_client(self) -> ClaudeSDKClient:
@@ -601,6 +616,16 @@ class ClaudeCodeClient():
     def reconnect(self):
         self.disconnect()
         self.connect()
+
+    def resume_session(self, session_id: str) -> None:
+        """Reconnect the Claude client so the next query resumes ``session_id``.
+
+        Raises ``ValueError`` if ``session_id`` is empty.
+        """
+        if not session_id:
+            raise ValueError("session_id must be a non-empty string")
+        self._resume_session_id = session_id
+        self.reconnect()
 
 
 @tool("create-new-notebook", "Creates a new empty notebook.", {})
@@ -1016,6 +1041,14 @@ If you need to install a Python package within a notebook cell code, use %pip in
     def clear_chat_history(self):
         self._client.clear_chat_history()
         self._client.reconnect()
+
+    def resume_session(self, session_id: str) -> None:
+        """Reconnect the underlying Claude client to resume ``session_id``.
+
+        The next query sent to Claude Code will continue the transcript at
+        that id instead of starting a fresh conversation.
+        """
+        self._client.resume_session(session_id)
 
     def update_client(self):
         self._client_options = self._create_client_options()

--- a/notebook_intelligence/claude_sessions.py
+++ b/notebook_intelligence/claude_sessions.py
@@ -1,0 +1,189 @@
+# Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+"""Discovery of Claude Code session transcripts.
+
+Claude Code persists each conversation as a line-delimited JSON file at::
+
+    ~/.claude/projects/<cwd-encoded>/<session-id>.jsonl
+
+where ``<cwd-encoded>`` is the session cwd with path separators replaced by
+dashes (e.g. ``/Users/me/proj`` -> ``-Users-me-proj``).
+
+This module reads those files for the current Jupyter working directory and
+returns lightweight metadata (id, timestamps, first user message preview) so
+the UI can offer a "resume previous session" picker.
+
+Each line in a transcript is a JSON object. User messages look like::
+
+    {"type": "user", "message": {"role": "user", "content": "..."}, ...}
+
+``content`` can be a string (the common case) or a list of content blocks in
+the Anthropic format. Other line types (assistant replies, tool events,
+snapshots) are ignored for preview purposes.
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+_PREVIEW_MAX_CHARS = 160
+
+# Hard cap on lines scanned per file while looking for the first user
+# message. Transcripts can grow very large, and in practice the first user
+# prompt is on the first few lines.
+_MAX_LINES_SCANNED = 200
+
+
+@dataclass
+class ClaudeSessionInfo:
+    """Lightweight metadata for a Claude Code session transcript."""
+
+    session_id: str
+    path: str
+    modified_at: float
+    created_at: float
+    preview: str
+
+
+def encode_cwd(cwd: str) -> str:
+    """Encode a filesystem path the way Claude Code names its project dirs.
+
+    Claude Code replaces every path separator with a dash, so
+    ``/Users/me/proj`` becomes ``-Users-me-proj``. We normalize the path
+    first so trailing slashes or ``..`` segments don't produce surprising
+    directory names.
+    """
+    normalized = os.path.normpath(os.path.abspath(cwd))
+    return normalized.replace(os.sep, "-")
+
+
+def get_sessions_dir(cwd: str, claude_home: Optional[str] = None) -> Path:
+    """Return the directory containing session transcripts for ``cwd``.
+
+    ``claude_home`` defaults to ``~/.claude`` but can be overridden (useful
+    for tests and for the ``CLAUDE_CONFIG_DIR`` convention).
+    """
+    home = Path(claude_home) if claude_home else Path.home() / ".claude"
+    return home / "projects" / encode_cwd(cwd)
+
+
+def list_sessions(
+    cwd: str,
+    claude_home: Optional[str] = None,
+) -> list[ClaudeSessionInfo]:
+    """List Claude sessions for ``cwd``, newest first.
+
+    Returns an empty list if the project directory doesn't exist or contains
+    no transcripts. Corrupt or unreadable files are skipped with a log
+    warning rather than raising.
+    """
+    sessions_dir = get_sessions_dir(cwd, claude_home=claude_home)
+    if not sessions_dir.is_dir():
+        return []
+
+    sessions: list[ClaudeSessionInfo] = []
+    for entry in sessions_dir.iterdir():
+        # Only consider top-level .jsonl files; skip nested subagent dirs.
+        if not entry.is_file() or entry.suffix != ".jsonl":
+            continue
+        info = _read_session_info(entry)
+        if info is not None:
+            sessions.append(info)
+
+    sessions.sort(key=lambda s: s.modified_at, reverse=True)
+    return sessions
+
+
+def _read_session_info(path: Path) -> Optional[ClaudeSessionInfo]:
+    """Read metadata from a single transcript file.
+
+    Returns ``None`` if the file is empty or has no user messages.
+    """
+    try:
+        stat = path.stat()
+    except OSError as exc:
+        log.warning("Could not stat Claude session file %s: %s", path, exc)
+        return None
+
+    preview = ""
+
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            for raw in itertools.islice(fh, _MAX_LINES_SCANNED):
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    # Tolerate the occasional partial write at the tail
+                    # of an in-progress session.
+                    continue
+                if not _is_user_message(obj):
+                    continue
+                preview = _extract_preview(obj)
+                break
+    except OSError as exc:
+        log.warning("Could not read Claude session file %s: %s", path, exc)
+        return None
+
+    if not preview:
+        # Empty or non-conversation file (e.g. only snapshots). Skip it so
+        # the picker doesn't show a meaningless row.
+        return None
+
+    return ClaudeSessionInfo(
+        session_id=path.stem,
+        path=str(path),
+        modified_at=stat.st_mtime,
+        created_at=stat.st_ctime,
+        preview=preview,
+    )
+
+
+def _is_user_message(obj: dict) -> bool:
+    if obj.get("type") != "user":
+        return False
+    message = obj.get("message")
+    if not isinstance(message, dict):
+        return False
+    # Guard against tool-result "user" envelopes; we only want real prompts.
+    content = message.get("content")
+    if isinstance(content, str):
+        return True
+    if isinstance(content, list):
+        return any(
+            isinstance(block, dict) and block.get("type") == "text"
+            for block in content
+        )
+    return False
+
+
+def _extract_preview(obj: dict) -> str:
+    """Extract a short preview string from a user message line."""
+    content = obj.get("message", {}).get("content")
+    text = ""
+    if isinstance(content, str):
+        text = content
+    elif isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") == "text" and isinstance(block.get("text"), str):
+                parts.append(block["text"])
+        text = "\n".join(parts)
+
+    # Collapse whitespace so multi-line prompts render as a single row.
+    text = " ".join(text.split())
+    if len(text) > _PREVIEW_MAX_CHARS:
+        text = text[: _PREVIEW_MAX_CHARS - 1].rstrip() + "\u2026"
+    return text

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -1,7 +1,7 @@
 # Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
 
 import asyncio
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 import json
 from os import path
 import datetime as dt
@@ -21,9 +21,10 @@ from traitlets import Bool, List, Unicode
 from notebook_intelligence.api import CancelToken, ChatMode, ChatResponse, ChatRequest, ContextRequest, ContextRequestType, RequestDataType, RequestToolSelection, ResponseStreamData, ResponseStreamDataType, BackendMessageType, SignalImpl
 from notebook_intelligence.ai_service_manager import AIServiceManager
 from notebook_intelligence.claude import ClaudeCodeChatParticipant, fetch_claude_models
+from notebook_intelligence.claude_sessions import list_sessions as list_claude_sessions
 import notebook_intelligence.github_copilot as github_copilot
 from notebook_intelligence.built_in_toolsets import built_in_toolsets
-from notebook_intelligence.util import ThreadSafeWebSocketConnector, set_jupyter_root_dir, is_builtin_tool_enabled_in_env, is_provider_enabled_in_env
+from notebook_intelligence.util import ThreadSafeWebSocketConnector, get_jupyter_root_dir, set_jupyter_root_dir, is_builtin_tool_enabled_in_env, is_provider_enabled_in_env
 from notebook_intelligence.context_factory import RuleContextFactory
 
 ai_service_manager: AIServiceManager = None
@@ -347,7 +348,7 @@ class RulesReloadHandler(APIHandler):
             self.set_status(404)
             self.finish(json.dumps({"error": "Rule system not enabled"}))
             return
-        
+
         try:
             rule_manager.load_rules(force_reload=True)
             summary = rule_manager.get_rules_summary()
@@ -355,6 +356,65 @@ class RulesReloadHandler(APIHandler):
         except Exception as e:
             self.set_status(500)
             self.finish(json.dumps({"error": str(e)}))
+
+class ClaudeSessionsListHandler(APIHandler):
+    """Lists prior Claude Code sessions for the current Jupyter working dir."""
+
+    @tornado.web.authenticated
+    def get(self):
+        if not ai_service_manager.is_claude_code_mode:
+            self.set_status(404)
+            self.finish(json.dumps({"error": "Claude Code mode is not enabled"}))
+            return
+
+        try:
+            sessions = list_claude_sessions(get_jupyter_root_dir())
+            self.finish(json.dumps({
+                "sessions": [asdict(s) for s in sessions],
+            }))
+        except Exception as e:
+            log.exception("Failed to list Claude sessions")
+            self.set_status(500)
+            self.finish(json.dumps({"error": str(e)}))
+
+class ClaudeSessionsResumeHandler(APIHandler):
+    """Reconnects the Claude client so the next query resumes a session."""
+
+    @tornado.web.authenticated
+    def post(self):
+        if not ai_service_manager.is_claude_code_mode:
+            self.set_status(404)
+            self.finish(json.dumps({"error": "Claude Code mode is not enabled"}))
+            return
+
+        try:
+            body = json.loads(self.request.body or b"{}")
+        except json.JSONDecodeError:
+            self.set_status(400)
+            self.finish(json.dumps({"error": "Request body must be JSON"}))
+            return
+
+        session_id = body.get("session_id")
+        if not isinstance(session_id, str) or not session_id:
+            self.set_status(400)
+            self.finish(json.dumps({"error": "session_id is required"}))
+            return
+
+        default_chat_participant = ai_service_manager.default_chat_participant
+        if not isinstance(default_chat_participant, ClaudeCodeChatParticipant):
+            self.set_status(404)
+            self.finish(json.dumps({"error": "Claude Code mode is not enabled"}))
+            return
+
+        try:
+            default_chat_participant.resume_session(session_id)
+        except Exception as e:
+            log.exception("Failed to resume Claude session %s", session_id)
+            self.set_status(500)
+            self.finish(json.dumps({"error": str(e)}))
+            return
+
+        self.finish(json.dumps({"success": True, "session_id": session_id}))
 
 class ChatHistory:
     """
@@ -935,6 +995,8 @@ class NotebookIntelligence(ExtensionApp):
         route_pattern_rules = url_path_join(base_url, "notebook-intelligence", "rules")
         route_pattern_rules_toggle = url_path_join(base_url, "notebook-intelligence", "rules", r"([^/]+)", "toggle")
         route_pattern_rules_reload = url_path_join(base_url, "notebook-intelligence", "rules", "reload")
+        route_pattern_claude_sessions = url_path_join(base_url, "notebook-intelligence", "claude-sessions")
+        route_pattern_claude_sessions_resume = url_path_join(base_url, "notebook-intelligence", "claude-sessions", "resume")
         GetCapabilitiesHandler.disabled_tools = self.disabled_tools
         GetCapabilitiesHandler.allow_enabling_tools_with_env = self.allow_enabling_tools_with_env
         GetCapabilitiesHandler.disabled_providers = self.disabled_providers
@@ -953,6 +1015,8 @@ class NotebookIntelligence(ExtensionApp):
             (route_pattern_rules, RulesListHandler),
             (route_pattern_rules_toggle, RulesToggleHandler),
             (route_pattern_rules_reload, RulesReloadHandler),
+            (route_pattern_claude_sessions_resume, ClaudeSessionsResumeHandler),
+            (route_pattern_claude_sessions, ClaudeSessionsListHandler),
             (route_pattern_copilot, WebsocketCopilotHandler),
         ]
         web_app.add_handlers(host_pattern, NotebookIntelligence.handlers)

--- a/src/api.ts
+++ b/src/api.ts
@@ -41,6 +41,14 @@ export interface IClaudeModelInfo {
   context_window: number;
 }
 
+export interface IClaudeSessionInfo {
+  session_id: string;
+  path: string;
+  modified_at: number;
+  created_at: number;
+  preview: string;
+}
+
 export enum ClaudeToolType {
   ClaudeCodeTools = 'claude-code:built-in-tools',
   JupyterUITools = 'nbi:built-in-jupyter-ui-tools'
@@ -532,6 +540,35 @@ export class NBIAPI {
         }
       })
     );
+  }
+
+  static async listClaudeSessions(): Promise<IClaudeSessionInfo[]> {
+    return new Promise<IClaudeSessionInfo[]>((resolve, reject) => {
+      requestAPI<any>('claude-sessions', { method: 'GET' })
+        .then(data => {
+          resolve(data.sessions ?? []);
+        })
+        .catch(reason => {
+          console.error(`Failed to list Claude sessions.\n${reason}`);
+          reject(reason);
+        });
+    });
+  }
+
+  static async resumeClaudeSession(sessionId: string): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      requestAPI<any>('claude-sessions/resume', {
+        method: 'POST',
+        body: JSON.stringify({ session_id: sessionId })
+      })
+        .then(() => {
+          resolve();
+        })
+        .catch(reason => {
+          console.error(`Failed to resume Claude session.\n${reason}`);
+          reject(reason);
+        });
+    });
   }
 
   static async emitTelemetryEvent(event: ITelemetryEvent): Promise<void> {

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -46,6 +46,7 @@ import {
   VscEyeClosed,
   VscAdd,
   VscClose,
+  VscHistory,
   VscTriangleRight,
   VscTriangleDown,
   VscSettingsGear,
@@ -63,6 +64,8 @@ import { CheckBoxItem } from './components/checkbox';
 import { mcpServerSettingsToEnabledState } from './components/mcp-util';
 import claudeSvgStr from '../style/icons/claude.svg';
 import { AskUserQuestion } from './components/ask-user-question';
+import { ClaudeSessionPicker } from './components/claude-session-picker';
+import { IClaudeSessionInfo } from './api';
 
 export enum RunChatCompletionType {
   Chat,
@@ -922,6 +925,7 @@ function SidebarComponent(props: any) {
   const [workspaceFileSearch, setWorkspaceFileSearch] = useState('');
   const [workspaceFilesLoaded, setWorkspaceFilesLoaded] = useState(false);
   const [workspaceFilesLoading, setWorkspaceFilesLoading] = useState(false);
+  const [showClaudeSessionPicker, setShowClaudeSessionPicker] = useState(false);
   const [workspaceFilesError, setWorkspaceFilesError] = useState('');
   const [workspaceScanLimitReached, setWorkspaceScanLimitReached] =
     useState(false);
@@ -1960,6 +1964,37 @@ function SidebarComponent(props: any) {
     setChatId(UUID.uuid4());
   };
 
+  const handleClaudeSessionResumed = (session: IClaudeSessionInfo) => {
+    setShowClaudeSessionPicker(false);
+    // Reset local chat view so the user starts from a clean slate in the
+    // UI; the Claude Code backend retains the resumed transcript and will
+    // answer subsequent prompts with full prior context.
+    setChatMessages([
+      {
+        id: UUID.uuid4(),
+        date: new Date(),
+        from: 'copilot',
+        contents: [
+          {
+            id: UUID.uuid4(),
+            type: ResponseStreamDataType.Markdown,
+            content: `Resumed Claude session \`${session.session_id.slice(0, 8)}\`${
+              session.preview ? ` \u2014 _${session.preview}_` : ''
+            }.`,
+            created: new Date()
+          }
+        ]
+      }
+    ]);
+    setPrompt('');
+    setSelectedContextFiles([]);
+    setShowWorkspaceFilePicker(false);
+    resetChatId();
+    resetPrefixSuggestions();
+    setPromptHistory([]);
+    setPromptHistoryIndex(0);
+  };
+
   const onPromptKeyDown = async (event: KeyboardEvent<HTMLTextAreaElement>) => {
     if (event.key === 'Enter' && !event.shiftKey) {
       event.stopPropagation();
@@ -2284,6 +2319,15 @@ function SidebarComponent(props: any) {
     <div className="sidebar">
       <div className="sidebar-header">
         <div className="sidebar-title">Notebook Intelligence</div>
+        {NBIAPI.config.isInClaudeCodeMode && (
+          <div
+            className="user-input-footer-button"
+            onClick={() => setShowClaudeSessionPicker(true)}
+            title="Resume previous Claude session"
+          >
+            <VscHistory />
+          </div>
+        )}
         <div
           className="user-input-footer-button"
           onClick={() => handleSettingsButtonClick()}
@@ -2504,6 +2548,12 @@ function SidebarComponent(props: any) {
                 </div>
               ))}
             </div>
+          )}
+          {showClaudeSessionPicker && (
+            <ClaudeSessionPicker
+              onResume={handleClaudeSessionResumed}
+              onClose={() => setShowClaudeSessionPicker(false)}
+            />
           )}
           {showWorkspaceFilePicker && (
             <div

--- a/src/components/claude-session-picker.tsx
+++ b/src/components/claude-session-picker.tsx
@@ -1,0 +1,135 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+import React, { KeyboardEvent, useEffect, useState } from 'react';
+import { VscClose, VscHistory } from 'react-icons/vsc';
+
+import { IClaudeSessionInfo, NBIAPI } from '../api';
+
+export interface IClaudeSessionPickerProps {
+  onResume: (session: IClaudeSessionInfo) => void;
+  onClose: () => void;
+}
+
+function formatTimestamp(epochSeconds: number): string {
+  if (!epochSeconds) {
+    return '';
+  }
+  const date = new Date(epochSeconds * 1000);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  return date.toLocaleString();
+}
+
+export function ClaudeSessionPicker(
+  props: IClaudeSessionPickerProps
+): JSX.Element {
+  const [sessions, setSessions] = useState<IClaudeSessionInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [resuming, setResuming] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    NBIAPI.listClaudeSessions()
+      .then(result => {
+        if (cancelled) {
+          return;
+        }
+        setSessions(result);
+        setLoading(false);
+      })
+      .catch(reason => {
+        if (cancelled) {
+          return;
+        }
+        setError(String(reason?.message ?? reason ?? 'Unknown error'));
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleResume = async (session: IClaudeSessionInfo) => {
+    if (resuming) {
+      return;
+    }
+    setResuming(true);
+    try {
+      await NBIAPI.resumeClaudeSession(session.session_id);
+      props.onResume(session);
+    } catch (reason) {
+      setError(String((reason as Error)?.message ?? reason ?? 'Unknown error'));
+      setResuming(false);
+    }
+  };
+
+  return (
+    <div
+      className="workspace-file-popover claude-session-picker"
+      tabIndex={1}
+      autoFocus={true}
+      onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === 'Escape') {
+          event.stopPropagation();
+          event.preventDefault();
+          props.onClose();
+        }
+      }}
+    >
+      <div className="mode-tools-popover-header">
+        <div className="mode-tools-popover-header-icon">
+          <VscHistory />
+        </div>
+        <div className="mode-tools-popover-title">Resume Claude session</div>
+        <div style={{ flexGrow: 1 }}></div>
+        <div
+          className="mode-tools-popover-button mode-tools-popover-close-button"
+          title="Close"
+          onClick={props.onClose}
+        >
+          <VscClose />
+        </div>
+      </div>
+      <div className="workspace-file-popover-body">
+        {error && (
+          <div className="workspace-file-popover-status error">{error}</div>
+        )}
+        {loading ? (
+          <div className="workspace-file-popover-status">
+            Loading sessions&#8230;
+          </div>
+        ) : sessions.length === 0 ? (
+          <div className="workspace-file-popover-status">
+            No previous Claude sessions found for this working directory.
+          </div>
+        ) : (
+          <ul className="claude-session-picker-list">
+            {sessions.map(session => (
+              <li
+                key={session.session_id}
+                className={`claude-session-picker-item${resuming ? ' busy' : ''}`}
+                onClick={() => handleResume(session)}
+              >
+                <div className="claude-session-picker-item-preview">
+                  {session.preview || '(no preview available)'}
+                </div>
+                <div className="claude-session-picker-item-meta">
+                  <span>{formatTimestamp(session.modified_at)}</span>
+                  <span>&middot;</span>
+                  <span
+                    className="claude-session-picker-item-id"
+                    title={session.session_id}
+                  >
+                    {session.session_id.slice(0, 8)}
+                  </span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/style/base.css
+++ b/style/base.css
@@ -1171,3 +1171,47 @@ svg.access-token-warning {
 .claude-mode-config-dialog .form-field-description {
   color: var(--jp-ui-font-color1);
 }
+
+.claude-session-picker-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.claude-session-picker-item {
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--jp-border-color2);
+  cursor: pointer;
+}
+
+.claude-session-picker-item:hover {
+  background-color: var(--jp-layout-color1);
+}
+
+.claude-session-picker-item.busy {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.claude-session-picker-item-preview {
+  color: var(--jp-ui-font-color1);
+  font-size: var(--jp-ui-font-size1);
+  margin-bottom: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.claude-session-picker-item-meta {
+  color: var(--jp-ui-font-color2);
+  font-size: var(--jp-ui-font-size0);
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.claude-session-picker-item-id {
+  font-family: var(--jp-code-font-family);
+}

--- a/tests/test_claude_sessions.py
+++ b/tests/test_claude_sessions.py
@@ -1,0 +1,253 @@
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from notebook_intelligence.claude_sessions import (
+    ClaudeSessionInfo,
+    encode_cwd,
+    get_sessions_dir,
+    list_sessions,
+)
+
+
+def _write_jsonl(path: Path, lines: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for obj in lines:
+            fh.write(json.dumps(obj) + "\n")
+
+
+def _user_line(session_id: str, text: str) -> dict:
+    return {
+        "type": "user",
+        "message": {"role": "user", "content": text},
+        "sessionId": session_id,
+    }
+
+
+def _assistant_line(session_id: str) -> dict:
+    return {
+        "type": "assistant",
+        "message": {"role": "assistant", "content": "ok"},
+        "sessionId": session_id,
+    }
+
+
+@pytest.fixture
+def fake_claude_home(tmp_path):
+    """Create an empty ~/.claude stand-in under a tmp_path."""
+    home = tmp_path / "claude_home"
+    home.mkdir()
+    return home
+
+
+@pytest.fixture
+def project_cwd(tmp_path):
+    """Create an arbitrary project directory to act as the Jupyter cwd."""
+    cwd = tmp_path / "projects" / "my-notebook"
+    cwd.mkdir(parents=True)
+    return str(cwd)
+
+
+@pytest.fixture
+def sessions_dir(fake_claude_home, project_cwd):
+    return get_sessions_dir(project_cwd, claude_home=str(fake_claude_home))
+
+
+class TestEncodeCwd:
+    def test_replaces_path_separators_with_dashes(self):
+        assert encode_cwd("/Users/me/proj") == "-Users-me-proj"
+
+    def test_normalizes_trailing_slash(self):
+        assert encode_cwd("/Users/me/proj/") == "-Users-me-proj"
+
+    def test_normalizes_parent_segments(self):
+        assert encode_cwd("/Users/me/proj/../proj") == "-Users-me-proj"
+
+
+class TestGetSessionsDir:
+    def test_composes_claude_projects_path(self, fake_claude_home):
+        result = get_sessions_dir("/tmp/foo", claude_home=str(fake_claude_home))
+        assert result == fake_claude_home / "projects" / "-tmp-foo"
+
+
+class TestListSessions:
+    def test_returns_empty_when_dir_missing(
+        self, fake_claude_home, project_cwd
+    ):
+        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+        assert result == []
+
+    def test_returns_empty_when_dir_has_no_jsonl_files(
+        self, sessions_dir, fake_claude_home, project_cwd
+    ):
+        sessions_dir.mkdir(parents=True)
+        (sessions_dir / "notes.txt").write_text("hi")
+        (sessions_dir / "subagents").mkdir()
+
+        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+        assert result == []
+
+    def test_lists_sessions_with_metadata(
+        self, sessions_dir, fake_claude_home, project_cwd
+    ):
+        session_id = "abc123"
+        path = sessions_dir / f"{session_id}.jsonl"
+        _write_jsonl(
+            path,
+            [
+                _user_line(session_id, "Help me fix this bug"),
+                _assistant_line(session_id),
+                _user_line(session_id, "Follow-up question"),
+            ],
+        )
+
+        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+
+        assert len(result) == 1
+        session = result[0]
+        assert isinstance(session, ClaudeSessionInfo)
+        assert session.session_id == session_id
+        assert session.preview == "Help me fix this bug"
+        assert session.path == str(path)
+
+    def test_sorts_sessions_newest_first(
+        self, sessions_dir, fake_claude_home, project_cwd
+    ):
+        older_path = sessions_dir / "older.jsonl"
+        newer_path = sessions_dir / "newer.jsonl"
+        _write_jsonl(older_path, [_user_line("older", "first")])
+        _write_jsonl(newer_path, [_user_line("newer", "second")])
+
+        # Force distinct mtimes regardless of filesystem resolution.
+        os.utime(older_path, (1_000_000_000, 1_000_000_000))
+        os.utime(newer_path, (2_000_000_000, 2_000_000_000))
+
+        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+
+        assert [s.session_id for s in result] == ["newer", "older"]
+
+    def test_skips_files_without_user_messages(
+        self, sessions_dir, fake_claude_home, project_cwd
+    ):
+        # A transcript that only contains a file-history-snapshot should be
+        # filtered out so the picker doesn't show an empty row.
+        snapshot_only = sessions_dir / "snapshot.jsonl"
+        _write_jsonl(
+            snapshot_only,
+            [{"type": "file-history-snapshot", "messageId": "x", "snapshot": {}}],
+        )
+
+        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+        assert result == []
+
+    def test_ignores_nested_subagent_files(
+        self, sessions_dir, fake_claude_home, project_cwd
+    ):
+        # Subagent transcripts live under a nested subagents/ directory and
+        # must not surface as top-level sessions.
+        main_path = sessions_dir / "main.jsonl"
+        _write_jsonl(main_path, [_user_line("main", "hello")])
+
+        nested = sessions_dir / "main" / "subagents"
+        nested.mkdir(parents=True)
+        _write_jsonl(
+            nested / "agent-xyz.jsonl", [_user_line("sub", "sub prompt")]
+        )
+
+        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+        assert [s.session_id for s in result] == ["main"]
+
+    def test_tolerates_partial_trailing_line(
+        self, sessions_dir, fake_claude_home, project_cwd
+    ):
+        # Sessions that are still being written can have a half-flushed
+        # trailing line; we should keep parsing earlier messages instead of
+        # dropping the whole file.
+        sessions_dir.mkdir(parents=True)
+        path = sessions_dir / "partial.jsonl"
+        with path.open("w", encoding="utf-8") as fh:
+            fh.write(json.dumps(_user_line("partial", "first message")) + "\n")
+            fh.write('{"type": "user", "message": {"role": "user", "content')
+
+        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+        assert len(result) == 1
+        assert result[0].preview == "first message"
+
+    def test_preview_is_truncated(
+        self, sessions_dir, fake_claude_home, project_cwd
+    ):
+        long_text = "a" * 500
+        _write_jsonl(
+            sessions_dir / "long.jsonl",
+            [_user_line("long", long_text)],
+        )
+
+        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+        assert len(result[0].preview) < len(long_text)
+        assert result[0].preview.endswith("\u2026")
+
+    def test_preview_collapses_whitespace(
+        self, sessions_dir, fake_claude_home, project_cwd
+    ):
+        _write_jsonl(
+            sessions_dir / "ws.jsonl",
+            [_user_line("ws", "line one\n\n   line two\tthree")],
+        )
+
+        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+        assert result[0].preview == "line one line two three"
+
+    def test_handles_structured_content_blocks(
+        self, sessions_dir, fake_claude_home, project_cwd
+    ):
+        _write_jsonl(
+            sessions_dir / "blocks.jsonl",
+            [
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "hello"},
+                            {"type": "image", "source": {}},
+                            {"type": "text", "text": "world"},
+                        ],
+                    },
+                }
+            ],
+        )
+
+        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+        assert result[0].preview == "hello world"
+
+    def test_skips_tool_result_user_envelopes(
+        self, sessions_dir, fake_claude_home, project_cwd
+    ):
+        # Tool results are wrapped in user messages but carry no real
+        # prompt text. They should not steal the preview from a real user
+        # turn.
+        _write_jsonl(
+            sessions_dir / "tools.jsonl",
+            [
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "abc",
+                                "content": "done",
+                            }
+                        ],
+                    },
+                },
+                _user_line("tools", "actual prompt"),
+            ],
+        )
+
+        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+        assert result[0].preview == "actual prompt"


### PR DESCRIPTION
## Summary

  Claude Code already persists every conversation as a JSONL transcript under `~/.claude/projects/<cwd-encoded>/`. Today NBI ignores those transcripts, so every time you reopen JupyterLab in Claude mode you start from a blank context. This PR surfaces prior sessions for the current Jupyter working directory in a picker and reconnects the Claude SDK client with `resume=<session_id>`, matching the behavior of `claude --resume` in the CLI.

  ## What it does

  - New `notebook_intelligence/claude_sessions.py` discovers transcripts for the current cwd and extracts a first-user-message preview.
  - New REST endpoints `GET /claude-sessions` and `POST /claude-sessions/resume`.
  - `ClaudeCodeClient.resume_session(session_id)` sets a one-shot `_resume_session_id` and reconnects, which `_create_client()` applies to `ClaudeAgentOptions.resume` (mutually exclusive with
    `continue_conversation`). The field is cleared after one use so a later reconnect does not unexpectedly re-resume.
  - A new history icon in the sidebar header (only shown in Claude mode) opens a popover using the existing `workspace-file-popover` / `mode-tools-popover-*` styles. Clicking a session reconnects the backend; the chat view resets with a banner noting the resume.
  - Unit tests in `tests/test_claude_sessions.py` cover transcript discovery, sorting, preview extraction, tool-result envelope filtering, structured content blocks, and partial-trailing-line tolerance.

  Docs: new "Resuming a previous Claude session" subsection in README.

  ## Test plan

  - [x] `pytest tests/test_claude_sessions.py` — 15 passing
  - [x] Local build via `jlpm build`
  - [x] Manual: enable Claude mode in NBI settings, click history icon, select a prior session, send a new message, confirm Claude answers with full prior context.