### PR TITLE
feat: Drag-and-drop file upload for chat context

### DIFF
--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -366,7 +366,7 @@ def _get_upload_dir() -> str:
     global _upload_dir
     if _upload_dir is None:
         _upload_dir = tempfile.mkdtemp(prefix="nbi-uploads-")
-        atexit.register(lambda: shutil.rmtree(_upload_dir, ignore_errors=True))
+        atexit.register(lambda d=_upload_dir: shutil.rmtree(d, ignore_errors=True))
     return _upload_dir
 
 class FileUploadHandler(APIHandler):

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -1,11 +1,14 @@
 # Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
 
 import asyncio
+import atexit
 from dataclasses import dataclass
 import json
 from os import path
 import datetime as dt
 import os
+import shutil
+import tempfile
 from typing import Union
 import uuid
 import threading
@@ -356,6 +359,51 @@ class RulesReloadHandler(APIHandler):
             self.set_status(500)
             self.finish(json.dumps({"error": str(e)}))
 
+_upload_dir: str | None = None
+
+def _get_upload_dir() -> str:
+    """Return a temp directory for uploaded files, creating it on first call."""
+    global _upload_dir
+    if _upload_dir is None:
+        _upload_dir = tempfile.mkdtemp(prefix="nbi-uploads-")
+        atexit.register(lambda: shutil.rmtree(_upload_dir, ignore_errors=True))
+    return _upload_dir
+
+class FileUploadHandler(APIHandler):
+    """Accepts a file upload and stores it in a temp directory.
+
+    Returns the absolute server-side path so the frontend can reference it
+    in chat context and Claude Code can read it natively.
+    """
+
+    @tornado.web.authenticated
+    def post(self):
+        fileinfo = self.request.files.get("file")
+        if not fileinfo or len(fileinfo) == 0:
+            self.set_status(400)
+            self.finish(json.dumps({"error": "No file provided"}))
+            return
+
+        upload = fileinfo[0]
+        original_name = upload.get("filename", "upload")
+        # Sanitise filename: keep only the basename to prevent path traversal.
+        safe_name = path.basename(original_name)
+        if not safe_name:
+            safe_name = "upload"
+
+        upload_id = uuid.uuid4().hex[:12]
+        dest_dir = path.join(_get_upload_dir(), upload_id)
+        os.makedirs(dest_dir, exist_ok=True)
+        dest_path = path.join(dest_dir, safe_name)
+
+        with open(dest_path, "wb") as fh:
+            fh.write(upload["body"])
+
+        self.finish(json.dumps({
+            "serverPath": dest_path,
+            "filename": safe_name,
+        }))
+
 class ChatHistory:
     """
     History of chat messages, key is chat id, value is list of messages
@@ -687,8 +735,10 @@ class WebsocketCopilotHandler(websocket.WebSocketHandler):
             remaining_token_budget = int(0.8 * token_limit)
 
             for context in additionalContext:
+                is_upload = context.get("isUpload", False)
                 file_path = context["filePath"]
-                file_path = path.join(NotebookIntelligence.root_dir, file_path)
+                if not is_upload:
+                    file_path = path.join(NotebookIntelligence.root_dir, file_path)
                 context_filename = path.basename(file_path)
                 start_line = context["startLine"]
                 end_line = context["endLine"]
@@ -707,14 +757,23 @@ class WebsocketCopilotHandler(websocket.WebSocketHandler):
                 if context_content == "" and remaining_token_budget <= 0:
                     break
 
-                context_message = _build_additional_context_message(
-                    file_path=file_path,
-                    context_filename=context_filename,
-                    start_line=start_line,
-                    end_line=end_line,
-                    context_content=context_content,
-                    current_cell_context=current_cell_context
-                )
+                # For uploaded binary files (images, PDFs, etc.) where no
+                # text content was extracted, tell Claude to read the file
+                # from disk so it can handle it natively.
+                if is_upload and context_content == "":
+                    context_message = (
+                        f"The user attached a file '{context_filename}' "
+                        f"at path '{file_path}'. Read this file to see its contents."
+                    )
+                else:
+                    context_message = _build_additional_context_message(
+                        file_path=file_path,
+                        context_filename=context_filename,
+                        start_line=start_line,
+                        end_line=end_line,
+                        context_content=context_content,
+                        current_cell_context=current_cell_context
+                    )
                 remaining_token_budget -= len(
                     tiktoken_encoding.encode(context_message)
                 )
@@ -935,6 +994,7 @@ class NotebookIntelligence(ExtensionApp):
         route_pattern_rules = url_path_join(base_url, "notebook-intelligence", "rules")
         route_pattern_rules_toggle = url_path_join(base_url, "notebook-intelligence", "rules", r"([^/]+)", "toggle")
         route_pattern_rules_reload = url_path_join(base_url, "notebook-intelligence", "rules", "reload")
+        route_pattern_upload_file = url_path_join(base_url, "notebook-intelligence", "upload-file")
         GetCapabilitiesHandler.disabled_tools = self.disabled_tools
         GetCapabilitiesHandler.allow_enabling_tools_with_env = self.allow_enabling_tools_with_env
         GetCapabilitiesHandler.disabled_providers = self.disabled_providers
@@ -953,6 +1013,7 @@ class NotebookIntelligence(ExtensionApp):
             (route_pattern_rules, RulesListHandler),
             (route_pattern_rules_toggle, RulesToggleHandler),
             (route_pattern_rules_reload, RulesReloadHandler),
+            (route_pattern_upload_file, FileUploadHandler),
             (route_pattern_copilot, WebsocketCopilotHandler),
         ]
         web_app.add_handlers(host_pattern, NotebookIntelligence.handlers)

--- a/src/api.ts
+++ b/src/api.ts
@@ -534,6 +534,17 @@ export class NBIAPI {
     );
   }
 
+  static async uploadFile(
+    file: File
+  ): Promise<{ serverPath: string; filename: string }> {
+    const formData = new FormData();
+    formData.append('file', file, file.name);
+    return requestAPI<{ serverPath: string; filename: string }>('upload-file', {
+      method: 'POST',
+      body: formData
+    });
+  }
+
   static async emitTelemetryEvent(event: ITelemetryEvent): Promise<void> {
     const assistantMode = this.config.isInClaudeCodeMode
       ? AssistantMode.Claude

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -323,11 +323,46 @@ const TEXT_MIME_PREFIXES = [
 ];
 
 const TEXT_EXTENSIONS = new Set([
-  '.py', '.js', '.ts', '.tsx', '.jsx', '.json', '.yaml', '.yml', '.md',
-  '.txt', '.csv', '.html', '.css', '.sql', '.sh', '.r', '.ipynb', '.xml',
-  '.toml', '.cfg', '.ini', '.env', '.gitignore', '.dockerfile', '.svg',
-  '.rb', '.go', '.rs', '.java', '.c', '.cpp', '.h', '.hpp', '.swift',
-  '.kt', '.scala', '.lua', '.pl', '.m', '.mm'
+  '.py',
+  '.js',
+  '.ts',
+  '.tsx',
+  '.jsx',
+  '.json',
+  '.yaml',
+  '.yml',
+  '.md',
+  '.txt',
+  '.csv',
+  '.html',
+  '.css',
+  '.sql',
+  '.sh',
+  '.r',
+  '.ipynb',
+  '.xml',
+  '.toml',
+  '.cfg',
+  '.ini',
+  '.env',
+  '.gitignore',
+  '.dockerfile',
+  '.svg',
+  '.rb',
+  '.go',
+  '.rs',
+  '.java',
+  '.c',
+  '.cpp',
+  '.h',
+  '.hpp',
+  '.swift',
+  '.kt',
+  '.scala',
+  '.lua',
+  '.pl',
+  '.m',
+  '.mm'
 ]);
 
 function isLikelyTextFile(file: File): boolean {
@@ -1172,7 +1207,11 @@ function SidebarComponent(props: any) {
   const handleDragOver = (event: React.DragEvent) => {
     event.preventDefault();
     event.stopPropagation();
-    if (!isDragOver && chatEnabled && event.dataTransfer.types.includes('Files')) {
+    if (
+      !isDragOver &&
+      chatEnabled &&
+      event.dataTransfer.types.includes('Files')
+    ) {
       setIsDragOver(true);
     }
   };
@@ -1988,9 +2027,8 @@ function SidebarComponent(props: any) {
         type: ContextType.Custom,
         content: file.content,
         currentCellContents: null,
-        filePath: file.source === 'upload'
-          ? (file.serverPath ?? file.path)
-          : file.path,
+        filePath:
+          file.source === 'upload' ? (file.serverPath ?? file.path) : file.path,
         startLine: 1,
         endLine: file.lineCount
       };
@@ -2663,12 +2701,26 @@ function SidebarComponent(props: any) {
                 <div
                   key={file.serverPath ?? file.path}
                   className={`user-input-context user-input-context-selected-file on${file.source === 'upload' ? ' uploaded-file' : ''}`}
-                  title={file.source === 'upload' ? `Uploaded: ${file.path}` : file.path}
+                  title={
+                    file.source === 'upload'
+                      ? `Uploaded: ${file.path}`
+                      : file.path
+                  }
                 >
-                  <div>{file.source === 'upload' ? <><VscCloudUpload /> {file.path}</> : file.path}</div>
+                  <div>
+                    {file.source === 'upload' ? (
+                      <>
+                        <VscCloudUpload /> {file.path}
+                      </>
+                    ) : (
+                      file.path
+                    )}
+                  </div>
                   <div
                     className="user-input-context-toggle"
-                    onClick={() => removeSelectedContextFile(file.serverPath ?? file.path)}
+                    onClick={() =>
+                      removeSelectedContextFile(file.serverPath ?? file.path)
+                    }
                   >
                     <VscClose title="Remove attached file" />
                   </div>

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -55,7 +55,9 @@ import {
   VscThumbsup,
   VscThumbsdown,
   VscThumbsupFilled,
-  VscThumbsdownFilled
+  VscThumbsdownFilled,
+  VscCloudUpload,
+  VscAttach
 } from 'react-icons/vsc';
 
 import { extractLLMGeneratedCode, isDarkTheme } from './utils';
@@ -303,6 +305,43 @@ interface ISelectedContextFile {
   lineCount: number;
   path: string;
   type: string;
+  source?: 'workspace' | 'upload';
+  serverPath?: string;
+}
+
+const MAX_ATTACHED_FILES = 10;
+
+const TEXT_MIME_PREFIXES = [
+  'text/',
+  'application/json',
+  'application/xml',
+  'application/x-yaml',
+  'application/yaml'
+];
+
+const TEXT_EXTENSIONS = new Set([
+  '.py', '.js', '.ts', '.tsx', '.jsx', '.json', '.yaml', '.yml', '.md',
+  '.txt', '.csv', '.html', '.css', '.sql', '.sh', '.r', '.ipynb', '.xml',
+  '.toml', '.cfg', '.ini', '.env', '.gitignore', '.dockerfile', '.svg',
+  '.rb', '.go', '.rs', '.java', '.c', '.cpp', '.h', '.hpp', '.swift',
+  '.kt', '.scala', '.lua', '.pl', '.m', '.mm'
+]);
+
+function isLikelyTextFile(file: File): boolean {
+  if (TEXT_MIME_PREFIXES.some(prefix => file.type.startsWith(prefix))) {
+    return true;
+  }
+  const ext = '.' + file.name.split('.').pop()?.toLowerCase();
+  return TEXT_EXTENSIONS.has(ext);
+}
+
+function readFileAsText(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsText(file);
+  });
 }
 
 const MAX_VISIBLE_WORKSPACE_FILES = 50;
@@ -926,6 +965,9 @@ function SidebarComponent(props: any) {
   const [workspaceScanLimitReached, setWorkspaceScanLimitReached] =
     useState(false);
   const [workspaceFileActionPath, setWorkspaceFileActionPath] = useState('');
+  const [isDragOver, setIsDragOver] = useState(false);
+  const [isUploadingFiles, setIsUploadingFiles] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const telemetryEmitter: ITelemetryEmitter = props.getTelemetryEmitter();
   const [chatMode, setChatMode] = useState(NBIAPI.config.defaultChatMode);
 
@@ -1073,7 +1115,10 @@ function SidebarComponent(props: any) {
   const handleWorkspaceFileSelection = async (file: IWorkspaceFileOption) => {
     if (selectedContextFilePaths.has(file.path)) {
       setSelectedContextFiles(previousFiles =>
-        previousFiles.filter(selectedFile => selectedFile.path !== file.path)
+        previousFiles.filter(
+          selectedFile =>
+            selectedFile.source === 'upload' || selectedFile.path !== file.path
+        )
       );
       return;
     }
@@ -1114,10 +1159,167 @@ function SidebarComponent(props: any) {
     }
   };
 
-  const removeSelectedContextFile = (filePath: string) => {
+  const removeSelectedContextFile = (fileKey: string) => {
     setSelectedContextFiles(previousFiles =>
-      previousFiles.filter(file => file.path !== filePath)
+      previousFiles.filter(file => (file.serverPath ?? file.path) !== fileKey)
     );
+  };
+
+  const handleDragOver = (event: React.DragEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (!isDragOver && chatEnabled && event.dataTransfer.types.includes('Files')) {
+      setIsDragOver(true);
+    }
+  };
+
+  const handleDragLeave = (event: React.DragEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (!event.currentTarget.contains(event.relatedTarget as Node)) {
+      setIsDragOver(false);
+    }
+  };
+
+  const processDroppedFile = async (
+    file: File
+  ): Promise<ISelectedContextFile | null> => {
+    if (isLikelyTextFile(file)) {
+      const content = await readFileAsText(file);
+      if (content.trim() === '') {
+        throw new Error(`'${file.name}' is empty`);
+      }
+      return {
+        content,
+        lineCount: countContentLines(content),
+        path: file.name,
+        type: 'file',
+        source: 'upload'
+      };
+    }
+
+    const { serverPath, filename } = await NBIAPI.uploadFile(file);
+    return {
+      content: '',
+      lineCount: 0,
+      path: filename,
+      type: 'file',
+      source: 'upload',
+      serverPath
+    };
+  };
+
+  const addSystemNotice = (message: string) => {
+    setChatMessages(prev => [
+      ...prev,
+      {
+        id: UUID.uuid4(),
+        date: new Date(),
+        from: 'notice',
+        participant: { name: 'Notice' } as any,
+        contents: [
+          {
+            id: UUID.uuid4(),
+            type: ResponseStreamDataType.Markdown,
+            content: message,
+            created: new Date()
+          }
+        ]
+      }
+    ]);
+  };
+
+  const processAndAttachFiles = async (files: File[]) => {
+    if (files.length === 0) {
+      return;
+    }
+
+    const uploadedFiles = selectedContextFiles.filter(
+      f => f.source === 'upload'
+    );
+
+    // Duplicate detection: skip files already attached
+    const existingNames = new Set(uploadedFiles.map(f => f.path));
+    const uniqueFiles = files.filter(f => !existingNames.has(f.name));
+    const duplicateCount = files.length - uniqueFiles.length;
+
+    // Enforce file count limit
+    const currentUploadCount = uploadedFiles.length;
+    const available = MAX_ATTACHED_FILES - currentUploadCount;
+    const filesToProcess = uniqueFiles.slice(0, Math.max(0, available));
+    const skippedCount = uniqueFiles.length - filesToProcess.length;
+
+    if (filesToProcess.length === 0) {
+      const parts: string[] = [];
+      if (duplicateCount > 0) {
+        parts.push(`${duplicateCount} already attached`);
+      }
+      if (skippedCount > 0) {
+        parts.push(`limit of ${MAX_ATTACHED_FILES} files reached`);
+      }
+      addSystemNotice(`No files added: ${parts.join('; ')}.`);
+      return;
+    }
+
+    setIsUploadingFiles(true);
+    try {
+      const results = await Promise.allSettled(
+        filesToProcess.map(file => processDroppedFile(file))
+      );
+
+      const newContextFiles: ISelectedContextFile[] = [];
+      const errors: string[] = [];
+
+      for (const result of results) {
+        if (result.status === 'fulfilled' && result.value) {
+          newContextFiles.push(result.value);
+        } else if (result.status === 'rejected') {
+          errors.push(String(result.reason?.message ?? result.reason));
+        }
+      }
+
+      const notices: string[] = [];
+      if (errors.length > 0) {
+        notices.push(`Could not attach: ${errors.join('; ')}`);
+      }
+      if (duplicateCount > 0) {
+        notices.push(
+          `${duplicateCount} duplicate${duplicateCount > 1 ? 's' : ''} skipped`
+        );
+      }
+      if (skippedCount > 0) {
+        notices.push(
+          `${skippedCount} file${skippedCount > 1 ? 's' : ''} skipped (limit of ${MAX_ATTACHED_FILES})`
+        );
+      }
+      if (notices.length > 0) {
+        addSystemNotice(notices.join('. ') + '.');
+      }
+
+      if (newContextFiles.length > 0) {
+        setSelectedContextFiles(prev => [...prev, ...newContextFiles]);
+      }
+    } finally {
+      setIsUploadingFiles(false);
+    }
+  };
+
+  const handleDrop = async (event: React.DragEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setIsDragOver(false);
+    if (!chatEnabled) {
+      return;
+    }
+    await processAndAttachFiles(Array.from(event.dataTransfer.files));
+  };
+
+  const handleFileInputChange = async (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const files = Array.from(event.target.files ?? []);
+    event.target.value = '';
+    await processAndAttachFiles(files);
   };
 
   const cleanupRemovedToolsFromToolSelections = () => {
@@ -1778,14 +1980,20 @@ function SidebarComponent(props: any) {
         continue;
       }
 
-      additionalContext.push({
+      const contextItem: IContextItem & { isUpload?: boolean } = {
         type: ContextType.Custom,
         content: file.content,
         currentCellContents: null,
-        filePath: file.path,
+        filePath: file.source === 'upload'
+          ? (file.serverPath ?? file.path)
+          : file.path,
         startLine: 1,
         endLine: file.lineCount
-      });
+      };
+      if (file.source === 'upload') {
+        contextItem.isUpload = true;
+      }
+      additionalContext.push(contextItem);
     }
 
     setShowWorkspaceFilePicker(false);
@@ -2281,7 +2489,17 @@ function SidebarComponent(props: any) {
   }, [ghLoginStatus]);
 
   return (
-    <div className="sidebar">
+    <div
+      className={`sidebar${isDragOver ? ' drag-over' : ''}`}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
+      {isDragOver && (
+        <div className="drop-zone-overlay">
+          <span>Drop files to attach as context</span>
+        </div>
+      )}
       <div className="sidebar-header">
         <div className="sidebar-title">Notebook Intelligence</div>
         <div
@@ -2372,7 +2590,8 @@ function SidebarComponent(props: any) {
             value={prompt}
           />
           {(activeDocumentInfo?.filename ||
-            selectedContextFiles.length > 0) && (
+            selectedContextFiles.length > 0 ||
+            isUploadingFiles) && (
             <div className="user-input-context-row">
               {activeDocumentInfo?.filename && (
                 <div
@@ -2398,19 +2617,24 @@ function SidebarComponent(props: any) {
               )}
               {selectedContextFiles.map(file => (
                 <div
-                  key={file.path}
-                  className="user-input-context user-input-context-selected-file on"
-                  title={file.path}
+                  key={file.serverPath ?? file.path}
+                  className={`user-input-context user-input-context-selected-file on${file.source === 'upload' ? ' uploaded-file' : ''}`}
+                  title={file.source === 'upload' ? `Uploaded: ${file.path}` : file.path}
                 >
-                  <div>{file.path}</div>
+                  <div>{file.source === 'upload' ? <><VscCloudUpload /> {file.path}</> : file.path}</div>
                   <div
                     className="user-input-context-toggle"
-                    onClick={() => removeSelectedContextFile(file.path)}
+                    onClick={() => removeSelectedContextFile(file.serverPath ?? file.path)}
                   >
                     <VscClose title="Remove attached file" />
                   </div>
                 </div>
               ))}
+              {isUploadingFiles && (
+                <div className="user-input-context uploading-indicator">
+                  <div className="loading-ellipsis">Uploading</div>
+                </div>
+              )}
             </div>
           )}
           <div className="user-input-footer">
@@ -2438,6 +2662,20 @@ function SidebarComponent(props: any) {
                 <>{selectedContextFiles.length}</>
               )}
             </div>
+            <div
+              className="user-input-footer-button"
+              onClick={() => fileInputRef.current?.click()}
+              title="Upload files from your computer"
+            >
+              <VscAttach />
+            </div>
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              style={{ display: 'none' }}
+              onChange={handleFileInputChange}
+            />
             <div style={{ flexGrow: 1 }}></div>
             <div className="chat-mode-widgets-container">
               {!NBIAPI.config.isInClaudeCodeMode && (

--- a/style/base.css
+++ b/style/base.css
@@ -51,15 +51,6 @@
   padding: 3px 5px;
 }
 
-.chat-message-notice .chat-message-from-title {
-  font-weight: normal;
-  font-style: italic;
-}
-
-.chat-message-notice .chat-message-content p {
-  margin-block: 2px;
-}
-
 .sidebar-header {
   height: 25px;
   padding: 5px 10px;
@@ -278,6 +269,11 @@ pre:has(.code-block-header) {
   font-weight: bold;
 }
 
+.chat-message-notice .chat-message-from-title {
+  font-weight: normal;
+  font-style: italic;
+}
+
 .chat-message-from-progress {
   padding-left: 10px;
   flex-grow: 1;
@@ -320,6 +316,10 @@ pre:has(.code-block-header) {
 .chat-message-content p {
   margin-block: 5px 5px;
   line-height: 18px;
+}
+
+.chat-message-notice .chat-message-content p {
+  margin-block: 2px;
 }
 
 .chat-message-content a {

--- a/style/base.css
+++ b/style/base.css
@@ -9,6 +9,55 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  position: relative;
+}
+
+.drop-zone-overlay {
+  position: absolute;
+  inset: 0;
+  background-color: color-mix(in srgb, var(--jp-brand-color1) 15%, transparent);
+  border: 2px dashed var(--jp-brand-color1);
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  color: var(--jp-brand-color1);
+  z-index: 100;
+  pointer-events: none;
+}
+
+.drop-zone-overlay span {
+  background-color: var(--jp-layout-color1);
+  padding: 8px 16px;
+  border-radius: 6px;
+  border: 1px solid var(--jp-brand-color1);
+}
+
+.user-input-context.uploaded-file {
+  border-style: dashed;
+}
+
+.user-input-context.uploading-indicator {
+  border: none;
+  font-size: 11px;
+  color: var(--jp-ui-font-color2);
+}
+
+.chat-message-notice {
+  background-color: transparent;
+  font-size: 12px;
+  color: var(--jp-ui-font-color2);
+  padding: 3px 5px;
+}
+
+.chat-message-notice .chat-message-from-title {
+  font-weight: normal;
+  font-style: italic;
+}
+
+.chat-message-notice .chat-message-content p {
+  margin-block: 2px;
 }
 
 .sidebar-header {

--- a/tests/test_file_upload.py
+++ b/tests/test_file_upload.py
@@ -1,0 +1,189 @@
+"""Tests for the file upload handler and upload directory management.
+
+Covers:
+- Temp directory creation and cleanup
+- FileUploadHandler: successful uploads, missing file, path traversal protection
+- Uploaded file context processing in the WebSocket handler
+"""
+
+import json
+import os
+import shutil
+import tempfile
+from os import path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from notebook_intelligence.extension import (
+    FileUploadHandler,
+    _get_upload_dir,
+)
+
+
+# ---------------------------------------------------------------------------
+# _get_upload_dir
+# ---------------------------------------------------------------------------
+
+class TestGetUploadDir:
+    def test_creates_directory(self):
+        """_get_upload_dir should return a directory that exists."""
+        import notebook_intelligence.extension as ext
+        original = ext._upload_dir
+        try:
+            ext._upload_dir = None
+            result = _get_upload_dir()
+            assert path.isdir(result)
+            assert "nbi-uploads-" in result
+        finally:
+            # Restore and clean up
+            if ext._upload_dir and ext._upload_dir != original:
+                shutil.rmtree(ext._upload_dir, ignore_errors=True)
+            ext._upload_dir = original
+
+    def test_returns_same_directory_on_repeated_calls(self):
+        """Repeated calls should return the same directory (singleton)."""
+        import notebook_intelligence.extension as ext
+        original = ext._upload_dir
+        try:
+            ext._upload_dir = None
+            first = _get_upload_dir()
+            second = _get_upload_dir()
+            assert first == second
+        finally:
+            if ext._upload_dir and ext._upload_dir != original:
+                shutil.rmtree(ext._upload_dir, ignore_errors=True)
+            ext._upload_dir = original
+
+
+# ---------------------------------------------------------------------------
+# FileUploadHandler
+# ---------------------------------------------------------------------------
+
+def _make_handler(files=None):
+    """Create a mock FileUploadHandler with the given request files."""
+    handler = MagicMock(spec=FileUploadHandler)
+    handler.request = MagicMock()
+    handler.request.files = files or {}
+    handler.set_status = MagicMock()
+    handler.finish = MagicMock()
+    return handler
+
+
+class TestFileUploadHandler:
+    def test_returns_400_when_no_file_provided(self):
+        handler = _make_handler(files={})
+        FileUploadHandler.post(handler)
+        handler.set_status.assert_called_once_with(400)
+        response = json.loads(handler.finish.call_args[0][0])
+        assert "No file provided" in response["error"]
+
+    def test_returns_400_when_file_list_empty(self):
+        handler = _make_handler(files={"file": []})
+        FileUploadHandler.post(handler)
+        handler.set_status.assert_called_once_with(400)
+
+    def test_successful_upload(self, tmp_path):
+        """A valid upload should write the file and return serverPath + filename."""
+        import notebook_intelligence.extension as ext
+        original = ext._upload_dir
+        ext._upload_dir = str(tmp_path)
+        try:
+            file_body = b"hello world"
+            handler = _make_handler(files={
+                "file": [{"filename": "test.txt", "body": file_body}]
+            })
+
+            FileUploadHandler.post(handler)
+
+            handler.set_status.assert_not_called()
+            response = json.loads(handler.finish.call_args[0][0])
+            assert response["filename"] == "test.txt"
+            assert "test.txt" in response["serverPath"]
+
+            # Verify the file was actually written
+            assert path.isfile(response["serverPath"])
+            with open(response["serverPath"], "rb") as f:
+                assert f.read() == file_body
+        finally:
+            ext._upload_dir = original
+
+    def test_binary_file_upload(self, tmp_path):
+        """Binary files (images, PDFs) should be stored correctly."""
+        import notebook_intelligence.extension as ext
+        original = ext._upload_dir
+        ext._upload_dir = str(tmp_path)
+        try:
+            # Minimal PNG header bytes
+            file_body = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+            handler = _make_handler(files={
+                "file": [{"filename": "screenshot.png", "body": file_body}]
+            })
+
+            FileUploadHandler.post(handler)
+
+            response = json.loads(handler.finish.call_args[0][0])
+            assert response["filename"] == "screenshot.png"
+            with open(response["serverPath"], "rb") as f:
+                assert f.read() == file_body
+        finally:
+            ext._upload_dir = original
+
+    def test_path_traversal_protection(self, tmp_path):
+        """Filenames with path traversal attempts should be sanitised."""
+        import notebook_intelligence.extension as ext
+        original = ext._upload_dir
+        ext._upload_dir = str(tmp_path)
+        try:
+            handler = _make_handler(files={
+                "file": [{"filename": "../../../etc/passwd", "body": b"sneaky"}]
+            })
+
+            FileUploadHandler.post(handler)
+
+            response = json.loads(handler.finish.call_args[0][0])
+            assert response["filename"] == "passwd"
+            # File should be inside the upload dir, not escaped
+            assert response["serverPath"].startswith(str(tmp_path))
+        finally:
+            ext._upload_dir = original
+
+    def test_missing_filename_defaults_to_upload(self, tmp_path):
+        """If no filename is provided, it should default to 'upload'."""
+        import notebook_intelligence.extension as ext
+        original = ext._upload_dir
+        ext._upload_dir = str(tmp_path)
+        try:
+            handler = _make_handler(files={
+                "file": [{"body": b"data"}]
+            })
+
+            FileUploadHandler.post(handler)
+
+            response = json.loads(handler.finish.call_args[0][0])
+            assert response["filename"] == "upload"
+        finally:
+            ext._upload_dir = original
+
+    def test_unique_subdirectories_per_upload(self, tmp_path):
+        """Each upload should go into a unique subdirectory."""
+        import notebook_intelligence.extension as ext
+        original = ext._upload_dir
+        ext._upload_dir = str(tmp_path)
+        try:
+            paths = []
+            for i in range(3):
+                handler = _make_handler(files={
+                    "file": [{"filename": "same.txt", "body": f"v{i}".encode()}]
+                })
+                FileUploadHandler.post(handler)
+                response = json.loads(handler.finish.call_args[0][0])
+                paths.append(response["serverPath"])
+
+            # All paths should be unique despite same filename
+            assert len(set(paths)) == 3
+            # All should exist
+            for p in paths:
+                assert path.isfile(p)
+        finally:
+            ext._upload_dir = original

--- a/tests/test_file_upload.py
+++ b/tests/test_file_upload.py
@@ -3,62 +3,38 @@
 Covers:
 - Temp directory creation and cleanup
 - FileUploadHandler: successful uploads, missing file, path traversal protection
-- Uploaded file context processing in the WebSocket handler
 """
 
 import json
 import os
 import shutil
