### PR TITLE
feat(agent): support thought process and non-tool text display

### DIFF
--- a/notebook_intelligence/api.py
+++ b/notebook_intelligence/api.py
@@ -131,6 +131,7 @@ class ResponseStreamData:
 class MarkdownData(ResponseStreamData):
     content: str = ''
     detail: dict = None
+    reasoning_content: str = ''
 
     @property
     def data_type(self) -> ResponseStreamDataType:
@@ -139,6 +140,7 @@ class MarkdownData(ResponseStreamData):
 @dataclass
 class MarkdownPartData(ResponseStreamData):
     content: str = ''
+    reasoning_content: str = ''
 
     @property
     def data_type(self) -> ResponseStreamDataType:
@@ -584,13 +586,33 @@ class ChatParticipant:
                 options['tool_choice'] = 'auto'
 
                 for choice in tool_response['choices']:
-                    if choice['message'].get('tool_calls', None) is not None:
-                        for tool_call in choice['message']['tool_calls']:
+                    message = choice['message']
+                    # Some models use 'reasoning', some use 'reasoning_content'
+                    raw_reasoning = message.get('reasoning') or message.get('reasoning_content') or ''
+                    
+                    reasoning = ''
+                    if isinstance(raw_reasoning, dict):
+                        reasoning = (raw_reasoning.get('text') or 
+                                     raw_reasoning.get('content') or 
+                                     raw_reasoning.get('thought') or 
+                                     str(raw_reasoning))
+                    else:
+                        reasoning = str(raw_reasoning)
+                    
+                    content = message.get('content') or ''
+                    if not isinstance(content, str):
+                        content = str(content)
+                    
+                    if reasoning or content:
+                        response.stream(MarkdownData(content=content, reasoning_content=reasoning))
+
+                    if message.get('tool_calls', None) is not None:
+                        for tool_call in message['tool_calls']:
                             tool_call_rounds.append(tool_call)
                     elif choice['message'].get('content', None) is not None:
                         response.stream(MarkdownData(tool_response['choices'][0]['message']['content']))
 
-                    messages.append(choice['message'])
+                    messages.append(message)
 
                 had_tool_call = len(tool_call_rounds) > 0
 

--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -410,22 +410,52 @@ class ClaudeCodeClient():
 
                             if not already_handled and not request.cancel_token.is_cancel_requested:
                                 await client.query(client_query)
+                                
+                                streamed_lengths = {} # track length per block index or id
+                                
                                 async for message in client.receive_response():
                                     if request.cancel_token.is_cancel_requested:
                                         continue
                                     if isinstance(message, AssistantMessage):
-                                        for block in message.content:
+                                        for i, block in enumerate(message.content):
                                             if isinstance(block, TextBlock):
-                                                response.stream(MarkdownData(block.text))
+                                                full_text = block.text
+                                                last_len = streamed_lengths.get(i, 0)
+                                                delta = full_text[last_len:]
+                                                if delta:
+                                                    response.stream(MarkdownPartData(content=delta))
+                                                    streamed_lengths[i] = len(full_text)
+                                            elif hasattr(block, 'thinking') or hasattr(block, 'thought') or hasattr(block, 'reasoning'):
+                                                full_thinking = getattr(block, 'thinking', getattr(block, 'thought', getattr(block, 'reasoning', '')))
+                                                last_len = streamed_lengths.get(f"thinking_{i}", 0)
+                                                delta = full_thinking[last_len:]
+                                                if delta:
+                                                    response.stream(MarkdownPartData(reasoning_content=delta))
+                                                    streamed_lengths[f"thinking_{i}"] = len(full_thinking)
+                                            elif getattr(block, 'type', None) in ['thinking', 'thought', 'reasoning']:
+                                                full_thinking = getattr(block, 'thinking', getattr(block, 'thought', getattr(block, 'reasoning', '')))
+                                                last_len = streamed_lengths.get(f"thinking_{i}", 0)
+                                                delta = full_thinking[last_len:]
+                                                if delta:
+                                                    response.stream(MarkdownPartData(reasoning_content=delta))
+                                                    streamed_lengths[f"thinking_{i}"] = len(full_thinking)
                                     elif isinstance(message, UserMessage):
                                         if isinstance(message.content, str):
                                             content = message.content
                                             content = content.replace('<local-command-stdout>', '').replace('</local-command-stdout>', '')
