### PR TITLE
fix: Style markdown tables and other elements in chat messages

### DIFF
--- a/style/base.css
+++ b/style/base.css
@@ -277,6 +277,92 @@ pre:has(.code-block-header) {
   text-decoration: underline;
 }
 
+.chat-message-content table {
+  border-collapse: collapse;
+  margin: 8px 0;
+  font-size: 12px;
+  line-height: 1.4;
+  display: block;
+  overflow-x: auto;
+  max-width: 100%;
+}
+
+.chat-message-content th,
+.chat-message-content td {
+  border: 1px solid var(--jp-border-color1);
+  padding: 4px 8px;
+  text-align: left;
+  vertical-align: top;
+}
+
+.chat-message-content thead th {
+  background-color: var(--jp-layout-color2);
+  font-weight: bold;
+}
+
+.chat-message-content tbody tr:nth-child(even) {
+  background-color: var(--jp-layout-color1);
+}
+
+.chat-message-content ul,
+.chat-message-content ol {
+  margin-block: 5px;
+  padding-left: 24px;
+}
+
+.chat-message-content li {
+  margin-block: 2px;
+  line-height: 18px;
+}
+
+.chat-message-content blockquote {
+  margin: 8px 0;
+  padding: 2px 10px;
+  border-left: 3px solid var(--jp-border-color1);
+  color: var(--jp-ui-font-color2);
+}
+
+.chat-message-content hr {
+  border: none;
+  border-top: 1px solid var(--jp-border-color2);
+  margin: 10px 0;
+}
+
+.chat-message-content h1,
+.chat-message-content h2,
+.chat-message-content h3,
+.chat-message-content h4,
+.chat-message-content h5,
+.chat-message-content h6 {
+  margin-block: 10px 5px;
+  line-height: 1.3;
+}
+
+.chat-message-content h1 {
+  font-size: 18px;
+}
+
+.chat-message-content h2 {
+  font-size: 16px;
+}
+
+.chat-message-content h3 {
+  font-size: 14px;
+}
+
+.chat-message-content h4,
+.chat-message-content h5,
+.chat-message-content h6 {
+  font-size: 13px;
+}
+
+.chat-message-content :not(pre) > code {
+  background-color: var(--jp-layout-color2);
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-size: 0.9em;
+}
+
 .chat-message-copilot {
   background-color: rgb(159 153 208 / 15%);
 }


### PR DESCRIPTION
## Problem

Markdown tables rendered in the chat sidebar appear without borders, padding, or visual hierarchy. `remark-gfm` is already enabled in `MarkdownRenderer`, so the HTML is being generated correctly — there's just no CSS to style it. The result is hard to read and looks unfinished.

While investigating, I noticed the same gap for other common markdown elements (headings, lists, blockquotes, horizontal rules, inline code), so this PR addresses them together.

## Changes

CSS-only, all rules scoped to `.chat-message-content` to avoid affecting anything outside the chat sidebar. Uses JupyterLab theme variables (`--jp-border-color1`, `--jp-layout-color1`, etc.) so styles adapt to light and dark themes automatically.                                                                                                            
                                                                                                                          
  - **Tables**: `border-collapse`, 1px cell borders, header background, alternating row striping, horizontal scroll for wide tables via `display: block; overflow-x: auto`
  - **Lists**: consistent padding, tighter per-item spacing
  - **Blockquotes**: left border accent with muted text color
  - **Horizontal rules**: subtle top border instead of default 3D groove
  - **Headings (h1–h6)**: sized down from browser defaults to fit the narrow sidebar
  - **Inline code**: subtle background tint and rounded corners (excludes code blocks via `:not(pre) > code`)

No JS/TSX changes. No new dependencies.

## How to test                                                                                                            
                                                                                                                          
  1. Open the NBI chat sidebar                                                                                              
  2. Ask the assistant to output a markdown table (e.g., "output a table of Python built-in types and their descriptions")
  3. Verify the table renders with visible borders, a shaded header row, and alternating row stripes                        
  4. Also try prompts that exercise headings, bulleted/numbered lists, blockquotes (`>`), horizontal rules (`---`), and     
  inline code — all should be readable and consistent                                                                       
  5. Toggle between light and dark JupyterLab themes and verify styles still look right           