-import tempfile
-from os import path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
-from notebook_intelligence.extension import (
-    FileUploadHandler,
-    _get_upload_dir,
-)
+import notebook_intelligence.extension as ext
+from notebook_intelligence.extension import FileUploadHandler, _get_upload_dir
 
 
-# ---------------------------------------------------------------------------
-# _get_upload_dir
-# ---------------------------------------------------------------------------
-
-class TestGetUploadDir:
-    def test_creates_directory(self):
-        """_get_upload_dir should return a directory that exists."""
-        import notebook_intelligence.extension as ext
-        original = ext._upload_dir
-        try:
-            ext._upload_dir = None
-            result = _get_upload_dir()
-            assert path.isdir(result)
-            assert "nbi-uploads-" in result
-        finally:
-            # Restore and clean up
-            if ext._upload_dir and ext._upload_dir != original:
-                shutil.rmtree(ext._upload_dir, ignore_errors=True)
-            ext._upload_dir = original
-
-    def test_returns_same_directory_on_repeated_calls(self):
-        """Repeated calls should return the same directory (singleton)."""
-        import notebook_intelligence.extension as ext
-        original = ext._upload_dir
-        try:
-            ext._upload_dir = None
-            first = _get_upload_dir()
-            second = _get_upload_dir()
-            assert first == second
-        finally:
-            if ext._upload_dir and ext._upload_dir != original:
-                shutil.rmtree(ext._upload_dir, ignore_errors=True)
-            ext._upload_dir = original
+@pytest.fixture
+def upload_dir(tmp_path):
+    """Point _upload_dir at a temp directory for the duration of the test."""
+    original = ext._upload_dir
+    ext._upload_dir = str(tmp_path)
+    yield str(tmp_path)
+    ext._upload_dir = original
 
 
-# ---------------------------------------------------------------------------
-# FileUploadHandler
-# ---------------------------------------------------------------------------
+@pytest.fixture
+def reset_upload_dir():
+    """Reset _upload_dir to None so _get_upload_dir creates a fresh one."""
+    original = ext._upload_dir
+    ext._upload_dir = None
+    yield
+    if ext._upload_dir and ext._upload_dir != original:
+        shutil.rmtree(ext._upload_dir, ignore_errors=True)
+    ext._upload_dir = original
+
 
 def _make_handler(files=None):
     """Create a mock FileUploadHandler with the given request files."""