-                                            response.stream(MarkdownData(content))
+                                            last_len = streamed_lengths.get("user_msg", 0)
+                                            delta = content[last_len:]
+                                            if delta:
+                                                response.stream(MarkdownPartData(content=delta))
+                                                streamed_lengths["user_msg"] = len(content)
                                         elif isinstance(message.content, TextBlock):
                                             content = message.content.text
                                             content = content.replace('<local-command-stdout>', '').replace('</local-command-stdout>', '')
-                                            response.stream(MarkdownData(content))
+                                            last_len = streamed_lengths.get("user_msg_textblock", 0)
+                                            delta = content[last_len:]
+                                            if delta:
+                                                response.stream(MarkdownPartData(content=delta))
+                                                streamed_lengths["user_msg_textblock"] = len(content)
                                     else:
                                         pass
                         except Exception as e:

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -406,6 +406,7 @@ class WebsocketCopilotResponseEmitter(ChatResponse):
         self.websocket_handler = websocket_handler
         self.chat_history = chat_history
         self.streamed_contents = []
+        self.streamed_reasoning_contents = []
 
     @property
     def chat_id(self) -> str:
@@ -419,7 +420,7 @@ class WebsocketCopilotResponseEmitter(ChatResponse):
         data_type = ResponseStreamDataType.LLMRaw if type(data) is dict else data.data_type
 
         if data_type == ResponseStreamDataType.Markdown:
-            self.chat_history.add_message(self.chatId, {"role": "assistant", "content": data.content})
+            self.chat_history.add_message(self.chatId, {"role": "assistant", "content": data.content, "reasoning_content": data.reasoning_content})
             data = {
                 "choices": [
                     {
@@ -427,6 +428,7 @@ class WebsocketCopilotResponseEmitter(ChatResponse):
                             "nbiContent": {
                                 "type": data_type,
                                 "content": data.content,
+                                "reasoning_content": data.reasoning_content,
                                 "detail": data.detail
                             },
                             "content": "",
@@ -568,13 +570,15 @@ class WebsocketCopilotResponseEmitter(ChatResponse):
             }
         elif data_type == ResponseStreamDataType.MarkdownPart:
             content = data.content
+            reasoning_content = data.reasoning_content
             data = {
                 "choices": [
                     {
                         "delta": {
                             "nbiContent": {
                                 "type": data_type,
-                                "content": data.content
+                                "content": data.content,
+                                "reasoning_content": data.reasoning_content
                             },
                             "content": "",
                             "role": "assistant"
@@ -582,14 +586,19 @@ class WebsocketCopilotResponseEmitter(ChatResponse):
                     }
                 ]
             }
-            part = content
-            if part is not None:
-                self.streamed_contents.append(part)
+            if content is not None:
+                self.streamed_contents.append(content)
+            if reasoning_content is not None:
+                self.streamed_reasoning_contents.append(reasoning_content)
         else: # ResponseStreamDataType.LLMRaw
             if len(data.get("choices", [])) > 0:
-                part = data["choices"][0].get("delta", {}).get("content", "")
-                if part is not None:
-                    self.streamed_contents.append(part)
+                delta = data["choices"][0].get("delta", {})
+                content = delta.get("content", "")
+                reasoning_content = delta.get("reasoning_content", "")
+                if content is not None:
+                    self.streamed_contents.append(content)
+                if reasoning_content is not None:
+                    self.streamed_reasoning_contents.append(reasoning_content)
 
         self.websocket_handler.write_message({
             "id": self.messageId,
@@ -600,8 +609,9 @@ class WebsocketCopilotResponseEmitter(ChatResponse):
         })
 
     def finish(self) -> None:
-        self.chat_history.add_message(self.chatId, {"role": "assistant", "content": "".join(self.streamed_contents)})
+        self.chat_history.add_message(self.chatId, {"role": "assistant", "content": "".join(self.streamed_contents), "reasoning_content": "".join(self.streamed_reasoning_contents)})
         self.streamed_contents = []
+        self.streamed_reasoning_contents = []
         self.websocket_handler.write_message({
             "id": self.messageId,
             "participant": self.participant_id,

--- a/notebook_intelligence/llm_providers/litellm_compatible_llm_provider.py
+++ b/notebook_intelligence/llm_providers/litellm_compatible_llm_provider.py
@@ -54,19 +54,32 @@ class LiteLLMCompatibleChatModel(ChatModel):
 
         if stream:
             for chunk in litellm_resp:
+                if len(chunk.choices) == 0:
+                    continue
+                delta = chunk.choices[0].delta
+                reasoning = getattr(delta, 'reasoning_content', None) or getattr(delta, 'reasoning', None)
+                if reasoning is not None:
+                    reasoning = str(reasoning)
                 response.stream({
                         "choices": [{
                             "delta": {
-                                "role": chunk.choices[0].delta.role,
-                                "content": chunk.choices[0].delta.content
+                                "role": delta.role,
+                                "content": delta.content,
+                                "reasoning_content": reasoning
                             }
                         }]
                     })
             response.finish()
             return
         else:
-            json_resp = json.loads(litellm_resp.model_dump_json())
-            return json_resp
+            json_resp = json.loads(litellm_resp.model_dump_json()) 
+            # Capture reasoning fields if they exist as extra attributes
+            for i, choice in enumerate(litellm_resp.choices):
+                message = choice.message
+                reasoning = getattr(message, 'reasoning_content', None) or getattr(message, 'reasoning', None)
+                if reasoning:
+                    json_resp['choices'][i]['message']['reasoning_content'] = str(reasoning)
+            return json_resp 
     
 class LiteLLMCompatibleInlineCompletionModel(InlineCompletionModel):
     def __init__(self, provider: "LiteLLMCompatibleLLMProvider"):

--- a/notebook_intelligence/llm_providers/ollama_llm_provider.py
+++ b/notebook_intelligence/llm_providers/ollama_llm_provider.py
@@ -50,11 +50,16 @@ class OllamaChatModel(ChatModel):
 
         if stream:
             for chunk in ollama_response:
+                delta = chunk['message']
+                reasoning = delta.get('reasoning_content') or delta.get('reasoning')
+                if reasoning is not None:
+                    reasoning = str(reasoning)
                 response.stream({
                         "choices": [{
                             "delta": {
-                                "role": chunk['message']['role'],
-                                "content": chunk['message']['content']
+                                "role": delta['role'],
+                                "content": delta['content'],
+                                "reasoning_content": reasoning
                             }
                         }]
                     })
@@ -62,6 +67,10 @@ class OllamaChatModel(ChatModel):
             return
         else:
             json_resp = json.loads(ollama_response.model_dump_json())
+            message = ollama_response.message
+            reasoning = getattr(message, 'reasoning_content', None) or getattr(message, 'reasoning', None)
+            if reasoning:
+                json_resp['message']['reasoning_content'] = str(reasoning)
 
             return {
                 'choices': [

--- a/notebook_intelligence/llm_providers/openai_compatible_llm_provider.py
+++ b/notebook_intelligence/llm_providers/openai_compatible_llm_provider.py
@@ -58,11 +58,18 @@ class OpenAICompatibleChatModel(ChatModel):
 
         if stream:
             for chunk in resp:
+                if len(chunk.choices) == 0:
+                    continue
+                delta = chunk.choices[0].delta
+                reasoning = getattr(delta, 'reasoning_content', None) or getattr(delta, 'reasoning', None)
+                if reasoning is not None:
+                    reasoning = str(reasoning)
                 response.stream({
                         "choices": [{
                             "delta": {
-                                "role": chunk.choices[0].delta.role,
-                                "content": chunk.choices[0].delta.content
+                                "role": delta.role,
+                                "content": delta.content,
+                                "reasoning_content": reasoning
                             }
                         }]
                     })
@@ -70,6 +77,12 @@ class OpenAICompatibleChatModel(ChatModel):
             return
         else:
             json_resp = json.loads(resp.model_dump_json())
+            # Capture reasoning fields if they exist as extra attributes
+            for i, choice in enumerate(resp.choices):
+                message = choice.message
+                reasoning = getattr(message, 'reasoning_content', None) or getattr(message, 'reasoning', None)
+                if reasoning:
+                    json_resp['choices'][i]['message']['reasoning_content'] = str(reasoning)
             return json_resp
     
 class OpenAICompatibleInlineCompletionModel(InlineCompletionModel):

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -398,11 +398,11 @@ function ChatResponse(props: any) {
   const extractReasoningContent = (item: IChatMessageContent) => {
     let currentContent = item.content as string;
     if (typeof currentContent !== 'string') {
-      return false;
+      return item.reasoningContent && !item.reasoningFinished;
     }
 
     let reasoningContent = '';
-    let reasoningStartTime = new Date();
+    let reasoningStartTime = new Date(item.created);
     const reasoningEndTime = new Date();
 
     let startPos = -1;
@@ -416,16 +416,17 @@ function ChatResponse(props: any) {
     }
 
     const hasStart = startPos >= 0;
-    reasoningStartTime = new Date(item.created);
 
     if (hasStart) {
       currentContent = currentContent.substring(startPos + startTag.length);
     }
 
     let endPos = -1;
+    let endTag = '';
     for (const tag of responseDetailTags) {
       endPos = currentContent.indexOf(tag);
       if (endPos >= 0) {
+        endTag = tag;
         break;
       }
     }
@@ -433,7 +434,7 @@ function ChatResponse(props: any) {
 
     if (hasEnd) {
       reasoningContent += currentContent.substring(0, endPos);
-      currentContent = currentContent.substring(endPos + startTag.length);
+      currentContent = currentContent.substring(endPos + endTag.length);
     } else {
       if (hasStart) {
         reasoningContent += currentContent;
@@ -441,14 +442,19 @@ function ChatResponse(props: any) {
       }
     }
 
-    item.content = currentContent;
-    item.reasoningTag = startTag;
-    item.reasoningContent = reasoningContent;
-    item.reasoningFinished = hasEnd;
-    item.reasoningTime =
-      (reasoningEndTime.getTime() - reasoningStartTime.getTime()) / 1000;
+    if (hasStart) {
+      item.content = currentContent;
+      item.reasoningTag = startTag;
+      item.reasoningContent = (item.reasoningContent || '') + reasoningContent;
+      item.reasoningFinished = hasEnd;
+    }
 
-    return hasStart && !hasEnd; // is thinking
+    if (item.reasoningContent) {
+      item.reasoningTime =
+        (reasoningEndTime.getTime() - reasoningStartTime.getTime()) / 1000;
+    }
+
+    return hasStart && !hasEnd; // is thinking extracted now
   };
 
   for (let i = 0; i < msg.contents.length; i++) {
@@ -458,7 +464,14 @@ function ChatResponse(props: any) {
       lastItemType === ResponseStreamDataType.MarkdownPart
     ) {
       const lastItem = groupedContents[groupedContents.length - 1];
-      lastItem.content += item.content;
+      lastItem.content += (item.content || '');
+      if (item.reasoningContent) {
+        lastItem.reasoningContent =
+          (lastItem.reasoningContent || '') + item.reasoningContent;
+      }
+      if (item.reasoningFinished) {
+        lastItem.reasoningFinished = true;
+      }
     } else {
       groupedContents.push(structuredClone(item));
       lastItemType = item.type;
@@ -496,18 +509,14 @@ function ChatResponse(props: any) {
   };
 
   const getReasoningTitle = (item: IChatMessageContent) => {
-    if (item.reasoningTag === '<think>') {
-      return item.reasoningFinished
-        ? 'Thought'
-        : `Thinking (${Math.floor(item.reasoningTime)} s)`;
-    } else if (item.reasoningTag === '<terminal-output>') {
+    if (item.reasoningTag === '<terminal-output>') {
       return item.reasoningFinished
         ? 'Output'
         : `Running (${Math.floor(item.reasoningTime)} s)`;
     }
     return item.reasoningFinished
-      ? 'Output'
-      : `Output (${Math.floor(item.reasoningTime)} s)`;
+      ? 'Thought'
+      : `Thinking (${Math.floor(item.reasoningTime)} s)`;
   };
 
   const chatParticipantId = msg.participant?.id || 'default';
@@ -547,8 +556,8 @@ function ChatResponse(props: any) {
             case ResponseStreamDataType.MarkdownPart:
               return (
                 <>
-                  {item.reasoningContent && (
-                    <div className="expandable-content expanded">
+                  {item.reasoningContent && typeof item.reasoningContent === 'string' && (
+                    <div className={`expandable-content ${!item.reasoningFinished ? 'expanded' : ''}`}>
                       <div
                         className="expandable-content-title"
                         onClick={(event: any) => onExpandCollapseClick(event)}
@@ -559,7 +568,7 @@ function ChatResponse(props: any) {
                       </div>
                       <div className="expandable-content-text">
                         <MarkdownRenderer
-                          key={`key-${index}`}
+                          key={`reasoning-${index}`}
                           getApp={props.getApp}
                           getActiveDocumentInfo={props.getActiveDocumentInfo}
                         >
@@ -1820,20 +1829,44 @@ function SidebarComponent(props: any) {
               contents.push({
                 id: UUID.uuid4(),
                 type: nbiContent.type,
-                content: nbiContent.content,
+                content: nbiContent.content || '',
+                reasoningContent: nbiContent.reasoning_content || '',
+                reasoningTag: nbiContent.reasoning_content ? '<think>' : undefined,
+                reasoningFinished:
+                  nbiContent.type === ResponseStreamDataType.Markdown &&
+                  nbiContent.reasoning_content
+                    ? true
+                    : false,
                 contentDetail: nbiContent.detail,
                 created: new Date(response.created)
               });
             } else {
               responseMessage =
                 response.data['choices']?.[0]?.['delta']?.['content'];
-              if (!responseMessage) {
+              const reasoningContent =
+                response.data['choices']?.[0]?.['delta']?.['reasoning_content'];
+              if (!responseMessage && !reasoningContent) {
                 return;
               }
+
+              // If we have existing reasoning content and now we get normal content, mark reasoning as finished
+              const lastMarkdownItem = contents
+                .filter(c => c.type === ResponseStreamDataType.MarkdownPart)
+                .pop();
+              if (
+                lastMarkdownItem &&
+                lastMarkdownItem.reasoningContent &&
+                responseMessage &&
+                !lastMarkdownItem.reasoningFinished
+              ) {
+                lastMarkdownItem.reasoningFinished = true;
+              }
+
               contents.push({
                 id: UUID.uuid4(),
                 type: ResponseStreamDataType.MarkdownPart,
-                content: responseMessage,
+                content: responseMessage || '',
+                reasoningContent: reasoningContent || '',
                 created: new Date(response.created)
               });
             }
@@ -2143,20 +2176,44 @@ function SidebarComponent(props: any) {
               contents.push({
                 id: UUID.uuid4(),
                 type: nbiContent.type,
-                content: nbiContent.content,
+                content: nbiContent.content || '',
+                reasoningContent: nbiContent.reasoning_content || '',
+                reasoningTag: nbiContent.reasoning_content ? '<think>' : undefined,
+                reasoningFinished:
+                  nbiContent.type === ResponseStreamDataType.Markdown &&
+                  nbiContent.reasoning_content
+                    ? true
+                    : false,
                 contentDetail: nbiContent.detail,
                 created: new Date(response.created)
               });
             } else {
               const responseMessage =
                 response.data['choices']?.[0]?.['delta']?.['content'];
-              if (!responseMessage) {
+              const reasoningContent =
+                response.data['choices']?.[0]?.['delta']?.['reasoning_content'];
+              if (!responseMessage && !reasoningContent) {
                 return;
               }
+
+              // If we have existing reasoning content and now we get normal content, mark reasoning as finished
+              const lastMarkdownItem = contents
+                .filter(c => c.type === ResponseStreamDataType.MarkdownPart)
+                .pop();
+              if (
+                lastMarkdownItem &&
+                lastMarkdownItem.reasoningContent &&
+                responseMessage &&
+                !lastMarkdownItem.reasoningFinished
+              ) {
+                lastMarkdownItem.reasoningFinished = true;
+              }
+
               contents.push({
                 id: response.id,
                 type: ResponseStreamDataType.MarkdownPart,
-                content: responseMessage,
+                content: responseMessage || '',
+                reasoningContent: reasoningContent || '',
                 created: new Date(response.created)
               });
             }


### PR DESCRIPTION
 🚀 Overview

This PR improves the visibility of model outputs in Agent and Chat modes, specifically addressing the issue where model reasoning (thinking) and intermediate text were previously hidden or ignored. 

It ensures that when using models with reasoning capabilities, the "thought process" is displayed in a dedicated, expandable UI component, providing a much more transparent user experience.


🩹 Problem Solved
 1. Chat Mode: Thinking/Reasoning text was previously not displayed, making it hard to follow the model's logic before the final answer.
2. Agent Mode: The UI was restricted to showing only tool call parameters. Any "thinking" or explanatory text generated by the model before or between tool calls was invisible to the user.

✨ Key Changes
1. Multi-Provider Reasoning Extraction (notebook_intelligence/)
   * Updated openai_compatible, ollama, and litellm providers to capture reasoning_content (or reasoning) fields from both streaming and non-streaming responses.
   * Extended the backend protocol (api.py and extension.py) to stream reasoning_content alongside standard content.

2. Agent Mode Enhancements (api.py)
   * Refactored ChatParticipant to allow streaming of MarkdownData even when tool calls are present. This ensures that the model's intent and reasoning are shown to the user while the agent is preparing to execute tools.

3. Frontend UI/UX (src/chat-sidebar.tsx)
   * Introduced a dedicated expandable "Thinking" section in the chat sidebar.
   * Added a real-time Thinking/Running timer to provide interactive feedback while the model is processing.
   * Improved streaming logic to handle mixed content (reasoning + normal text + tool calls) smoothly.

🛠️ Verification
   * Tested with openai_compatible provider (using models with reasoning fields).
   * Verified that Agent Mode now correctly displays the model's explanatory text before initiating tool calls.
   * Verified that Chat Mode correctly renders the reasoning process in the new expandable UI.

  📸 UI Preview 

Ask Mode:
<img width="345" height="782" alt="8feb78f7-bd76-49b7-b2fd-f259ffada419" src="https://github.com/user-attachments/assets/d998027a-3ab4-4d92-b978-0e287ab675df" />

Agent Mode
<img width="399" height="784" alt="856c8c46-c296-4feb-b1e6-a30ef5d04d6c" src="https://github.com/user-attachments/assets/cbcac96f-ca1e-4a6e-ad6c-37ae2499cbb5" />