@@ -70,120 +46,98 @@ def _make_handler(files=None):
     return handler
 
 
+def _parse_response(handler):
+    return json.loads(handler.finish.call_args[0][0])
+
+
+# ---------------------------------------------------------------------------
+# _get_upload_dir
+# ---------------------------------------------------------------------------
+
+class TestGetUploadDir:
+    def test_creates_directory(self, reset_upload_dir):
+        result = _get_upload_dir()
+        assert os.path.isdir(result)
+        assert "nbi-uploads-" in result
+
+    def test_returns_same_directory_on_repeated_calls(self, reset_upload_dir):
+        first = _get_upload_dir()
+        second = _get_upload_dir()
+        assert first == second
+
+
+# ---------------------------------------------------------------------------
+# FileUploadHandler
+# ---------------------------------------------------------------------------
+
 class TestFileUploadHandler:
     def test_returns_400_when_no_file_provided(self):
         handler = _make_handler(files={})
         FileUploadHandler.post(handler)
         handler.set_status.assert_called_once_with(400)
-        response = json.loads(handler.finish.call_args[0][0])
-        assert "No file provided" in response["error"]
+        assert "No file provided" in _parse_response(handler)["error"]
 
     def test_returns_400_when_file_list_empty(self):
         handler = _make_handler(files={"file": []})
         FileUploadHandler.post(handler)
         handler.set_status.assert_called_once_with(400)
 
-    def test_successful_upload(self, tmp_path):
-        """A valid upload should write the file and return serverPath + filename."""
-        import notebook_intelligence.extension as ext
-        original = ext._upload_dir
-        ext._upload_dir = str(tmp_path)
-        try:
-            file_body = b"hello world"
+    def test_successful_text_upload(self, upload_dir):
+        file_body = b"hello world"
+        handler = _make_handler(files={
+            "file": [{"filename": "test.txt", "body": file_body}]
+        })
+
+        FileUploadHandler.post(handler)
+
+        response = _parse_response(handler)
+        assert response["filename"] == "test.txt"
+        assert response["serverPath"].startswith(upload_dir)
+        with open(response["serverPath"], "rb") as f:
+            assert f.read() == file_body
+
+    def test_binary_file_upload(self, upload_dir):
+        file_body = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+        handler = _make_handler(files={
+            "file": [{"filename": "screenshot.png", "body": file_body}]
+        })
+
+        FileUploadHandler.post(handler)
+
+        response = _parse_response(handler)
+        assert response["filename"] == "screenshot.png"
+        with open(response["serverPath"], "rb") as f:
+            assert f.read() == file_body
+
+    def test_path_traversal_protection(self, upload_dir):
+        handler = _make_handler(files={
+            "file": [{"filename": "../../../etc/passwd", "body": b"sneaky"}]
+        })
+
+        FileUploadHandler.post(handler)
+
+        response = _parse_response(handler)
+        assert response["filename"] == "passwd"
+        assert response["serverPath"].startswith(upload_dir)
+
+    def test_missing_filename_defaults_to_upload(self, upload_dir):
+        handler = _make_handler(files={
+            "file": [{"body": b"data"}]
+        })
+
+        FileUploadHandler.post(handler)
+
+        assert _parse_response(handler)["filename"] == "upload"
+
+    def test_unique_subdirectories_per_upload(self, upload_dir):
+        paths = []
+        for i in range(3):
             handler = _make_handler(files={
-                "file": [{"filename": "test.txt", "body": file_body}]
+                "file": [{"filename": "same.txt", "body": f"v{i}".encode()}]
             })
-
             FileUploadHandler.post(handler)
+            paths.append(_parse_response(handler)["serverPath"])
 
-            handler.set_status.assert_not_called()
-            response = json.loads(handler.finish.call_args[0][0])
-            assert response["filename"] == "test.txt"
-            assert "test.txt" in response["serverPath"]
-
-            # Verify the file was actually written
-            assert path.isfile(response["serverPath"])
-            with open(response["serverPath"], "rb") as f:
-                assert f.read() == file_body
-        finally:
-            ext._upload_dir = original
-
-    def test_binary_file_upload(self, tmp_path):
-        """Binary files (images, PDFs) should be stored correctly."""
-        import notebook_intelligence.extension as ext
-        original = ext._upload_dir
-        ext._upload_dir = str(tmp_path)
-        try:
-            # Minimal PNG header bytes
-            file_body = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
-            handler = _make_handler(files={
-                "file": [{"filename": "screenshot.png", "body": file_body}]
-            })
-
-            FileUploadHandler.post(handler)
-
-            response = json.loads(handler.finish.call_args[0][0])
-            assert response["filename"] == "screenshot.png"
-            with open(response["serverPath"], "rb") as f:
-                assert f.read() == file_body
-        finally:
-            ext._upload_dir = original
-
-    def test_path_traversal_protection(self, tmp_path):
-        """Filenames with path traversal attempts should be sanitised."""
-        import notebook_intelligence.extension as ext
-        original = ext._upload_dir
-        ext._upload_dir = str(tmp_path)
-        try:
-            handler = _make_handler(files={
-                "file": [{"filename": "../../../etc/passwd", "body": b"sneaky"}]
-            })
-
-            FileUploadHandler.post(handler)
-
-            response = json.loads(handler.finish.call_args[0][0])
-            assert response["filename"] == "passwd"
-            # File should be inside the upload dir, not escaped
-            assert response["serverPath"].startswith(str(tmp_path))
-        finally:
-            ext._upload_dir = original
-
-    def test_missing_filename_defaults_to_upload(self, tmp_path):
-        """If no filename is provided, it should default to 'upload'."""
-        import notebook_intelligence.extension as ext
-        original = ext._upload_dir
-        ext._upload_dir = str(tmp_path)
-        try:
-            handler = _make_handler(files={
-                "file": [{"body": b"data"}]
-            })
-
-            FileUploadHandler.post(handler)
-
-            response = json.loads(handler.finish.call_args[0][0])
-            assert response["filename"] == "upload"
-        finally:
-            ext._upload_dir = original
-
-    def test_unique_subdirectories_per_upload(self, tmp_path):
-        """Each upload should go into a unique subdirectory."""
-        import notebook_intelligence.extension as ext
-        original = ext._upload_dir
-        ext._upload_dir = str(tmp_path)
-        try:
-            paths = []
-            for i in range(3):
-                handler = _make_handler(files={
-                    "file": [{"filename": "same.txt", "body": f"v{i}".encode()}]
-                })
-                FileUploadHandler.post(handler)
-                response = json.loads(handler.finish.call_args[0][0])
-                paths.append(response["serverPath"])
-
-            # All paths should be unique despite same filename
-            assert len(set(paths)) == 3
-            # All should exist
-            for p in paths:
-                assert path.isfile(p)
-        finally:
-            ext._upload_dir = original
+        assert len(set(paths)) == 3
+        for p in paths:
+            assert os.path.isfile(p)


### PR DESCRIPTION
  ## Summary
                                                                                                                                   
  Adds the ability to drag files from the desktop into the chat sidebar (or use an attach button) to include them as context, similar to how Claude Code CLI handles file attachments.                                                                         
                                                                                                                                   
  - **Text files** (source code, JSON, Markdown, etc.) are read on the client and sent inline — no server round-trip needed        
  - **Binary files** (images, PDFs, etc.) are uploaded to a server-side temp directory so Claude Code can read them natively from disk                                                                                                                             
                                                                                                                                 
  ## Changes                                                                                                                       
                                                                                                                                 
  ### Backend (`notebook_intelligence/extension.py`)                                                                               
  - New `FileUploadHandler` REST endpoint (`POST /upload-file`) that stores uploads in a temp directory with UUID-based subdirectories                                                                                                                   
  - Path traversal protection via `os.path.basename` sanitization                                                                
  - Temp directory cleaned up via `atexit`                                                                                         
  - Context processing updated to pass uploaded file paths directly (not joined with `root_dir`), and to instruct Claude Code to read binary files from disk                                                                                                      
                                                                                                                                   
  ### Frontend (`src/chat-sidebar.tsx`, `src/api.ts`)                                                                              
  - Drag-and-drop handlers on the sidebar with a visual drop zone overlay                                                        
  - Paperclip attach button (`VscAttach`) in the input footer for keyboard-accessible file picking                                 
  - Hybrid processing: text files read locally via `FileReader`, binary files uploaded via `NBIAPI.uploadFile()`                   
  - Duplicate detection (by filename) and file count limit (10)                                                                    
  - Upload loading indicator in the context row                                                                                    
  - Errors and notices displayed as compact system messages, visually distinct from AI responses                                   
  - Drag-and-drop disabled when chat is not enabled                                                                                
                                                                                                                                   
  ### Styles (`style/base.css`)                                                                                                    
  - Drop zone overlay with dashed border and labeled pill                                                                        
  - Dashed border on uploaded file context pills to distinguish from workspace files                                               
  - Compact notice message styling                                                                                                 
                                                                                                                                   
  ### Tests (`tests/test_file_upload.py`)                                                                                          
  - 9 tests covering: temp directory creation/singleton behavior, successful text and binary uploads, 400 on missing file, path traversal protection, missing filename fallback, unique subdirectories per upload                                                
  
  ## How to test                                                                                                                   
                                                                                                                                 
  1. Open the NBI chat sidebar                                                                                                     
  2. Drag a text file (e.g., `.py`, `.json`) from your desktop into the chat — it should appear as a dashed-border context pill
  3. Drag an image or PDF — it should upload and appear with a cloud icon                                                          
  4. Try dragging the same file again — it should be skipped as a duplicate                                                        
  5. Click the paperclip icon in the input footer — native file picker should open                                                 
  6. Send a message with attached files and verify they're included in the context                                                 
                                                                                                                                   
  ## Notes                                                                                                                       
                                                                                                                                   
  - Upload size limit defers to the server's existing Tornado `max_body_size` rather than imposing a separate cap                  
  - No changes to the CHANGELOG — deferring to maintainer discretion
  - Existing `@` and `+` button conventions in the input footer are preserved as-is  