### PR TITLE
feat: Add Claude Skills management panel 

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ Configure via environment variables (also available as traitlets on `NotebookInt
 
 - `NBI_SKILLS_MANIFEST` — URL (`https://...`) or local filesystem path to the manifest. Empty/unset disables the feature.
 - `NBI_SKILLS_MANIFEST_INTERVAL` — seconds between reconciles. Default `86400` (24h). Reconciliation also runs once at startup.
-- `NBI_SKILLS_MANIFEST_TOKEN` — optional bearer token for fetching the manifest itself over HTTPS. When the manifest URL is hosted on github.com / `raw.githubusercontent.com` / `*.githubusercontent.com` and this var is unset, NBI falls back to the same `GITHUB_TOKEN` / `GH_TOKEN` / `gh auth token` chain used for skill-tarball fetches, so users with an existing GitHub login get private-manifest access automatically.
+- `NBI_MANAGED_SKILLS_TOKEN` — optional bearer token used for **all** managed-skills GitHub operations: fetching the manifest, probing commits, and downloading skill tarballs. Lets an org deploy a minimal-privilege scoped token covering the whole managed pathway — user-initiated imports (the Import-from-GitHub dialog, `POST /skills/import`) do **not** see this token and continue to use `GITHUB_TOKEN` / `GH_TOKEN` / `gh auth`. When unset, managed operations fall back to the same chain. If set and a managed operation fails with an auth error, it fails loudly (no retry with the fallback chain) so misconfigured or expired scoped tokens stay visible to the admin.
 
 Manifest schema:
 

--- a/README.md
+++ b/README.md
@@ -365,6 +365,27 @@ Rules are automatically discovered from:
 
 Rules are applied in priority order (lower numbers first) and can be toggled on/off without deleting the files.
 
+### Managing Claude Skills
+
+When Claude mode is enabled, the NBI settings panel shows a **Skills** tab for viewing, creating, editing, and deleting the skills that Claude can invoke. Skills are Claude Agent SDK artifacts stored on disk:
+
+- **User skills**: `~/.claude/skills/`
+- **Project skills**: `<project_root>/.claude/skills/`
+
+Skills live in a directory named `<name>/` containing a `SKILL.md` entry file (with YAML frontmatter for `name`, `description`, `allowed-tools`) plus any helper files the skill references.
+
+The Skills tab lets you:
+
+- Add new skills in either scope, editing `SKILL.md` and helper files inline
+- **Rename** a skill (updates the bundle directory and frontmatter)
+- **Duplicate** a skill into the same or opposite scope under a new name
+- **Delete** a skill, with an undo toast that restores the full bundle contents if clicked within 8 seconds
+- Open or delete additional files in the bundle (`SKILL.md` itself is protected from deletion)
+
+**Importing from GitHub.** Click **Import from GitHub** to install a skill from a public repo. Paste any `https://github.com/<owner>/<repo>` URL — or a deep link like `/tree/<ref>/<subpath>` pointing at the directory that contains `SKILL.md` — pick the target scope, and the bundle is fetched, validated, and installed. The canonical source URL is recorded in the skill's frontmatter as `source:` so you can trace where each imported skill came from.
+
+When a skill is saved, added, or removed — either through the UI or directly on disk — the Claude SDK session is transparently reloaded (preserving conversation history via the session's resume behavior), and a **"Skills reloaded"** banner briefly appears in the chat sidebar.
+
 ### Developer documentation
 
 For building locally and contributing see the [developer documentatation](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -405,8 +405,8 @@ Manifest schema:
 ```yaml
 skills:
   - url: https://github.com/org/repo/tree/main/skills/data-eda
-    name: data-eda        # optional: override the installed skill name
-    scope: user           # optional: "user" (default) or "project"
+    name: data-eda # optional: override the installed skill name
+    scope: user # optional: "user" (default) or "project"
   - url: https://github.com/org/repo/tree/main/skills/ml-recipes
 ```
 

--- a/README.md
+++ b/README.md
@@ -390,6 +390,33 @@ The Skills tab lets you:
 
 When a skill is saved, added, or removed — either through the UI or directly on disk — the Claude SDK session is transparently reloaded (preserving conversation history via the session's resume behavior), and a **"Skills reloaded"** banner briefly appears in the chat sidebar.
 
+#### Managed skills via an org manifest
+
+For organization-wide deployments (e.g., Kubeflow notebooks), NBI can install and keep a curated set of Claude skills in sync from a YAML/JSON manifest. Skills installed this way are marked **Managed** in the UI — they are read-only (edit/rename/delete disabled) and are refreshed on a schedule.
+
+Configure via environment variables (also available as traitlets on `NotebookIntelligence`):
+
+- `NBI_SKILLS_MANIFEST` — URL (`https://...`) or local filesystem path to the manifest. Empty/unset disables the feature.
+- `NBI_SKILLS_MANIFEST_INTERVAL` — seconds between reconciles. Default `86400` (24h). Reconciliation also runs once at startup.
+- `NBI_SKILLS_MANIFEST_TOKEN` — optional bearer token for fetching the manifest itself over HTTPS. When the manifest URL is hosted on github.com / `raw.githubusercontent.com` / `*.githubusercontent.com` and this var is unset, NBI falls back to the same `GITHUB_TOKEN` / `GH_TOKEN` / `gh auth token` chain used for skill-tarball fetches, so users with an existing GitHub login get private-manifest access automatically.
+
+Manifest schema:
+
+```yaml
+skills:
+  - url: https://github.com/org/repo/tree/main/skills/data-eda
+    name: data-eda        # optional: override the installed skill name
+    scope: user           # optional: "user" (default) or "project"
+  - url: https://github.com/org/repo/tree/main/skills/ml-recipes
+```
+
+Behavior:
+
+- The reconciler probes GitHub's commits API for each entry's `subpath`/`ref` and skips fetching the tarball when the installed `managed_ref` already matches the latest SHA. Full-SHA URLs skip the probe.
+- Managed skills present in the install but missing from the manifest are **removed**. User-authored skills are never touched; if a user-authored skill has the same name as a manifest entry, the reconciler leaves it alone and reports a per-entry error.
+- A manual **Sync managed skills** button appears in the Skills panel when any managed skill is installed, and a `POST /notebook-intelligence/skills/reconcile` endpoint is available for scripted triggers.
+- If the manifest cannot be loaded (network, bad YAML, missing `skills:` list), the reconciler logs the error and leaves all managed skills in place rather than mass-deleting on a transient failure.
+
 ### Developer documentation
 
 For building locally and contributing see the [developer documentatation](CONTRIBUTING.md).

--- a/notebook_intelligence/ai_service_manager.py
+++ b/notebook_intelligence/ai_service_manager.py
@@ -19,7 +19,8 @@ from notebook_intelligence.llm_providers.ollama_llm_provider import OllamaLLMPro
 from notebook_intelligence.llm_providers.openai_compatible_llm_provider import OpenAICompatibleLLMProvider
 from notebook_intelligence.mcp_manager import MCPManager
 from notebook_intelligence.rule_manager import RuleManager
-from notebook_intelligence.util import ThreadSafeWebSocketConnector
+from notebook_intelligence.skill_manager import SkillManager
+from notebook_intelligence.util import ThreadSafeWebSocketConnector, get_jupyter_root_dir
 
 log = logging.getLogger(__name__)
 
@@ -56,7 +57,12 @@ class AIServiceManager(Host):
         self._websocket_connector: ThreadSafeWebSocketConnector = None
         # Initialize rule manager if rules are enabled
         self._rule_manager = RuleManager(self._nbi_config.rules_directory) if self._nbi_config.rules_enabled else None
+        self._skill_manager = SkillManager(
+            user_dir=self._nbi_config.user_skills_directory,
+            project_dir=self._nbi_config.project_skills_directory(get_jupyter_root_dir()),
+        )
         self.initialize()
+        self._skill_manager.start_watching()
 
     @property
     def nbi_config(self) -> NBIConfig:
@@ -69,11 +75,15 @@ class AIServiceManager(Host):
     def get_rule_manager(self) -> Optional[RuleManager]:
         """Get the rule manager instance."""
         return self._rule_manager
-    
+
     def reload_rules(self):
         """Reload rules from disk (for development/testing)."""
         if self._rule_manager:
             self._rule_manager.load_rules(force_reload=True)
+
+    def get_skill_manager(self) -> SkillManager:
+        """Get the skill manager instance."""
+        return self._skill_manager
 
     @property
     def websocket_connector(self) -> ThreadSafeWebSocketConnector:

--- a/notebook_intelligence/ai_service_manager.py
+++ b/notebook_intelligence/ai_service_manager.py
@@ -20,6 +20,7 @@ from notebook_intelligence.llm_providers.openai_compatible_llm_provider import O
 from notebook_intelligence.mcp_manager import MCPManager
 from notebook_intelligence.rule_manager import RuleManager
 from notebook_intelligence.skill_manager import SkillManager
+from notebook_intelligence.skill_reconciler import SkillReconciler
 from notebook_intelligence.util import ThreadSafeWebSocketConnector, get_jupyter_root_dir
 
 log = logging.getLogger(__name__)
@@ -61,8 +62,19 @@ class AIServiceManager(Host):
             user_dir=self._nbi_config.user_skills_directory,
             project_dir=self._nbi_config.project_skills_directory(get_jupyter_root_dir()),
         )
+        self._skill_reconciler: Optional[SkillReconciler] = None
+        manifest_source = (self._options.get("skills_manifest") or "").strip()
+        if manifest_source:
+            self._skill_reconciler = SkillReconciler(
+                skill_manager=self._skill_manager,
+                manifest_source=manifest_source,
+                interval_seconds=int(self._options.get("skills_manifest_interval", 86400)),
+                manifest_token=self._options.get("skills_manifest_token") or None,
+            )
         self.initialize()
         self._skill_manager.start_watching()
+        if self._skill_reconciler is not None:
+            self._skill_reconciler.start()
 
     @property
     def nbi_config(self) -> NBIConfig:
@@ -84,6 +96,10 @@ class AIServiceManager(Host):
     def get_skill_manager(self) -> SkillManager:
         """Get the skill manager instance."""
         return self._skill_manager
+
+    def get_skill_reconciler(self) -> Optional[SkillReconciler]:
+        """Get the managed-skills reconciler, if one is configured."""
+        return self._skill_reconciler
 
     @property
     def websocket_connector(self) -> ThreadSafeWebSocketConnector:
@@ -495,6 +511,8 @@ class AIServiceManager(Host):
 
     def handle_stop_request(self):
         self._mcp_manager.handle_stop_request()
+        if self._skill_reconciler is not None:
+            self._skill_reconciler.stop()
 
     def update_mcp_server_connections(self, disabled_mcp_servers: list[str]):
         self._mcp_manager.update_mcp_server_connections(disabled_mcp_servers)

--- a/notebook_intelligence/ai_service_manager.py
+++ b/notebook_intelligence/ai_service_manager.py
@@ -69,7 +69,7 @@ class AIServiceManager(Host):
                 skill_manager=self._skill_manager,
                 manifest_source=manifest_source,
                 interval_seconds=int(self._options.get("skills_manifest_interval", 86400)),
-                manifest_token=self._options.get("skills_manifest_token") or None,
+                managed_token=self._options.get("managed_skills_token") or None,
             )
         self.initialize()
         self._skill_manager.start_watching()

--- a/notebook_intelligence/api.py
+++ b/notebook_intelligence/api.py
@@ -33,6 +33,7 @@ class BackendMessageType(str, Enum):
     GitHubCopilotLoginStatusChange = 'github-copilot-login-status-change'
     MCPServerStatusChange = 'mcp-server-status-change'
     ClaudeCodeStatusChange = 'claude-code-status-change'
+    SkillsReloaded = 'skills-reloaded'
 
 class ResponseStreamDataType(str, Enum):
     LLMRaw = 'llm-raw'
@@ -887,6 +888,10 @@ class Host:
     
     def get_rule_manager(self):
         """Get the rule manager instance if available."""
+        return NotImplemented
+
+    def get_skill_manager(self):
+        """Get the skill manager instance if available."""
         return NotImplemented
 
     @property

--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -50,7 +50,7 @@ class ClaudeAgentClientStatus(str, Enum):
 
 CLAUDE_AGENT_CLIENT_RESPONSE_WAIT_TIME = float(os.getenv("NBI_CLAUDE_AGENT_CLIENT_RESPONSE_WAIT_TIME", "0.5"))
 CLAUDE_AGENT_CLIENT_RESPONSE_TIMEOUT = float(os.getenv("NBI_CLAUDE_AGENT_CLIENT_RESPONSE_TIMEOUT", "1800"))
-CLAUDE_AGENT_CLIENT_UPDATE_WAIT_TIME = float(os.getenv("NBI_CLAUDE_AGENT_CLIENT_UPDATE_WAIT_TIME", "3"))
+CLAUDE_AGENT_CLIENT_UPDATE_WAIT_TIME = float(os.getenv("NBI_CLAUDE_AGENT_CLIENT_UPDATE_WAIT_TIME", "0.5"))
 
 _current_request = None
 _current_response = None
@@ -301,6 +301,14 @@ class ClaudeCodeClient():
     @property
     def status(self) -> ClaudeAgentClientStatus:
         return self._status
+
+    @property
+    def continue_conversation(self) -> bool | None:
+        return self._continue_conversation
+
+    @continue_conversation.setter
+    def continue_conversation(self, value: bool | None):
+        self._continue_conversation = value
 
     def is_connected(self):
         return self._client_thread is not None
@@ -888,6 +896,25 @@ class ClaudeCodeChatParticipant(BaseChatParticipant):
         self._host = host
         self._client_options: ClaudeAgentOptions = self._create_client_options()
         self._client = ClaudeCodeClient(host, self._client_options)
+        skill_manager = host.get_skill_manager()
+        if skill_manager is not None and skill_manager is not NotImplemented:
+            skill_manager.on_skills_changed(self._on_skills_changed)
+
+    def _on_skills_changed(self):
+        # Called from the skill watcher thread. Marshal onto the Tornado event loop before
+        # touching asyncio state — update_client_debounced uses asyncio.get_event_loop().
+        connector = self._host.websocket_connector
+        if connector is None:
+            return
+        try:
+            self._client.continue_conversation = True
+            connector.schedule(self.update_client_debounced)
+            connector.write_message({
+                "type": BackendMessageType.SkillsReloaded,
+                "data": {}
+            })
+        except Exception as e:
+            log.error(f"Error while handling skills changed event: {e}")
 
     @property
     def id(self) -> str:
@@ -1032,4 +1059,6 @@ If you need to install a Python package within a notebook cell code, use %pip in
 
     async def _update_client_debounced(self):
         await asyncio.sleep(CLAUDE_AGENT_CLIENT_UPDATE_WAIT_TIME)
-        self.update_client()
+        # update_client() does synchronous disconnect/connect with blocking time.sleep
+        # inside _send_claude_agent_request. Run it off the event loop thread.
+        await asyncio.get_event_loop().run_in_executor(None, self.update_client)

--- a/notebook_intelligence/config.py
+++ b/notebook_intelligence/config.py
@@ -144,6 +144,16 @@ class NBIConfig:
         return os.path.join(self.nbi_user_dir, 'rules')
 
     @property
+    def user_skills_directory(self) -> str:
+        # Mirrors Claude's own CLAUDE_CONFIG_DIR override so the extension picks up
+        # skills from the same directory Claude is using.
+        base = os.environ.get('CLAUDE_CONFIG_DIR') or os.path.join(os.path.expanduser('~'), '.claude')
+        return os.path.join(base, 'skills')
+
+    def project_skills_directory(self, project_root: str) -> str:
+        return os.path.join(project_root, '.claude', 'skills')
+
+    @property
     def active_rules(self) -> dict:
         """Get dictionary of active rule states (filename -> bool)."""
         return self.get('active_rules', {})

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -1289,11 +1289,15 @@ class NotebookIntelligence(ExtensionApp):
         config=True,
     )
 
-    skills_manifest_token = Unicode(
+    managed_skills_token = Unicode(
         default_value="",
         help="""
-        Optional bearer token used when fetching the manifest over HTTPS.
-        Overridden by the NBI_SKILLS_MANIFEST_TOKEN environment variable.
+        Optional bearer token used for ALL managed-skills GitHub operations:
+        fetching the manifest, probing commits, and downloading skill tarballs.
+        Lets an org scope a minimal-privilege token for the whole managed
+        pathway without affecting user-initiated imports (which continue to use
+        GITHUB_TOKEN / GH_TOKEN / `gh auth`). Overridden by the
+        NBI_MANAGED_SKILLS_TOKEN environment variable.
         """,
         config=True,
     )
@@ -1312,9 +1316,9 @@ class NotebookIntelligence(ExtensionApp):
     def initialize_ai_service(self, server_root_dir: str):
         global ai_service_manager
         manifest_source = os.environ.get("NBI_SKILLS_MANIFEST", "").strip() or self.skills_manifest.strip()
-        manifest_token = (
-            os.environ.get("NBI_SKILLS_MANIFEST_TOKEN", "").strip()
-            or self.skills_manifest_token.strip()
+        managed_token = (
+            os.environ.get("NBI_MANAGED_SKILLS_TOKEN", "").strip()
+            or self.managed_skills_token.strip()
         )
         interval_env = os.environ.get("NBI_SKILLS_MANIFEST_INTERVAL", "").strip()
         manifest_interval = self.skills_manifest_interval
@@ -1329,7 +1333,7 @@ class NotebookIntelligence(ExtensionApp):
             "server_root_dir": server_root_dir,
             "skills_manifest": manifest_source,
             "skills_manifest_interval": manifest_interval,
-            "skills_manifest_token": manifest_token,
+            "managed_skills_token": managed_token,
         })
 
     def initialize_templates(self):

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -20,7 +20,7 @@ from jupyter_server.base.handlers import APIHandler
 from jupyter_server.utils import url_path_join
 import tornado
 from tornado import websocket
-from traitlets import Bool, List, Unicode
+from traitlets import Bool, Int, List, Unicode
 from notebook_intelligence.api import CancelToken, ChatMode, ChatResponse, ChatRequest, ContextRequest, ContextRequestType, RequestDataType, RequestToolSelection, ResponseStreamData, ResponseStreamDataType, BackendMessageType, SignalImpl
 from notebook_intelligence.ai_service_manager import AIServiceManager
 from notebook_intelligence.claude import ClaudeCodeChatParticipant, fetch_claude_models
@@ -515,6 +515,24 @@ class SkillsImportHandler(SkillsBaseHandler):
             self.finish(json.dumps({"skill": skill.to_dict(include_body=True)}))
         except (FileExistsError, FileNotFoundError, ValueError) as e:
             self._error(e)
+
+
+class SkillsReconcileHandler(SkillsBaseHandler):
+    """Manual trigger for the managed-skills reconciler."""
+
+    @tornado.web.authenticated
+    async def post(self):
+        reconciler = ai_service_manager.get_skill_reconciler()
+        if reconciler is None:
+            self.set_status(409)
+            self.finish(json.dumps({
+                "error": "No managed-skills manifest configured (set NBI_SKILLS_MANIFEST)."
+            }))
+            return
+        # reconcile() does blocking HTTP + tarball extraction; run off the event loop.
+        loop = asyncio.get_event_loop()
+        result = await loop.run_in_executor(None, reconciler.reconcile)
+        self.finish(json.dumps(result.to_dict()))
 
 
 class SkillRenameHandler(SkillsBaseHandler):
@@ -1252,6 +1270,34 @@ class NotebookIntelligence(ExtensionApp):
         config=True,
     )
 
+    skills_manifest = Unicode(
+        default_value="",
+        help="""
+        URL or filesystem path to a YAML/JSON manifest describing managed
+        Claude skills to install and keep in sync. Empty disables the feature.
+        Overridden by the NBI_SKILLS_MANIFEST environment variable.
+        """,
+        config=True,
+    )
+
+    skills_manifest_interval = Int(
+        default_value=86400,
+        help="""
+        Interval in seconds between managed-skills reconciles.
+        Overridden by the NBI_SKILLS_MANIFEST_INTERVAL environment variable.
+        """,
+        config=True,
+    )
+
+    skills_manifest_token = Unicode(
+        default_value="",
+        help="""
+        Optional bearer token used when fetching the manifest over HTTPS.
+        Overridden by the NBI_SKILLS_MANIFEST_TOKEN environment variable.
+        """,
+        config=True,
+    )
+
     def initialize_settings(self):
         pass
 
@@ -1262,10 +1308,29 @@ class NotebookIntelligence(ExtensionApp):
         self.initialize_ai_service(server_root_dir)
         self._setup_handlers(self.serverapp.web_app)
         self.serverapp.log.info(f"Registered {self.name} server extension")
-    
+
     def initialize_ai_service(self, server_root_dir: str):
         global ai_service_manager
-        ai_service_manager = AIServiceManager({"server_root_dir": server_root_dir})
+        manifest_source = os.environ.get("NBI_SKILLS_MANIFEST", "").strip() or self.skills_manifest.strip()
+        manifest_token = (
+            os.environ.get("NBI_SKILLS_MANIFEST_TOKEN", "").strip()
+            or self.skills_manifest_token.strip()
+        )
+        interval_env = os.environ.get("NBI_SKILLS_MANIFEST_INTERVAL", "").strip()
+        manifest_interval = self.skills_manifest_interval
+        if interval_env:
+            try:
+                manifest_interval = int(interval_env)
+            except ValueError:
+                log.warning(
+                    "Ignoring invalid NBI_SKILLS_MANIFEST_INTERVAL=%r", interval_env
+                )
+        ai_service_manager = AIServiceManager({
+            "server_root_dir": server_root_dir,
+            "skills_manifest": manifest_source,
+            "skills_manifest_interval": manifest_interval,
+            "skills_manifest_token": manifest_token,
+        })
 
     def initialize_templates(self):
         pass
@@ -1297,6 +1362,7 @@ class NotebookIntelligence(ExtensionApp):
         route_pattern_skills_context = url_path_join(base_url, "notebook-intelligence", "skills", "context")
         route_pattern_skills_import_preview = url_path_join(base_url, "notebook-intelligence", "skills", "import", "preview")
         route_pattern_skills_import = url_path_join(base_url, "notebook-intelligence", "skills", "import")
+        route_pattern_skills_reconcile = url_path_join(base_url, "notebook-intelligence", "skills", "reconcile")
         route_pattern_skill_detail = url_path_join(base_url, "notebook-intelligence", "skills", r"(user|project)", skill_name)
         route_pattern_skill_rename = url_path_join(base_url, "notebook-intelligence", "skills", r"(user|project)", skill_name, "rename")
         route_pattern_skill_bundle_file = url_path_join(base_url, "notebook-intelligence", "skills", r"(user|project)", skill_name, "files")
@@ -1329,6 +1395,7 @@ class NotebookIntelligence(ExtensionApp):
             (route_pattern_skills_context, SkillsContextHandler),
             (route_pattern_skills_import_preview, SkillsImportPreviewHandler),
             (route_pattern_skills_import, SkillsImportHandler),
+            (route_pattern_skills_reconcile, SkillsReconcileHandler),
             (route_pattern_skill_bundle_file_rename, SkillBundleFileRenameHandler),
             (route_pattern_skill_bundle_file, SkillBundleFileHandler),
             (route_pattern_skill_rename, SkillRenameHandler),

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -23,8 +23,9 @@ from notebook_intelligence.ai_service_manager import AIServiceManager
 from notebook_intelligence.claude import ClaudeCodeChatParticipant, fetch_claude_models
 import notebook_intelligence.github_copilot as github_copilot
 from notebook_intelligence.built_in_toolsets import built_in_toolsets
-from notebook_intelligence.util import ThreadSafeWebSocketConnector, set_jupyter_root_dir, is_builtin_tool_enabled_in_env, is_provider_enabled_in_env
+from notebook_intelligence.util import ThreadSafeWebSocketConnector, set_jupyter_root_dir, get_jupyter_root_dir, is_builtin_tool_enabled_in_env, is_provider_enabled_in_env
 from notebook_intelligence.context_factory import RuleContextFactory
+from notebook_intelligence.skillset import SKILL_NAME_REGEX
 
 ai_service_manager: AIServiceManager = None
 log = logging.getLogger(__name__)
@@ -347,7 +348,7 @@ class RulesReloadHandler(APIHandler):
             self.set_status(404)
             self.finish(json.dumps({"error": "Rule system not enabled"}))
             return
-        
+
         try:
             rule_manager.load_rules(force_reload=True)
             summary = rule_manager.get_rules_summary()
@@ -355,6 +356,241 @@ class RulesReloadHandler(APIHandler):
         except Exception as e:
             self.set_status(500)
             self.finish(json.dumps({"error": str(e)}))
+
+
+class SkillsBaseHandler(APIHandler):
+    """Shared helpers for skills endpoints."""
+
+    @property
+    def skill_manager(self):
+        return ai_service_manager.get_skill_manager()
+
+    def _error(self, exc):
+        if isinstance(exc, FileExistsError):
+            self.set_status(409)
+        elif isinstance(exc, FileNotFoundError):
+            self.set_status(404)
+        else:
+            self.set_status(400)
+        self.finish(json.dumps({"error": str(exc)}))
+
+    def _bundle_rel_path(self):
+        rel_path = self.get_query_argument("path", default=None)
+        if not rel_path:
+            self.set_status(400)
+            self.finish(json.dumps({"error": "Missing required 'path' query parameter"}))
+            return None
+        return rel_path
+
+    def _parse_json_body(self):
+        try:
+            return json.loads(self.request.body)
+        except json.JSONDecodeError as e:
+            self.set_status(400)
+            self.finish(json.dumps({"error": f"Invalid JSON: {e}"}))
+            return None
+
+
+class SkillsListHandler(SkillsBaseHandler):
+    @tornado.web.authenticated
+    def get(self):
+        # Skip the per-bundle file walk — the list view only needs metadata.
+        skills = [s.to_dict(include_files=False) for s in self.skill_manager.list_skills()]
+        self.finish(json.dumps({"skills": skills}))
+
+    @tornado.web.authenticated
+    def post(self):
+        data = self._parse_json_body()
+        if data is None:
+            return
+        try:
+            skill = self.skill_manager.create_skill(
+                scope=data["scope"],
+                name=data["name"],
+                description=data.get("description", ""),
+                allowed_tools=data.get("allowed_tools", []),
+                body=data.get("body", ""),
+            )
+            self.finish(json.dumps({"skill": skill.to_dict(include_body=True)}))
+        except (FileExistsError, FileNotFoundError, ValueError, KeyError) as e:
+            self._error(e)
+
+
+class SkillsContextHandler(SkillsBaseHandler):
+    @tornado.web.authenticated
+    def get(self):
+        project_root = get_jupyter_root_dir() or ""
+        project_name = os.path.basename(os.path.normpath(project_root)) if project_root else ""
+        self.finish(json.dumps({
+            "project_root": project_root,
+            "project_name": project_name,
+            "user_skills_dir": str(self.skill_manager.scope_dir("user")),
+            "project_skills_dir": str(self.skill_manager.scope_dir("project")),
+        }))
+
+
+class SkillDetailHandler(SkillsBaseHandler):
+    @tornado.web.authenticated
+    def get(self, scope, name):
+        try:
+            skill = self.skill_manager.get_skill(scope, name)
+        except ValueError as e:
+            self._error(e)
+            return
+        if skill is None:
+            self.set_status(404)
+            self.finish(json.dumps({"error": f"Skill '{name}' not found in {scope} scope"}))
+            return
+        self.finish(json.dumps({"skill": skill.to_dict(include_body=True)}))
+
+    @tornado.web.authenticated
+    def put(self, scope, name):
+        data = self._parse_json_body()
+        if data is None:
+            return
+        try:
+            skill = self.skill_manager.update_skill(
+                scope=scope,
+                name=name,
+                description=data.get("description"),
+                allowed_tools=data.get("allowed_tools"),
+                body=data.get("body"),
+            )
+            self.finish(json.dumps({"skill": skill.to_dict(include_body=True)}))
+        except (FileNotFoundError, ValueError) as e:
+            self._error(e)
+
+    @tornado.web.authenticated
+    def delete(self, scope, name):
+        try:
+            self.skill_manager.delete_skill(scope, name)
+            self.finish(json.dumps({"success": True}))
+        except (FileNotFoundError, ValueError) as e:
+            self._error(e)
+
+
+class SkillsImportPreviewHandler(SkillsBaseHandler):
+    @tornado.web.authenticated
+    def post(self):
+        data = self._parse_json_body()
+        if data is None:
+            return
+        url = data.get("url")
+        if not url:
+            self.set_status(400)
+            self.finish(json.dumps({"error": "Missing required 'url'"}))
+            return
+        try:
+            preview = self.skill_manager.preview_github_import(url)
+            self.finish(json.dumps({"preview": preview}))
+        except (FileNotFoundError, ValueError) as e:
+            self._error(e)
+
+
+class SkillsImportHandler(SkillsBaseHandler):
+    @tornado.web.authenticated
+    def post(self):
+        data = self._parse_json_body()
+        if data is None:
+            return
+        url = data.get("url")
+        scope = data.get("scope")
+        if not url or scope not in ("user", "project"):
+            self.set_status(400)
+            self.finish(json.dumps({
+                "error": "Missing 'url' or invalid 'scope' (must be 'user' or 'project')"
+            }))
+            return
+        try:
+            skill = self.skill_manager.import_from_github(
+                url=url,
+                scope=scope,
+                name_override=data.get("name"),
+                overwrite=bool(data.get("overwrite", False)),
+            )
+            self.finish(json.dumps({"skill": skill.to_dict(include_body=True)}))
+        except (FileExistsError, FileNotFoundError, ValueError) as e:
+            self._error(e)
+
+
+class SkillRenameHandler(SkillsBaseHandler):
+    @tornado.web.authenticated
+    def post(self, scope, name):
+        data = self._parse_json_body()
+        if data is None:
+            return
+        new_name = data.get("new_name")
+        if not new_name:
+            self.set_status(400)
+            self.finish(json.dumps({"error": "Missing required 'new_name'"}))
+            return
+        try:
+            skill = self.skill_manager.rename_skill(scope, name, new_name)
+            self.finish(json.dumps({"skill": skill.to_dict(include_body=True)}))
+        except (FileExistsError, FileNotFoundError, ValueError) as e:
+            self._error(e)
+
+
+class SkillBundleFileHandler(SkillsBaseHandler):
+    @tornado.web.authenticated
+    def get(self, scope, name):
+        rel_path = self._bundle_rel_path()
+        if rel_path is None:
+            return
+        try:
+            content = self.skill_manager.read_bundle_file(scope, name, rel_path)
+            self.finish(json.dumps({"content": content}))
+        except (FileNotFoundError, ValueError) as e:
+            self._error(e)
+
+    @tornado.web.authenticated
+    def put(self, scope, name):
+        rel_path = self._bundle_rel_path()
+        if rel_path is None:
+            return
+        data = self._parse_json_body()
+        if data is None:
+            return
+        if "content" not in data:
+            self.set_status(400)
+            self.finish(json.dumps({"error": "Missing required 'content' field"}))
+            return
+        try:
+            self.skill_manager.write_bundle_file(scope, name, rel_path, data["content"])
+            self.finish(json.dumps({"success": True}))
+        except (FileNotFoundError, ValueError) as e:
+            self._error(e)
+
+    @tornado.web.authenticated
+    def delete(self, scope, name):
+        rel_path = self._bundle_rel_path()
+        if rel_path is None:
+            return
+        try:
+            self.skill_manager.delete_bundle_file(scope, name, rel_path)
+            self.finish(json.dumps({"success": True}))
+        except (FileNotFoundError, ValueError) as e:
+            self._error(e)
+
+
+class SkillBundleFileRenameHandler(SkillsBaseHandler):
+    @tornado.web.authenticated
+    def post(self, scope, name):
+        data = self._parse_json_body()
+        if data is None:
+            return
+        try:
+            old_path = data["from"]
+            new_path = data["to"]
+        except KeyError as e:
+            self.set_status(400)
+            self.finish(json.dumps({"error": f"Invalid request: missing {e}"}))
+            return
+        try:
+            self.skill_manager.rename_bundle_file(scope, name, old_path, new_path)
+            self.finish(json.dumps({"success": True}))
+        except (FileExistsError, FileNotFoundError, ValueError) as e:
+            self._error(e)
 
 class ChatHistory:
     """
@@ -935,6 +1171,15 @@ class NotebookIntelligence(ExtensionApp):
         route_pattern_rules = url_path_join(base_url, "notebook-intelligence", "rules")
         route_pattern_rules_toggle = url_path_join(base_url, "notebook-intelligence", "rules", r"([^/]+)", "toggle")
         route_pattern_rules_reload = url_path_join(base_url, "notebook-intelligence", "rules", "reload")
+        skill_name = f"({SKILL_NAME_REGEX})"
+        route_pattern_skills = url_path_join(base_url, "notebook-intelligence", "skills")
+        route_pattern_skills_context = url_path_join(base_url, "notebook-intelligence", "skills", "context")
+        route_pattern_skills_import_preview = url_path_join(base_url, "notebook-intelligence", "skills", "import", "preview")
+        route_pattern_skills_import = url_path_join(base_url, "notebook-intelligence", "skills", "import")
+        route_pattern_skill_detail = url_path_join(base_url, "notebook-intelligence", "skills", r"(user|project)", skill_name)
+        route_pattern_skill_rename = url_path_join(base_url, "notebook-intelligence", "skills", r"(user|project)", skill_name, "rename")
+        route_pattern_skill_bundle_file = url_path_join(base_url, "notebook-intelligence", "skills", r"(user|project)", skill_name, "files")
+        route_pattern_skill_bundle_file_rename = url_path_join(base_url, "notebook-intelligence", "skills", r"(user|project)", skill_name, "files", "rename")
         GetCapabilitiesHandler.disabled_tools = self.disabled_tools
         GetCapabilitiesHandler.allow_enabling_tools_with_env = self.allow_enabling_tools_with_env
         GetCapabilitiesHandler.disabled_providers = self.disabled_providers
@@ -953,6 +1198,17 @@ class NotebookIntelligence(ExtensionApp):
             (route_pattern_rules, RulesListHandler),
             (route_pattern_rules_toggle, RulesToggleHandler),
             (route_pattern_rules_reload, RulesReloadHandler),
+            # Skill routes: order matters. Tornado matches in registration order, and the
+            # SKILL_NAME_REGEX in `skill_detail` would otherwise eat "import", "context", etc.
+            # Always register more specific routes before the {scope}/{name} catch-all.
+            (route_pattern_skills, SkillsListHandler),
+            (route_pattern_skills_context, SkillsContextHandler),
+            (route_pattern_skills_import_preview, SkillsImportPreviewHandler),
+            (route_pattern_skills_import, SkillsImportHandler),
+            (route_pattern_skill_bundle_file_rename, SkillBundleFileRenameHandler),
+            (route_pattern_skill_bundle_file, SkillBundleFileHandler),
+            (route_pattern_skill_rename, SkillRenameHandler),
+            (route_pattern_skill_detail, SkillDetailHandler),
             (route_pattern_copilot, WebsocketCopilotHandler),
         ]
         web_app.add_handlers(host_pattern, NotebookIntelligence.handlers)

--- a/notebook_intelligence/skill_github_import.py
+++ b/notebook_intelligence/skill_github_import.py
@@ -11,6 +11,7 @@ optional — a token is picked up from GITHUB_TOKEN / GH_TOKEN / `gh auth token`
 when available (needed for private repos, SSO, and higher rate limits).
 """
 import io
+import json
 import logging
 import os
 import re
@@ -119,8 +120,8 @@ def _get_github_token() -> Optional[str]:
     return None
 
 
-def _fetch_tarball(owner: str, repo: str, ref: Optional[str]) -> bytes:
-    url = _tarball_url(owner, repo, ref)
+def _github_api_headers() -> dict:
+    """Standard headers for GitHub API requests, with Bearer auth when available."""
     headers = {
         "User-Agent": "notebook-intelligence-skills-import",
         "Accept": "application/vnd.github+json",
@@ -129,13 +130,20 @@ def _fetch_tarball(owner: str, repo: str, ref: Optional[str]) -> bytes:
     token = _get_github_token()
     if token:
         headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _fetch_tarball(owner: str, repo: str, ref: Optional[str]) -> bytes:
+    url = _tarball_url(owner, repo, ref)
+    headers = _github_api_headers()
+    has_token = "Authorization" in headers
     req = urllib.request.Request(url, headers=headers)
     try:
         with urllib.request.urlopen(req, timeout=FETCH_TIMEOUT_SECONDS) as response:
             data = response.read(MAX_ARCHIVE_BYTES + 1)
     except urllib.error.HTTPError as e:
         if e.code in (401, 403):
-            if token:
+            if has_token:
                 raise ValueError(
                     f"GitHub rejected the token (HTTP {e.code}). Check that "
                     "GITHUB_TOKEN / GH_TOKEN / `gh auth` has access to "
@@ -150,7 +158,7 @@ def _fetch_tarball(owner: str, repo: str, ref: Optional[str]) -> bytes:
             # so we can't distinguish "missing" from "private" — hint at both.
             hint = (
                 ""
-                if token
+                if has_token
                 else " (private repos require GITHUB_TOKEN or `gh auth login`)"
             )
             raise ValueError(
@@ -166,6 +174,40 @@ def _fetch_tarball(owner: str, repo: str, ref: Optional[str]) -> bytes:
             f"Archive exceeds size limit ({MAX_ARCHIVE_BYTES // (1024 * 1024)} MB)"
         )
     return data
+
+
+def get_latest_commit_sha(
+    owner: str, repo: str, ref: Optional[str], subpath: str
+) -> Optional[str]:
+    """Return the SHA of the most recent commit touching `subpath` on `ref`.
+
+    Used by the managed-skills reconciler to skip re-downloading tarballs when
+    nothing has changed. Returns None on any error (network, rate-limit, auth);
+    callers should fall back to fetching the tarball.
+    """
+    params = {"per_page": "1"}
+    if ref:
+        params["sha"] = ref
+    if subpath:
+        params["path"] = subpath
+    query = urllib.parse.urlencode(params)
+    url = f"https://api.github.com/repos/{owner}/{repo}/commits?{query}"
+    req = urllib.request.Request(url, headers=_github_api_headers())
+    try:
+        with urllib.request.urlopen(req, timeout=FETCH_TIMEOUT_SECONDS) as response:
+            data = response.read(64 * 1024)  # commits list is small; hard cap prevents abuse
+    except (urllib.error.HTTPError, urllib.error.URLError) as e:
+        log.warning("GitHub commits API probe failed for %s/%s: %s", owner, repo, e)
+        return None
+    try:
+        parsed = json.loads(data)
+    except (ValueError, TypeError) as e:
+        log.warning("GitHub commits API returned invalid JSON: %s", e)
+        return None
+    if not isinstance(parsed, list) or not parsed:
+        return None
+    sha = parsed[0].get("sha") if isinstance(parsed[0], dict) else None
+    return sha if isinstance(sha, str) and sha else None
 
 
 def _extract_skill(

--- a/notebook_intelligence/skill_github_import.py
+++ b/notebook_intelligence/skill_github_import.py
@@ -6,11 +6,15 @@ URL formats supported:
   - https://github.com/{owner}/{repo}/tree/{ref}/{subpath}
   - https://github.com/{owner}/{repo}/tree/{ref}
 
-Uses the public GitHub tarball API; no auth, no git binary.
+Uses the GitHub tarball API over HTTPS; no git binary required. Auth is
+optional — a token is picked up from GITHUB_TOKEN / GH_TOKEN / `gh auth token`
+when available (needed for private repos, SSO, and higher rate limits).
 """
 import io
 import logging
+import os
 import re
+import subprocess
 import tarfile
 import tempfile
 import urllib.error
@@ -88,19 +92,71 @@ def _tarball_url(owner: str, repo: str, ref: Optional[str]) -> str:
     return f"https://api.github.com/repos/{owner}/{repo}/tarball/{ref_path}"
 
 
+def _get_github_token() -> Optional[str]:
+    """Look up a GitHub token for API auth.
+
+    Order matches the gh CLI's own precedence: GITHUB_TOKEN, then GH_TOKEN,
+    then whatever `gh auth token` returns. The gh-CLI fallback lets users in
+    corporate/SSO environments inherit their existing login without setting
+    an env var.
+    """
+    for var in ("GITHUB_TOKEN", "GH_TOKEN"):
+        token = os.environ.get(var)
+        if token and token.strip():
+            return token.strip()
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "token"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    stdout = result.stdout.strip()
+    if result.returncode == 0 and stdout:
+        return stdout
+    return None
+
+
 def _fetch_tarball(owner: str, repo: str, ref: Optional[str]) -> bytes:
     url = _tarball_url(owner, repo, ref)
-    req = urllib.request.Request(
-        url, headers={"User-Agent": "notebook-intelligence-skills-import"}
-    )
+    headers = {
+        "User-Agent": "notebook-intelligence-skills-import",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    token = _get_github_token()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, headers=headers)
     try:
         with urllib.request.urlopen(req, timeout=FETCH_TIMEOUT_SECONDS) as response:
             data = response.read(MAX_ARCHIVE_BYTES + 1)
     except urllib.error.HTTPError as e:
+        if e.code in (401, 403):
+            if token:
+                raise ValueError(
+                    f"GitHub rejected the token (HTTP {e.code}). Check that "
+                    "GITHUB_TOKEN / GH_TOKEN / `gh auth` has access to "
+                    f"github.com/{owner}/{repo}."
+                )
+            raise ValueError(
+                f"GitHub requires authentication (HTTP {e.code}). "
+                "Set GITHUB_TOKEN or run `gh auth login`, then retry."
+            )
         if e.code == 404:
+            # GitHub returns 404 (not 403) for private repos to unauth'd callers,
+            # so we can't distinguish "missing" from "private" — hint at both.
+            hint = (
+                ""
+                if token
+                else " (private repos require GITHUB_TOKEN or `gh auth login`)"
+            )
             raise ValueError(
                 f"Repo or ref not found: github.com/{owner}/{repo}"
                 + (f" @ {ref}" if ref else "")
+                + hint
             )
         raise ValueError(f"GitHub returned HTTP {e.code}: {e.reason}")
     except urllib.error.URLError as e:

--- a/notebook_intelligence/skill_github_import.py
+++ b/notebook_intelligence/skill_github_import.py
@@ -1,0 +1,230 @@
+"""Fetch and validate Claude skill bundles from public GitHub repositories.
+
+URL formats supported:
+  - https://github.com/{owner}/{repo}
+  - https://github.com/{owner}/{repo}.git
+  - https://github.com/{owner}/{repo}/tree/{ref}/{subpath}
+  - https://github.com/{owner}/{repo}/tree/{ref}
+
+Uses the public GitHub tarball API; no auth, no git binary.
+"""
+import io
+import logging
+import re
+import tarfile
+import tempfile
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from notebook_intelligence.skillset import (
+    SKILL_ENTRY_FILE,
+    SKILL_NAME_PATTERN,
+    _parse_frontmatter,
+    list_bundle_files,
+)
+
+log = logging.getLogger(__name__)
+
+MAX_ARCHIVE_BYTES = 10 * 1024 * 1024  # 10 MB on-wire
+MAX_EXTRACTED_BYTES = 20 * 1024 * 1024  # 20 MB after decompression
+FETCH_TIMEOUT_SECONDS = 30
+
+
+@dataclass
+class GitHubRef:
+    owner: str
+    repo: str
+    ref: Optional[str]  # branch/tag/sha; None → default branch
+    subpath: str        # "" if skill is at repo root
+
+
+@dataclass
+class StagedSkill:
+    """A validated skill extracted into a temporary directory."""
+    name: str
+    description: str
+    allowed_tools: list
+    body: str
+    files: list  # all file paths relative to skill_root, excluding SKILL.md
+    skill_root: Path
+    tmp_root: Path  # temp dir created for this import; caller cleans up
+    source_url: str
+    canonical_url: str  # URL with resolved ref, for storing as `source`
+
+
+def parse_github_url(url: str) -> GitHubRef:
+    """Parse a GitHub URL into (owner, repo, ref, subpath). Raises ValueError."""
+    try:
+        parsed = urllib.parse.urlparse(url.strip())
+    except ValueError as e:
+        raise ValueError(f"Invalid URL: {e}")
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError("URL must use https://")
+    if parsed.netloc not in ("github.com", "www.github.com"):
+        raise ValueError("Only github.com URLs are supported")
+    parts = [p for p in parsed.path.split("/") if p]
+    if len(parts) < 2:
+        raise ValueError(
+            "URL must reference a repo: https://github.com/<owner>/<repo>"
+        )
+    owner = parts[0]
+    repo = parts[1]
+    if repo.endswith(".git"):
+        repo = repo[:-4]
+    ref: Optional[str] = None
+    subpath = ""
+    if len(parts) >= 4 and parts[2] in ("tree", "blob"):
+        ref = parts[3]
+        subpath = "/".join(parts[4:])
+    return GitHubRef(owner=owner, repo=repo, ref=ref, subpath=subpath)
+
+
+def _tarball_url(owner: str, repo: str, ref: Optional[str]) -> str:
+    ref_path = ref if ref else "HEAD"
+    return f"https://api.github.com/repos/{owner}/{repo}/tarball/{ref_path}"
+
+
+def _fetch_tarball(owner: str, repo: str, ref: Optional[str]) -> bytes:
+    url = _tarball_url(owner, repo, ref)
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "notebook-intelligence-skills-import"}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=FETCH_TIMEOUT_SECONDS) as response:
+            data = response.read(MAX_ARCHIVE_BYTES + 1)
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            raise ValueError(
+                f"Repo or ref not found: github.com/{owner}/{repo}"
+                + (f" @ {ref}" if ref else "")
+            )
+        raise ValueError(f"GitHub returned HTTP {e.code}: {e.reason}")
+    except urllib.error.URLError as e:
+        raise ValueError(f"Could not reach GitHub: {e.reason}")
+    if len(data) > MAX_ARCHIVE_BYTES:
+        raise ValueError(
+            f"Archive exceeds size limit ({MAX_ARCHIVE_BYTES // (1024 * 1024)} MB)"
+        )
+    return data
+
+
+def _extract_skill(
+    tarball_bytes: bytes, subpath: str, into: Path
+) -> Path:
+    """Extract into `into`, validate, return the skill root directory."""
+    total_bytes = 0
+    with tarfile.open(fileobj=io.BytesIO(tarball_bytes), mode="r:gz") as tar:
+        members = tar.getmembers()
+        if not members:
+            raise ValueError("Empty archive")
+        # GitHub tarballs wrap every entry in a single `{repo}-{sha}/` top-level directory.
+        # The first member is that directory itself, so its name is our wrapper prefix.
+        top_dir = members[0].name.split("/")[0]
+        safe_members = []
+        for m in members:
+            if m.issym() or m.islnk():
+                # Skip symlinks for safety — they can escape the extraction dir.
+                continue
+            name = m.name.lstrip("/")
+            parts = Path(name).parts
+            if any(p == ".." for p in parts):
+                raise ValueError(f"Unsafe path in archive: {m.name}")
+            if m.isfile():
+                total_bytes += m.size
+                if total_bytes > MAX_EXTRACTED_BYTES:
+                    raise ValueError(
+                        "Extracted archive exceeds size limit "
+                        f"({MAX_EXTRACTED_BYTES // (1024 * 1024)} MB)"
+                    )
+            safe_members.append(m)
+        tar.extractall(into, members=safe_members)
+
+    extracted = into / top_dir
+    if not extracted.is_dir():
+        raise ValueError("Unexpected archive layout")
+    skill_root = extracted / subpath if subpath else extracted
+    if not skill_root.is_dir():
+        raise ValueError(f"Path '{subpath}' not found in repo")
+    if not (skill_root / SKILL_ENTRY_FILE).exists():
+        location = subpath if subpath else "repo root"
+        raise ValueError(f"No {SKILL_ENTRY_FILE} found at {location}")
+    return skill_root
+
+
+def _slug(value: str) -> str:
+    """Normalize an arbitrary string into a valid skill-name candidate."""
+    s = value.lower()
+    s = re.sub(r"[^a-z0-9-]+", "-", s)
+    s = re.sub(r"-+", "-", s).strip("-")
+    return s[:64] if s else ""
+
+
+def _derive_name(
+    frontmatter_name: Optional[str], ref: GitHubRef
+) -> str:
+    """Pick a default skill name: frontmatter > subpath basename > repo name."""
+    candidates = []
+    if frontmatter_name:
+        candidates.append(frontmatter_name)
+    if ref.subpath:
+        candidates.append(Path(ref.subpath).name)
+    candidates.append(ref.repo)
+    for c in candidates:
+        slug = _slug(c)
+        if SKILL_NAME_PATTERN.match(slug):
+            return slug
+    raise ValueError(
+        "Could not derive a valid skill name from the repo; "
+        "specify one explicitly."
+    )
+
+
+def stage_skill_from_github(url: str) -> StagedSkill:
+    """Fetch, extract, and validate a skill. Returns a StagedSkill.
+
+    Caller is responsible for cleaning up `staged.tmp_root` when done.
+    """
+    import shutil
+
+    ref = parse_github_url(url)
+    tarball = _fetch_tarball(ref.owner, ref.repo, ref.ref)
+    tmp_root = Path(tempfile.mkdtemp(prefix="nbi-skill-import-"))
+    try:
+        skill_root = _extract_skill(tarball, ref.subpath, tmp_root)
+        skill_md = skill_root / SKILL_ENTRY_FILE
+        try:
+            frontmatter, body = _parse_frontmatter(
+                skill_md.read_text(encoding="utf-8"), skill_md
+            )
+        except Exception as e:
+            raise ValueError(f"Invalid {SKILL_ENTRY_FILE}: {e}")
+
+        description = frontmatter.get("description") or ""
+        allowed_tools = list(frontmatter.get("allowed-tools", []) or [])
+        name = _derive_name(frontmatter.get("name"), ref)
+        files = [f for f in list_bundle_files(skill_root) if f != SKILL_ENTRY_FILE]
+    except Exception:
+        shutil.rmtree(tmp_root, ignore_errors=True)
+        raise
+
+    canonical = (
+        f"https://github.com/{ref.owner}/{ref.repo}"
+        + (f"/tree/{ref.ref}" if ref.ref else "")
+        + (f"/{ref.subpath}" if ref.subpath else "")
+    )
+
+    return StagedSkill(
+        name=name,
+        description=description,
+        allowed_tools=allowed_tools,
+        body=body,
+        files=files,
+        skill_root=skill_root,
+        tmp_root=tmp_root,
+        source_url=url,
+        canonical_url=canonical,
+    )

--- a/notebook_intelligence/skill_github_import.py
+++ b/notebook_intelligence/skill_github_import.py
@@ -120,22 +120,30 @@ def _get_github_token() -> Optional[str]:
     return None
 
 
-def _github_api_headers() -> dict:
-    """Standard headers for GitHub API requests, with Bearer auth when available."""
+def _github_api_headers(override_token: Optional[str] = None) -> dict:
+    """Standard headers for GitHub API requests, with Bearer auth when available.
+
+    If `override_token` is provided it is used directly (no fallback). Otherwise
+    the standard `GITHUB_TOKEN` / `GH_TOKEN` / `gh auth token` chain is consulted.
+    Managed-skill operations pass the deployment's scoped token explicitly so it
+    doesn't get overridden by whatever the user has in their environment.
+    """
     headers = {
         "User-Agent": "notebook-intelligence-skills-import",
         "Accept": "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
     }
-    token = _get_github_token()
+    token = override_token if override_token is not None else _get_github_token()
     if token:
         headers["Authorization"] = f"Bearer {token}"
     return headers
 
 
-def _fetch_tarball(owner: str, repo: str, ref: Optional[str]) -> bytes:
+def _fetch_tarball(
+    owner: str, repo: str, ref: Optional[str], *, token: Optional[str] = None
+) -> bytes:
     url = _tarball_url(owner, repo, ref)
-    headers = _github_api_headers()
+    headers = _github_api_headers(override_token=token)
     has_token = "Authorization" in headers
     req = urllib.request.Request(url, headers=headers)
     try:
@@ -177,7 +185,12 @@ def _fetch_tarball(owner: str, repo: str, ref: Optional[str]) -> bytes:
 
 
 def get_latest_commit_sha(
-    owner: str, repo: str, ref: Optional[str], subpath: str
+    owner: str,
+    repo: str,
+    ref: Optional[str],
+    subpath: str,
+    *,
+    token: Optional[str] = None,
 ) -> Optional[str]:
     """Return the SHA of the most recent commit touching `subpath` on `ref`.
 
@@ -192,7 +205,7 @@ def get_latest_commit_sha(
         params["path"] = subpath
     query = urllib.parse.urlencode(params)
     url = f"https://api.github.com/repos/{owner}/{repo}/commits?{query}"
-    req = urllib.request.Request(url, headers=_github_api_headers())
+    req = urllib.request.Request(url, headers=_github_api_headers(override_token=token))
     try:
         with urllib.request.urlopen(req, timeout=FETCH_TIMEOUT_SECONDS) as response:
             data = response.read(64 * 1024)  # commits list is small; hard cap prevents abuse
@@ -281,15 +294,18 @@ def _derive_name(
     )
 
 
-def stage_skill_from_github(url: str) -> StagedSkill:
+def stage_skill_from_github(url: str, *, token: Optional[str] = None) -> StagedSkill:
     """Fetch, extract, and validate a skill. Returns a StagedSkill.
 
-    Caller is responsible for cleaning up `staged.tmp_root` when done.
+    Caller is responsible for cleaning up `staged.tmp_root` when done. An
+    explicit `token` overrides the standard GITHUB_TOKEN / GH_TOKEN / gh-CLI
+    chain — used by the managed-skills reconciler to scope tarball fetches to
+    the deployment's provided token.
     """
     import shutil
 
     ref = parse_github_url(url)
-    tarball = _fetch_tarball(ref.owner, ref.repo, ref.ref)
+    tarball = _fetch_tarball(ref.owner, ref.repo, ref.ref, token=token)
     tmp_root = Path(tempfile.mkdtemp(prefix="nbi-skill-import-"))
     try:
         skill_root = _extract_skill(tarball, ref.subpath, tmp_root)

--- a/notebook_intelligence/skill_manager.py
+++ b/notebook_intelligence/skill_manager.py
@@ -190,7 +190,13 @@ class SkillManager:
         new_body = body if body is not None else skill.body
 
         md_content = serialize_skill_md(
-            name, new_description, new_allowed_tools, new_body, source=skill.source
+            name,
+            new_description,
+            new_allowed_tools,
+            new_body,
+            source=skill.source,
+            managed_source=skill.managed_source,
+            managed_ref=skill.managed_ref,
         )
         skill.skill_md_path().write_text(md_content, encoding="utf-8")
 
@@ -204,6 +210,8 @@ class SkillManager:
             allowed_tools=list(new_allowed_tools),
             body=new_body,
             source=skill.source,
+            managed_source=skill.managed_source,
+            managed_ref=skill.managed_ref,
         )
         self._notify_skills_changed()
         return updated
@@ -231,6 +239,8 @@ class SkillManager:
             skill.allowed_tools,
             skill.body,
             source=skill.source,
+            managed_source=skill.managed_source,
+            managed_ref=skill.managed_ref,
         )
         (new_bundle_dir / SKILL_ENTRY_FILE).write_text(md_content, encoding="utf-8")
 
@@ -362,6 +372,63 @@ class SkillManager:
             return skill
         finally:
             shutil.rmtree(staged.tmp_root, ignore_errors=True)
+
+    def install_managed_from_github(
+        self,
+        url: str,
+        scope: SkillScope,
+        managed_source: str,
+        managed_ref: str,
+        name_override: Optional[str] = None,
+    ) -> Skill:
+        """Install a skill from GitHub as a managed bundle.
+
+        Differs from `import_from_github`:
+        - Stamps `managed_source` and `managed_ref` frontmatter keys alongside `source`.
+        - Always overwrites existing managed bundles, but refuses to overwrite a
+          user-authored bundle of the same name (re-reads frontmatter to check).
+        """
+        staged = stage_skill_from_github(url)
+        try:
+            name = name_override.strip() if name_override else staged.name
+            _validate_name(name)
+
+            scope_dir = self.scope_dir(scope)
+            scope_dir.mkdir(parents=True, exist_ok=True)
+            target_dir = scope_dir / name
+            if target_dir.exists():
+                existing_md = target_dir / SKILL_ENTRY_FILE
+                if existing_md.exists():
+                    existing = Skill.from_path(target_dir, scope)
+                    if not existing.managed:
+                        raise FileExistsError(
+                            f"Skill '{name}' already exists in {scope} scope "
+                            "as a user-authored bundle; refusing to overwrite"
+                        )
+                shutil.rmtree(target_dir)
+
+            shutil.copytree(staged.skill_root, target_dir)
+
+            md_content = serialize_skill_md(
+                name,
+                staged.description,
+                staged.allowed_tools,
+                staged.body,
+                source=staged.canonical_url,
+                managed_source=managed_source,
+                managed_ref=managed_ref,
+            )
+            (target_dir / SKILL_ENTRY_FILE).write_text(md_content, encoding="utf-8")
+
+            skill = Skill.from_path(target_dir, scope)
+            self._notify_skills_changed()
+            return skill
+        finally:
+            shutil.rmtree(staged.tmp_root, ignore_errors=True)
+
+    def list_managed_skills(self) -> List[Skill]:
+        """Return only the installed skills that carry a `managed_source`."""
+        return [s for s in self.list_skills() if s.managed]
 
 
 def _validate_name(name: str) -> None:

--- a/notebook_intelligence/skill_manager.py
+++ b/notebook_intelligence/skill_manager.py
@@ -1,0 +1,369 @@
+import logging
+import shutil
+import threading
+from pathlib import Path
+from typing import Callable, Dict, List, Optional
+
+from notebook_intelligence.skillset import (
+    SKILL_ENTRY_FILE,
+    SKILL_NAME_PATTERN,
+    SKILL_NAME_REQUIREMENT,
+    Skill,
+    SkillScope,
+    serialize_skill_md,
+)
+from notebook_intelligence.skill_github_import import stage_skill_from_github
+
+log = logging.getLogger(__name__)
+
+
+class SkillManager:
+    """Discovers, creates, updates, and deletes Claude skills in user and project scopes."""
+
+    WATCH_INTERVAL_SECONDS = 2.0
+
+    def __init__(self, user_dir: Path, project_dir: Path):
+        self._scope_dirs: Dict[SkillScope, Path] = {
+            "user": Path(user_dir),
+            "project": Path(project_dir),
+        }
+        self._listeners: List[Callable[[], None]] = []
+        self._listeners_lock = threading.Lock()
+        self._last_mtime: float = 0.0
+        self._watcher_thread: Optional[threading.Thread] = None
+        self._watcher_stop = threading.Event()
+
+    def scope_dir(self, scope: SkillScope) -> Path:
+        if scope not in self._scope_dirs:
+            raise ValueError(f"Unknown scope: {scope}")
+        return self._scope_dirs[scope]
+
+    def on_skills_changed(self, listener: Callable[[], None]) -> None:
+        with self._listeners_lock:
+            self._listeners.append(listener)
+
+    def _notify_skills_changed(self) -> None:
+        # Suppress the next watcher-driven fire so self-triggered mutations don't double-notify.
+        self._last_mtime = self._compute_mtime()
+        with self._listeners_lock:
+            listeners = list(self._listeners)
+        for listener in listeners:
+            try:
+                listener()
+            except Exception as e:
+                log.error(f"Skill change listener raised: {e}")
+
+    def start_watching(self) -> None:
+        if self._watcher_thread is not None:
+            return
+        self._watcher_stop.clear()
+        # Baseline is computed on the watcher thread to avoid blocking startup.
+        self._last_mtime = 0.0
+        self._watcher_thread = threading.Thread(
+            name="Skill Watcher",
+            target=self._watch_loop,
+            daemon=True,
+        )
+        self._watcher_thread.start()
+
+    def stop_watching(self, timeout: float = 5.0) -> None:
+        thread = self._watcher_thread
+        self._watcher_stop.set()
+        if thread is not None:
+            thread.join(timeout=timeout)
+        self._watcher_thread = None
+
+    def _watch_loop(self) -> None:
+        self._last_mtime = self._compute_mtime()
+        while not self._watcher_stop.wait(self.WATCH_INTERVAL_SECONDS):
+            current = self._compute_mtime()
+            if current > self._last_mtime:
+                self._last_mtime = current
+                log.info("Skill directory change detected; notifying listeners")
+                self._notify_skills_changed()
+
+    def _compute_mtime(self) -> float:
+        """Max mtime of scope dirs, each bundle dir, and each bundle's SKILL.md.
+
+        We intentionally skip walking bundle contents so large helper trees don't inflate
+        the polling cost. Bundle-internal edits still bump the bundle dir's mtime.
+        """
+        max_mtime = 0.0
+        for scope_dir in self._scope_dirs.values():
+            if not scope_dir.exists():
+                continue
+            try:
+                max_mtime = max(max_mtime, scope_dir.stat().st_mtime)
+                for entry in scope_dir.iterdir():
+                    if not entry.is_dir():
+                        continue
+                    try:
+                        max_mtime = max(max_mtime, entry.stat().st_mtime)
+                        skill_md = entry / SKILL_ENTRY_FILE
+                        if skill_md.exists():
+                            max_mtime = max(max_mtime, skill_md.stat().st_mtime)
+                    except OSError:
+                        continue
+            except OSError:
+                continue
+        return max_mtime
+
+    def list_skills(self) -> List[Skill]:
+        skills: List[Skill] = []
+        for scope, scope_dir in self._scope_dirs.items():
+            if not scope_dir.exists():
+                continue
+            skills.extend(self._discover_scope(scope, scope_dir))
+        skills.sort(key=lambda s: (s.scope, s.name))
+        return skills
+
+    def _discover_scope(self, scope: SkillScope, scope_dir: Path) -> List[Skill]:
+        results: List[Skill] = []
+        for entry in sorted(scope_dir.iterdir()):
+            if not (entry.is_dir() and (entry / SKILL_ENTRY_FILE).exists()):
+                continue
+            try:
+                results.append(Skill.from_path(entry, scope))
+            except Exception as e:
+                log.error(f"Failed to load skill from {entry}: {e}")
+        return results
+
+    def _locate_skill_path(self, scope: SkillScope, name: str) -> Optional[Path]:
+        """Return the bundle dir for a skill, or None if it doesn't exist."""
+        # Validate before concatenating into a path — blocks "../" and similar traversal.
+        _validate_name(name)
+        bundle_dir = self.scope_dir(scope) / name
+        if bundle_dir.is_dir() and (bundle_dir / SKILL_ENTRY_FILE).exists():
+            return bundle_dir
+        return None
+
+    def get_skill(self, scope: SkillScope, name: str) -> Optional[Skill]:
+        _validate_name(name)
+        path = self._locate_skill_path(scope, name)
+        if path is None:
+            return None
+        try:
+            return Skill.from_path(path, scope)
+        except Exception as e:
+            log.error(f"Failed to load skill from {path}: {e}")
+            return None
+
+    def create_skill(
+        self,
+        scope: SkillScope,
+        name: str,
+        description: str,
+        allowed_tools: List[str],
+        body: str,
+    ) -> Skill:
+        _validate_name(name)
+
+        scope_dir = self.scope_dir(scope)
+        scope_dir.mkdir(parents=True, exist_ok=True)
+
+        if self._locate_skill_path(scope, name) is not None:
+            raise ValueError(f"Skill '{name}' already exists in {scope} scope")
+
+        bundle_dir = scope_dir / name
+        bundle_dir.mkdir(parents=True, exist_ok=False)
+        md_content = serialize_skill_md(name, description, allowed_tools, body)
+        (bundle_dir / SKILL_ENTRY_FILE).write_text(md_content, encoding="utf-8")
+        skill = Skill.from_path(bundle_dir, scope)
+
+        self._notify_skills_changed()
+        return skill
+
+    def update_skill(
+        self,
+        scope: SkillScope,
+        name: str,
+        description: Optional[str] = None,
+        allowed_tools: Optional[List[str]] = None,
+        body: Optional[str] = None,
+    ) -> Skill:
+        skill = self.get_skill(scope, name)
+        if skill is None:
+            raise FileNotFoundError(f"Skill '{name}' not found in {scope} scope")
+
+        new_description = description if description is not None else skill.description
+        new_allowed_tools = allowed_tools if allowed_tools is not None else skill.allowed_tools
+        new_body = body if body is not None else skill.body
+
+        md_content = serialize_skill_md(
+            name, new_description, new_allowed_tools, new_body, source=skill.source
+        )
+        skill.skill_md_path().write_text(md_content, encoding="utf-8")
+
+        # Construct the updated Skill in-memory rather than re-reading + re-parsing from disk:
+        # we just wrote the file, so we already know every field it will contain.
+        updated = Skill(
+            name=name,
+            scope=scope,
+            root_path=skill.root_path,
+            description=new_description,
+            allowed_tools=list(new_allowed_tools),
+            body=new_body,
+            source=skill.source,
+        )
+        self._notify_skills_changed()
+        return updated
+
+    def rename_skill(self, scope: SkillScope, old_name: str, new_name: str) -> Skill:
+        _validate_name(old_name)
+        _validate_name(new_name)
+        skill = self.get_skill(scope, old_name)
+        if skill is None:
+            raise FileNotFoundError(f"Skill '{old_name}' not found in {scope} scope")
+        if old_name == new_name:
+            return skill
+
+        scope_dir = self.scope_dir(scope)
+        new_bundle_dir = scope_dir / new_name
+        if new_bundle_dir.exists():
+            raise FileExistsError(f"Skill '{new_name}' already exists in {scope} scope")
+
+        skill.root_path.rename(new_bundle_dir)
+        # Rewrite SKILL.md so its `name:` frontmatter matches the new directory name.
+        # Claude uses the frontmatter name, not the directory, to identify the skill.
+        md_content = serialize_skill_md(
+            new_name,
+            skill.description,
+            skill.allowed_tools,
+            skill.body,
+            source=skill.source,
+        )
+        (new_bundle_dir / SKILL_ENTRY_FILE).write_text(md_content, encoding="utf-8")
+
+        renamed = Skill.from_path(new_bundle_dir, scope)
+        self._notify_skills_changed()
+        return renamed
+
+    def delete_skill(self, scope: SkillScope, name: str) -> None:
+        _validate_name(name)
+        path = self._locate_skill_path(scope, name)
+        if path is None:
+            raise FileNotFoundError(f"Skill '{name}' not found in {scope} scope")
+        shutil.rmtree(path)
+        self._notify_skills_changed()
+
+    def _require_bundle(self, scope: SkillScope, name: str) -> Skill:
+        _validate_name(name)
+        scope_dir = self.scope_dir(scope)
+        bundle_dir = scope_dir / name
+        if not (bundle_dir.is_dir() and (bundle_dir / SKILL_ENTRY_FILE).exists()):
+            raise FileNotFoundError(f"Bundle skill '{name}' not found in {scope} scope")
+        return Skill.from_path(bundle_dir, scope)
+
+    def read_bundle_file(self, scope: SkillScope, name: str, rel_path: str) -> str:
+        skill = self._require_bundle(scope, name)
+        target = skill.resolve_bundle_path(rel_path)
+        if not target.is_file():
+            raise FileNotFoundError(f"Bundle file not found: {rel_path}")
+        return target.read_text(encoding="utf-8")
+
+    def write_bundle_file(self, scope: SkillScope, name: str, rel_path: str, content: str) -> None:
+        skill = self._require_bundle(scope, name)
+        target = skill.resolve_bundle_path(rel_path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+        self._notify_skills_changed()
+
+    def rename_bundle_file(
+        self, scope: SkillScope, name: str, old_rel_path: str, new_rel_path: str
+    ) -> None:
+        if old_rel_path == SKILL_ENTRY_FILE or new_rel_path == SKILL_ENTRY_FILE:
+            raise ValueError(f"Cannot rename to/from {SKILL_ENTRY_FILE}")
+        if old_rel_path == new_rel_path:
+            return
+        skill = self._require_bundle(scope, name)
+        source = skill.resolve_bundle_path(old_rel_path)
+        target = skill.resolve_bundle_path(new_rel_path)
+        if not source.exists():
+            raise FileNotFoundError(f"Bundle file not found: {old_rel_path}")
+        if target.exists():
+            raise FileExistsError(f"Destination already exists: {new_rel_path}")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        source.rename(target)
+        self._notify_skills_changed()
+
+    def delete_bundle_file(self, scope: SkillScope, name: str, rel_path: str) -> None:
+        if rel_path == SKILL_ENTRY_FILE:
+            raise ValueError(f"Cannot delete {SKILL_ENTRY_FILE}; delete the whole skill instead")
+        skill = self._require_bundle(scope, name)
+        target = skill.resolve_bundle_path(rel_path)
+        if target.is_dir():
+            shutil.rmtree(target)
+        elif target.exists():
+            target.unlink()
+        else:
+            raise FileNotFoundError(f"Bundle file not found: {rel_path}")
+        self._notify_skills_changed()
+
+
+    def preview_github_import(self, url: str) -> Dict:
+        """Fetch and validate a skill from GitHub, returning a preview dict.
+
+        Does not install the skill; staged temp dir is cleaned up before returning.
+        """
+        staged = stage_skill_from_github(url)
+        try:
+            return {
+                "name": staged.name,
+                "description": staged.description,
+                "allowed_tools": staged.allowed_tools,
+                "body": staged.body,
+                "files": staged.files,
+                "source_url": staged.source_url,
+                "canonical_url": staged.canonical_url,
+                "exists_in_user_scope": self._locate_skill_path("user", staged.name) is not None,
+                "exists_in_project_scope": self._locate_skill_path("project", staged.name) is not None,
+            }
+        finally:
+            shutil.rmtree(staged.tmp_root, ignore_errors=True)
+
+    def import_from_github(
+        self,
+        url: str,
+        scope: SkillScope,
+        name_override: Optional[str] = None,
+        overwrite: bool = False,
+    ) -> Skill:
+        """Fetch, validate, and install a skill from GitHub into the given scope."""
+        staged = stage_skill_from_github(url)
+        try:
+            name = name_override.strip() if name_override else staged.name
+            _validate_name(name)
+
+            scope_dir = self.scope_dir(scope)
+            scope_dir.mkdir(parents=True, exist_ok=True)
+            target_dir = scope_dir / name
+            if target_dir.exists():
+                if not overwrite:
+                    raise FileExistsError(
+                        f"Skill '{name}' already exists in {scope} scope"
+                    )
+                shutil.rmtree(target_dir)
+
+            shutil.copytree(staged.skill_root, target_dir)
+
+            # Rewrite SKILL.md to (a) honor the user's name override and (b) stamp the
+            # canonical GitHub URL into `source:` so we can trace provenance later.
+            md_content = serialize_skill_md(
+                name,
+                staged.description,
+                staged.allowed_tools,
+                staged.body,
+                source=staged.canonical_url,
+            )
+            (target_dir / SKILL_ENTRY_FILE).write_text(md_content, encoding="utf-8")
+
+            skill = Skill.from_path(target_dir, scope)
+            self._notify_skills_changed()
+            return skill
+        finally:
+            shutil.rmtree(staged.tmp_root, ignore_errors=True)
+
+
+def _validate_name(name: str) -> None:
+    if not isinstance(name, str) or not SKILL_NAME_PATTERN.match(name):
+        raise ValueError(f"Invalid skill name '{name}': {SKILL_NAME_REQUIREMENT}")

--- a/notebook_intelligence/skill_manager.py
+++ b/notebook_intelligence/skill_manager.py
@@ -380,6 +380,7 @@ class SkillManager:
         managed_source: str,
         managed_ref: str,
         name_override: Optional[str] = None,
+        token: Optional[str] = None,
     ) -> Skill:
         """Install a skill from GitHub as a managed bundle.
 
@@ -387,8 +388,10 @@ class SkillManager:
         - Stamps `managed_source` and `managed_ref` frontmatter keys alongside `source`.
         - Always overwrites existing managed bundles, but refuses to overwrite a
           user-authored bundle of the same name (re-reads frontmatter to check).
+        - Accepts an explicit `token` (the deployment's managed-skills token)
+          instead of the caller's personal GITHUB_TOKEN / gh-CLI chain.
         """
-        staged = stage_skill_from_github(url)
+        staged = stage_skill_from_github(url, token=token)
         try:
             name = name_override.strip() if name_override else staged.name
             _validate_name(name)

--- a/notebook_intelligence/skill_manifest.py
+++ b/notebook_intelligence/skill_manifest.py
@@ -1,0 +1,164 @@
+"""Loads the managed-skills manifest (YAML/JSON) from a URL or local file path.
+
+The manifest describes the set of Claude skills that should be installed on this
+notebook. See the README for the schema; briefly:
+
+    skills:
+      - url: https://github.com/org/repo/tree/main/skills/data-eda
+        name: data-eda        # optional override of the installed skill name
+        scope: user           # optional, "user" or "project" (default "user")
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+
+import yaml
+
+from notebook_intelligence.skill_github_import import _get_github_token
+from notebook_intelligence.skillset import SKILL_NAME_PATTERN
+
+log = logging.getLogger(__name__)
+
+MAX_MANIFEST_BYTES = 1 * 1024 * 1024  # 1 MB
+FETCH_TIMEOUT_SECONDS = 15.0
+_VALID_SCOPES = ("user", "project")
+_URL_RE = re.compile(r"^https?://", re.IGNORECASE)
+_GITHUB_HOSTS = (
+    "github.com",
+    "www.github.com",
+    "api.github.com",
+    "raw.githubusercontent.com",
+)
+
+
+def _is_github_host(url: str) -> bool:
+    try:
+        host = urllib.parse.urlparse(url).netloc.lower()
+    except ValueError:
+        return False
+    return host in _GITHUB_HOSTS or host.endswith(".githubusercontent.com")
+
+
+class ManifestError(ValueError):
+    """Raised when a manifest cannot be loaded or fails validation."""
+
+
+@dataclass
+class ManifestEntry:
+    url: str
+    name: Optional[str] = None
+    scope: str = "user"
+
+
+@dataclass
+class SkillsManifest:
+    entries: List[ManifestEntry]
+
+
+def load_manifest(source: str, *, token: Optional[str] = None) -> SkillsManifest:
+    """Load and validate a manifest from a URL or local filesystem path.
+
+    URLs use `Authorization: Bearer {token}` when token is provided; useful for
+    manifests hosted on private GitHub repos via raw.githubusercontent.com.
+    """
+    if not isinstance(source, str) or not source.strip():
+        raise ManifestError("Manifest source is empty")
+    source = source.strip()
+
+    raw = _read_source(source, token=token)
+    try:
+        parsed = yaml.safe_load(raw)
+    except yaml.YAMLError as e:
+        raise ManifestError(f"Manifest is not valid YAML/JSON: {e}")
+
+    if not isinstance(parsed, dict):
+        raise ManifestError("Manifest root must be a mapping")
+    raw_entries = parsed.get("skills")
+    if raw_entries is None:
+        raise ManifestError("Manifest must have a top-level 'skills' list")
+    if not isinstance(raw_entries, list):
+        raise ManifestError("'skills' must be a list")
+
+    entries: List[ManifestEntry] = []
+    for idx, item in enumerate(raw_entries):
+        entries.append(_parse_entry(item, idx))
+
+    return SkillsManifest(entries=entries)
+
+
+def _parse_entry(item, index: int) -> ManifestEntry:
+    if not isinstance(item, dict):
+        raise ManifestError(f"skills[{index}] must be a mapping")
+    url = item.get("url")
+    if not isinstance(url, str) or not url.strip():
+        raise ManifestError(f"skills[{index}].url is required")
+
+    name = item.get("name")
+    if name is not None:
+        if not isinstance(name, str) or not SKILL_NAME_PATTERN.match(name):
+            raise ManifestError(
+                f"skills[{index}].name '{name}' is not a valid skill name"
+            )
+
+    scope = item.get("scope", "user")
+    if scope not in _VALID_SCOPES:
+        raise ManifestError(
+            f"skills[{index}].scope must be one of {_VALID_SCOPES}, got {scope!r}"
+        )
+
+    return ManifestEntry(url=url.strip(), name=name, scope=scope)
+
+
+def _read_source(source: str, *, token: Optional[str]) -> str:
+    if _URL_RE.match(source):
+        return _fetch_url(source, token=token)
+    # Treat as a filesystem path (e.g., k8s ConfigMap mount).
+    path = Path(source).expanduser()
+    try:
+        data = path.read_bytes()
+    except FileNotFoundError:
+        raise ManifestError(f"Manifest file not found: {source}")
+    except OSError as e:
+        raise ManifestError(f"Could not read manifest file {source}: {e}")
+    if len(data) > MAX_MANIFEST_BYTES:
+        raise ManifestError(
+            f"Manifest file exceeds {MAX_MANIFEST_BYTES} bytes"
+        )
+    return data.decode("utf-8", errors="replace")
+
+
+def _fetch_url(url: str, *, token: Optional[str]) -> str:
+    headers = {
+        "User-Agent": "notebook-intelligence-skills-manifest",
+        "Accept": "application/x-yaml, application/json, text/plain, */*",
+    }
+    # Explicit NBI_SKILLS_MANIFEST_TOKEN wins. Otherwise, for github-hosted
+    # manifests, fall back to the same GITHUB_TOKEN / GH_TOKEN / `gh auth token`
+    # chain used for fetching skill tarballs — private-repo manifests should
+    # just work when the user already has a GitHub login.
+    effective_token = token
+    if not effective_token and _is_github_host(url):
+        effective_token = _get_github_token()
+    if effective_token:
+        headers["Authorization"] = f"Bearer {effective_token}"
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=FETCH_TIMEOUT_SECONDS) as resp:
+            data = resp.read(MAX_MANIFEST_BYTES + 1)
+    except urllib.error.HTTPError as e:
+        raise ManifestError(f"Manifest fetch failed (HTTP {e.code}): {e.reason}")
+    except urllib.error.URLError as e:
+        raise ManifestError(f"Could not reach manifest URL {url}: {e.reason}")
+    if len(data) > MAX_MANIFEST_BYTES:
+        raise ManifestError(
+            f"Manifest at {url} exceeds {MAX_MANIFEST_BYTES} bytes"
+        )
+    return data.decode("utf-8", errors="replace")

--- a/notebook_intelligence/skill_manifest.py
+++ b/notebook_intelligence/skill_manifest.py
@@ -140,7 +140,7 @@ def _fetch_url(url: str, *, token: Optional[str]) -> str:
         "User-Agent": "notebook-intelligence-skills-manifest",
         "Accept": "application/x-yaml, application/json, text/plain, */*",
     }
-    # Explicit NBI_SKILLS_MANIFEST_TOKEN wins. Otherwise, for github-hosted
+    # Explicit NBI_MANAGED_SKILLS_TOKEN wins. Otherwise, for github-hosted
     # manifests, fall back to the same GITHUB_TOKEN / GH_TOKEN / `gh auth token`
     # chain used for fetching skill tarballs — private-repo manifests should
     # just work when the user already has a GitHub login.

--- a/notebook_intelligence/skill_reconciler.py
+++ b/notebook_intelligence/skill_reconciler.py
@@ -61,12 +61,14 @@ class SkillReconciler:
         skill_manager: SkillManager,
         manifest_source: str,
         interval_seconds: int,
-        manifest_token: Optional[str] = None,
+        managed_token: Optional[str] = None,
     ):
         self._skill_manager = skill_manager
         self._manifest_source = manifest_source
         self._interval_seconds = max(int(interval_seconds), 1)
-        self._manifest_token = manifest_token
+        # Used for manifest fetch, commits-API probe, and tarball download — the
+        # whole managed pathway. User-initiated imports do not see this token.
+        self._managed_token = managed_token
         self._thread: Optional[threading.Thread] = None
         self._stop = threading.Event()
 
@@ -75,7 +77,7 @@ class SkillReconciler:
         result = ReconcileResult()
         try:
             manifest = load_manifest(
-                self._manifest_source, token=self._manifest_token
+                self._manifest_source, token=self._managed_token
             )
         except ManifestError as e:
             msg = f"Could not load manifest: {e}"
@@ -168,6 +170,7 @@ class SkillReconciler:
             managed_source=entry.url,
             managed_ref=desired_sha or "",
             name_override=entry.name,
+            token=self._managed_token,
         )
         if existing is not None:
             result.updated += 1
@@ -179,7 +182,11 @@ class SkillReconciler:
         if ref_info.ref and _SHA_RE.match(ref_info.ref):
             return ref_info.ref
         return get_latest_commit_sha(
-            ref_info.owner, ref_info.repo, ref_info.ref, ref_info.subpath
+            ref_info.owner,
+            ref_info.repo,
+            ref_info.ref,
+            ref_info.subpath,
+            token=self._managed_token,
         )
 
     def _remove_stale(

--- a/notebook_intelligence/skill_reconciler.py
+++ b/notebook_intelligence/skill_reconciler.py
@@ -1,0 +1,200 @@
+"""Background reconciliation of managed Claude skills against a manifest.
+
+Reads a manifest (`NBI_SKILLS_MANIFEST`) listing Claude skills to install from
+GitHub, installs/updates them, and removes managed skills that have been dropped
+from the manifest. User-authored skills are never touched.
+
+See `skill_manifest.py` for the manifest schema.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import threading
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, cast
+
+from notebook_intelligence.skill_github_import import (
+    get_latest_commit_sha,
+    parse_github_url,
+)
+from notebook_intelligence.skill_manager import SkillManager
+from notebook_intelligence.skill_manifest import (
+    ManifestEntry,
+    ManifestError,
+    load_manifest,
+)
+from notebook_intelligence.skillset import Skill, SkillScope
+
+log = logging.getLogger(__name__)
+
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+@dataclass
+class ReconcileResult:
+    added: int = 0
+    updated: int = 0
+    removed: int = 0
+    unchanged: int = 0
+    errors: List[str] = field(default_factory=list)
+
+    def mutated(self) -> bool:
+        return self.added or self.updated or self.removed
+
+    def to_dict(self) -> dict:
+        return {
+            "added": self.added,
+            "updated": self.updated,
+            "removed": self.removed,
+            "unchanged": self.unchanged,
+            "errors": list(self.errors),
+        }
+
+
+class SkillReconciler:
+    """Reconciles installed managed skills against a manifest on a schedule."""
+
+    def __init__(
+        self,
+        skill_manager: SkillManager,
+        manifest_source: str,
+        interval_seconds: int,
+        manifest_token: Optional[str] = None,
+    ):
+        self._skill_manager = skill_manager
+        self._manifest_source = manifest_source
+        self._interval_seconds = max(int(interval_seconds), 1)
+        self._manifest_token = manifest_token
+        self._thread: Optional[threading.Thread] = None
+        self._stop = threading.Event()
+
+    def reconcile(self) -> ReconcileResult:
+        """One pass: load manifest, apply installs/updates/removes. Synchronous."""
+        result = ReconcileResult()
+        try:
+            manifest = load_manifest(
+                self._manifest_source, token=self._manifest_token
+            )
+        except ManifestError as e:
+            msg = f"Could not load manifest: {e}"
+            log.error(msg)
+            result.errors.append(msg)
+            return result
+
+        # Snapshot managed skills once per cycle. Both the per-entry apply and
+        # the stale-removal pass read from this dict, avoiding an O(N*M) disk
+        # re-scan for every manifest entry.
+        managed_by_url: Dict[str, Skill] = {
+            s.managed_source: s
+            for s in self._skill_manager.list_managed_skills()
+            if s.managed_source
+        }
+        manifest_urls = {entry.url for entry in manifest.entries}
+
+        for entry in manifest.entries:
+            try:
+                self._apply_entry(entry, managed_by_url, result)
+            except Exception as e:  # noqa: BLE001 — per-entry isolation
+                msg = f"{entry.url}: {e}"
+                log.exception("Failed to reconcile skill %s", entry.url)
+                result.errors.append(msg)
+
+        self._remove_stale(manifest_urls, managed_by_url, result)
+
+        # Intermediate install/delete calls each fire the skill_manager's listeners
+        # already; the downstream Claude client update is debounced, so per-entry
+        # notifications coalesce into a single reconnect.
+
+        return result
+
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(
+            name="Skill Reconciler",
+            target=self._run_loop,
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self, timeout: float = 5.0) -> None:
+        thread = self._thread
+        self._stop.set()
+        if thread is not None:
+            thread.join(timeout=timeout)
+        self._thread = None
+
+    # -- internals ----------------------------------------------------------
+
+    def _run_loop(self) -> None:
+        # First pass runs immediately, then we sleep between reconciles.
+        while not self._stop.is_set():
+            try:
+                self.reconcile()
+            except Exception:  # noqa: BLE001 — thread must survive any error
+                log.exception("Reconciler pass raised; continuing")
+            if self._stop.wait(self._interval_seconds):
+                return
+
+    def _apply_entry(
+        self,
+        entry: ManifestEntry,
+        managed_by_url: Dict[str, Skill],
+        result: ReconcileResult,
+    ) -> None:
+        ref_info = parse_github_url(entry.url)
+        existing = managed_by_url.get(entry.url)
+        desired_sha = self._resolve_desired_sha(ref_info)
+
+        # Already installed and the SHA still matches — nothing to do.
+        if existing is not None and desired_sha and existing.managed_ref == desired_sha:
+            result.unchanged += 1
+            return
+
+        # Probe failed (None) and we already have this skill installed — leave it
+        # alone rather than re-downloading the tarball every cycle on transient
+        # commits-API errors. A genuine upstream update will produce a concrete
+        # SHA on a later cycle.
+        if existing is not None and desired_sha is None:
+            result.unchanged += 1
+            return
+
+        self._skill_manager.install_managed_from_github(
+            url=entry.url,
+            scope=cast(SkillScope, entry.scope),
+            managed_source=entry.url,
+            managed_ref=desired_sha or "",
+            name_override=entry.name,
+        )
+        if existing is not None:
+            result.updated += 1
+        else:
+            result.added += 1
+
+    def _resolve_desired_sha(self, ref_info) -> Optional[str]:
+        # If the ref is already a full SHA, no API probe needed.
+        if ref_info.ref and _SHA_RE.match(ref_info.ref):
+            return ref_info.ref
+        return get_latest_commit_sha(
+            ref_info.owner, ref_info.repo, ref_info.ref, ref_info.subpath
+        )
+
+    def _remove_stale(
+        self,
+        manifest_urls: set,
+        managed_by_url: Dict[str, Skill],
+        result: ReconcileResult,
+    ) -> None:
+        for url, skill in managed_by_url.items():
+            if url in manifest_urls:
+                continue
+            try:
+                self._skill_manager.delete_skill(skill.scope, skill.name)
+                result.removed += 1
+            except Exception as e:  # noqa: BLE001
+                msg = f"Could not remove stale managed skill {skill.name}: {e}"
+                log.exception(msg)
+                result.errors.append(msg)

--- a/notebook_intelligence/skillset.py
+++ b/notebook_intelligence/skillset.py
@@ -1,0 +1,144 @@
+from dataclasses import dataclass, field
+from typing import Dict, List, Any, Literal
+from pathlib import Path
+import logging
+import re
+import yaml
+
+log = logging.getLogger(__name__)
+
+SkillScope = Literal["user", "project"]
+
+SKILL_ENTRY_FILE = "SKILL.md"
+
+# Single source of truth for valid skill names. Mirrored to frontend as SKILL_NAME_PATTERN
+# in src/components/skills-panel.tsx and to Tornado routes in extension.py.
+SKILL_NAME_REGEX = r"[a-z0-9][a-z0-9-]{0,63}"
+SKILL_NAME_PATTERN = re.compile(f"^{SKILL_NAME_REGEX}$")
+SKILL_NAME_REQUIREMENT = (
+    "Must be lowercase letters, digits, or hyphens (starting with a letter or digit), "
+    "1-64 chars"
+)
+
+
+@dataclass
+class Skill:
+    """A Claude skill bundle: a directory containing SKILL.md and optional supporting files."""
+    name: str
+    scope: SkillScope
+    root_path: Path
+    description: str = ""
+    allowed_tools: List[str] = field(default_factory=list)
+    body: str = ""
+    source: str = ""
+
+    @classmethod
+    def from_path(cls, dir_path: Path, scope: SkillScope) -> 'Skill':
+        dir_path = Path(dir_path)
+        skill_md = dir_path / SKILL_ENTRY_FILE
+        if not skill_md.exists():
+            raise FileNotFoundError(f"Bundle missing {SKILL_ENTRY_FILE}: {dir_path}")
+        frontmatter, body = _parse_frontmatter(skill_md.read_text(encoding="utf-8"), skill_md)
+        name = frontmatter.get("name") or dir_path.name
+        return cls(
+            name=name,
+            scope=scope,
+            root_path=dir_path,
+            description=frontmatter.get("description", ""),
+            allowed_tools=list(frontmatter.get("allowed-tools", []) or []),
+            body=body,
+            source=frontmatter.get("source", "") or "",
+        )
+
+    def skill_md_path(self) -> Path:
+        return self.root_path / SKILL_ENTRY_FILE
+
+    def list_files(self) -> List[str]:
+        """List files inside the bundle, relative to root_path."""
+        return list_bundle_files(self.root_path)
+
+    def resolve_bundle_path(self, rel_path: str) -> Path:
+        """Resolve a bundle-internal path, blocking traversal outside root_path."""
+        if not rel_path or rel_path.startswith("/") or "\\" in rel_path:
+            raise ValueError(f"Invalid bundle path: {rel_path}")
+        resolved = (self.root_path / rel_path).resolve()
+        root_resolved = self.root_path.resolve()
+        try:
+            resolved.relative_to(root_resolved)
+        except ValueError:
+            raise ValueError(f"Path escapes bundle root: {rel_path}")
+        return resolved
+
+    def to_dict(self, include_body: bool = False, include_files: bool = True) -> Dict[str, Any]:
+        data = {
+            "name": self.name,
+            "scope": self.scope,
+            "description": self.description,
+            "allowed_tools": self.allowed_tools,
+            "root_path": str(self.root_path),
+            "source": self.source,
+        }
+        if include_files:
+            data["files"] = self.list_files()
+        if include_body:
+            data["body"] = self.body
+        return data
+
+
+def list_bundle_files(root: Path) -> List[str]:
+    """List files inside a bundle directory, relative to root. Skips dotfiles and __pycache__."""
+    results: List[str] = []
+
+    def walk(dir_path: Path) -> None:
+        for entry in sorted(dir_path.iterdir()):
+            if entry.name.startswith(".") or entry.name == "__pycache__":
+                continue
+            if entry.is_dir():
+                walk(entry)
+            elif entry.is_file():
+                results.append(str(entry.relative_to(root)))
+
+    walk(root)
+    return results
+
+
+def _parse_frontmatter(content: str, source_path: Path) -> tuple[Dict[str, Any], str]:
+    """Parse YAML frontmatter from a markdown file. Returns (frontmatter_dict, body_string)."""
+    if not content.startswith("---\n"):
+        log.warning(f"Skill file {source_path} has no YAML frontmatter")
+        return {}, content
+
+    parts = content.split("---\n", 2)
+    if len(parts) < 3:
+        log.warning(f"Skill file {source_path} has malformed frontmatter")
+        return {}, content
+
+    try:
+        frontmatter = yaml.safe_load(parts[1]) or {}
+    except yaml.YAMLError as e:
+        log.error(f"Invalid YAML in skill file {source_path}: {e}")
+        raise ValueError(f"Invalid YAML frontmatter in {source_path}: {e}")
+
+    if not isinstance(frontmatter, dict):
+        log.warning(f"Skill frontmatter in {source_path} is not a mapping; ignoring")
+        frontmatter = {}
+
+    return frontmatter, parts[2].lstrip("\n")
+
+
+def serialize_skill_md(
+    name: str,
+    description: str,
+    allowed_tools: List[str],
+    body: str,
+    source: str = "",
+) -> str:
+    """Render a SKILL.md markdown string from its fields."""
+    frontmatter: Dict[str, Any] = {"name": name, "description": description}
+    if allowed_tools:
+        frontmatter["allowed-tools"] = list(allowed_tools)
+    if source:
+        frontmatter["source"] = source
+    yaml_text = yaml.safe_dump(frontmatter, sort_keys=False, default_flow_style=False).strip()
+    body_text = body.rstrip() + "\n" if body.strip() else ""
+    return f"---\n{yaml_text}\n---\n\n{body_text}"

--- a/notebook_intelligence/skillset.py
+++ b/notebook_intelligence/skillset.py
@@ -31,6 +31,8 @@ class Skill:
     allowed_tools: List[str] = field(default_factory=list)
     body: str = ""
     source: str = ""
+    managed_source: str = ""
+    managed_ref: str = ""
 
     @classmethod
     def from_path(cls, dir_path: Path, scope: SkillScope) -> 'Skill':
@@ -48,7 +50,13 @@ class Skill:
             allowed_tools=list(frontmatter.get("allowed-tools", []) or []),
             body=body,
             source=frontmatter.get("source", "") or "",
+            managed_source=frontmatter.get("managed_source", "") or "",
+            managed_ref=frontmatter.get("managed_ref", "") or "",
         )
+
+    @property
+    def managed(self) -> bool:
+        return bool(self.managed_source)
 
     def skill_md_path(self) -> Path:
         return self.root_path / SKILL_ENTRY_FILE
@@ -77,6 +85,9 @@ class Skill:
             "allowed_tools": self.allowed_tools,
             "root_path": str(self.root_path),
             "source": self.source,
+            "managed": self.managed,
+            "managed_source": self.managed_source,
+            "managed_ref": self.managed_ref,
         }
         if include_files:
             data["files"] = self.list_files()
@@ -132,6 +143,9 @@ def serialize_skill_md(
     allowed_tools: List[str],
     body: str,
     source: str = "",
+    *,
+    managed_source: str = "",
+    managed_ref: str = "",
 ) -> str:
     """Render a SKILL.md markdown string from its fields."""
     frontmatter: Dict[str, Any] = {"name": name, "description": description}
@@ -139,6 +153,10 @@ def serialize_skill_md(
         frontmatter["allowed-tools"] = list(allowed_tools)
     if source:
         frontmatter["source"] = source
+    if managed_source:
+        frontmatter["managed_source"] = managed_source
+    if managed_ref:
+        frontmatter["managed_ref"] = managed_ref
     yaml_text = yaml.safe_dump(frontmatter, sort_keys=False, default_flow_style=False).strip()
     body_text = body.rstrip() + "\n" if body.strip() else ""
     return f"---\n{yaml_text}\n---\n\n{body_text}"

--- a/notebook_intelligence/util.py
+++ b/notebook_intelligence/util.py
@@ -106,3 +106,7 @@ class ThreadSafeWebSocketConnector():
         self.websocket_handler.write_message(message)
     asyncio.set_event_loop(self.io_loop.asyncio_loop)
     self.io_loop.asyncio_loop.call_soon_threadsafe(_write_message)
+
+  def schedule(self, callback, *args):
+    """Schedule a callback on the Tornado asyncio loop from any thread."""
+    self.io_loop.asyncio_loop.call_soon_threadsafe(callback, *args)

--- a/src/api.ts
+++ b/src/api.ts
@@ -523,9 +523,15 @@ export class NBIAPI {
     }
   ): Promise<ISkillDetail> {
     const wire: any = {};
-    if (payload.description !== undefined) wire.description = payload.description;
-    if (payload.allowedTools !== undefined) wire.allowed_tools = payload.allowedTools;
-    if (payload.body !== undefined) wire.body = payload.body;
+    if (payload.description !== undefined) {
+      wire.description = payload.description;
+    }
+    if (payload.allowedTools !== undefined) {
+      wire.allowed_tools = payload.allowedTools;
+    }
+    if (payload.body !== undefined) {
+      wire.body = payload.body;
+    }
     const data = await requestAPI<any>(
       `skills/${scope}/${encodeURIComponent(name)}`,
       {
@@ -568,8 +574,12 @@ export class NBIAPI {
     overwrite?: boolean;
   }): Promise<ISkillDetail> {
     const wire: any = { url: payload.url, scope: payload.scope };
-    if (payload.name) wire.name = payload.name;
-    if (payload.overwrite) wire.overwrite = true;
+    if (payload.name) {
+      wire.name = payload.name;
+    }
+    if (payload.overwrite) {
+      wire.overwrite = true;
+    }
     const data = await requestAPI<any>('skills/import', {
       method: 'POST',
       body: JSON.stringify(wire)

--- a/src/api.ts
+++ b/src/api.ts
@@ -64,6 +64,17 @@ export interface ISkillSummary {
   rootPath: string;
   files: string[];
   source: string;
+  managed: boolean;
+  managedSource: string;
+  managedRef: string;
+}
+
+export interface IReconcileResult {
+  added: number;
+  updated: number;
+  removed: number;
+  unchanged: number;
+  errors: string[];
 }
 
 export interface ISkillDetail extends ISkillSummary {
@@ -98,6 +109,9 @@ function skillFromWire(wire: any): ISkillDetail {
     rootPath: wire.root_path,
     files: wire.files ?? [],
     source: wire.source ?? '',
+    managed: Boolean(wire.managed),
+    managedSource: wire.managed_source ?? '',
+    managedRef: wire.managed_ref ?? '',
     body: wire.body ?? ''
   };
 }
@@ -585,6 +599,19 @@ export class NBIAPI {
       body: JSON.stringify(wire)
     });
     return skillFromWire(data.skill);
+  }
+
+  static async reconcileManagedSkills(): Promise<IReconcileResult> {
+    const data = await requestAPI<any>('skills/reconcile', {
+      method: 'POST'
+    });
+    return {
+      added: Number(data.added ?? 0),
+      updated: Number(data.updated ?? 0),
+      removed: Number(data.removed ?? 0),
+      unchanged: Number(data.unchanged ?? 0),
+      errors: Array.isArray(data.errors) ? data.errors.map(String) : []
+    };
   }
 
   static async renameSkill(

--- a/src/api.ts
+++ b/src/api.ts
@@ -38,12 +38,68 @@ export enum ClaudeModelType {
 export interface IClaudeModelInfo {
   id: string;
   name: string;
-  context_window: number;
+  contextWindow: number;
 }
 
 export enum ClaudeToolType {
   ClaudeCodeTools = 'claude-code:built-in-tools',
   JupyterUITools = 'nbi:built-in-jupyter-ui-tools'
+}
+
+export type SkillScope = 'user' | 'project';
+
+export interface ISkillSummary {
+  scope: SkillScope;
+  name: string;
+  description: string;
+  allowedTools: string[];
+  rootPath: string;
+  files: string[];
+  source: string;
+}
+
+export interface ISkillDetail extends ISkillSummary {
+  body: string;
+}
+
+export interface ISkillsContext {
+  projectRoot: string;
+  projectName: string;
+  userSkillsDir: string;
+  projectSkillsDir: string;
+}
+
+export interface ISkillImportPreview {
+  name: string;
+  description: string;
+  allowedTools: string[];
+  body: string;
+  files: string[];
+  sourceUrl: string;
+  canonicalUrl: string;
+  existsInUserScope: boolean;
+  existsInProjectScope: boolean;
+}
+
+function skillFromWire(wire: any): ISkillDetail {
+  return {
+    scope: wire.scope,
+    name: wire.name,
+    description: wire.description,
+    allowedTools: wire.allowed_tools ?? [],
+    rootPath: wire.root_path,
+    files: wire.files ?? [],
+    source: wire.source ?? '',
+    body: wire.body ?? ''
+  };
+}
+
+function claudeModelFromWire(wire: any): IClaudeModelInfo {
+  return {
+    id: wire.id,
+    name: wire.name,
+    contextWindow: wire.context_window
+  };
 }
 
 export class NBIConfig {
@@ -127,7 +183,7 @@ export class NBIConfig {
   }
 
   get claudeModels(): IClaudeModelInfo[] {
-    return this.capabilities.claude_models ?? [];
+    return (this.capabilities.claude_models ?? []).map(claudeModelFromWire);
   }
 
   get isInClaudeCodeMode(): boolean {
@@ -155,6 +211,7 @@ export class NBIAPI {
   static config = new NBIConfig();
   static configChanged = this.config.changed;
   static githubLoginStatusChanged = new Signal<unknown, void>(this);
+  static skillsReloaded = new Signal<unknown, void>(this);
 
   static async initialize() {
     await this.fetchCapabilities();
@@ -175,6 +232,8 @@ export class NBIAPI {
         this.updateGitHubLoginStatus().then(() => {
           this.githubLoginStatusChanged.emit();
         });
+      } else if (msg.type === BackendMessageType.SkillsReloaded) {
+        this.skillsReloaded.emit();
       }
     });
   }
@@ -398,6 +457,184 @@ export class NBIAPI {
           reject(reason);
         });
     });
+  }
+
+  static async listSkills(): Promise<ISkillSummary[]> {
+    const data = await requestAPI<any>('skills', { method: 'GET' });
+    return (data.skills ?? []).map(skillFromWire);
+  }
+
+  static async getSkillsContext(): Promise<ISkillsContext> {
+    const data = await requestAPI<any>('skills/context', { method: 'GET' });
+    return {
+      projectRoot: data.project_root ?? '',
+      projectName: data.project_name ?? '',
+      userSkillsDir: data.user_skills_dir ?? '',
+      projectSkillsDir: data.project_skills_dir ?? ''
+    };
+  }
+
+  static async readSkill(
+    scope: SkillScope,
+    name: string
+  ): Promise<ISkillDetail> {
+    const data = await requestAPI<any>(
+      `skills/${scope}/${encodeURIComponent(name)}`,
+      { method: 'GET' }
+    );
+    return skillFromWire(data.skill);
+  }
+
+  static async createSkill(payload: {
+    scope: SkillScope;
+    name: string;
+    description: string;
+    allowedTools: string[];
+    body: string;
+  }): Promise<ISkillDetail> {
+    const data = await requestAPI<any>('skills', {
+      method: 'POST',
+      body: JSON.stringify({
+        scope: payload.scope,
+        name: payload.name,
+        description: payload.description,
+        allowed_tools: payload.allowedTools,
+        body: payload.body
+      })
+    });
+    return skillFromWire(data.skill);
+  }
+
+  static async updateSkill(
+    scope: SkillScope,
+    name: string,
+    payload: {
+      description?: string;
+      allowedTools?: string[];
+      body?: string;
+    }
+  ): Promise<ISkillDetail> {
+    const wire: any = {};
+    if (payload.description !== undefined) wire.description = payload.description;
+    if (payload.allowedTools !== undefined) wire.allowed_tools = payload.allowedTools;
+    if (payload.body !== undefined) wire.body = payload.body;
+    const data = await requestAPI<any>(
+      `skills/${scope}/${encodeURIComponent(name)}`,
+      {
+        method: 'PUT',
+        body: JSON.stringify(wire)
+      }
+    );
+    return skillFromWire(data.skill);
+  }
+
+  static async deleteSkill(scope: SkillScope, name: string): Promise<void> {
+    await requestAPI<any>(`skills/${scope}/${encodeURIComponent(name)}`, {
+      method: 'DELETE'
+    });
+  }
+
+  static async previewSkillImport(url: string): Promise<ISkillImportPreview> {
+    const data = await requestAPI<any>('skills/import/preview', {
+      method: 'POST',
+      body: JSON.stringify({ url })
+    });
+    const p = data.preview;
+    return {
+      name: p.name,
+      description: p.description ?? '',
+      allowedTools: p.allowed_tools ?? [],
+      body: p.body ?? '',
+      files: p.files ?? [],
+      sourceUrl: p.source_url ?? '',
+      canonicalUrl: p.canonical_url ?? '',
+      existsInUserScope: p.exists_in_user_scope === true,
+      existsInProjectScope: p.exists_in_project_scope === true
+    };
+  }
+
+  static async importSkill(payload: {
+    url: string;
+    scope: SkillScope;
+    name?: string;
+    overwrite?: boolean;
+  }): Promise<ISkillDetail> {
+    const wire: any = { url: payload.url, scope: payload.scope };
+    if (payload.name) wire.name = payload.name;
+    if (payload.overwrite) wire.overwrite = true;
+    const data = await requestAPI<any>('skills/import', {
+      method: 'POST',
+      body: JSON.stringify(wire)
+    });
+    return skillFromWire(data.skill);
+  }
+
+  static async renameSkill(
+    scope: SkillScope,
+    name: string,
+    newName: string
+  ): Promise<ISkillDetail> {
+    const data = await requestAPI<any>(
+      `skills/${scope}/${encodeURIComponent(name)}/rename`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ new_name: newName })
+      }
+    );
+    return skillFromWire(data.skill);
+  }
+
+  static async readBundleFile(
+    scope: SkillScope,
+    name: string,
+    path: string
+  ): Promise<string> {
+    const data = await requestAPI<any>(
+      `skills/${scope}/${encodeURIComponent(name)}/files?path=${encodeURIComponent(path)}`,
+      { method: 'GET' }
+    );
+    return data.content;
+  }
+
+  static async writeBundleFile(
+    scope: SkillScope,
+    name: string,
+    path: string,
+    content: string
+  ): Promise<void> {
+    await requestAPI<any>(
+      `skills/${scope}/${encodeURIComponent(name)}/files?path=${encodeURIComponent(path)}`,
+      {
+        method: 'PUT',
+        body: JSON.stringify({ content })
+      }
+    );
+  }
+
+  static async deleteBundleFile(
+    scope: SkillScope,
+    name: string,
+    path: string
+  ): Promise<void> {
+    await requestAPI<any>(
+      `skills/${scope}/${encodeURIComponent(name)}/files?path=${encodeURIComponent(path)}`,
+      { method: 'DELETE' }
+    );
+  }
+
+  static async renameBundleFile(
+    scope: SkillScope,
+    name: string,
+    from: string,
+    to: string
+  ): Promise<void> {
+    await requestAPI<any>(
+      `skills/${scope}/${encodeURIComponent(name)}/files/rename`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ from, to })
+      }
+    );
   }
 
   static async chatRequest(

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -479,7 +479,7 @@ function ChatResponse(props: any) {
     }
 
     let reasoningContent = '';
-    let reasoningStartTime = new Date(item.created);
+    const reasoningStartTime = new Date(item.created);
     const reasoningEndTime = new Date();
 
     let startPos = -1;

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -2267,12 +2267,33 @@ function SidebarComponent(props: any) {
     NBIAPI.getGHLoginRequired()
   );
   const [chatEnabled, setChatEnabled] = useState(NBIAPI.getChatEnabled());
+  const [skillsReloadedVisible, setSkillsReloadedVisible] = useState(false);
 
   useEffect(() => {
     NBIAPI.configChanged.connect(() => {
       setGHLoginRequired(NBIAPI.getGHLoginRequired());
       setChatEnabled(NBIAPI.getChatEnabled());
     });
+  }, []);
+
+  useEffect(() => {
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+    const listener = () => {
+      setSkillsReloadedVisible(true);
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      timeout = setTimeout(() => {
+        setSkillsReloadedVisible(false);
+      }, 4000);
+    };
+    NBIAPI.skillsReloaded.connect(listener);
+    return () => {
+      NBIAPI.skillsReloaded.disconnect(listener);
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    };
   }, []);
 
   useEffect(() => {
@@ -2290,6 +2311,13 @@ function SidebarComponent(props: any) {
         >
           <VscSettingsGear />
         </div>
+      </div>
+      <div className="nbi-skills-reloaded-banner-live" aria-live="polite">
+        {skillsReloadedVisible && (
+          <div className="nbi-skills-reloaded-banner">
+            Skills reloaded — applied to the current session.
+          </div>
+        )}
       </div>
       {!chatEnabled && !ghLoginRequired && (
         <div className="sidebar-login-info">

--- a/src/components/settings-panel.tsx
+++ b/src/components/settings-panel.tsx
@@ -982,283 +982,287 @@ function SettingsPanelComponentClaude(props: any) {
       )}
       {claudeSubTab === 'skills' && <SettingsPanelComponentSkills />}
       {claudeSubTab === 'settings' && (
-      <div className="config-dialog-body">
-        <div className="model-config-section">
-          <div className="model-config-section-header">Enable Claude mode</div>
-          <div className="model-config-section-body">
-            <div className="model-config-section-row">
-              <span>
-                This requires a{' '}
-                <a href="https://claude.ai" target="_blank">
-                  Claude
-                </a>{' '}
-                account and{' '}
-                <a href="https://code.claude.com/" target="_blank">
-                  Claude Code
-                </a>{' '}
-                installed in your system.
-              </span>
+        <div className="config-dialog-body">
+          <div className="model-config-section">
+            <div className="model-config-section-header">
+              Enable Claude mode
             </div>
-            <div className="model-config-section-row">
-              <div className="model-config-section-column">
-                <div>
-                  <CheckBoxItem
-                    header={true}
-                    label="Enable Claude mode"
-                    checked={claudeEnabled}
-                    onClick={() => {
-                      setClaudeEnabled(!claudeEnabled);
-                    }}
-                  ></CheckBoxItem>
+            <div className="model-config-section-body">
+              <div className="model-config-section-row">
+                <span>
+                  This requires a{' '}
+                  <a href="https://claude.ai" target="_blank">
+                    Claude
+                  </a>{' '}
+                  account and{' '}
+                  <a href="https://code.claude.com/" target="_blank">
+                    Claude Code
+                  </a>{' '}
+                  installed in your system.
+                </span>
+              </div>
+              <div className="model-config-section-row">
+                <div className="model-config-section-column">
+                  <div>
+                    <CheckBoxItem
+                      header={true}
+                      label="Enable Claude mode"
+                      checked={claudeEnabled}
+                      onClick={() => {
+                        setClaudeEnabled(!claudeEnabled);
+                      }}
+                    ></CheckBoxItem>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
 
-        <div className="model-config-section">
-          <div
-            className="model-config-section-header"
-            style={{ display: 'flex' }}
-          >
-            <div style={{ flexGrow: 1 }}>Models</div>
-            <div>
-              <button
-                className="jp-toast-button jp-mod-small jp-Button"
-                onClick={refreshClaudeModels}
-                disabled={loadingModels}
-              >
-                <div className="jp-Dialog-buttonLabel">
-                  {loadingModels ? 'Loading...' : 'Refresh'}
-                </div>
-              </button>
-            </div>
-          </div>
-          <div className="model-config-section-body">
-            <div className="model-config-section-row">
-              <div className="model-config-section-column">
-                <div>Chat model</div>
-                <div>
-                  <select
-                    className="jp-mod-styled"
-                    onChange={event => setChatModel(event.target.value)}
-                  >
-                    <option
-                      value={ClaudeModelType.Default}
-                      selected={chatModel === ClaudeModelType.Default}
-                    >
-                      Default (recommended)
-                    </option>
-                    {claudeModels.map(model => (
-                      <option
-                        key={model.id}
-                        value={model.id}
-                        selected={chatModel === model.id}
-                      >
-                        {model.name}
-                      </option>
-                    ))}
-                  </select>
-                </div>
+          <div className="model-config-section">
+            <div
+              className="model-config-section-header"
+              style={{ display: 'flex' }}
+            >
+              <div style={{ flexGrow: 1 }}>Models</div>
+              <div>
+                <button
+                  className="jp-toast-button jp-mod-small jp-Button"
+                  onClick={refreshClaudeModels}
+                  disabled={loadingModels}
+                >
+                  <div className="jp-Dialog-buttonLabel">
+                    {loadingModels ? 'Loading...' : 'Refresh'}
+                  </div>
+                </button>
               </div>
-              <div className="model-config-section-column">
-                <div>Auto-complete model</div>
-                <div>
-                  <select
-                    className="jp-mod-styled"
-                    onChange={event =>
-                      setInlineCompletionModel(event.target.value)
-                    }
-                  >
-                    <option
-                      value={ClaudeModelType.None}
-                      selected={inlineCompletionModel === ClaudeModelType.None}
+            </div>
+            <div className="model-config-section-body">
+              <div className="model-config-section-row">
+                <div className="model-config-section-column">
+                  <div>Chat model</div>
+                  <div>
+                    <select
+                      className="jp-mod-styled"
+                      onChange={event => setChatModel(event.target.value)}
                     >
-                      None
-                    </option>
-                    <option
-                      value={ClaudeModelType.Inherit}
-                      selected={
-                        inlineCompletionModel === ClaudeModelType.Inherit
+                      <option
+                        value={ClaudeModelType.Default}
+                        selected={chatModel === ClaudeModelType.Default}
+                      >
+                        Default (recommended)
+                      </option>
+                      {claudeModels.map(model => (
+                        <option
+                          key={model.id}
+                          value={model.id}
+                          selected={chatModel === model.id}
+                        >
+                          {model.name}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+                <div className="model-config-section-column">
+                  <div>Auto-complete model</div>
+                  <div>
+                    <select
+                      className="jp-mod-styled"
+                      onChange={event =>
+                        setInlineCompletionModel(event.target.value)
                       }
                     >
-                      Inherit from general settings
-                    </option>
-                    <option
-                      value={ClaudeModelType.Default}
-                      selected={
-                        inlineCompletionModel === ClaudeModelType.Default
-                      }
-                    >
-                      Default (recommended)
-                    </option>
-                    {claudeModels.map(model => (
                       <option
-                        key={model.id}
-                        value={model.id}
-                        selected={inlineCompletionModel === model.id}
+                        value={ClaudeModelType.None}
+                        selected={
+                          inlineCompletionModel === ClaudeModelType.None
+                        }
                       >
-                        {model.name}
+                        None
                       </option>
-                    ))}
-                  </select>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div className="model-config-section">
-          <div className="model-config-section-header">
-            Chat Agent setting sources
-          </div>
-          <div className="model-config-section-body">
-            <div className="model-config-section-row">
-              <div className="model-config-section-column">
-                <div>
-                  <CheckBoxItem
-                    header={true}
-                    label="User"
-                    checked={settingSources.includes('user')}
-                    onClick={() => {
-                      setSettingSources(
-                        settingSources.includes('user')
-                          ? settingSources.filter(
-                              (source: string) => source !== 'user'
-                            )
-                          : [...settingSources, 'user']
-                      );
-                    }}
-                  ></CheckBoxItem>
-                </div>
-              </div>
-              <div className="model-config-section-column">
-                <div>
-                  <CheckBoxItem
-                    header={true}
-                    label="Project (Jupyter root directory)"
-                    checked={settingSources.includes('project')}
-                    onClick={() => {
-                      setSettingSources(
-                        settingSources.includes('project')
-                          ? settingSources.filter(
-                              (source: string) => source !== 'project'
-                            )
-                          : [...settingSources, 'project']
-                      );
-                    }}
-                  ></CheckBoxItem>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div className="model-config-section">
-          <div className="model-config-section-header">Chat Agent tools</div>
-          <div className="model-config-section-body">
-            <div className="model-config-section-row">
-              <div className="model-config-section-column">
-                <div>
-                  <CheckBoxItem
-                    header={true}
-                    label="Claude Code tools"
-                    checked={tools.includes(ClaudeToolType.ClaudeCodeTools)}
-                    disabled={true}
-                    onClick={() => {
-                      setTools(
-                        tools.includes(ClaudeToolType.ClaudeCodeTools)
-                          ? tools.filter(
-                              (tool: string) =>
-                                tool !== ClaudeToolType.ClaudeCodeTools
-                            )
-                          : [...tools, ClaudeToolType.ClaudeCodeTools]
-                      );
-                    }}
-                  ></CheckBoxItem>
-                </div>
-              </div>
-              <div className="model-config-section-column">
-                <div>
-                  <CheckBoxItem
-                    header={true}
-                    label="Jupyter UI tools"
-                    checked={tools.includes(ClaudeToolType.JupyterUITools)}
-                    onClick={() => {
-                      setTools(
-                        tools.includes(ClaudeToolType.JupyterUITools)
-                          ? tools.filter(
-                              (tool: string) =>
-                                tool !== ClaudeToolType.JupyterUITools
-                            )
-                          : [...tools, ClaudeToolType.JupyterUITools]
-                      );
-                    }}
-                  ></CheckBoxItem>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div className="model-config-section">
-          <div className="model-config-section-header">
-            Conversation History
-          </div>
-          <div className="model-config-section-body">
-            <div className="model-config-section-row">
-              <div className="model-config-section-column">
-                <div>
-                  <CheckBoxItem
-                    header={true}
-                    label="Remember conversation history"
-                    checked={continueConversation}
-                    onClick={() => {
-                      setContinueConversation(!continueConversation);
-                    }}
-                  ></CheckBoxItem>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div className="model-config-section">
-          <div className="model-config-section-header">Claude account</div>
-          <div className="model-config-section-body">
-            <div className="model-config-section-row">
-              <div className="model-config-section-column">
-                <div className="form-field-row">
-                  <div className="form-field-description">
-                    API Key (optional)
+                      <option
+                        value={ClaudeModelType.Inherit}
+                        selected={
+                          inlineCompletionModel === ClaudeModelType.Inherit
+                        }
+                      >
+                        Inherit from general settings
+                      </option>
+                      <option
+                        value={ClaudeModelType.Default}
+                        selected={
+                          inlineCompletionModel === ClaudeModelType.Default
+                        }
+                      >
+                        Default (recommended)
+                      </option>
+                      {claudeModels.map(model => (
+                        <option
+                          key={model.id}
+                          value={model.id}
+                          selected={inlineCompletionModel === model.id}
+                        >
+                          {model.name}
+                        </option>
+                      ))}
+                    </select>
                   </div>
-                  <input
-                    name="chat-model-id-input"
-                    placeholder="API Key"
-                    className="jp-mod-styled"
-                    spellCheck={false}
-                    value={apiKey}
-                    onChange={event => setApiKey(event.target.value)}
-                  />
                 </div>
-                <div className="form-field-row">
-                  <div className="form-field-description">
-                    Base URL (optional)
+              </div>
+            </div>
+          </div>
+
+          <div className="model-config-section">
+            <div className="model-config-section-header">
+              Chat Agent setting sources
+            </div>
+            <div className="model-config-section-body">
+              <div className="model-config-section-row">
+                <div className="model-config-section-column">
+                  <div>
+                    <CheckBoxItem
+                      header={true}
+                      label="User"
+                      checked={settingSources.includes('user')}
+                      onClick={() => {
+                        setSettingSources(
+                          settingSources.includes('user')
+                            ? settingSources.filter(
+                                (source: string) => source !== 'user'
+                              )
+                            : [...settingSources, 'user']
+                        );
+                      }}
+                    ></CheckBoxItem>
                   </div>
-                  <input
-                    name="chat-model-id-input"
-                    placeholder="https://api.anthropic.com"
-                    className="jp-mod-styled"
-                    spellCheck={false}
-                    value={baseUrl}
-                    onChange={event => setBaseUrl(event.target.value)}
-                  />
+                </div>
+                <div className="model-config-section-column">
+                  <div>
+                    <CheckBoxItem
+                      header={true}
+                      label="Project (Jupyter root directory)"
+                      checked={settingSources.includes('project')}
+                      onClick={() => {
+                        setSettingSources(
+                          settingSources.includes('project')
+                            ? settingSources.filter(
+                                (source: string) => source !== 'project'
+                              )
+                            : [...settingSources, 'project']
+                        );
+                      }}
+                    ></CheckBoxItem>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="model-config-section">
+            <div className="model-config-section-header">Chat Agent tools</div>
+            <div className="model-config-section-body">
+              <div className="model-config-section-row">
+                <div className="model-config-section-column">
+                  <div>
+                    <CheckBoxItem
+                      header={true}
+                      label="Claude Code tools"
+                      checked={tools.includes(ClaudeToolType.ClaudeCodeTools)}
+                      disabled={true}
+                      onClick={() => {
+                        setTools(
+                          tools.includes(ClaudeToolType.ClaudeCodeTools)
+                            ? tools.filter(
+                                (tool: string) =>
+                                  tool !== ClaudeToolType.ClaudeCodeTools
+                              )
+                            : [...tools, ClaudeToolType.ClaudeCodeTools]
+                        );
+                      }}
+                    ></CheckBoxItem>
+                  </div>
+                </div>
+                <div className="model-config-section-column">
+                  <div>
+                    <CheckBoxItem
+                      header={true}
+                      label="Jupyter UI tools"
+                      checked={tools.includes(ClaudeToolType.JupyterUITools)}
+                      onClick={() => {
+                        setTools(
+                          tools.includes(ClaudeToolType.JupyterUITools)
+                            ? tools.filter(
+                                (tool: string) =>
+                                  tool !== ClaudeToolType.JupyterUITools
+                              )
+                            : [...tools, ClaudeToolType.JupyterUITools]
+                        );
+                      }}
+                    ></CheckBoxItem>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="model-config-section">
+            <div className="model-config-section-header">
+              Conversation History
+            </div>
+            <div className="model-config-section-body">
+              <div className="model-config-section-row">
+                <div className="model-config-section-column">
+                  <div>
+                    <CheckBoxItem
+                      header={true}
+                      label="Remember conversation history"
+                      checked={continueConversation}
+                      onClick={() => {
+                        setContinueConversation(!continueConversation);
+                      }}
+                    ></CheckBoxItem>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="model-config-section">
+            <div className="model-config-section-header">Claude account</div>
+            <div className="model-config-section-body">
+              <div className="model-config-section-row">
+                <div className="model-config-section-column">
+                  <div className="form-field-row">
+                    <div className="form-field-description">
+                      API Key (optional)
+                    </div>
+                    <input
+                      name="chat-model-id-input"
+                      placeholder="API Key"
+                      className="jp-mod-styled"
+                      spellCheck={false}
+                      value={apiKey}
+                      onChange={event => setApiKey(event.target.value)}
+                    />
+                  </div>
+                  <div className="form-field-row">
+                    <div className="form-field-description">
+                      Base URL (optional)
+                    </div>
+                    <input
+                      name="chat-model-id-input"
+                      placeholder="https://api.anthropic.com"
+                      className="jp-mod-styled"
+                      spellCheck={false}
+                      value={baseUrl}
+                      onChange={event => setBaseUrl(event.target.value)}
+                    />
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
       )}
     </div>
   );

--- a/src/components/settings-panel.tsx
+++ b/src/components/settings-panel.tsx
@@ -16,6 +16,7 @@ import {
 import { CheckBoxItem } from './checkbox';
 import { PillItem } from './pill';
 import { mcpServerSettingsToEnabledState } from './mcp-util';
+import { SettingsPanelComponentSkills } from './skills-panel';
 
 const OPENAI_COMPATIBLE_CHAT_MODEL_ID = 'openai-compatible-chat-model';
 const LITELLM_COMPATIBLE_CHAT_MODEL_ID = 'litellm-compatible-chat-model';
@@ -951,8 +952,36 @@ function SettingsPanelComponentClaude(props: any) {
     continueConversation
   ]);
 
+  const [claudeSubTab, setClaudeSubTab] = useState<'settings' | 'skills'>(
+    'settings'
+  );
+
+  useEffect(() => {
+    if (!nbiConfig.isInClaudeCodeMode && claudeSubTab !== 'settings') {
+      setClaudeSubTab('settings');
+    }
+  }, [nbiConfig.isInClaudeCodeMode, claudeSubTab]);
+
   return (
     <div className="config-dialog claude-mode-config-dialog">
+      {nbiConfig.isInClaudeCodeMode && (
+        <div className="nbi-subtab-bar">
+          <div
+            className={`nbi-subtab ${claudeSubTab === 'settings' ? 'active' : ''}`}
+            onClick={() => setClaudeSubTab('settings')}
+          >
+            Settings
+          </div>
+          <div
+            className={`nbi-subtab ${claudeSubTab === 'skills' ? 'active' : ''}`}
+            onClick={() => setClaudeSubTab('skills')}
+          >
+            Skills
+          </div>
+        </div>
+      )}
+      {claudeSubTab === 'skills' && <SettingsPanelComponentSkills />}
+      {claudeSubTab === 'settings' && (
       <div className="config-dialog-body">
         <div className="model-config-section">
           <div className="model-config-section-header">Enable Claude mode</div>
@@ -1230,6 +1259,7 @@ function SettingsPanelComponentClaude(props: any) {
           </div>
         </div>
       </div>
+      )}
     </div>
   );
 }

--- a/src/components/skills-panel.tsx
+++ b/src/components/skills-panel.tsx
@@ -1,6 +1,12 @@
 // Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
 
-import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
 import { Dialog, showDialog } from '@jupyterlab/apputils';
 import {
   ISkillDetail,
@@ -108,10 +114,7 @@ export function SettingsPanelComponentSkills(_props: any): JSX.Element {
     const result = await showDialog({
       title: 'Delete skill?',
       body: `"${skill.name}" will be deleted.`,
-      buttons: [
-        Dialog.cancelButton(),
-        Dialog.warnButton({ label: 'Delete' })
-      ]
+      buttons: [Dialog.cancelButton(), Dialog.warnButton({ label: 'Delete' })]
     });
     if (!result.button.accept) {
       return;
@@ -162,7 +165,9 @@ export function SettingsPanelComponentSkills(_props: any): JSX.Element {
   };
 
   const handleUndoDelete = async () => {
-    if (!undo) return;
+    if (!undo) {
+      return;
+    }
     const { detail, bundleFiles } = undo;
     dismissUndo();
     try {
@@ -262,7 +267,9 @@ export function SettingsPanelComponentSkills(_props: any): JSX.Element {
           </button>
           <button
             className="jp-Dialog-button jp-mod-reject jp-mod-styled"
-            onClick={() => setView({ kind: 'editor', scope: 'user', name: null })}
+            onClick={() =>
+              setView({ kind: 'editor', scope: 'user', name: null })
+            }
           >
             <div className="jp-Dialog-buttonLabel">New Skill</div>
           </button>
@@ -288,19 +295,13 @@ export function SettingsPanelComponentSkills(_props: any): JSX.Element {
       <SkillScopeSection
         scope="project"
         label={
-          context?.projectName
-            ? `PROJECT · ${context.projectName}`
-            : 'PROJECT'
+          context?.projectName ? `PROJECT · ${context.projectName}` : 'PROJECT'
         }
-        pathHint={
-          context?.projectSkillsDir || '<project>/.claude/skills/'
-        }
+        pathHint={context?.projectSkillsDir || '<project>/.claude/skills/'}
         skills={projectSkills}
         loading={loading}
         onEdit={s => setView({ kind: 'editor', scope: s.scope, name: s.name })}
-        onNew={() =>
-          setView({ kind: 'editor', scope: 'project', name: null })
-        }
+        onNew={() => setView({ kind: 'editor', scope: 'project', name: null })}
         onRename={handleRename}
         onDuplicate={handleDuplicate}
         onDelete={handleDelete}
@@ -362,7 +363,9 @@ function GitHubImportDialog(props: {
 
   const handleFetchPreview = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!canFetchPreview) return;
+    if (!canFetchPreview) {
+      return;
+    }
     setBusy(true);
     setError(null);
     try {
@@ -380,7 +383,9 @@ function GitHubImportDialog(props: {
 
   const handleInstall = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!canInstall || !preview) return;
+    if (!canInstall || !preview) {
+      return;
+    }
     setBusy(true);
     setError(null);
     try {
@@ -487,7 +492,9 @@ function GitHubImportDialog(props: {
                 </div>
               </div>
               <div className="nbi-form-field">
-                <label htmlFor="nbi-import-name">Name (optional override)</label>
+                <label htmlFor="nbi-import-name">
+                  Name (optional override)
+                </label>
                 <input
                   id="nbi-import-name"
                   type="text"
@@ -586,10 +593,7 @@ function SkillScopeSection(props: {
 }): JSX.Element {
   return (
     <div className="nbi-skills-section">
-      <div
-        className="nbi-skills-section-caption"
-        title={props.pathHint}
-      >
+      <div className="nbi-skills-section-caption" title={props.pathHint}>
         {props.label} · {props.skills.length}
       </div>
       {props.loading && props.skills.length === 0 && (
@@ -598,8 +602,7 @@ function SkillScopeSection(props: {
       {!props.loading && props.skills.length === 0 && (
         <div className="nbi-skills-empty">
           <span>
-            No {props.scope} skills. They live in{' '}
-            <code>{props.pathHint}</code>.
+            No {props.scope} skills. They live in <code>{props.pathHint}</code>.
           </span>
           <button
             className="jp-toast-button jp-mod-small jp-Button"
@@ -730,15 +733,16 @@ function SkillPromptDialog(props: {
   const conflict = props.existingNames.some(
     s => s.scope === scope && s.name === trimmed && !isUnchangedRename
   );
-  const canSubmit =
-    !busy && nameValid && !conflict && !isUnchangedRename;
+  const canSubmit = !busy && nameValid && !conflict && !isUnchangedRename;
 
   const title = isRename ? 'Rename skill' : 'Duplicate skill';
   const submitLabel = isRename ? 'Rename' : 'Duplicate';
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!canSubmit) return;
+    if (!canSubmit) {
+      return;
+    }
     setBusy(true);
     setError(null);
     try {
@@ -995,8 +999,7 @@ function SkillEditor(props: {
 
   const nameValid = SKILL_NAME_PATTERN.test(name);
   const descriptionValid = description.trim().length > 0;
-  const canSave =
-    !saving && (!effectiveIsNew || nameValid) && descriptionValid;
+  const canSave = !saving && (!effectiveIsNew || nameValid) && descriptionValid;
 
   const updateBuffer = (path: string, content: string) => {
     setBuffers(prev => {
@@ -1085,7 +1088,11 @@ function SkillEditor(props: {
           for (const path of savedPaths) {
             const b = next.get(path);
             if (b) {
-              next.set(path, { content: b.content, saved: b.content, loaded: true });
+              next.set(path, {
+                content: b.content,
+                saved: b.content,
+                loaded: true
+              });
             }
           }
           return next;
@@ -1159,10 +1166,7 @@ function SkillEditor(props: {
     const result = await showDialog({
       title: 'Delete file?',
       body: `"${path}" will be permanently deleted.`,
-      buttons: [
-        Dialog.cancelButton(),
-        Dialog.warnButton({ label: 'Delete' })
-      ]
+      buttons: [Dialog.cancelButton(), Dialog.warnButton({ label: 'Delete' })]
     });
     if (!result.button.accept) {
       return;
@@ -1291,7 +1295,9 @@ function SkillEditor(props: {
           >
             Skills
           </button>
-          <span className="nbi-breadcrumb-separator" aria-hidden="true">/</span>
+          <span className="nbi-breadcrumb-separator" aria-hidden="true">
+            /
+          </span>
           <span className="nbi-breadcrumb-current">
             {effectiveIsNew ? 'New skill' : effectiveName}
           </span>
@@ -1313,7 +1319,8 @@ function SkillEditor(props: {
               {saving ? 'Saving…' : 'Save'}
               {anyDirty && (
                 <span className="nbi-dirty-marker" aria-label="Unsaved changes">
-                  {' '}•
+                  {' '}
+                  •
                 </span>
               )}
             </div>
@@ -1453,7 +1460,9 @@ function BundleFileTabs(props: {
   const [adding, setAdding] = useState(false);
 
   useEffect(() => {
-    if (!openMenu) return;
+    if (!openMenu) {
+      return;
+    }
     const onDocClick = () => setOpenMenu(null);
     document.addEventListener('click', onDocClick);
     return () => document.removeEventListener('click', onDocClick);
@@ -1656,9 +1665,7 @@ function AllowedToolsPicker(props: {
           onChange={e => setDraft(e.target.value)}
           onKeyDown={handleKeyDown}
           onBlur={() => draft.trim() && commit(draft)}
-          placeholder={
-            props.value.length === 0 ? 'e.g. Bash(git:*)' : ''
-          }
+          placeholder={props.value.length === 0 ? 'e.g. Bash(git:*)' : ''}
         />
       </div>
       <div className="nbi-tools-picker-suggestions">
@@ -1699,7 +1706,10 @@ function AutoGrowTextarea(props: {
         : parsed;
     }
     ta.style.height = 'auto';
-    const next = Math.max(ta.scrollHeight, props.minRows * lineHeightRef.current);
+    const next = Math.max(
+      ta.scrollHeight,
+      props.minRows * lineHeightRef.current
+    );
     ta.style.height = `${next}px`;
   }, [props.value, props.minRows]);
 
@@ -1714,4 +1724,3 @@ function AutoGrowTextarea(props: {
     />
   );
 }
-

--- a/src/components/skills-panel.tsx
+++ b/src/components/skills-panel.tsx
@@ -1,0 +1,1706 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { Dialog, showDialog } from '@jupyterlab/apputils';
+import {
+  ISkillDetail,
+  ISkillImportPreview,
+  ISkillsContext,
+  ISkillSummary,
+  NBIAPI,
+  SkillScope
+} from '../api';
+
+// Must match SKILL_NAME_PATTERN in notebook_intelligence/skillset.py
+const SKILL_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
+const SKILL_NAME_REQUIREMENT =
+  'Must be lowercase letters, digits, or hyphens (starting with a letter or digit), max 64 chars.';
+const SKILL_ENTRY_FILE = 'SKILL.md';
+const COMMON_TOOLS = [
+  'Read',
+  'Write',
+  'Edit',
+  'Bash',
+  'Glob',
+  'Grep',
+  'Task',
+  'TodoWrite',
+  'WebFetch',
+  'WebSearch',
+  'NotebookEdit'
+];
+
+type ViewMode =
+  | { kind: 'list' }
+  | { kind: 'editor'; scope: SkillScope; name: string | null };
+
+type PromptMode =
+  | null
+  | { kind: 'rename'; skill: ISkillSummary }
+  | { kind: 'duplicate'; skill: ISkillSummary };
+
+interface IUndoState {
+  detail: ISkillDetail;
+  bundleFiles: { path: string; content: string }[];
+  timerId: number;
+}
+
+export function SettingsPanelComponentSkills(_props: any): JSX.Element {
+  const [skills, setSkills] = useState<ISkillSummary[]>([]);
+  const [context, setContext] = useState<ISkillsContext | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [view, setView] = useState<ViewMode>({ kind: 'list' });
+  const [prompt, setPrompt] = useState<PromptMode>(null);
+  const [undo, setUndo] = useState<IUndoState | null>(null);
+  const [importOpen, setImportOpen] = useState(false);
+
+  const refresh = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const list = await NBIAPI.listSkills();
+      setSkills(list);
+    } catch (e: any) {
+      setError(e?.message ?? String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+    NBIAPI.getSkillsContext()
+      .then(setContext)
+      .catch(() => {
+        // Non-fatal — panel still works without the context hints.
+      });
+    const listener = () => {
+      refresh();
+    };
+    NBIAPI.skillsReloaded.connect(listener);
+    return () => {
+      NBIAPI.skillsReloaded.disconnect(listener);
+    };
+  }, []);
+
+  const undoRef = useRef<IUndoState | null>(null);
+  undoRef.current = undo;
+
+  const dismissUndo = () => {
+    setUndo(prev => {
+      if (prev) {
+        window.clearTimeout(prev.timerId);
+      }
+      return null;
+    });
+  };
+
+  useEffect(() => {
+    return () => {
+      if (undoRef.current) {
+        window.clearTimeout(undoRef.current.timerId);
+      }
+    };
+  }, []);
+
+  const handleDelete = async (skill: ISkillSummary) => {
+    // Snapshot the full bundle (SKILL.md + helper files) *before* deleting so the Undo
+    // toast can recreate it byte-for-byte. The backend only exposes a shallow delete
+    // API, so restoration is the client's job.
+    let detail: ISkillDetail;
+    try {
+      detail = await NBIAPI.readSkill(skill.scope, skill.name);
+    } catch (e: any) {
+      setError(`Failed to read skill: ${e?.message ?? e}`);
+      return;
+    }
+    const pathsToSnapshot = (detail.files ?? []).filter(
+      p => p !== SKILL_ENTRY_FILE
+    );
+    const snapshots = await Promise.all(
+      pathsToSnapshot.map(async path => {
+        try {
+          const content = await NBIAPI.readBundleFile(
+            skill.scope,
+            skill.name,
+            path
+          );
+          return { path, content };
+        } catch {
+          // Best-effort snapshot — skip unreadable files.
+          return null;
+        }
+      })
+    );
+    const bundleFiles = snapshots.filter(
+      (s): s is { path: string; content: string } => s !== null
+    );
+    try {
+      await NBIAPI.deleteSkill(skill.scope, skill.name);
+      await refresh();
+    } catch (e: any) {
+      setError(`Failed to delete skill: ${e?.message ?? e}`);
+      return;
+    }
+    dismissUndo();
+    const timerId = window.setTimeout(() => {
+      setUndo(null);
+    }, 8000);
+    setUndo({ detail, bundleFiles, timerId });
+  };
+
+  const handleUndoDelete = async () => {
+    if (!undo) return;
+    const { detail, bundleFiles } = undo;
+    dismissUndo();
+    try {
+      await NBIAPI.createSkill({
+        scope: detail.scope,
+        name: detail.name,
+        description: detail.description,
+        allowedTools: detail.allowedTools,
+        body: detail.body
+      });
+      await Promise.all(
+        bundleFiles.map(({ path, content }) =>
+          NBIAPI.writeBundleFile(
+            detail.scope,
+            detail.name,
+            path,
+            content
+          ).catch(() => {
+            // Non-fatal — skill is restored even if a bundle file fails.
+          })
+        )
+      );
+      await refresh();
+    } catch (e: any) {
+      setError(`Failed to restore skill: ${e?.message ?? e}`);
+    }
+  };
+
+  const handleRename = (skill: ISkillSummary) => {
+    setPrompt({ kind: 'rename', skill });
+  };
+
+  const handleDuplicate = (skill: ISkillSummary) => {
+    setPrompt({ kind: 'duplicate', skill });
+  };
+
+  const commitRename = async (skill: ISkillSummary, newName: string) => {
+    await NBIAPI.renameSkill(skill.scope, skill.name, newName);
+    setPrompt(null);
+    await refresh();
+  };
+
+  const commitDuplicate = async (
+    skill: ISkillSummary,
+    targetScope: SkillScope,
+    newName: string
+  ) => {
+    const detail = await NBIAPI.readSkill(skill.scope, skill.name);
+    await NBIAPI.createSkill({
+      scope: targetScope,
+      name: newName,
+      description: detail.description,
+      allowedTools: detail.allowedTools,
+      body: detail.body
+    });
+    const filesToCopy = detail.files.filter(f => f !== SKILL_ENTRY_FILE);
+    await Promise.all(
+      filesToCopy.map(async file => {
+        const content = await NBIAPI.readBundleFile(
+          skill.scope,
+          skill.name,
+          file
+        );
+        await NBIAPI.writeBundleFile(targetScope, newName, file, content);
+      })
+    );
+    setPrompt(null);
+    await refresh();
+  };
+
+  if (view.kind === 'editor') {
+    return (
+      <SkillEditor
+        scope={view.scope}
+        name={view.name}
+        onClose={async () => {
+          await refresh();
+          setView({ kind: 'list' });
+        }}
+      />
+    );
+  }
+
+  const userSkills = skills.filter(s => s.scope === 'user');
+  const projectSkills = skills.filter(s => s.scope === 'project');
+
+  return (
+    <div className="config-dialog-body nbi-skills-panel">
+      <div className="nbi-skills-header">
+        <div className="nbi-skills-title">Claude Skills</div>
+        <div className="nbi-skills-header-actions">
+          <button
+            className="jp-Dialog-button jp-mod-reject jp-mod-styled"
+            onClick={() => setImportOpen(true)}
+          >
+            <div className="jp-Dialog-buttonLabel">Import from GitHub</div>
+          </button>
+          <button
+            className="jp-Dialog-button jp-mod-reject jp-mod-styled"
+            onClick={() => setView({ kind: 'editor', scope: 'user', name: null })}
+          >
+            <div className="jp-Dialog-buttonLabel">New Skill</div>
+          </button>
+        </div>
+      </div>
+      {error && (
+        <div className="nbi-skills-error" role="alert">
+          {error}
+        </div>
+      )}
+      <SkillScopeSection
+        scope="user"
+        label="USER"
+        pathHint={context?.userSkillsDir || '~/.claude/skills/'}
+        skills={userSkills}
+        loading={loading}
+        onEdit={s => setView({ kind: 'editor', scope: s.scope, name: s.name })}
+        onNew={() => setView({ kind: 'editor', scope: 'user', name: null })}
+        onRename={handleRename}
+        onDuplicate={handleDuplicate}
+        onDelete={handleDelete}
+      />
+      <SkillScopeSection
+        scope="project"
+        label={
+          context?.projectName
+            ? `PROJECT · ${context.projectName}`
+            : 'PROJECT'
+        }
+        pathHint={
+          context?.projectSkillsDir || '<project>/.claude/skills/'
+        }
+        skills={projectSkills}
+        loading={loading}
+        onEdit={s => setView({ kind: 'editor', scope: s.scope, name: s.name })}
+        onNew={() =>
+          setView({ kind: 'editor', scope: 'project', name: null })
+        }
+        onRename={handleRename}
+        onDuplicate={handleDuplicate}
+        onDelete={handleDelete}
+      />
+      {prompt && (
+        <SkillPromptDialog
+          prompt={prompt}
+          existingNames={skills}
+          onCancel={() => setPrompt(null)}
+          onRename={commitRename}
+          onDuplicate={commitDuplicate}
+        />
+      )}
+      {undo && (
+        <UndoToast
+          message={`Deleted "${undo.detail.name}"`}
+          onUndo={handleUndoDelete}
+          onDismiss={dismissUndo}
+        />
+      )}
+      {importOpen && (
+        <GitHubImportDialog
+          onCancel={() => setImportOpen(false)}
+          onImported={async () => {
+            setImportOpen(false);
+            await refresh();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function GitHubImportDialog(props: {
+  onCancel: () => void;
+  onImported: () => Promise<void> | void;
+}): JSX.Element {
+  type Step = 'url' | 'preview';
+  const [step, setStep] = useState<Step>('url');
+  const [url, setUrl] = useState('');
+  const [scope, setScope] = useState<SkillScope>('user');
+  const [preview, setPreview] = useState<ISkillImportPreview | null>(null);
+  const [nameOverride, setNameOverride] = useState('');
+  const [overwrite, setOverwrite] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const effectiveName = (nameOverride.trim() || preview?.name || '').trim();
+  const nameValid = SKILL_NAME_PATTERN.test(effectiveName);
+  const collides =
+    preview !== null &&
+    ((scope === 'user' && preview.existsInUserScope) ||
+      (scope === 'project' && preview.existsInProjectScope)) &&
+    effectiveName === preview.name;
+
+  const canFetchPreview = !busy && url.trim().length > 0;
+  const canInstall =
+    !busy && preview !== null && nameValid && (!collides || overwrite);
+
+  const handleFetchPreview = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canFetchPreview) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const p = await NBIAPI.previewSkillImport(url.trim());
+      setPreview(p);
+      setNameOverride('');
+      setOverwrite(false);
+      setStep('preview');
+    } catch (err: any) {
+      setError(err?.message ?? String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleInstall = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canInstall || !preview) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await NBIAPI.importSkill({
+        url: url.trim(),
+        scope,
+        name: effectiveName !== preview.name ? effectiveName : undefined,
+        overwrite: collides ? true : undefined
+      });
+      await props.onImported();
+    } catch (err: any) {
+      setError(err?.message ?? String(err));
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="nbi-modal-backdrop" onClick={props.onCancel}>
+      <form
+        className="nbi-modal-card"
+        onClick={e => e.stopPropagation()}
+        onSubmit={step === 'url' ? handleFetchPreview : handleInstall}
+      >
+        <div className="nbi-modal-title">Import skill from GitHub</div>
+        <div className="nbi-modal-body">
+          {step === 'url' && (
+            <>
+              <div className="nbi-form-field">
+                <label htmlFor="nbi-import-url">GitHub repo URL</label>
+                <input
+                  id="nbi-import-url"
+                  type="text"
+                  autoFocus
+                  value={url}
+                  onChange={e => setUrl(e.target.value)}
+                  placeholder="https://github.com/owner/repo or .../tree/main/path/to/skill"
+                  onKeyDown={e => {
+                    if (e.key === 'Escape') {
+                      e.preventDefault();
+                      props.onCancel();
+                    }
+                  }}
+                />
+                <div className="nbi-form-hint">
+                  Public repos only. Link to the repo root, a branch, or a
+                  subdirectory containing <code>SKILL.md</code>.
+                </div>
+              </div>
+              <div className="nbi-form-field">
+                <label htmlFor="nbi-import-scope">Install into</label>
+                <select
+                  id="nbi-import-scope"
+                  value={scope}
+                  onChange={e => setScope(e.target.value as SkillScope)}
+                >
+                  <option value="user">User (available in all projects)</option>
+                  <option value="project">Project (this project only)</option>
+                </select>
+              </div>
+            </>
+          )}
+          {step === 'preview' && preview && (
+            <>
+              <div className="nbi-import-preview">
+                <div className="nbi-import-preview-row">
+                  <span className="nbi-import-preview-label">Name</span>
+                  <span className="nbi-import-preview-value">
+                    {preview.name}
+                  </span>
+                </div>
+                {preview.description && (
+                  <div className="nbi-import-preview-row">
+                    <span className="nbi-import-preview-label">
+                      Description
+                    </span>
+                    <span className="nbi-import-preview-value">
+                      {preview.description}
+                    </span>
+                  </div>
+                )}
+                {preview.allowedTools.length > 0 && (
+                  <div className="nbi-import-preview-row">
+                    <span className="nbi-import-preview-label">
+                      Allowed tools
+                    </span>
+                    <span className="nbi-import-preview-value">
+                      {preview.allowedTools.join(', ')}
+                    </span>
+                  </div>
+                )}
+                <div className="nbi-import-preview-row">
+                  <span className="nbi-import-preview-label">Files</span>
+                  <span className="nbi-import-preview-value">
+                    SKILL.md
+                    {preview.files.length > 0 &&
+                      ` + ${preview.files.length} other${preview.files.length === 1 ? '' : 's'}`}
+                  </span>
+                </div>
+                <div className="nbi-import-preview-row">
+                  <span className="nbi-import-preview-label">Source</span>
+                  <span className="nbi-import-preview-value nbi-import-preview-source">
+                    {preview.canonicalUrl}
+                  </span>
+                </div>
+              </div>
+              <div className="nbi-form-field">
+                <label htmlFor="nbi-import-name">Name (optional override)</label>
+                <input
+                  id="nbi-import-name"
+                  type="text"
+                  value={nameOverride}
+                  onChange={e => setNameOverride(e.target.value)}
+                  placeholder={preview.name}
+                  aria-invalid={
+                    effectiveName.length > 0 && !nameValid ? true : undefined
+                  }
+                />
+                {effectiveName.length > 0 && !nameValid && (
+                  <div className="nbi-form-field-error">
+                    {SKILL_NAME_REQUIREMENT}
+                  </div>
+                )}
+              </div>
+              {collides && (
+                <div className="nbi-form-field">
+                  <label className="nbi-checkbox-label">
+                    <input
+                      type="checkbox"
+                      checked={overwrite}
+                      onChange={e => setOverwrite(e.target.checked)}
+                    />
+                    Overwrite existing {scope} skill "{preview.name}"
+                  </label>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+        {error && (
+          <div className="nbi-skills-error" role="alert">
+            {error}
+          </div>
+        )}
+        <div className="nbi-modal-actions">
+          {step === 'preview' && (
+            <button
+              type="button"
+              className="jp-Dialog-button jp-mod-reject jp-mod-styled"
+              onClick={() => {
+                setStep('url');
+                setPreview(null);
+                setError(null);
+              }}
+            >
+              <div className="jp-Dialog-buttonLabel">Back</div>
+            </button>
+          )}
+          <button
+            type="button"
+            className="jp-Dialog-button jp-mod-reject jp-mod-styled"
+            onClick={props.onCancel}
+          >
+            <div className="jp-Dialog-buttonLabel">Cancel</div>
+          </button>
+          {step === 'url' ? (
+            <button
+              type="submit"
+              className="jp-Dialog-button jp-mod-accept jp-mod-styled"
+              disabled={!canFetchPreview}
+            >
+              <div className="jp-Dialog-buttonLabel">
+                {busy ? 'Fetching…' : 'Next'}
+              </div>
+            </button>
+          ) : (
+            <button
+              type="submit"
+              className="jp-Dialog-button jp-mod-accept jp-mod-styled"
+              disabled={!canInstall}
+            >
+              <div className="jp-Dialog-buttonLabel">
+                {busy ? 'Installing…' : 'Install'}
+              </div>
+            </button>
+          )}
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function SkillScopeSection(props: {
+  scope: SkillScope;
+  label: string;
+  pathHint: string;
+  skills: ISkillSummary[];
+  loading: boolean;
+  onEdit: (skill: ISkillSummary) => void;
+  onNew: () => void;
+  onRename: (skill: ISkillSummary) => void;
+  onDuplicate: (skill: ISkillSummary) => void;
+  onDelete: (skill: ISkillSummary) => void;
+}): JSX.Element {
+  return (
+    <div className="nbi-skills-section">
+      <div
+        className="nbi-skills-section-caption"
+        title={props.pathHint}
+      >
+        {props.label} · {props.skills.length}
+      </div>
+      {props.loading && props.skills.length === 0 && (
+        <div className="nbi-skills-empty">Loading…</div>
+      )}
+      {!props.loading && props.skills.length === 0 && (
+        <div className="nbi-skills-empty">
+          <span>
+            No {props.scope} skills. They live in{' '}
+            <code>{props.pathHint}</code>.
+          </span>
+          <button
+            className="jp-toast-button jp-mod-small jp-Button"
+            onClick={props.onNew}
+          >
+            <div className="jp-Dialog-buttonLabel">
+              + New {props.scope} skill
+            </div>
+          </button>
+        </div>
+      )}
+      {props.skills.map(skill => (
+        <SkillRow
+          key={`${skill.scope}:${skill.name}`}
+          skill={skill}
+          onEdit={() => props.onEdit(skill)}
+          onRename={() => props.onRename(skill)}
+          onDuplicate={() => props.onDuplicate(skill)}
+          onDelete={() => props.onDelete(skill)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function SkillRow(props: {
+  skill: ISkillSummary;
+  onEdit: () => void;
+  onRename: () => void;
+  onDuplicate: () => void;
+  onDelete: () => void;
+}): JSX.Element {
+  const { skill } = props;
+  const stopAnd = (fn: () => void) => (e: React.MouseEvent) => {
+    e.stopPropagation();
+    fn();
+  };
+  return (
+    <div
+      className="nbi-skill-row"
+      onClick={props.onEdit}
+      role="button"
+      tabIndex={0}
+      onKeyDown={e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          props.onEdit();
+        }
+      }}
+    >
+      <div className="nbi-skill-row-main">
+        <div className="nbi-skill-row-name">{skill.name}</div>
+        {skill.description && (
+          <div className="nbi-skill-row-description">{skill.description}</div>
+        )}
+      </div>
+      <div className="nbi-skill-row-actions" onClick={e => e.stopPropagation()}>
+        <button
+          type="button"
+          className="nbi-icon-button"
+          aria-label="Edit skill"
+          title="Edit"
+          onClick={stopAnd(props.onEdit)}
+        >
+          ✎
+        </button>
+        <button
+          type="button"
+          className="nbi-icon-button"
+          aria-label="Rename skill"
+          title="Rename"
+          onClick={stopAnd(props.onRename)}
+        >
+          Aa
+        </button>
+        <button
+          type="button"
+          className="nbi-icon-button"
+          aria-label="Duplicate skill"
+          title="Duplicate"
+          onClick={stopAnd(props.onDuplicate)}
+        >
+          ⧉
+        </button>
+        <button
+          type="button"
+          className="nbi-icon-button danger"
+          aria-label="Delete skill"
+          title="Delete"
+          onClick={stopAnd(props.onDelete)}
+        >
+          🗑
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function SkillPromptDialog(props: {
+  prompt: Exclude<PromptMode, null>;
+  existingNames: ISkillSummary[];
+  onCancel: () => void;
+  onRename: (skill: ISkillSummary, newName: string) => Promise<void>;
+  onDuplicate: (
+    skill: ISkillSummary,
+    scope: SkillScope,
+    newName: string
+  ) => Promise<void>;
+}): JSX.Element {
+  const { prompt } = props;
+  const isRename = prompt.kind === 'rename';
+  const initialName = isRename
+    ? prompt.skill.name
+    : `${prompt.skill.name}-copy`;
+  const initialScope: SkillScope = isRename
+    ? prompt.skill.scope
+    : prompt.skill.scope === 'user'
+      ? 'project'
+      : 'user';
+  const [name, setName] = useState(initialName);
+  const [scope, setScope] = useState<SkillScope>(initialScope);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const trimmed = name.trim();
+  const nameValid = SKILL_NAME_PATTERN.test(trimmed);
+  const isUnchangedRename = isRename && trimmed === prompt.skill.name;
+  const conflict = props.existingNames.some(
+    s => s.scope === scope && s.name === trimmed && !isUnchangedRename
+  );
+  const canSubmit =
+    !busy && nameValid && !conflict && !isUnchangedRename;
+
+  const title = isRename ? 'Rename skill' : 'Duplicate skill';
+  const submitLabel = isRename ? 'Rename' : 'Duplicate';
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setBusy(true);
+    setError(null);
+    try {
+      if (isRename) {
+        await props.onRename(prompt.skill, trimmed);
+      } else {
+        await props.onDuplicate(prompt.skill, scope, trimmed);
+      }
+    } catch (err: any) {
+      setError(err?.message ?? String(err));
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="nbi-modal-backdrop" onClick={props.onCancel}>
+      <form
+        className="nbi-modal-card"
+        onClick={e => e.stopPropagation()}
+        onSubmit={handleSubmit}
+      >
+        <div className="nbi-modal-title">{title}</div>
+        <div className="nbi-modal-body">
+          {!isRename && (
+            <div className="nbi-form-field">
+              <label htmlFor="nbi-dup-scope">Target scope</label>
+              <select
+                id="nbi-dup-scope"
+                value={scope}
+                onChange={e => setScope(e.target.value as SkillScope)}
+              >
+                <option value="user">User</option>
+                <option value="project">Project</option>
+              </select>
+            </div>
+          )}
+          <div className="nbi-form-field">
+            <label htmlFor="nbi-prompt-name">New name</label>
+            <input
+              id="nbi-prompt-name"
+              type="text"
+              autoFocus
+              value={name}
+              onChange={e => setName(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Escape') {
+                  e.preventDefault();
+                  props.onCancel();
+                }
+              }}
+              aria-invalid={
+                (!nameValid && trimmed.length > 0) || conflict
+                  ? true
+                  : undefined
+              }
+            />
+            {trimmed.length > 0 && !nameValid && (
+              <div className="nbi-form-field-error">
+                {SKILL_NAME_REQUIREMENT}
+              </div>
+            )}
+            {conflict && (
+              <div className="nbi-form-field-error">
+                A {scope} skill named "{trimmed}" already exists.
+              </div>
+            )}
+          </div>
+        </div>
+        {error && (
+          <div className="nbi-skills-error" role="alert">
+            {error}
+          </div>
+        )}
+        <div className="nbi-modal-actions">
+          <button
+            type="button"
+            className="jp-Dialog-button jp-mod-reject jp-mod-styled"
+            onClick={props.onCancel}
+          >
+            <div className="jp-Dialog-buttonLabel">Cancel</div>
+          </button>
+          <button
+            type="submit"
+            className="jp-Dialog-button jp-mod-accept jp-mod-styled"
+            disabled={!canSubmit}
+          >
+            <div className="jp-Dialog-buttonLabel">
+              {busy ? 'Working…' : submitLabel}
+            </div>
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function UndoToast(props: {
+  message: string;
+  onUndo: () => void;
+  onDismiss: () => void;
+}): JSX.Element {
+  return (
+    <div className="nbi-undo-toast" role="status">
+      <span className="nbi-undo-toast-message">{props.message}</span>
+      <button
+        type="button"
+        className="nbi-undo-toast-action"
+        onClick={props.onUndo}
+      >
+        Undo
+      </button>
+      <button
+        type="button"
+        className="nbi-undo-toast-close"
+        aria-label="Dismiss"
+        onClick={props.onDismiss}
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+
+interface IFileBuffer {
+  content: string;
+  saved: string;
+  loaded: boolean;
+}
+
+function SkillEditor(props: {
+  scope: SkillScope;
+  name: string | null;
+  onClose: () => void;
+}): JSX.Element {
+  const isNew = props.name === null;
+  const [scope, setScope] = useState<SkillScope>(props.scope);
+  const [name, setName] = useState(props.name ?? '');
+  const [description, setDescription] = useState('');
+  const [allowedTools, setAllowedTools] = useState<string[]>([]);
+  const [savedMeta, setSavedMeta] = useState({
+    description: '',
+    allowedTools: [] as string[]
+  });
+  // Bundle files are lazy-loaded when the user switches to their tab (see the fetch effect
+  // below). `loaded: false` means we know the file exists on disk but haven't fetched its
+  // content yet. SKILL.md is always loaded eagerly in loadSkill().
+  const [buffers, setBuffers] = useState<Map<string, IFileBuffer>>(
+    new Map([[SKILL_ENTRY_FILE, { content: '', saved: '', loaded: true }]])
+  );
+  const orderedFileList = useMemo(
+    () => [
+      SKILL_ENTRY_FILE,
+      ...Array.from(buffers.keys())
+        .filter(f => f !== SKILL_ENTRY_FILE)
+        .sort()
+    ],
+    [buffers]
+  );
+  const [activeFile, setActiveFile] = useState<string>(SKILL_ENTRY_FILE);
+  const [renaming, setRenaming] = useState<string | null>(null);
+  const [renameDraft, setRenameDraft] = useState('');
+  const [addFileDraft, setAddFileDraft] = useState('');
+  const [loading, setLoading] = useState(!isNew);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hasCreated, setHasCreated] = useState(false);
+  const errorRef = useRef<HTMLDivElement>(null);
+
+  const effectiveName = isNew && !hasCreated ? name : (props.name ?? name);
+  const effectiveIsNew = isNew && !hasCreated;
+
+  const loadSkill = async (s: SkillScope, n: string) => {
+    const skill: ISkillDetail = await NBIAPI.readSkill(s, n);
+    setDescription(skill.description);
+    setAllowedTools(skill.allowedTools ?? []);
+    const skillMdBody = skill.body ?? '';
+    setSavedMeta({
+      description: skill.description,
+      allowedTools: skill.allowedTools ?? []
+    });
+    const newBuffers = new Map<string, IFileBuffer>();
+    newBuffers.set(SKILL_ENTRY_FILE, {
+      content: skillMdBody,
+      saved: skillMdBody,
+      loaded: true
+    });
+    for (const file of skill.files ?? []) {
+      if (file !== SKILL_ENTRY_FILE) {
+        newBuffers.set(file, { content: '', saved: '', loaded: false });
+      }
+    }
+    setBuffers(newBuffers);
+    setActiveFile(SKILL_ENTRY_FILE);
+  };
+
+  useEffect(() => {
+    if (isNew) {
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        await loadSkill(props.scope, props.name as string);
+      } catch (e: any) {
+        if (!cancelled) {
+          setError(e?.message ?? String(e));
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isNew, props.scope, props.name]);
+
+  useEffect(() => {
+    if (isNew && !hasCreated) {
+      return;
+    }
+    const onReload = () => {
+      const skillName = props.name ?? (hasCreated ? name : null);
+      if (!skillName) {
+        return;
+      }
+      loadSkill(props.scope, skillName).catch((e: any) => {
+        setError(e?.message ?? String(e));
+      });
+    };
+    NBIAPI.skillsReloaded.connect(onReload);
+    return () => {
+      NBIAPI.skillsReloaded.disconnect(onReload);
+    };
+  }, [isNew, hasCreated, props.scope, props.name, name]);
+
+  useEffect(() => {
+    if (error) {
+      errorRef.current?.scrollIntoView({ block: 'nearest' });
+    }
+  }, [error]);
+
+  const metaDirty =
+    description !== savedMeta.description ||
+    allowedTools.length !== savedMeta.allowedTools.length ||
+    allowedTools.some((t, i) => t !== savedMeta.allowedTools[i]);
+  const fileDirty = (path: string): boolean => {
+    const b = buffers.get(path);
+    return b !== undefined && b.content !== b.saved;
+  };
+  const anyFileDirty = Array.from(buffers.keys()).some(fileDirty);
+  const anyDirty = metaDirty || anyFileDirty;
+
+  const nameValid = SKILL_NAME_PATTERN.test(name);
+  const descriptionValid = description.trim().length > 0;
+  const canSave =
+    !saving && (!effectiveIsNew || nameValid) && descriptionValid;
+
+  const updateBuffer = (path: string, content: string) => {
+    setBuffers(prev => {
+      const next = new Map(prev);
+      const existing = next.get(path) ?? {
+        content: '',
+        saved: '',
+        loaded: true
+      };
+      next.set(path, { ...existing, content });
+      return next;
+    });
+  };
+
+  const currentBuffer = buffers.get(activeFile)?.content ?? '';
+
+  const handleSave = async () => {
+    setError(null);
+    if (effectiveIsNew && !nameValid) {
+      setError(`Invalid name. ${SKILL_NAME_REQUIREMENT}`);
+      return;
+    }
+    setSaving(true);
+    try {
+      if (effectiveIsNew) {
+        const initialBody = buffers.get(SKILL_ENTRY_FILE)?.content ?? '';
+        await NBIAPI.createSkill({
+          scope,
+          name,
+          description,
+          allowedTools,
+          body: initialBody
+        });
+        const extraFiles = Array.from(buffers.entries()).filter(
+          ([p]) => p !== SKILL_ENTRY_FILE
+        );
+        for (const [path, buf] of extraFiles) {
+          try {
+            await NBIAPI.writeBundleFile(scope, name, path, buf.content);
+          } catch (e: any) {
+            setError(`${path}: ${e?.message ?? String(e)}`);
+          }
+        }
+        setHasCreated(true);
+        await loadSkill(scope, name);
+      } else {
+        const skillName = effectiveName;
+        const dirtyFilePaths = Array.from(buffers.keys()).filter(
+          p => p !== SKILL_ENTRY_FILE && fileDirty(p)
+        );
+        const skillMdBody = buffers.get(SKILL_ENTRY_FILE)?.content ?? '';
+        const skillMdDirty = fileDirty(SKILL_ENTRY_FILE);
+        const savedPaths = new Set<string>();
+        const fileResults = await Promise.allSettled(
+          dirtyFilePaths.map(p =>
+            NBIAPI.writeBundleFile(scope, skillName, p, buffers.get(p)!.content)
+          )
+        );
+        const errors: string[] = [];
+        fileResults.forEach((result, i) => {
+          const p = dirtyFilePaths[i];
+          if (result.status === 'fulfilled') {
+            savedPaths.add(p);
+          } else {
+            errors.push(`${p}: ${result.reason?.message ?? result.reason}`);
+          }
+        });
+        let metaSaved = !(metaDirty || skillMdDirty);
+        if (metaDirty || skillMdDirty) {
+          try {
+            await NBIAPI.updateSkill(scope, skillName, {
+              description,
+              allowedTools,
+              body: skillMdBody
+            });
+            metaSaved = true;
+            if (skillMdDirty) {
+              savedPaths.add(SKILL_ENTRY_FILE);
+            }
+          } catch (e: any) {
+            errors.push(e?.message ?? String(e));
+          }
+        }
+        setBuffers(prev => {
+          const next = new Map(prev);
+          for (const path of savedPaths) {
+            const b = next.get(path);
+            if (b) {
+              next.set(path, { content: b.content, saved: b.content, loaded: true });
+            }
+          }
+          return next;
+        });
+        if (metaSaved) {
+          setSavedMeta({ description, allowedTools });
+        }
+        if (errors.length > 0) {
+          setError(errors.join('\n'));
+        }
+      }
+    } catch (e: any) {
+      setError(e?.message ?? String(e));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleBack = async () => {
+    if (anyDirty) {
+      const result = await showDialog({
+        title: 'Discard unsaved changes?',
+        body: 'This skill has unsaved changes. Discard them?',
+        buttons: [
+          Dialog.cancelButton({ label: 'Keep editing' }),
+          Dialog.warnButton({ label: 'Discard' })
+        ]
+      });
+      if (!result.button.accept) {
+        return;
+      }
+    }
+    props.onClose();
+  };
+
+  const handleSelectFile = (path: string) => {
+    if (path === activeFile) {
+      return;
+    }
+    setActiveFile(path);
+  };
+
+  const handleAddFile = async () => {
+    const relPath = addFileDraft.trim();
+    if (!relPath) {
+      return;
+    }
+    if (buffers.has(relPath)) {
+      setError(`"${relPath}" already exists in this bundle.`);
+      return;
+    }
+    try {
+      if (!effectiveIsNew) {
+        await NBIAPI.writeBundleFile(scope, effectiveName, relPath, '');
+      }
+      setBuffers(prev => {
+        const next = new Map(prev);
+        // For new skills, mark as dirty (saved='' vs content='' — equal, so not dirty;
+        // but the initial empty file write happens on skill creation save).
+        next.set(relPath, { content: '', saved: '', loaded: true });
+        return next;
+      });
+      setActiveFile(relPath);
+      setAddFileDraft('');
+    } catch (e: any) {
+      setError(e?.message ?? String(e));
+    }
+  };
+
+  const handleDeleteFile = async (path: string) => {
+    const result = await showDialog({
+      title: 'Delete file?',
+      body: `"${path}" will be permanently deleted.`,
+      buttons: [
+        Dialog.cancelButton(),
+        Dialog.warnButton({ label: 'Delete' })
+      ]
+    });
+    if (!result.button.accept) {
+      return;
+    }
+    try {
+      if (!effectiveIsNew) {
+        await NBIAPI.deleteBundleFile(scope, effectiveName, path);
+      }
+      setBuffers(prev => {
+        const next = new Map(prev);
+        next.delete(path);
+        return next;
+      });
+      if (activeFile === path) {
+        setActiveFile(SKILL_ENTRY_FILE);
+      }
+    } catch (e: any) {
+      setError(e?.message ?? String(e));
+    }
+  };
+
+  const handleBeginRename = (path: string) => {
+    setRenaming(path);
+    setRenameDraft(path);
+  };
+
+  const handleCommitRename = async () => {
+    if (renaming === null) {
+      return;
+    }
+    const newPath = renameDraft.trim();
+    if (!newPath || newPath === renaming) {
+      setRenaming(null);
+      return;
+    }
+    try {
+      if (!effectiveIsNew) {
+        await NBIAPI.renameBundleFile(scope, effectiveName, renaming, newPath);
+      }
+      setBuffers(prev => {
+        const next = new Map(prev);
+        const b = next.get(renaming!);
+        if (b) {
+          next.set(newPath, b);
+          next.delete(renaming!);
+        }
+        return next;
+      });
+      if (activeFile === renaming) {
+        setActiveFile(newPath);
+      }
+      setRenaming(null);
+      setRenameDraft('');
+    } catch (e: any) {
+      setError(e?.message ?? String(e));
+      setRenaming(null);
+    }
+  };
+
+  useEffect(() => {
+    if (effectiveIsNew || activeFile === SKILL_ENTRY_FILE) {
+      return;
+    }
+    const existing = buffers.get(activeFile);
+    if (existing?.loaded) {
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const content = await NBIAPI.readBundleFile(
+          scope,
+          effectiveName,
+          activeFile
+        );
+        if (cancelled) {
+          return;
+        }
+        setBuffers(prev => {
+          const existing = prev.get(activeFile);
+          // Don't clobber user edits that happened while the fetch was in flight.
+          if (existing?.loaded) {
+            return prev;
+          }
+          const next = new Map(prev);
+          next.set(activeFile, { content, saved: content, loaded: true });
+          return next;
+        });
+      } catch (e: any) {
+        if (!cancelled) {
+          setError(e?.message ?? String(e));
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeFile, effectiveIsNew, scope, effectiveName]);
+
+  const nameError =
+    effectiveIsNew && name && !nameValid ? SKILL_NAME_REQUIREMENT : null;
+  const descriptionError =
+    !descriptionValid && (description.length > 0 || !effectiveIsNew)
+      ? 'Description is required.'
+      : null;
+
+  const editingSkillMd = activeFile === SKILL_ENTRY_FILE;
+  const bodyLanguageHint = editingSkillMd ? 'markdown' : activeFile;
+
+  return (
+    <form
+      className="nbi-skill-editor"
+      onSubmit={e => {
+        e.preventDefault();
+        if (canSave && (effectiveIsNew || anyDirty)) {
+          handleSave();
+        }
+      }}
+    >
+      <div className="nbi-skill-editor-header">
+        <nav className="nbi-skill-editor-breadcrumb" aria-label="Breadcrumb">
+          <button
+            type="button"
+            className="nbi-breadcrumb-link"
+            onClick={handleBack}
+          >
+            Skills
+          </button>
+          <span className="nbi-breadcrumb-separator" aria-hidden="true">/</span>
+          <span className="nbi-breadcrumb-current">
+            {effectiveIsNew ? 'New skill' : effectiveName}
+          </span>
+        </nav>
+        <div className="nbi-skill-editor-actions">
+          <button
+            type="button"
+            className="jp-Dialog-button jp-mod-reject jp-mod-styled"
+            onClick={handleBack}
+          >
+            <div className="jp-Dialog-buttonLabel">Cancel</div>
+          </button>
+          <button
+            type="submit"
+            className="jp-Dialog-button jp-mod-accept jp-mod-styled"
+            disabled={!canSave || (!effectiveIsNew && !anyDirty)}
+          >
+            <div className="jp-Dialog-buttonLabel">
+              {saving ? 'Saving…' : 'Save'}
+              {anyDirty && (
+                <span className="nbi-dirty-marker" aria-label="Unsaved changes">
+                  {' '}•
+                </span>
+              )}
+            </div>
+          </button>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="nbi-skill-editor-loading">Loading skill…</div>
+      ) : (
+        <>
+          {error && (
+            <div className="nbi-skills-error" role="alert" ref={errorRef}>
+              {error}
+            </div>
+          )}
+
+          <div className="nbi-skill-editor-meta">
+            <div className="nbi-form-row">
+              <div className="nbi-form-row-inline">
+                <div className="nbi-form-field">
+                  <label>Scope</label>
+                  <select
+                    value={scope}
+                    disabled={!effectiveIsNew}
+                    onChange={e => setScope(e.target.value as SkillScope)}
+                  >
+                    <option value="user">User</option>
+                    <option value="project">Project</option>
+                  </select>
+                </div>
+                <div className="nbi-form-field">
+                  <label>Name</label>
+                  <input
+                    type="text"
+                    value={name}
+                    disabled={!effectiveIsNew}
+                    onChange={e => setName(e.target.value)}
+                    placeholder="my-skill-name"
+                    aria-invalid={nameError ? true : undefined}
+                  />
+                  {nameError && (
+                    <div className="nbi-form-field-error">{nameError}</div>
+                  )}
+                </div>
+              </div>
+              {!effectiveIsNew && (
+                <div className="nbi-form-hint">
+                  Scope and name are set at creation and can't be changed.
+                  Delete and recreate to change them.
+                </div>
+              )}
+            </div>
+
+            <div className="nbi-form-field nbi-form-field-wide">
+              <label>Description</label>
+              <textarea
+                rows={3}
+                value={description}
+                onChange={e => setDescription(e.target.value)}
+                placeholder="What this skill does, shown to Claude when deciding whether to use it"
+                aria-invalid={descriptionError ? true : undefined}
+                required
+              />
+              {descriptionError ? (
+                <div className="nbi-form-field-error">{descriptionError}</div>
+              ) : (
+                <div className="nbi-form-hint">
+                  Required. Claude uses this to decide when to apply the skill.
+                </div>
+              )}
+            </div>
+
+            <div className="nbi-form-field nbi-form-field-wide">
+              <label>Allowed tools</label>
+              <AllowedToolsPicker
+                value={allowedTools}
+                onChange={setAllowedTools}
+              />
+              <div className="nbi-form-hint">
+                Quick-add pills cover common tools. Type patterns like{' '}
+                <code>Bash(git:*)</code> or <code>Read(./docs/**)</code> for
+                finer-grained permissions.
+              </div>
+            </div>
+          </div>
+
+          <BundleFileTabs
+            files={orderedFileList}
+            activeFile={activeFile}
+            renaming={renaming}
+            renameDraft={renameDraft}
+            addFileDraft={addFileDraft}
+            fileDirty={fileDirty}
+            onSelect={handleSelectFile}
+            onBeginRename={handleBeginRename}
+            onCommitRename={handleCommitRename}
+            onCancelRename={() => setRenaming(null)}
+            onRenameDraftChange={setRenameDraft}
+            onDelete={handleDeleteFile}
+            onAddFileDraftChange={setAddFileDraft}
+            onAddFile={handleAddFile}
+          />
+          <div className="nbi-skill-editor-body">
+            <div className="nbi-skill-editor-pane">
+              <AutoGrowTextarea
+                value={currentBuffer}
+                onChange={v => updateBuffer(activeFile, v)}
+                minRows={18}
+                languageHint={bodyLanguageHint}
+              />
+            </div>
+          </div>
+        </>
+      )}
+    </form>
+  );
+}
+
+function BundleFileTabs(props: {
+  files: string[];
+  activeFile: string;
+  renaming: string | null;
+  renameDraft: string;
+  addFileDraft: string;
+  fileDirty: (path: string) => boolean;
+  onSelect: (path: string) => void;
+  onBeginRename: (path: string) => void;
+  onCommitRename: () => void;
+  onCancelRename: () => void;
+  onRenameDraftChange: (v: string) => void;
+  onDelete: (path: string) => void;
+  onAddFileDraftChange: (v: string) => void;
+  onAddFile: () => void;
+}): JSX.Element {
+  const [openMenu, setOpenMenu] = useState<string | null>(null);
+  const [adding, setAdding] = useState(false);
+
+  useEffect(() => {
+    if (!openMenu) return;
+    const onDocClick = () => setOpenMenu(null);
+    document.addEventListener('click', onDocClick);
+    return () => document.removeEventListener('click', onDocClick);
+  }, [openMenu]);
+
+  const commitAdd = () => {
+    if (props.addFileDraft.trim()) {
+      props.onAddFile();
+    }
+    setAdding(false);
+  };
+
+  return (
+    <div className="nbi-skill-editor-tabs" role="tablist">
+      {props.files.map(file => {
+        const active = file === props.activeFile;
+        const dirty = props.fileDirty(file);
+        const isRenaming = props.renaming === file;
+        const canModify = file !== SKILL_ENTRY_FILE;
+        return (
+          <div
+            key={file}
+            role="tab"
+            aria-selected={active}
+            className={`nbi-skill-editor-tab${active ? ' active' : ''}`}
+            onClick={() => !isRenaming && props.onSelect(file)}
+          >
+            {isRenaming ? (
+              <input
+                type="text"
+                autoFocus
+                value={props.renameDraft}
+                onChange={e => props.onRenameDraftChange(e.target.value)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    props.onCommitRename();
+                  } else if (e.key === 'Escape') {
+                    e.preventDefault();
+                    props.onCancelRename();
+                  }
+                }}
+                onBlur={props.onCancelRename}
+                onClick={e => e.stopPropagation()}
+                className="nbi-skill-editor-tab-rename-input"
+              />
+            ) : (
+              <>
+                <span className="nbi-skill-editor-tab-label">
+                  {file}
+                  {dirty && <span className="nbi-dirty-marker"> •</span>}
+                </span>
+                {canModify && (
+                  <div
+                    className="nbi-skill-editor-tab-kebab-wrap"
+                    onClick={e => e.stopPropagation()}
+                  >
+                    <button
+                      type="button"
+                      className="nbi-icon-button"
+                      aria-label={`Actions for ${file}`}
+                      aria-haspopup="menu"
+                      aria-expanded={openMenu === file}
+                      onClick={e => {
+                        e.stopPropagation();
+                        setOpenMenu(openMenu === file ? null : file);
+                      }}
+                    >
+                      ⋯
+                    </button>
+                    {openMenu === file && (
+                      <div className="nbi-skill-editor-tab-menu" role="menu">
+                        <button
+                          type="button"
+                          role="menuitem"
+                          onClick={() => {
+                            setOpenMenu(null);
+                            props.onBeginRename(file);
+                          }}
+                        >
+                          Rename
+                        </button>
+                        <button
+                          type="button"
+                          role="menuitem"
+                          className="danger"
+                          onClick={() => {
+                            setOpenMenu(null);
+                            props.onDelete(file);
+                          }}
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        );
+      })}
+      {adding ? (
+        <div className="nbi-skill-editor-tab adding">
+          <input
+            type="text"
+            autoFocus
+            placeholder="new-file.md"
+            value={props.addFileDraft}
+            onChange={e => props.onAddFileDraftChange(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                commitAdd();
+              } else if (e.key === 'Escape') {
+                e.preventDefault();
+                props.onAddFileDraftChange('');
+                setAdding(false);
+              }
+            }}
+            onBlur={commitAdd}
+            className="nbi-skill-editor-tab-rename-input"
+          />
+        </div>
+      ) : (
+        <button
+          type="button"
+          className="nbi-skill-editor-tab-add"
+          aria-label="Add file"
+          title="Add file"
+          onClick={() => setAdding(true)}
+        >
+          +
+        </button>
+      )}
+    </div>
+  );
+}
+
+function AllowedToolsPicker(props: {
+  value: string[];
+  onChange: (next: string[]) => void;
+}): JSX.Element {
+  const [draft, setDraft] = useState('');
+
+  const commit = (raw: string) => {
+    const parts = raw
+      .split(',')
+      .map(t => t.trim())
+      .filter(t => t.length > 0 && !props.value.includes(t));
+    if (parts.length === 0) {
+      setDraft('');
+      return;
+    }
+    props.onChange([...props.value, ...parts]);
+    setDraft('');
+  };
+
+  const toggle = (tool: string) => {
+    if (props.value.includes(tool)) {
+      props.onChange(props.value.filter(t => t !== tool));
+    } else {
+      props.onChange([...props.value, tool]);
+    }
+  };
+
+  const remove = (tool: string) => {
+    props.onChange(props.value.filter(t => t !== tool));
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' || e.key === ',') {
+      if (draft.trim()) {
+        e.preventDefault();
+        commit(draft);
+      }
+    } else if (e.key === 'Backspace' && !draft && props.value.length > 0) {
+      remove(props.value[props.value.length - 1]);
+    }
+  };
+
+  return (
+    <div>
+      <div className="nbi-tools-picker-input">
+        {props.value.map(tool => (
+          <span key={tool} className="pill-item checked">
+            {tool}
+            <button
+              onClick={() => remove(tool)}
+              aria-label={`Remove ${tool}`}
+              className="nbi-pill-remove"
+            >
+              ×
+            </button>
+          </span>
+        ))}
+        <input
+          type="text"
+          value={draft}
+          onChange={e => setDraft(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onBlur={() => draft.trim() && commit(draft)}
+          placeholder={
+            props.value.length === 0 ? 'e.g. Bash(git:*)' : ''
+          }
+        />
+      </div>
+      <div className="nbi-tools-picker-suggestions">
+        {COMMON_TOOLS.map(tool => (
+          <span
+            key={tool}
+            className={`pill-item${props.value.includes(tool) ? ' checked' : ''}`}
+            onClick={() => toggle(tool)}
+          >
+            {tool}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function AutoGrowTextarea(props: {
+  value: string;
+  onChange: (v: string) => void;
+  minRows: number;
+  languageHint?: string;
+}): JSX.Element {
+  const ref = useRef<HTMLTextAreaElement>(null);
+  const lineHeightRef = useRef<number | null>(null);
+
+  useLayoutEffect(() => {
+    const ta = ref.current;
+    if (!ta) {
+      return;
+    }
+    if (lineHeightRef.current === null) {
+      const computed = window.getComputedStyle(ta);
+      const parsed = parseFloat(computed.lineHeight);
+      // CSS "normal" resolves to NaN here; 1.4× font-size is a standard approximation.
+      lineHeightRef.current = Number.isNaN(parsed)
+        ? parseFloat(computed.fontSize) * 1.4
+        : parsed;
+    }
+    ta.style.height = 'auto';
+    const next = Math.max(ta.scrollHeight, props.minRows * lineHeightRef.current);
+    ta.style.height = `${next}px`;
+  }, [props.value, props.minRows]);
+
+  return (
+    <textarea
+      ref={ref}
+      className="nbi-skill-editor-textarea"
+      value={props.value}
+      onChange={e => props.onChange(e.target.value)}
+      spellCheck={false}
+      data-language={props.languageHint}
+    />
+  );
+}
+

--- a/src/components/skills-panel.tsx
+++ b/src/components/skills-panel.tsx
@@ -724,16 +724,17 @@ function SkillRow(props: {
         >
           ✎
         </button>
-        <button
-          type="button"
-          className="nbi-icon-button"
-          aria-label="Rename skill"
-          title={skill.managed ? 'Managed skills cannot be renamed' : 'Rename'}
-          disabled={skill.managed}
-          onClick={stopAnd(props.onRename)}
-        >
-          Aa
-        </button>
+        {!skill.managed && (
+          <button
+            type="button"
+            className="nbi-icon-button"
+            aria-label="Rename skill"
+            title="Rename"
+            onClick={stopAnd(props.onRename)}
+          >
+            Aa
+          </button>
+        )}
         <button
           type="button"
           className="nbi-icon-button"
@@ -743,16 +744,17 @@ function SkillRow(props: {
         >
           ⧉
         </button>
-        <button
-          type="button"
-          className="nbi-icon-button danger"
-          aria-label="Delete skill"
-          title={skill.managed ? 'Managed skills cannot be deleted' : 'Delete'}
-          disabled={skill.managed}
-          onClick={stopAnd(props.onDelete)}
-        >
-          🗑
-        </button>
+        {!skill.managed && (
+          <button
+            type="button"
+            className="nbi-icon-button danger"
+            aria-label="Delete skill"
+            title="Delete"
+            onClick={stopAnd(props.onDelete)}
+          >
+            🗑
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/components/skills-panel.tsx
+++ b/src/components/skills-panel.tsx
@@ -105,6 +105,17 @@ export function SettingsPanelComponentSkills(_props: any): JSX.Element {
   }, []);
 
   const handleDelete = async (skill: ISkillSummary) => {
+    const result = await showDialog({
+      title: 'Delete skill?',
+      body: `"${skill.name}" will be deleted.`,
+      buttons: [
+        Dialog.cancelButton(),
+        Dialog.warnButton({ label: 'Delete' })
+      ]
+    });
+    if (!result.button.accept) {
+      return;
+    }
     // Snapshot the full bundle (SKILL.md + helper files) *before* deleting so the Undo
     // toast can recreate it byte-for-byte. The backend only exposes a shallow delete
     // API, so restoration is the client's job.

--- a/src/components/skills-panel.tsx
+++ b/src/components/skills-panel.tsx
@@ -60,6 +60,9 @@ export function SettingsPanelComponentSkills(_props: any): JSX.Element {
   const [prompt, setPrompt] = useState<PromptMode>(null);
   const [undo, setUndo] = useState<IUndoState | null>(null);
   const [importOpen, setImportOpen] = useState(false);
+  const [syncing, setSyncing] = useState(false);
+  const [syncMessage, setSyncMessage] = useState<string | null>(null);
+  const hasManagedSkills = skills.some(s => s.managed);
 
   const refresh = async () => {
     setLoading(true);
@@ -109,6 +112,27 @@ export function SettingsPanelComponentSkills(_props: any): JSX.Element {
       }
     };
   }, []);
+
+  const handleSyncManaged = async () => {
+    setSyncing(true);
+    setSyncMessage(null);
+    setError(null);
+    try {
+      const r = await NBIAPI.reconcileManagedSkills();
+      const summary = `Sync complete — ${r.added} added, ${r.updated} updated, ${r.removed} removed, ${r.unchanged} unchanged.`;
+      setSyncMessage(
+        r.errors.length ? `${summary} (${r.errors.length} error(s))` : summary
+      );
+      if (r.errors.length) {
+        setError(r.errors.join('\n'));
+      }
+      await refresh();
+    } catch (e: any) {
+      setError(`Sync failed: ${e?.message ?? e}`);
+    } finally {
+      setSyncing(false);
+    }
+  };
 
   const handleDelete = async (skill: ISkillSummary) => {
     const result = await showDialog({
@@ -259,6 +283,18 @@ export function SettingsPanelComponentSkills(_props: any): JSX.Element {
       <div className="nbi-skills-header">
         <div className="nbi-skills-title">Claude Skills</div>
         <div className="nbi-skills-header-actions">
+          {hasManagedSkills && (
+            <button
+              className="jp-Dialog-button jp-mod-reject jp-mod-styled"
+              onClick={handleSyncManaged}
+              disabled={syncing}
+              title="Reconcile managed skills against the org manifest"
+            >
+              <div className="jp-Dialog-buttonLabel">
+                {syncing ? 'Syncing…' : 'Sync managed skills'}
+              </div>
+            </button>
+          )}
           <button
             className="jp-Dialog-button jp-mod-reject jp-mod-styled"
             onClick={() => setImportOpen(true)}
@@ -275,6 +311,11 @@ export function SettingsPanelComponentSkills(_props: any): JSX.Element {
           </button>
         </div>
       </div>
+      {syncMessage && (
+        <div className="nbi-skills-sync-message" role="status">
+          {syncMessage}
+        </div>
+      )}
       {error && (
         <div className="nbi-skills-error" role="alert">
           {error}
@@ -628,6 +669,17 @@ function SkillScopeSection(props: {
   );
 }
 
+function ManagedBadge(props: { source?: string }): JSX.Element {
+  return (
+    <span
+      className="nbi-skill-managed-badge"
+      title={`Managed by org manifest (${props.source ?? ''})`}
+    >
+      Managed
+    </span>
+  );
+}
+
 function SkillRow(props: {
   skill: ISkillSummary;
   onEdit: () => void;
@@ -654,7 +706,10 @@ function SkillRow(props: {
       }}
     >
       <div className="nbi-skill-row-main">
-        <div className="nbi-skill-row-name">{skill.name}</div>
+        <div className="nbi-skill-row-name">
+          {skill.name}
+          {skill.managed && <ManagedBadge source={skill.managedSource} />}
+        </div>
         {skill.description && (
           <div className="nbi-skill-row-description">{skill.description}</div>
         )}
@@ -663,8 +718,8 @@ function SkillRow(props: {
         <button
           type="button"
           className="nbi-icon-button"
-          aria-label="Edit skill"
-          title="Edit"
+          aria-label={skill.managed ? 'View skill' : 'Edit skill'}
+          title={skill.managed ? 'View (managed, read-only)' : 'Edit'}
           onClick={stopAnd(props.onEdit)}
         >
           ✎
@@ -673,7 +728,8 @@ function SkillRow(props: {
           type="button"
           className="nbi-icon-button"
           aria-label="Rename skill"
-          title="Rename"
+          title={skill.managed ? 'Managed skills cannot be renamed' : 'Rename'}
+          disabled={skill.managed}
           onClick={stopAnd(props.onRename)}
         >
           Aa
@@ -691,7 +747,8 @@ function SkillRow(props: {
           type="button"
           className="nbi-icon-button danger"
           aria-label="Delete skill"
-          title="Delete"
+          title={skill.managed ? 'Managed skills cannot be deleted' : 'Delete'}
+          disabled={skill.managed}
           onClick={stopAnd(props.onDelete)}
         >
           🗑
@@ -909,6 +966,8 @@ function SkillEditor(props: {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [hasCreated, setHasCreated] = useState(false);
+  const [managed, setManaged] = useState(false);
+  const [managedSource, setManagedSource] = useState('');
   const errorRef = useRef<HTMLDivElement>(null);
 
   const effectiveName = isNew && !hasCreated ? name : (props.name ?? name);
@@ -918,6 +977,8 @@ function SkillEditor(props: {
     const skill: ISkillDetail = await NBIAPI.readSkill(s, n);
     setDescription(skill.description);
     setAllowedTools(skill.allowedTools ?? []);
+    setManaged(skill.managed);
+    setManagedSource(skill.managedSource ?? '');
     const skillMdBody = skill.body ?? '';
     setSavedMeta({
       description: skill.description,
@@ -999,7 +1060,8 @@ function SkillEditor(props: {
 
   const nameValid = SKILL_NAME_PATTERN.test(name);
   const descriptionValid = description.trim().length > 0;
-  const canSave = !saving && (!effectiveIsNew || nameValid) && descriptionValid;
+  const canSave =
+    !saving && !managed && (!effectiveIsNew || nameValid) && descriptionValid;
 
   const updateBuffer = (path: string, content: string) => {
     setBuffers(prev => {
@@ -1300,6 +1362,7 @@ function SkillEditor(props: {
           </span>
           <span className="nbi-breadcrumb-current">
             {effectiveIsNew ? 'New skill' : effectiveName}
+            {managed && <ManagedBadge source={managedSource} />}
           </span>
         </nav>
         <div className="nbi-skill-editor-actions">
@@ -1308,25 +1371,38 @@ function SkillEditor(props: {
             className="jp-Dialog-button jp-mod-reject jp-mod-styled"
             onClick={handleBack}
           >
-            <div className="jp-Dialog-buttonLabel">Cancel</div>
-          </button>
-          <button
-            type="submit"
-            className="jp-Dialog-button jp-mod-accept jp-mod-styled"
-            disabled={!canSave || (!effectiveIsNew && !anyDirty)}
-          >
             <div className="jp-Dialog-buttonLabel">
-              {saving ? 'Saving…' : 'Save'}
-              {anyDirty && (
-                <span className="nbi-dirty-marker" aria-label="Unsaved changes">
-                  {' '}
-                  •
-                </span>
-              )}
+              {managed ? 'Close' : 'Cancel'}
             </div>
           </button>
+          {!managed && (
+            <button
+              type="submit"
+              className="jp-Dialog-button jp-mod-accept jp-mod-styled"
+              disabled={!canSave || (!effectiveIsNew && !anyDirty)}
+            >
+              <div className="jp-Dialog-buttonLabel">
+                {saving ? 'Saving…' : 'Save'}
+                {anyDirty && (
+                  <span
+                    className="nbi-dirty-marker"
+                    aria-label="Unsaved changes"
+                  >
+                    {' '}
+                    •
+                  </span>
+                )}
+              </div>
+            </button>
+          )}
         </div>
       </div>
+      {managed && (
+        <div className="nbi-skills-managed-banner" role="note">
+          This skill is managed by the organization manifest and is read-only.
+          Changes will be overwritten on the next sync.
+        </div>
+      )}
 
       {loading ? (
         <div className="nbi-skill-editor-loading">Loading skill…</div>

--- a/src/components/skills-panel.tsx
+++ b/src/components/skills-panel.tsx
@@ -22,6 +22,10 @@ const SKILL_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
 const SKILL_NAME_REQUIREMENT =
   'Must be lowercase letters, digits, or hyphens (starting with a letter or digit), max 64 chars.';
 const SKILL_ENTRY_FILE = 'SKILL.md';
+// Bundles with more files than this collapse their file tabs to just SKILL.md.
+// Keeps the tab strip usable for reference-data skills that ship hundreds of
+// helper files; those are easier to edit on disk anyway.
+const BUNDLE_FILE_DISPLAY_LIMIT = 20;
 const COMMON_TOOLS = [
   'Read',
   'Write',
@@ -963,7 +967,19 @@ function SkillEditor(props: {
     ],
     [buffers]
   );
+  const bundleOverflow = orderedFileList.length > BUNDLE_FILE_DISPLAY_LIMIT;
+  const displayedFileList = bundleOverflow
+    ? [SKILL_ENTRY_FILE]
+    : orderedFileList;
   const [activeFile, setActiveFile] = useState<string>(SKILL_ENTRY_FILE);
+  // If a reload pushes the bundle over the threshold while a helper file is
+  // selected, snap back to SKILL.md — otherwise the tab strip shows no active
+  // tab and there's no way to navigate anywhere else.
+  useEffect(() => {
+    if (bundleOverflow && activeFile !== SKILL_ENTRY_FILE) {
+      setActiveFile(SKILL_ENTRY_FILE);
+    }
+  }, [bundleOverflow, activeFile]);
   const [renaming, setRenaming] = useState<string | null>(null);
   const [renameDraft, setRenameDraft] = useState('');
   const [addFileDraft, setAddFileDraft] = useState('');
@@ -973,6 +989,7 @@ function SkillEditor(props: {
   const [hasCreated, setHasCreated] = useState(false);
   const [managed, setManaged] = useState(false);
   const [managedSource, setManagedSource] = useState('');
+  const [rootPath, setRootPath] = useState('');
   const errorRef = useRef<HTMLDivElement>(null);
 
   const effectiveName = isNew && !hasCreated ? name : (props.name ?? name);
@@ -984,6 +1001,7 @@ function SkillEditor(props: {
     setAllowedTools(skill.allowedTools ?? []);
     setManaged(skill.managed);
     setManagedSource(skill.managedSource ?? '');
+    setRootPath(skill.rootPath ?? '');
     const skillMdBody = skill.body ?? '';
     setSavedMeta({
       description: skill.description,
@@ -1489,13 +1507,26 @@ function SkillEditor(props: {
             </div>
           </div>
 
+          {bundleOverflow && (
+            <div className="nbi-form-hint">
+              Bundle contains {orderedFileList.length} files — showing{' '}
+              {SKILL_ENTRY_FILE} only. Edit supporting files directly on disk.
+              {rootPath && (
+                <>
+                  {' '}
+                  Path: <code>{rootPath}</code>
+                </>
+              )}
+            </div>
+          )}
           <BundleFileTabs
-            files={orderedFileList}
+            files={displayedFileList}
             activeFile={activeFile}
             renaming={renaming}
             renameDraft={renameDraft}
             addFileDraft={addFileDraft}
             fileDirty={fileDirty}
+            canAddFiles={!bundleOverflow}
             onSelect={handleSelectFile}
             onBeginRename={handleBeginRename}
             onCommitRename={handleCommitRename}
@@ -1528,6 +1559,7 @@ function BundleFileTabs(props: {
   renameDraft: string;
   addFileDraft: string;
   fileDirty: (path: string) => boolean;
+  canAddFiles: boolean;
   onSelect: (path: string) => void;
   onBeginRename: (path: string) => void;
   onCommitRename: () => void;
@@ -1646,39 +1678,40 @@ function BundleFileTabs(props: {
           </div>
         );
       })}
-      {adding ? (
-        <div className="nbi-skill-editor-tab adding">
-          <input
-            type="text"
-            autoFocus
-            placeholder="new-file.md"
-            value={props.addFileDraft}
-            onChange={e => props.onAddFileDraftChange(e.target.value)}
-            onKeyDown={e => {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-                commitAdd();
-              } else if (e.key === 'Escape') {
-                e.preventDefault();
-                props.onAddFileDraftChange('');
-                setAdding(false);
-              }
-            }}
-            onBlur={commitAdd}
-            className="nbi-skill-editor-tab-rename-input"
-          />
-        </div>
-      ) : (
-        <button
-          type="button"
-          className="nbi-skill-editor-tab-add"
-          aria-label="Add file"
-          title="Add file"
-          onClick={() => setAdding(true)}
-        >
-          +
-        </button>
-      )}
+      {props.canAddFiles &&
+        (adding ? (
+          <div className="nbi-skill-editor-tab adding">
+            <input
+              type="text"
+              autoFocus
+              placeholder="new-file.md"
+              value={props.addFileDraft}
+              onChange={e => props.onAddFileDraftChange(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  commitAdd();
+                } else if (e.key === 'Escape') {
+                  e.preventDefault();
+                  props.onAddFileDraftChange('');
+                  setAdding(false);
+                }
+              }}
+              onBlur={commitAdd}
+              className="nbi-skill-editor-tab-rename-input"
+            />
+          </div>
+        ) : (
+          <button
+            type="button"
+            className="nbi-skill-editor-tab-add"
+            aria-label="Add file"
+            title="Add file"
+            onClick={() => setAdding(true)}
+          >
+            +
+          </button>
+        ))}
     </div>
   );
 }

--- a/src/components/skills-panel.tsx
+++ b/src/components/skills-panel.tsx
@@ -298,8 +298,11 @@ export function SettingsPanelComponentSkills(_props: any): JSX.Element {
           <button
             className="jp-Dialog-button jp-mod-reject jp-mod-styled"
             onClick={() => setImportOpen(true)}
+            title="Import from GitHub"
           >
-            <div className="jp-Dialog-buttonLabel">Import from GitHub</div>
+            <div className="jp-Dialog-buttonLabel">
+              {hasManagedSkills ? 'Import' : 'Import from GitHub'}
+            </div>
           </button>
           <button
             className="jp-Dialog-button jp-mod-reject jp-mod-styled"

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -34,7 +34,8 @@ export enum BackendMessageType {
   RunUICommand = 'run-ui-command',
   GitHubCopilotLoginStatusChange = 'github-copilot-login-status-change',
   MCPServerStatusChange = 'mcp-server-status-change',
-  ClaudeCodeStatusChange = 'claude-code-status-change'
+  ClaudeCodeStatusChange = 'claude-code-status-change',
+  SkillsReloaded = 'skills-reloaded'
 }
 
 export enum ResponseStreamDataType {

--- a/style/base.css
+++ b/style/base.css
@@ -1048,7 +1048,7 @@ svg.access-token-warning {
 }
 
 .pill-item.checked {
-  background-color: var(--jp-brand-color3, rgba(68, 138, 255, 0.12));
+  background-color: var(--jp-brand-color3, rgb(68 138 255 / 12%));
   border-color: var(--jp-brand-color1);
   color: var(--jp-brand-color0, var(--jp-ui-font-color1));
 }
@@ -1156,7 +1156,7 @@ svg.access-token-warning {
 .nbi-skills-error {
   padding: 8px 12px;
   border-radius: 4px;
-  background-color: var(--jp-error-color3, rgba(230, 100, 100, 0.15));
+  background-color: var(--jp-error-color3, rgb(230 100 100 / 15%));
   color: var(--jp-ui-font-color1);
   border: 1px solid var(--jp-error-color1, #d32f2f);
   font-size: var(--jp-ui-font-size1);
@@ -1252,21 +1252,11 @@ svg.access-token-warning {
   opacity: 1;
 }
 
-.nbi-breadcrumb-link:focus-visible,
-.nbi-skill-editor-tab:focus-visible,
-.nbi-skill-editor-tab-add:focus-visible,
-.nbi-pill-remove:focus-visible,
-.pill-item:focus-visible,
-.nbi-icon-button:focus-visible {
-  outline: 2px solid var(--jp-brand-color1);
-  outline-offset: 1px;
-}
-
 /* Modal dialog used for rename/duplicate */
 .nbi-modal-backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.35);
+  background: rgb(0 0 0 / 35%);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1277,7 +1267,7 @@ svg.access-token-warning {
   background-color: var(--jp-layout-color1);
   border: 1px solid var(--jp-border-color1);
   border-radius: 6px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+  box-shadow: 0 4px 16px rgb(0 0 0 / 25%);
   padding: 16px;
   min-width: 320px;
   max-width: 420px;
@@ -1362,7 +1352,7 @@ svg.access-token-warning {
   background-color: var(--jp-inverse-layout-color1, #323232);
   color: var(--jp-inverse-ui-font-color1, #fff);
   border-radius: 4px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 2px 8px rgb(0 0 0 / 30%);
   font-size: var(--jp-ui-font-size1);
 }
 
@@ -1561,8 +1551,7 @@ svg.access-token-warning {
 
 .nbi-form-field input:focus,
 .nbi-form-field select:focus,
-.nbi-form-field textarea:focus,
-.nbi-tools-picker-input:focus-within {
+.nbi-form-field textarea:focus {
   outline: none;
   border-color: var(--jp-brand-color1);
   box-shadow: 0 0 0 1px var(--jp-brand-color1);
@@ -1598,6 +1587,13 @@ svg.access-token-warning {
   align-items: center;
 }
 
+.nbi-tools-picker-input:focus-within {
+  outline: none;
+  border-color: var(--jp-brand-color1);
+  box-shadow: 0 0 0 1px var(--jp-brand-color1);
+}
+
+/* stylelint-disable-next-line no-descending-specificity */
 .nbi-tools-picker-input input {
   flex: 1 1 100px;
   min-width: 100px;
@@ -1681,7 +1677,7 @@ svg.access-token-warning {
 }
 
 .nbi-skill-editor-tab.active {
-  background-color: var(--jp-brand-color3, rgba(68, 138, 255, 0.12));
+  background-color: var(--jp-brand-color3, rgb(68 138 255 / 12%));
   border-color: var(--jp-brand-color1);
   color: var(--jp-brand-color0, var(--jp-ui-font-color1));
   font-weight: 600;
@@ -1709,7 +1705,7 @@ svg.access-token-warning {
   background-color: var(--jp-layout-color1);
   border: 1px solid var(--jp-border-color1);
   border-radius: 3px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 2px 6px rgb(0 0 0 / 15%);
   padding: 4px 0;
 }
 
@@ -1729,7 +1725,7 @@ svg.access-token-warning {
 }
 
 .nbi-skill-editor-tab-menu button.danger:hover {
-  background-color: var(--jp-error-color3, rgba(230, 100, 100, 0.2));
+  background-color: var(--jp-error-color3, rgb(230 100 100 / 20%));
   color: var(--jp-error-color1, #d32f2f);
 }
 
@@ -1793,8 +1789,18 @@ svg.access-token-warning {
 }
 
 .nbi-icon-button.danger:hover {
-  background-color: var(--jp-error-color3, rgba(230, 100, 100, 0.2));
+  background-color: var(--jp-error-color3, rgb(230 100 100 / 20%));
   color: var(--jp-error-color1, #d32f2f);
+}
+
+.nbi-breadcrumb-link:focus-visible,
+.nbi-skill-editor-tab:focus-visible,
+.nbi-skill-editor-tab-add:focus-visible,
+.nbi-pill-remove:focus-visible,
+.pill-item:focus-visible,
+.nbi-icon-button:focus-visible {
+  outline: 2px solid var(--jp-brand-color1);
+  outline-offset: 1px;
 }
 
 .config-dialog-body a {
@@ -1855,6 +1861,7 @@ svg.access-token-warning {
   gap: 5px;
 }
 
+/* stylelint-disable-next-line no-descending-specificity */
 .ask-user-question-option-input-container input {
   transform: scale(1.25);
 }

--- a/style/base.css
+++ b/style/base.css
@@ -1246,7 +1246,8 @@ svg.access-token-warning {
   padding: 8px 12px;
   margin: 4px 8px;
   border-radius: 4px;
-  background-color: var(--jp-info-color3);
+  background-color: var(--jp-layout-color2);
+  border-left: 3px solid var(--jp-info-color1);
   color: var(--jp-ui-font-color1);
   font-size: var(--jp-ui-font-size0);
 }
@@ -1291,9 +1292,9 @@ svg.access-token-warning {
 .nbi-skills-error {
   padding: 8px 12px;
   border-radius: 4px;
-  background-color: var(--jp-error-color3, rgb(230 100 100 / 15%));
+  background-color: var(--jp-layout-color2);
   color: var(--jp-ui-font-color1);
-  border: 1px solid var(--jp-error-color1, #d32f2f);
+  border-left: 3px solid var(--jp-error-color1, #d32f2f);
   font-size: var(--jp-ui-font-size1);
 }
 
@@ -1517,8 +1518,9 @@ svg.access-token-warning {
   align-items: center;
   gap: 12px;
   padding: 8px 12px;
-  background-color: var(--jp-inverse-layout-color1, #323232);
-  color: var(--jp-inverse-ui-font-color1, #fff);
+  background-color: var(--jp-layout-color2);
+  color: var(--jp-ui-font-color1);
+  border: 1px solid var(--jp-border-color1);
   border-radius: 4px;
   box-shadow: 0 2px 8px rgb(0 0 0 / 30%);
   font-size: var(--jp-ui-font-size1);

--- a/style/base.css
+++ b/style/base.css
@@ -1211,6 +1211,38 @@ svg.access-token-warning {
   font-size: var(--jp-ui-font-size1);
 }
 
+.nbi-skills-sync-message {
+  padding: 6px 12px;
+  border-radius: 4px;
+  background-color: var(--jp-layout-color2);
+  color: var(--jp-ui-font-color1);
+  font-size: var(--jp-ui-font-size1);
+}
+
+.nbi-skills-managed-banner {
+  padding: 8px 12px;
+  margin-bottom: 8px;
+  border-radius: 4px;
+  background-color: var(--jp-layout-color2);
+  color: var(--jp-ui-font-color1);
+  border: 1px solid var(--jp-border-color2);
+  font-size: var(--jp-ui-font-size1);
+}
+
+.nbi-skill-managed-badge {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 1px 6px;
+  border-radius: 10px;
+  background-color: var(--jp-brand-color3, var(--jp-layout-color3));
+  color: var(--jp-ui-font-color0);
+  font-size: var(--jp-ui-font-size0);
+  font-weight: 600;
+  vertical-align: middle;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
 .nbi-skills-section {
   display: flex;
   flex-direction: column;

--- a/style/base.css
+++ b/style/base.css
@@ -1356,6 +1356,7 @@ svg.access-token-warning {
   text-align: center;
 }
 
+/* stylelint-disable-next-line no-descending-specificity */
 .nbi-skills-empty code {
   background-color: var(--jp-layout-color2);
   padding: 1px 4px;
@@ -1734,6 +1735,7 @@ svg.access-token-warning {
   color: var(--jp-ui-font-color2);
 }
 
+/* stylelint-disable-next-line no-descending-specificity */
 .nbi-form-hint code {
   background-color: var(--jp-layout-color2);
   padding: 1px 4px;

--- a/style/base.css
+++ b/style/base.css
@@ -1005,13 +1005,41 @@ svg.access-token-warning {
   padding: 20px;
 }
 
+.nbi-subtab-bar {
+  display: flex;
+  gap: 4px;
+  border-bottom: 1px solid var(--jp-border-color2);
+  margin-bottom: 16px;
+}
+
+.nbi-subtab {
+  cursor: pointer;
+  padding: 8px 16px;
+  border-bottom: 2px solid transparent;
+  color: var(--jp-ui-font-color2);
+  margin-bottom: -1px;
+}
+
+.nbi-subtab:hover {
+  color: var(--jp-ui-font-color1);
+}
+
+.nbi-subtab.active {
+  color: var(--jp-ui-font-color1);
+  border-bottom-color: var(--jp-brand-color1);
+  font-weight: bold;
+}
+
 .pill-item {
   cursor: pointer;
   background-color: var(--jp-layout-color1);
   display: inline-block;
-  padding: 2px 6px;
+  padding: 2px 8px;
   margin: 2px 4px;
-  border-radius: 4px;
+  border: 1px solid var(--jp-border-color2);
+  border-radius: 10px;
+  font-size: var(--jp-ui-font-size0);
+  color: var(--jp-ui-font-color1);
 }
 
 .pill-item:hover {
@@ -1020,7 +1048,9 @@ svg.access-token-warning {
 }
 
 .pill-item.checked {
-  background-color: var(--jp-layout-color3);
+  background-color: var(--jp-brand-color3, rgba(68, 138, 255, 0.12));
+  border-color: var(--jp-brand-color1);
+  color: var(--jp-brand-color0, var(--jp-ui-font-color1));
 }
 
 .server-status-indicator {
@@ -1077,10 +1107,694 @@ svg.access-token-warning {
   cursor: default;
 }
 
+.nbi-skills-reloaded-banner {
+  padding: 8px 12px;
+  margin: 4px 8px;
+  border-radius: 4px;
+  background-color: var(--jp-info-color3);
+  color: var(--jp-ui-font-color1);
+  font-size: var(--jp-ui-font-size0);
+}
+
 .mcp-server-tools-header,
 .mcp-server-prompts-header {
   margin: 5px;
   font-style: italic;
+}
+
+/* ============================================================
+ * Claude Skills panel
+ * ============================================================ */
+
+.nbi-skills-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.nbi-skills-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.nbi-skills-header-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.nbi-skills-title {
+  font-size: var(--jp-ui-font-size2);
+  font-weight: 600;
+}
+
+.nbi-skills-error {
+  padding: 8px 12px;
+  border-radius: 4px;
+  background-color: var(--jp-error-color3, rgba(230, 100, 100, 0.15));
+  color: var(--jp-ui-font-color1);
+  border: 1px solid var(--jp-error-color1, #d32f2f);
+  font-size: var(--jp-ui-font-size1);
+}
+
+.nbi-skills-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.nbi-skills-section-caption {
+  font-size: var(--jp-ui-font-size1);
+  color: var(--jp-ui-font-color1);
+  font-weight: 600;
+  padding: 4px 0;
+  border-bottom: 1px solid var(--jp-border-color2);
+}
+
+.nbi-skills-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 20px 12px;
+  border: 1px dashed var(--jp-border-color2);
+  border-radius: 4px;
+  color: var(--jp-ui-font-color2);
+  font-size: var(--jp-ui-font-size1);
+  text-align: center;
+}
+
+.nbi-skills-empty code {
+  background-color: var(--jp-layout-color2);
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-size: 0.9em;
+}
+
+.nbi-skill-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--jp-border-color2);
+  border-radius: 4px;
+  cursor: pointer;
+  background-color: var(--jp-layout-color1);
+}
+
+.nbi-skill-row:hover {
+  background-color: var(--jp-layout-color2);
+}
+
+.nbi-skill-row:focus {
+  outline: 2px solid var(--jp-brand-color1);
+  outline-offset: -2px;
+}
+
+.nbi-skill-row-main {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.nbi-skill-row-name {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  font-size: var(--jp-ui-font-size1);
+}
+
+.nbi-skill-row-description {
+  margin-top: 2px;
+  color: var(--jp-ui-font-color2);
+  font-size: var(--jp-ui-font-size0);
+}
+
+/* Inline row actions (reveal on hover/focus-within) */
+.nbi-skill-row-actions {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  opacity: 0;
+  transition: opacity 0.1s ease-in-out;
+}
+
+.nbi-skill-row:hover .nbi-skill-row-actions,
+.nbi-skill-row:focus-within .nbi-skill-row-actions,
+.nbi-skill-row:focus .nbi-skill-row-actions {
+  opacity: 1;
+}
+
+.nbi-breadcrumb-link:focus-visible,
+.nbi-skill-editor-tab:focus-visible,
+.nbi-skill-editor-tab-add:focus-visible,
+.nbi-pill-remove:focus-visible,
+.pill-item:focus-visible,
+.nbi-icon-button:focus-visible {
+  outline: 2px solid var(--jp-brand-color1);
+  outline-offset: 1px;
+}
+
+/* Modal dialog used for rename/duplicate */
+.nbi-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.nbi-modal-card {
+  background-color: var(--jp-layout-color1);
+  border: 1px solid var(--jp-border-color1);
+  border-radius: 6px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+  padding: 16px;
+  min-width: 320px;
+  max-width: 420px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.nbi-modal-title {
+  font-size: var(--jp-ui-font-size2);
+  font-weight: 600;
+}
+
+.nbi-modal-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.nbi-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.nbi-import-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px;
+  background-color: var(--jp-layout-color2);
+  border: 1px solid var(--jp-border-color2);
+  border-radius: 4px;
+  font-size: var(--jp-ui-font-size1);
+}
+
+.nbi-import-preview-row {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+}
+
+.nbi-import-preview-label {
+  flex: 0 0 90px;
+  color: var(--jp-ui-font-color2);
+  font-size: var(--jp-ui-font-size0);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.nbi-import-preview-value {
+  flex: 1 1 auto;
+  color: var(--jp-ui-font-color1);
+  word-break: break-word;
+}
+
+.nbi-import-preview-source {
+  font-family: var(--jp-code-font-family);
+  font-size: var(--jp-ui-font-size0);
+  color: var(--jp-ui-font-color2);
+}
+
+.nbi-checkbox-label {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  color: var(--jp-ui-font-color1);
+  font-size: var(--jp-ui-font-size1);
+}
+
+/* Undo toast */
+.nbi-undo-toast {
+  position: fixed;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1001;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px;
+  background-color: var(--jp-inverse-layout-color1, #323232);
+  color: var(--jp-inverse-ui-font-color1, #fff);
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  font-size: var(--jp-ui-font-size1);
+}
+
+.nbi-undo-toast-message {
+  flex: 1 1 auto;
+}
+
+.nbi-undo-toast-action {
+  background: transparent;
+  border: none;
+  color: var(--jp-brand-color2, #82b1ff);
+  cursor: pointer;
+  font-weight: 600;
+  text-transform: uppercase;
+  padding: 4px 6px;
+}
+
+.nbi-undo-toast-action:hover {
+  text-decoration: underline;
+}
+
+.nbi-undo-toast-close {
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 2px 6px;
+  opacity: 0.7;
+}
+
+.nbi-undo-toast-close:hover {
+  opacity: 1;
+}
+
+/* Editor */
+.nbi-skill-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.nbi-skill-editor-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.nbi-skill-editor-breadcrumb {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  min-width: 0;
+  font-size: var(--jp-ui-font-size1);
+}
+
+.nbi-breadcrumb-link {
+  background: transparent;
+  border: none;
+  padding: 0;
+  color: var(--jp-content-link-color, var(--jp-brand-color1));
+  cursor: pointer;
+  font: inherit;
+}
+
+.nbi-breadcrumb-link:hover {
+  text-decoration: underline;
+}
+
+.nbi-breadcrumb-separator {
+  color: var(--jp-ui-font-color2);
+}
+
+.nbi-breadcrumb-current {
+  font-weight: 600;
+  color: var(--jp-ui-font-color1);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.nbi-skill-editor-actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.nbi-skill-editor-actions .jp-Dialog-button.jp-mod-accept:not(:disabled) {
+  background-color: var(--jp-brand-color1);
+  color: #fff;
+  border-color: var(--jp-brand-color1);
+  font-weight: 600;
+}
+
+.nbi-skill-editor-actions .jp-Dialog-button:disabled,
+.nbi-skills-header .jp-Dialog-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.nbi-dirty-marker {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  margin-left: 6px;
+  border-radius: 50%;
+  background-color: var(--jp-warn-color1, #f57c00);
+  vertical-align: middle;
+  font-size: 0;
+  line-height: 0;
+}
+
+.nbi-skill-editor-loading {
+  padding: 20px;
+  text-align: center;
+  color: var(--jp-ui-font-color2);
+}
+
+.nbi-skill-editor-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px;
+  background-color: var(--jp-layout-color1);
+  border: 1px solid var(--jp-border-color2);
+  border-radius: 6px;
+  margin-bottom: 12px;
+}
+
+.nbi-form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.nbi-form-row-inline {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.nbi-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1 1 0;
+  min-width: 140px;
+}
+
+.nbi-form-field-wide {
+  width: 100%;
+}
+
+.nbi-form-field label {
+  font-size: var(--jp-ui-font-size1);
+  color: var(--jp-ui-font-color1);
+  font-weight: 500;
+}
+
+.nbi-form-field input,
+.nbi-form-field select,
+.nbi-form-field textarea {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 6px 8px;
+  border: 1px solid var(--jp-border-color1);
+  border-radius: 3px;
+  background-color: var(--jp-input-background, var(--jp-layout-color1));
+  color: var(--jp-ui-font-color1);
+  font-size: var(--jp-ui-font-size1);
+  font-family: inherit;
+}
+
+.nbi-form-field textarea {
+  resize: vertical;
+}
+
+.nbi-form-field input[aria-invalid='true'] {
+  border-color: var(--jp-error-color1, #d32f2f);
+}
+
+.nbi-form-field input:disabled,
+.nbi-form-field select:disabled {
+  background-color: var(--jp-layout-color2);
+  color: var(--jp-ui-font-color2);
+  border-color: var(--jp-border-color2);
+  cursor: not-allowed;
+}
+
+.nbi-form-field input:focus,
+.nbi-form-field select:focus,
+.nbi-form-field textarea:focus,
+.nbi-tools-picker-input:focus-within {
+  outline: none;
+  border-color: var(--jp-brand-color1);
+  box-shadow: 0 0 0 1px var(--jp-brand-color1);
+}
+
+.nbi-form-field-error {
+  font-size: var(--jp-ui-font-size0);
+  color: var(--jp-error-color1, #d32f2f);
+}
+
+.nbi-form-hint {
+  font-size: var(--jp-ui-font-size0);
+  color: var(--jp-ui-font-color2);
+}
+
+.nbi-form-hint code {
+  background-color: var(--jp-layout-color2);
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-size: 0.9em;
+}
+
+/* Tools picker */
+.nbi-tools-picker-input {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 4px 6px;
+  border: 1px solid var(--jp-border-color1);
+  border-radius: 3px;
+  background-color: var(--jp-input-background, var(--jp-layout-color1));
+  min-height: 30px;
+  align-items: center;
+}
+
+.nbi-tools-picker-input input {
+  flex: 1 1 100px;
+  min-width: 100px;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--jp-ui-font-color1);
+  font-size: var(--jp-ui-font-size1);
+  padding: 2px 4px;
+}
+
+.nbi-pill-remove {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  margin-left: 4px;
+  padding: 0 2px;
+  color: inherit;
+  font-size: 1em;
+  line-height: 1;
+}
+
+.nbi-pill-remove:hover {
+  color: var(--jp-error-color1, #d32f2f);
+}
+
+.nbi-tools-picker-suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 6px;
+}
+
+.nbi-tools-picker-suggestions .pill-item {
+  cursor: pointer;
+}
+
+/* Editor body */
+.nbi-skill-editor-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.nbi-skill-editor-pane {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+/* File tab strip */
+.nbi-skill-editor-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 0;
+  margin-bottom: 8px;
+}
+
+.nbi-skill-editor-tab {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border: 1px solid var(--jp-border-color2);
+  border-radius: 4px;
+  background-color: var(--jp-layout-color1);
+  color: var(--jp-ui-font-color2);
+  font-family: var(--jp-code-font-family, monospace);
+  font-size: var(--jp-ui-font-size0);
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.nbi-skill-editor-tab:hover {
+  background-color: var(--jp-layout-color2);
+  color: var(--jp-ui-font-color1);
+}
+
+.nbi-skill-editor-tab.active {
+  background-color: var(--jp-brand-color3, rgba(68, 138, 255, 0.12));
+  border-color: var(--jp-brand-color1);
+  color: var(--jp-brand-color0, var(--jp-ui-font-color1));
+  font-weight: 600;
+}
+
+.nbi-skill-editor-tab-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 200px;
+}
+
+.nbi-skill-editor-tab-kebab-wrap {
+  position: relative;
+  display: flex;
+}
+
+.nbi-skill-editor-tab-menu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  min-width: 120px;
+  background-color: var(--jp-layout-color1);
+  border: 1px solid var(--jp-border-color1);
+  border-radius: 3px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+  padding: 4px 0;
+}
+
+.nbi-skill-editor-tab-menu button {
+  background: transparent;
+  border: none;
+  padding: 6px 12px;
+  text-align: left;
+  cursor: pointer;
+  color: var(--jp-ui-font-color1);
+  font-size: var(--jp-ui-font-size1);
+  font-family: inherit;
+}
+
+.nbi-skill-editor-tab-menu button:hover {
+  background-color: var(--jp-layout-color2);
+}
+
+.nbi-skill-editor-tab-menu button.danger:hover {
+  background-color: var(--jp-error-color3, rgba(230, 100, 100, 0.2));
+  color: var(--jp-error-color1, #d32f2f);
+}
+
+.nbi-skill-editor-tab-rename-input {
+  padding: 2px 6px;
+  border: 1px solid var(--jp-brand-color1);
+  border-radius: 3px;
+  background-color: var(--jp-input-background, var(--jp-layout-color1));
+  color: var(--jp-ui-font-color1);
+  font-family: var(--jp-code-font-family, monospace);
+  font-size: var(--jp-ui-font-size0);
+  min-width: 120px;
+}
+
+.nbi-skill-editor-tab-add {
+  background: transparent;
+  border: 1px solid var(--jp-border-color2);
+  border-radius: 4px;
+  color: var(--jp-ui-font-color2);
+  cursor: pointer;
+  padding: 4px 10px;
+  font-size: var(--jp-ui-font-size1);
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.nbi-skill-editor-tab-add:hover {
+  background-color: var(--jp-layout-color2);
+  color: var(--jp-ui-font-color1);
+}
+
+.nbi-skill-editor-textarea {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 8px;
+  border: 1px solid var(--jp-border-color1);
+  border-radius: 3px;
+  background-color: var(--jp-input-background, var(--jp-layout-color1));
+  color: var(--jp-ui-font-color1);
+  font-family: var(--jp-code-font-family, monospace);
+  font-size: var(--jp-code-font-size, var(--jp-ui-font-size1));
+  line-height: 1.5;
+  resize: none;
+  overflow: hidden;
+  min-height: 200px;
+}
+
+.nbi-icon-button {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 3px;
+  color: var(--jp-ui-font-color1);
+  font-size: var(--jp-ui-font-size1);
+  line-height: 1;
+}
+
+.nbi-icon-button:hover {
+  background-color: var(--jp-layout-color3);
+}
+
+.nbi-icon-button.danger:hover {
+  background-color: var(--jp-error-color3, rgba(230, 100, 100, 0.2));
+  color: var(--jp-error-color1, #d32f2f);
 }
 
 .config-dialog-body a {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,24 @@
+import io
 import pytest
+import tarfile
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
 from notebook_intelligence.ruleset import RuleContext
 from notebook_intelligence.config import NBIConfig
+
+
+def build_tarball(file_map: dict) -> bytes:
+    """Build a gzipped tarball with the given {path: content} mapping."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for name, content in file_map.items():
+            data = content.encode("utf-8")
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
 
 
 @pytest.fixture

--- a/tests/test_ai_service_manager_integration.py
+++ b/tests/test_ai_service_manager_integration.py
@@ -12,6 +12,8 @@ class TestAIServiceManagerIntegration:
             mock_config.rules_enabled = True
             mock_config.rules_directory = "/test/rules"
             mock_config.mcp = {"mcpServers": {}, "participants": {}}
+            mock_config.user_skills_directory = "/test/user_skills"
+            mock_config.project_skills_directory = lambda _root: "/test/project_skills"
             mock_config_class.return_value = mock_config
             
             with patch('notebook_intelligence.ai_service_manager.RuleManager') as mock_rule_manager_class:
@@ -29,6 +31,8 @@ class TestAIServiceManagerIntegration:
             mock_config = Mock()
             mock_config.rules_enabled = False
             mock_config.mcp = {"mcpServers": {}, "participants": {}}
+            mock_config.user_skills_directory = "/test/user_skills"
+            mock_config.project_skills_directory = lambda _root: "/test/project_skills"
             mock_config_class.return_value = mock_config
             
             manager = AIServiceManager({"server_root_dir": "/test"})
@@ -42,6 +46,8 @@ class TestAIServiceManagerIntegration:
             mock_config.rules_enabled = True
             mock_config.rules_directory = "/test/rules"
             mock_config.mcp = {"mcpServers": {}, "participants": {}}
+            mock_config.user_skills_directory = "/test/user_skills"
+            mock_config.project_skills_directory = lambda _root: "/test/project_skills"
             mock_config_class.return_value = mock_config
             
             with patch('notebook_intelligence.ai_service_manager.RuleManager') as mock_rule_manager_class:
@@ -59,6 +65,8 @@ class TestAIServiceManagerIntegration:
             mock_config = Mock()
             mock_config.rules_enabled = False
             mock_config.mcp = {"mcpServers": {}, "participants": {}}
+            mock_config.user_skills_directory = "/test/user_skills"
+            mock_config.project_skills_directory = lambda _root: "/test/project_skills"
             mock_config_class.return_value = mock_config
             
             manager = AIServiceManager({"server_root_dir": "/test"})
@@ -73,6 +81,8 @@ class TestAIServiceManagerIntegration:
             mock_config.rules_enabled = True
             mock_config.rules_directory = "/test/rules"
             mock_config.mcp = {"mcpServers": {}, "participants": {}}
+            mock_config.user_skills_directory = "/test/user_skills"
+            mock_config.project_skills_directory = lambda _root: "/test/project_skills"
             mock_config_class.return_value = mock_config
             
             with patch('notebook_intelligence.ai_service_manager.RuleManager') as mock_rule_manager_class:
@@ -91,6 +101,8 @@ class TestAIServiceManagerIntegration:
             mock_config = Mock()
             mock_config.rules_enabled = False
             mock_config.mcp = {"mcpServers": {}, "participants": {}}
+            mock_config.user_skills_directory = "/test/user_skills"
+            mock_config.project_skills_directory = lambda _root: "/test/project_skills"
             mock_config_class.return_value = mock_config
             
             manager = AIServiceManager({"server_root_dir": "/test"})

--- a/tests/test_skill_github_import.py
+++ b/tests/test_skill_github_import.py
@@ -1,0 +1,203 @@
+import io
+import tarfile
+from unittest.mock import patch
+
+import pytest
+
+from notebook_intelligence.skill_github_import import (
+    _derive_name,
+    _extract_skill,
+    _slug,
+    parse_github_url,
+    stage_skill_from_github,
+)
+from tests.conftest import build_tarball
+
+
+class TestParseGitHubUrl:
+    def test_basic_repo(self):
+        ref = parse_github_url("https://github.com/owner/repo")
+        assert ref.owner == "owner"
+        assert ref.repo == "repo"
+        assert ref.ref is None
+        assert ref.subpath == ""
+
+    def test_dot_git_suffix_stripped(self):
+        ref = parse_github_url("https://github.com/owner/repo.git")
+        assert ref.repo == "repo"
+
+    def test_tree_with_ref(self):
+        ref = parse_github_url("https://github.com/owner/repo/tree/main")
+        assert ref.ref == "main"
+        assert ref.subpath == ""
+
+    def test_tree_with_ref_and_subpath(self):
+        ref = parse_github_url(
+            "https://github.com/owner/repo/tree/main/skills/foo"
+        )
+        assert ref.ref == "main"
+        assert ref.subpath == "skills/foo"
+
+    def test_rejects_non_github(self):
+        with pytest.raises(ValueError, match="github.com"):
+            parse_github_url("https://gitlab.com/owner/repo")
+
+    def test_rejects_non_https(self):
+        with pytest.raises(ValueError, match="https://"):
+            parse_github_url("ftp://github.com/owner/repo")
+
+    def test_rejects_missing_repo(self):
+        with pytest.raises(ValueError, match="repo"):
+            parse_github_url("https://github.com/owner")
+
+
+class TestSlugAndDerivedName:
+    def test_slug_basic(self):
+        assert _slug("My Skill Name") == "my-skill-name"
+
+    def test_slug_special_chars(self):
+        assert _slug("Foo_Bar!@#") == "foo-bar"
+
+    def test_derive_name_prefers_frontmatter(self):
+        ref = parse_github_url("https://github.com/owner/my-repo")
+        assert _derive_name("my-skill", ref) == "my-skill"
+
+    def test_derive_name_falls_back_to_subpath(self):
+        ref = parse_github_url(
+            "https://github.com/owner/repo/tree/main/skills/my-cool-skill"
+        )
+        assert _derive_name(None, ref) == "my-cool-skill"
+
+    def test_derive_name_falls_back_to_repo(self):
+        ref = parse_github_url("https://github.com/owner/my-repo")
+        assert _derive_name(None, ref) == "my-repo"
+
+
+class TestExtractSkill:
+    def test_extracts_valid_bundle(self, tmp_path):
+        tar_bytes = build_tarball({
+            "repo-abc123/SKILL.md": "---\nname: foo\ndescription: d\n---\nbody",
+            "repo-abc123/helper.py": "print('x')",
+        })
+        skill_root = _extract_skill(tar_bytes, "", tmp_path)
+        assert (skill_root / "SKILL.md").exists()
+        assert (skill_root / "helper.py").exists()
+
+    def test_extracts_subpath(self, tmp_path):
+        tar_bytes = build_tarball({
+            "repo-abc123/README.md": "readme",
+            "repo-abc123/skills/foo/SKILL.md": "---\nname: foo\ndescription: d\n---\nb",
+        })
+        skill_root = _extract_skill(tar_bytes, "skills/foo", tmp_path)
+        assert skill_root.name == "foo"
+        assert (skill_root / "SKILL.md").exists()
+
+    def test_missing_skill_md_raises(self, tmp_path):
+        tar_bytes = build_tarball({
+            "repo-abc123/README.md": "readme",
+        })
+        with pytest.raises(ValueError, match="SKILL.md"):
+            _extract_skill(tar_bytes, "", tmp_path)
+
+    def test_missing_subpath_raises(self, tmp_path):
+        tar_bytes = build_tarball({
+            "repo-abc123/SKILL.md": "---\nname: x\n---\n",
+        })
+        with pytest.raises(ValueError, match="not found"):
+            _extract_skill(tar_bytes, "nope", tmp_path)
+
+    def test_rejects_path_traversal(self, tmp_path):
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            data = b"evil"
+            info = tarfile.TarInfo(name="repo-abc/../escape.txt")
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+        with pytest.raises(ValueError, match="Unsafe path"):
+            _extract_skill(buf.getvalue(), "", tmp_path)
+
+    def test_skips_symlinks(self, tmp_path):
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            skill_data = b"---\nname: x\n---\n"
+            info = tarfile.TarInfo(name="repo-abc/SKILL.md")
+            info.size = len(skill_data)
+            tar.addfile(info, io.BytesIO(skill_data))
+            sym = tarfile.TarInfo(name="repo-abc/link")
+            sym.type = tarfile.SYMTYPE
+            sym.linkname = "/etc/passwd"
+            tar.addfile(sym)
+        skill_root = _extract_skill(buf.getvalue(), "", tmp_path)
+        assert not (skill_root / "link").exists()
+
+
+class TestStageSkillFromGitHub:
+    def _patch_fetch(self, tarball: bytes):
+        return patch(
+            "notebook_intelligence.skill_github_import._fetch_tarball",
+            return_value=tarball,
+        )
+
+    def test_happy_path(self, tmp_path):
+        tar = build_tarball({
+            "repo-abc/SKILL.md": (
+                "---\n"
+                "name: my-skill\n"
+                "description: A cool skill\n"
+                "allowed-tools: [Read, Bash]\n"
+                "---\n"
+                "This is the body"
+            ),
+            "repo-abc/helper.py": "print('x')",
+        })
+        with self._patch_fetch(tar):
+            staged = stage_skill_from_github(
+                "https://github.com/owner/repo"
+            )
+        try:
+            assert staged.name == "my-skill"
+            assert staged.description == "A cool skill"
+            assert "Read" in staged.allowed_tools
+            assert "Bash" in staged.allowed_tools
+            assert staged.body.strip() == "This is the body"
+            assert "helper.py" in staged.files
+            assert "SKILL.md" not in staged.files
+            assert staged.canonical_url == "https://github.com/owner/repo"
+        finally:
+            import shutil
+            shutil.rmtree(staged.tmp_root, ignore_errors=True)
+
+    def test_missing_skill_md_raises(self):
+        tar = build_tarball({
+            "repo-abc/README.md": "just a readme",
+        })
+        with self._patch_fetch(tar):
+            with pytest.raises(ValueError, match="SKILL.md"):
+                stage_skill_from_github("https://github.com/owner/repo")
+
+    def test_invalid_yaml_frontmatter_raises(self):
+        tar = build_tarball({
+            "repo-abc/SKILL.md": "---\n: : bad yaml\n---\nbody",
+        })
+        with self._patch_fetch(tar):
+            with pytest.raises(ValueError):
+                stage_skill_from_github("https://github.com/owner/repo")
+
+    def test_canonical_url_with_ref_and_subpath(self):
+        tar = build_tarball({
+            "repo-abc/skills/thing/SKILL.md": "---\nname: thing\ndescription: d\n---\n",
+        })
+        with self._patch_fetch(tar):
+            staged = stage_skill_from_github(
+                "https://github.com/owner/repo/tree/v1/skills/thing"
+            )
+        try:
+            assert staged.canonical_url == (
+                "https://github.com/owner/repo/tree/v1/skills/thing"
+            )
+        finally:
+            import shutil
+            tmp = staged.skill_root
+            while tmp.parent != tmp and not tmp.name.startswith("nbi-skill-import-"):
+                tmp = tmp.parent
+            shutil.rmtree(tmp, ignore_errors=True)

--- a/tests/test_skill_github_import.py
+++ b/tests/test_skill_github_import.py
@@ -1,5 +1,7 @@
 import io
+import subprocess
 import tarfile
+import urllib.error
 from unittest.mock import patch
 
 import pytest
@@ -7,6 +9,8 @@ import pytest
 from notebook_intelligence.skill_github_import import (
     _derive_name,
     _extract_skill,
+    _fetch_tarball,
+    _get_github_token,
     _slug,
     parse_github_url,
     stage_skill_from_github,
@@ -201,3 +205,183 @@ class TestStageSkillFromGitHub:
             while tmp.parent != tmp and not tmp.name.startswith("nbi-skill-import-"):
                 tmp = tmp.parent
             shutil.rmtree(tmp, ignore_errors=True)
+
+
+class TestGetGitHubToken:
+    def test_prefers_github_token_env(self):
+        with patch.dict(
+            "os.environ", {"GITHUB_TOKEN": "from-github-token", "GH_TOKEN": "other"}
+        ):
+            assert _get_github_token() == "from-github-token"
+
+    def test_falls_back_to_gh_token_env(self):
+        env = {"GH_TOKEN": "from-gh-token"}
+        # Clear GITHUB_TOKEN if present in the real env.
+        with patch.dict("os.environ", env, clear=True):
+            assert _get_github_token() == "from-gh-token"
+
+    def test_strips_whitespace(self):
+        with patch.dict("os.environ", {"GITHUB_TOKEN": "  padded  "}, clear=True):
+            assert _get_github_token() == "padded"
+
+    def test_ignores_empty_env(self):
+        # Empty env var should not short-circuit; fall through to gh CLI (mocked missing).
+        with patch.dict("os.environ", {"GITHUB_TOKEN": "   "}, clear=True):
+            with patch(
+                "notebook_intelligence.skill_github_import.subprocess.run",
+                side_effect=FileNotFoundError,
+            ):
+                assert _get_github_token() is None
+
+    def test_falls_back_to_gh_cli(self):
+        with patch.dict("os.environ", {}, clear=True):
+            fake = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="gh-cli-token\n", stderr=""
+            )
+            with patch(
+                "notebook_intelligence.skill_github_import.subprocess.run",
+                return_value=fake,
+            ):
+                assert _get_github_token() == "gh-cli-token"
+
+    def test_gh_cli_missing_returns_none(self):
+        with patch.dict("os.environ", {}, clear=True):
+            with patch(
+                "notebook_intelligence.skill_github_import.subprocess.run",
+                side_effect=FileNotFoundError,
+            ):
+                assert _get_github_token() is None
+
+    def test_gh_cli_error_returns_none(self):
+        with patch.dict("os.environ", {}, clear=True):
+            fake = subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="not logged in"
+            )
+            with patch(
+                "notebook_intelligence.skill_github_import.subprocess.run",
+                return_value=fake,
+            ):
+                assert _get_github_token() is None
+
+    def test_gh_cli_timeout_returns_none(self):
+        with patch.dict("os.environ", {}, clear=True):
+            with patch(
+                "notebook_intelligence.skill_github_import.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(cmd=["gh"], timeout=5),
+            ):
+                assert _get_github_token() is None
+
+
+class _FakeUrlopenResponse:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def read(self, n):
+        return b"tar-bytes"
+
+
+def _capture_headers_urlopen(captured: dict):
+    def fake_urlopen(req, timeout):
+        captured["headers"] = dict(req.header_items())
+        return _FakeUrlopenResponse()
+
+    return fake_urlopen
+
+
+class TestFetchTarballAuth:
+    def _http_error(self, code: int):
+        return urllib.error.HTTPError(
+            url="https://api.github.com/...",
+            code=code,
+            msg="err",
+            hdrs=None,
+            fp=None,
+        )
+
+    def test_adds_auth_header_when_token_present(self):
+        captured = {}
+        with patch(
+            "notebook_intelligence.skill_github_import._get_github_token",
+            return_value="secret-token",
+        ):
+            with patch(
+                "notebook_intelligence.skill_github_import.urllib.request.urlopen",
+                side_effect=_capture_headers_urlopen(captured),
+            ):
+                _fetch_tarball("owner", "repo", None)
+
+        # urllib lowercases/title-cases header keys; match case-insensitively.
+        lowered = {k.lower(): v for k, v in captured["headers"].items()}
+        assert lowered.get("authorization") == "Bearer secret-token"
+        assert lowered.get("accept") == "application/vnd.github+json"
+        assert lowered.get("x-github-api-version") == "2022-11-28"
+
+    def test_no_auth_header_when_no_token(self):
+        captured = {}
+        with patch(
+            "notebook_intelligence.skill_github_import._get_github_token",
+            return_value=None,
+        ):
+            with patch(
+                "notebook_intelligence.skill_github_import.urllib.request.urlopen",
+                side_effect=_capture_headers_urlopen(captured),
+            ):
+                _fetch_tarball("owner", "repo", None)
+
+        lowered = {k.lower(): v for k, v in captured["headers"].items()}
+        assert "authorization" not in lowered
+
+    def test_401_without_token_prompts_for_auth(self):
+        with patch(
+            "notebook_intelligence.skill_github_import._get_github_token",
+            return_value=None,
+        ):
+            with patch(
+                "notebook_intelligence.skill_github_import.urllib.request.urlopen",
+                side_effect=self._http_error(401),
+            ):
+                with pytest.raises(ValueError, match="requires authentication"):
+                    _fetch_tarball("owner", "repo", None)
+
+    def test_403_with_token_reports_rejection(self):
+        with patch(
+            "notebook_intelligence.skill_github_import._get_github_token",
+            return_value="bad-token",
+        ):
+            with patch(
+                "notebook_intelligence.skill_github_import.urllib.request.urlopen",
+                side_effect=self._http_error(403),
+            ):
+                with pytest.raises(ValueError, match="rejected the token"):
+                    _fetch_tarball("owner", "repo", None)
+
+    def test_404_without_token_hints_private(self):
+        with patch(
+            "notebook_intelligence.skill_github_import._get_github_token",
+            return_value=None,
+        ):
+            with patch(
+                "notebook_intelligence.skill_github_import.urllib.request.urlopen",
+                side_effect=self._http_error(404),
+            ):
+                with pytest.raises(ValueError, match="private repos require"):
+                    _fetch_tarball("owner", "repo", None)
+
+    def test_404_with_token_no_private_hint(self):
+        with patch(
+            "notebook_intelligence.skill_github_import._get_github_token",
+            return_value="some-token",
+        ):
+            with patch(
+                "notebook_intelligence.skill_github_import.urllib.request.urlopen",
+                side_effect=self._http_error(404),
+            ):
+                with pytest.raises(ValueError) as exc_info:
+                    _fetch_tarball("owner", "repo", None)
+                assert "private repos require" not in str(exc_info.value)
+                assert "not found" in str(exc_info.value)
+
+

--- a/tests/test_skill_manager.py
+++ b/tests/test_skill_manager.py
@@ -103,6 +103,76 @@ class TestDiscovery:
         assert skills[0].name == "good"
 
 
+class TestManagedFrontmatter:
+    def test_from_path_reads_managed_frontmatter(self, tmp_path):
+        bundle = tmp_path / "sk"
+        bundle.mkdir()
+        (bundle / SKILL_ENTRY_FILE).write_text(
+            serialize_skill_md(
+                "sk", "desc", [], "body",
+                source="https://github.com/org/repo/tree/main/sk",
+                managed_source="https://github.com/org/repo/tree/main/sk",
+                managed_ref="abc1234",
+            ),
+            encoding="utf-8",
+        )
+        skill = Skill.from_path(bundle, "user")
+        assert skill.managed is True
+        assert skill.managed_source == "https://github.com/org/repo/tree/main/sk"
+        assert skill.managed_ref == "abc1234"
+
+    def test_from_path_missing_managed_fields_defaults_to_unmanaged(self, tmp_path):
+        bundle = tmp_path / "sk"
+        bundle.mkdir()
+        (bundle / SKILL_ENTRY_FILE).write_text(
+            serialize_skill_md("sk", "d", [], "b"), encoding="utf-8"
+        )
+        skill = Skill.from_path(bundle, "user")
+        assert skill.managed is False
+        assert skill.managed_source == ""
+        assert skill.managed_ref == ""
+
+    def test_serialize_skill_md_omits_empty_managed_keys(self):
+        content = serialize_skill_md("sk", "d", [], "b")
+        assert "managed_source" not in content
+        assert "managed_ref" not in content
+
+    def test_update_skill_preserves_managed_fields(self, manager, skill_dirs):
+        user_dir, _ = skill_dirs
+        bundle = user_dir / "m"
+        bundle.mkdir()
+        (bundle / SKILL_ENTRY_FILE).write_text(
+            serialize_skill_md(
+                "m", "d", [], "b",
+                managed_source="https://github.com/org/repo/tree/main/m",
+                managed_ref="abc",
+            ),
+            encoding="utf-8",
+        )
+        updated = manager.update_skill("user", "m", description="new desc")
+        assert updated.managed_source == "https://github.com/org/repo/tree/main/m"
+        assert updated.managed_ref == "abc"
+        reloaded = Skill.from_path(bundle, "user")
+        assert reloaded.managed_source == "https://github.com/org/repo/tree/main/m"
+        assert reloaded.managed_ref == "abc"
+
+    def test_rename_skill_preserves_managed_fields(self, manager, skill_dirs):
+        user_dir, _ = skill_dirs
+        bundle = user_dir / "oldname"
+        bundle.mkdir()
+        (bundle / SKILL_ENTRY_FILE).write_text(
+            serialize_skill_md(
+                "oldname", "d", [], "b",
+                managed_source="https://github.com/org/repo/tree/main/oldname",
+                managed_ref="sha1",
+            ),
+            encoding="utf-8",
+        )
+        renamed = manager.rename_skill("user", "oldname", "newname")
+        assert renamed.managed_source == "https://github.com/org/repo/tree/main/oldname"
+        assert renamed.managed_ref == "sha1"
+
+
 class TestCreate:
     def test_create_skill(self, manager, skill_dirs):
         user_dir, _ = skill_dirs
@@ -462,3 +532,76 @@ class TestGitHubImport:
                 "https://github.com/owner/repo", scope="user"
             )
         assert calls == [1]
+
+
+class TestInstallManagedFromGithub:
+    def _patch(self, tar: bytes):
+        return patch(
+            "notebook_intelligence.skill_github_import._fetch_tarball",
+            return_value=tar,
+        )
+
+    def test_installs_and_stamps_managed_fields(self, manager, skill_dirs):
+        user_dir, _ = skill_dirs
+        tar = build_tarball({
+            "repo-xyz/SKILL.md": "---\nname: mgd\ndescription: d\n---\nbody",
+        })
+        with self._patch(tar):
+            skill = manager.install_managed_from_github(
+                "https://github.com/owner/repo",
+                scope="user",
+                managed_source="https://github.com/owner/repo/tree/main",
+                managed_ref="deadbeef",
+            )
+        assert skill.managed is True
+        assert skill.managed_source == "https://github.com/owner/repo/tree/main"
+        assert skill.managed_ref == "deadbeef"
+        md = (user_dir / "mgd" / SKILL_ENTRY_FILE).read_text()
+        assert "managed_source: https://github.com/owner/repo/tree/main" in md
+        assert "managed_ref: deadbeef" in md
+
+    def test_overwrites_existing_managed_bundle(self, manager, skill_dirs):
+        user_dir, _ = skill_dirs
+        tar1 = build_tarball({
+            "repo-xyz/SKILL.md": "---\nname: mgd\ndescription: v1\n---\nbody",
+        })
+        tar2 = build_tarball({
+            "repo-xyz/SKILL.md": "---\nname: mgd\ndescription: v2\n---\nbody",
+        })
+        with self._patch(tar1):
+            manager.install_managed_from_github(
+                "https://github.com/owner/repo", scope="user",
+                managed_source="src", managed_ref="sha1",
+            )
+        with self._patch(tar2):
+            skill = manager.install_managed_from_github(
+                "https://github.com/owner/repo", scope="user",
+                managed_source="src", managed_ref="sha2",
+            )
+        assert skill.description == "v2"
+        assert skill.managed_ref == "sha2"
+
+    def test_refuses_to_overwrite_user_authored(self, manager):
+        manager.create_skill("user", "mgd", "user bundle", [], "mine")
+        tar = build_tarball({
+            "repo-xyz/SKILL.md": "---\nname: mgd\ndescription: from gh\n---\nbody",
+        })
+        with self._patch(tar):
+            with pytest.raises(FileExistsError, match="user-authored"):
+                manager.install_managed_from_github(
+                    "https://github.com/owner/repo", scope="user",
+                    managed_source="src", managed_ref="sha",
+                )
+
+    def test_list_managed_skills_filters(self, manager, skill_dirs):
+        manager.create_skill("user", "plain", "d", [], "b")
+        tar = build_tarball({
+            "repo-xyz/SKILL.md": "---\nname: mgd\ndescription: d\n---\nb",
+        })
+        with self._patch(tar):
+            manager.install_managed_from_github(
+                "https://github.com/owner/repo", scope="user",
+                managed_source="src", managed_ref="sha",
+            )
+        managed = manager.list_managed_skills()
+        assert [s.name for s in managed] == ["mgd"]

--- a/tests/test_skill_manager.py
+++ b/tests/test_skill_manager.py
@@ -1,0 +1,464 @@
+import threading
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from notebook_intelligence.skill_manager import SkillManager
+from notebook_intelligence.skillset import SKILL_ENTRY_FILE, Skill, serialize_skill_md
+from tests.conftest import build_tarball
+
+
+@pytest.fixture
+def skill_dirs(tmp_path):
+    user_dir = tmp_path / "user_skills"
+    project_dir = tmp_path / "project_skills"
+    user_dir.mkdir()
+    project_dir.mkdir()
+    return user_dir, project_dir
+
+
+@pytest.fixture
+def manager(skill_dirs):
+    user_dir, project_dir = skill_dirs
+    return SkillManager(user_dir, project_dir)
+
+
+def _write_bundle(scope_dir: Path, name: str, description: str = "test", body: str = "body", tools=None):
+    bundle = scope_dir / name
+    bundle.mkdir(parents=True, exist_ok=True)
+    (bundle / SKILL_ENTRY_FILE).write_text(
+        serialize_skill_md(name, description, tools or [], body), encoding="utf-8"
+    )
+    return bundle
+
+
+class TestDiscovery:
+    def test_empty_dirs_return_empty_list(self, manager):
+        assert manager.list_skills() == []
+
+    def test_discovers_user_skill(self, manager, skill_dirs):
+        user_dir, _ = skill_dirs
+        _write_bundle(user_dir, "alpha", description="user skill")
+        skills = manager.list_skills()
+        assert len(skills) == 1
+        assert skills[0].name == "alpha"
+        assert skills[0].scope == "user"
+        assert skills[0].description == "user skill"
+
+    def test_discovers_project_skill(self, manager, skill_dirs):
+        _, project_dir = skill_dirs
+        _write_bundle(project_dir, "beta")
+        skills = manager.list_skills()
+        assert len(skills) == 1
+        assert skills[0].scope == "project"
+
+    def test_discovers_bundle_with_extra_files(self, manager, skill_dirs):
+        user_dir, _ = skill_dirs
+        bundle = _write_bundle(user_dir, "multi", description="bundle")
+        (bundle / "helper.py").write_text("print('hi')", encoding="utf-8")
+        skills = manager.list_skills()
+        assert len(skills) == 1
+        assert skills[0].name == "multi"
+        assert "helper.py" in skills[0].list_files()
+        assert SKILL_ENTRY_FILE in skills[0].list_files()
+
+    def test_discovers_mixed_scopes(self, manager, skill_dirs):
+        user_dir, project_dir = skill_dirs
+        _write_bundle(user_dir, "one")
+        _write_bundle(project_dir, "two")
+        _write_bundle(user_dir, "three")
+        skills = manager.list_skills()
+        assert {(s.name, s.scope) for s in skills} == {
+            ("one", "user"),
+            ("three", "user"),
+            ("two", "project"),
+        }
+
+    def test_top_level_md_files_are_ignored(self, manager, skill_dirs):
+        user_dir, _ = skill_dirs
+        (user_dir / "loose.md").write_text(
+            serialize_skill_md("loose", "d", [], "b"), encoding="utf-8"
+        )
+        assert manager.list_skills() == []
+
+    def test_directory_without_skill_md_is_ignored(self, manager, skill_dirs):
+        user_dir, _ = skill_dirs
+        stray = user_dir / "not-a-skill"
+        stray.mkdir()
+        (stray / "readme.md").write_text("not a skill", encoding="utf-8")
+        assert manager.list_skills() == []
+
+    def test_malformed_skill_is_skipped_without_crash(self, manager, skill_dirs, caplog):
+        user_dir, _ = skill_dirs
+        _write_bundle(user_dir, "good", description="desc", body="body")
+        bad = user_dir / "bad"
+        bad.mkdir()
+        (bad / SKILL_ENTRY_FILE).write_text(
+            "---\napply: [unclosed\n---\nbody", encoding="utf-8"
+        )
+        skills = manager.list_skills()
+        assert len(skills) == 1
+        assert skills[0].name == "good"
+
+
+class TestCreate:
+    def test_create_skill(self, manager, skill_dirs):
+        user_dir, _ = skill_dirs
+        skill = manager.create_skill(
+            scope="user",
+            name="my-skill",
+            description="does a thing",
+            allowed_tools=["Read", "Grep"],
+            body="# Body",
+        )
+        assert skill.name == "my-skill"
+        assert (user_dir / "my-skill" / SKILL_ENTRY_FILE).exists()
+        reloaded = Skill.from_path(user_dir / "my-skill", "user")
+        assert reloaded.description == "does a thing"
+        assert reloaded.allowed_tools == ["Read", "Grep"]
+
+    def test_create_rejects_duplicate_name(self, manager):
+        manager.create_skill("user", "dup", "d", [], "b")
+        with pytest.raises(ValueError, match="already exists"):
+            manager.create_skill("user", "dup", "d", [], "b")
+
+    def test_create_rejects_invalid_name(self, manager):
+        for bad in ["UPPER", "with space", "has/slash", "../escape", "", "a" * 100]:
+            with pytest.raises(ValueError, match="Invalid skill name"):
+                manager.create_skill("user", bad, "d", [], "b")
+
+    def test_create_same_name_in_different_scopes_is_allowed(self, manager):
+        manager.create_skill("user", "shared", "u", [], "")
+        manager.create_skill("project", "shared", "p", [], "")
+        skills = manager.list_skills()
+        assert len(skills) == 2
+
+
+class TestUpdate:
+    def test_update_changes_description(self, manager):
+        manager.create_skill("user", "edit-me", "old", [], "body")
+        updated = manager.update_skill("user", "edit-me", description="new")
+        assert updated.description == "new"
+
+    def test_update_missing_skill_raises(self, manager):
+        with pytest.raises(FileNotFoundError):
+            manager.update_skill("user", "nope", description="x")
+
+    def test_update_writes_to_skill_md(self, manager, skill_dirs):
+        user_dir, _ = skill_dirs
+        manager.create_skill("user", "bun", "d", [], "initial")
+        manager.update_skill("user", "bun", body="updated body")
+        content = (user_dir / "bun" / SKILL_ENTRY_FILE).read_text()
+        assert "updated body" in content
+
+
+class TestDelete:
+    def test_delete_removes_directory(self, manager, skill_dirs):
+        user_dir, _ = skill_dirs
+        manager.create_skill("user", "bun", "d", [], "")
+        (user_dir / "bun" / "helper.txt").write_text("x")
+        manager.delete_skill("user", "bun")
+        assert not (user_dir / "bun").exists()
+
+    def test_delete_missing_raises(self, manager):
+        with pytest.raises(FileNotFoundError):
+            manager.delete_skill("user", "nope")
+
+
+class TestRenameSkill:
+    def test_rename_moves_directory(self, manager, skill_dirs):
+        user_dir, _ = skill_dirs
+        manager.create_skill("user", "old", "d", [], "body")
+        renamed = manager.rename_skill("user", "old", "new")
+        assert renamed.name == "new"
+        assert not (user_dir / "old").exists()
+        assert (user_dir / "new" / SKILL_ENTRY_FILE).exists()
+
+    def test_rename_updates_frontmatter(self, manager, skill_dirs):
+        user_dir, _ = skill_dirs
+        manager.create_skill("user", "old", "d", [], "body")
+        manager.rename_skill("user", "old", "new")
+        content = (user_dir / "new" / SKILL_ENTRY_FILE).read_text()
+        assert "name: new" in content
+
+    def test_rename_preserves_bundle_files(self, manager, skill_dirs):
+        user_dir, _ = skill_dirs
+        manager.create_skill("user", "old", "d", [], "")
+        manager.write_bundle_file("user", "old", "helper.py", "print(1)")
+        manager.rename_skill("user", "old", "new")
+        assert (user_dir / "new" / "helper.py").read_text() == "print(1)"
+
+    def test_rename_rejects_invalid_new_name(self, manager):
+        manager.create_skill("user", "old", "d", [], "")
+        with pytest.raises(ValueError, match="Invalid skill name"):
+            manager.rename_skill("user", "old", "UPPER")
+
+    def test_rename_rejects_duplicate(self, manager):
+        manager.create_skill("user", "a", "d", [], "")
+        manager.create_skill("user", "b", "d", [], "")
+        with pytest.raises(FileExistsError):
+            manager.rename_skill("user", "a", "b")
+
+    def test_rename_missing_raises(self, manager):
+        with pytest.raises(FileNotFoundError):
+            manager.rename_skill("user", "nope", "new")
+
+    def test_rename_to_same_name_is_noop(self, manager):
+        manager.create_skill("user", "x", "d", [], "")
+        result = manager.rename_skill("user", "x", "x")
+        assert result.name == "x"
+
+    def test_rename_fires_listener(self, manager):
+        manager.create_skill("user", "old", "d", [], "")
+        calls = []
+        manager.on_skills_changed(lambda: calls.append(1))
+        manager.rename_skill("user", "old", "new")
+        assert calls == [1]
+
+
+class TestBundleFiles:
+    def test_write_read_bundle_file(self, manager):
+        manager.create_skill("user", "bun", "d", [], "")
+        manager.write_bundle_file("user", "bun", "helper.py", "print('hi')")
+        assert manager.read_bundle_file("user", "bun", "helper.py") == "print('hi')"
+
+    def test_write_rejects_path_traversal(self, manager):
+        manager.create_skill("user", "bun", "d", [], "")
+        for bad in ["../escape.py", "/absolute.py", "subdir\\win.py"]:
+            with pytest.raises(ValueError):
+                manager.write_bundle_file("user", "bun", bad, "x")
+
+    def test_write_allows_nested_paths(self, manager):
+        manager.create_skill("user", "bun", "d", [], "")
+        manager.write_bundle_file("user", "bun", "scripts/run.sh", "#!/bin/sh")
+        assert manager.read_bundle_file("user", "bun", "scripts/run.sh") == "#!/bin/sh"
+
+    def test_delete_skill_md_is_blocked(self, manager):
+        manager.create_skill("user", "bun", "d", [], "")
+        with pytest.raises(ValueError, match="Cannot delete"):
+            manager.delete_bundle_file("user", "bun", SKILL_ENTRY_FILE)
+
+    def test_delete_bundle_file(self, manager):
+        manager.create_skill("user", "bun", "d", [], "")
+        manager.write_bundle_file("user", "bun", "extra.txt", "junk")
+        manager.delete_bundle_file("user", "bun", "extra.txt")
+        with pytest.raises(FileNotFoundError):
+            manager.read_bundle_file("user", "bun", "extra.txt")
+
+    def test_rename_bundle_file(self, manager):
+        manager.create_skill("user", "bun", "d", [], "")
+        manager.write_bundle_file("user", "bun", "old.txt", "x")
+        manager.rename_bundle_file("user", "bun", "old.txt", "new.txt")
+        assert manager.read_bundle_file("user", "bun", "new.txt") == "x"
+        with pytest.raises(FileNotFoundError):
+            manager.read_bundle_file("user", "bun", "old.txt")
+
+    def test_rename_bundle_file_to_nested_path(self, manager):
+        manager.create_skill("user", "bun", "d", [], "")
+        manager.write_bundle_file("user", "bun", "a.txt", "x")
+        manager.rename_bundle_file("user", "bun", "a.txt", "sub/b.txt")
+        assert manager.read_bundle_file("user", "bun", "sub/b.txt") == "x"
+
+    def test_rename_bundle_file_rejects_skill_md(self, manager):
+        manager.create_skill("user", "bun", "d", [], "")
+        manager.write_bundle_file("user", "bun", "other.txt", "x")
+        with pytest.raises(ValueError):
+            manager.rename_bundle_file("user", "bun", SKILL_ENTRY_FILE, "other.md")
+        with pytest.raises(ValueError):
+            manager.rename_bundle_file("user", "bun", "other.txt", SKILL_ENTRY_FILE)
+
+    def test_rename_bundle_file_rejects_path_traversal(self, manager):
+        manager.create_skill("user", "bun", "d", [], "")
+        manager.write_bundle_file("user", "bun", "a.txt", "x")
+        with pytest.raises(ValueError):
+            manager.rename_bundle_file("user", "bun", "a.txt", "../escape.txt")
+
+    def test_rename_bundle_file_rejects_collision(self, manager):
+        manager.create_skill("user", "bun", "d", [], "")
+        manager.write_bundle_file("user", "bun", "a.txt", "x")
+        manager.write_bundle_file("user", "bun", "b.txt", "y")
+        with pytest.raises(FileExistsError):
+            manager.rename_bundle_file("user", "bun", "a.txt", "b.txt")
+
+    def test_rename_missing_file_raises(self, manager):
+        manager.create_skill("user", "bun", "d", [], "")
+        with pytest.raises(FileNotFoundError):
+            manager.rename_bundle_file("user", "bun", "missing.txt", "other.txt")
+
+
+class TestChangeNotifications:
+    def test_create_fires_listener(self, manager):
+        calls = []
+        manager.on_skills_changed(lambda: calls.append(1))
+        manager.create_skill("user", "x", "d", [], "")
+        assert calls == [1]
+
+    def test_update_fires_listener(self, manager):
+        manager.create_skill("user", "x", "d", [], "")
+        calls = []
+        manager.on_skills_changed(lambda: calls.append(1))
+        manager.update_skill("user", "x", description="new")
+        assert calls == [1]
+
+    def test_delete_fires_listener(self, manager):
+        manager.create_skill("user", "x", "d", [], "")
+        calls = []
+        manager.on_skills_changed(lambda: calls.append(1))
+        manager.delete_skill("user", "x")
+        assert calls == [1]
+
+    def test_listener_exception_does_not_block_others(self, manager):
+        calls = []
+        manager.on_skills_changed(lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+        manager.on_skills_changed(lambda: calls.append(1))
+        manager.create_skill("user", "x", "d", [], "")
+        assert calls == [1]
+
+
+class TestWatcher:
+    def test_watcher_detects_external_change(self, skill_dirs):
+        user_dir, project_dir = skill_dirs
+        manager = SkillManager(user_dir, project_dir)
+        manager.WATCH_INTERVAL_SECONDS = 0.05  # type: ignore[attr-defined]
+        fired = threading.Event()
+        manager.on_skills_changed(fired.set)
+        manager.start_watching()
+        try:
+            # Ensure mtime baseline is recorded before we mutate
+            time.sleep(0.1)
+            _write_bundle(user_dir, "external")
+            assert fired.wait(timeout=2.0), "watcher did not fire on external change"
+        finally:
+            manager.stop_watching()
+
+    def test_watcher_stop_is_idempotent(self, manager):
+        manager.stop_watching()
+        manager.stop_watching()
+
+
+class TestGitHubImport:
+    def _patch(self, tar: bytes):
+        return patch(
+            "notebook_intelligence.skill_github_import._fetch_tarball",
+            return_value=tar,
+        )
+
+    def test_preview_returns_metadata(self, manager):
+        tar = build_tarball({
+            "repo-xyz/SKILL.md": (
+                "---\nname: my-skill\ndescription: desc\n"
+                "allowed-tools: [Read]\n---\nbody text"
+            ),
+            "repo-xyz/notes.md": "notes",
+        })
+        with self._patch(tar):
+            preview = manager.preview_github_import(
+                "https://github.com/owner/repo"
+            )
+        assert preview["name"] == "my-skill"
+        assert preview["description"] == "desc"
+        assert preview["allowed_tools"] == ["Read"]
+        assert preview["files"] == ["notes.md"]
+        assert preview["exists_in_user_scope"] is False
+        assert preview["exists_in_project_scope"] is False
+
+    def test_preview_flags_existing_skill(self, manager):
+        manager.create_skill("user", "my-skill", "d", [], "")
+        tar = build_tarball({
+            "repo-xyz/SKILL.md": "---\nname: my-skill\ndescription: d\n---\nb",
+        })
+        with self._patch(tar):
+            preview = manager.preview_github_import(
+                "https://github.com/owner/repo"
+            )
+        assert preview["exists_in_user_scope"] is True
+        assert preview["exists_in_project_scope"] is False
+
+    def test_import_installs_skill_with_source(self, manager, skill_dirs):
+        user_dir, _ = skill_dirs
+        tar = build_tarball({
+            "repo-xyz/SKILL.md": (
+                "---\nname: imported\ndescription: from gh\n---\nhello"
+            ),
+            "repo-xyz/helper.txt": "assets",
+        })
+        with self._patch(tar):
+            skill = manager.import_from_github(
+                "https://github.com/owner/repo", scope="user"
+            )
+        assert skill.name == "imported"
+        assert skill.source == "https://github.com/owner/repo"
+        assert (user_dir / "imported" / SKILL_ENTRY_FILE).exists()
+        assert (user_dir / "imported" / "helper.txt").exists()
+        md = (user_dir / "imported" / SKILL_ENTRY_FILE).read_text()
+        assert "source: https://github.com/owner/repo" in md
+
+    def test_import_with_name_override(self, manager, skill_dirs):
+        user_dir, _ = skill_dirs
+        tar = build_tarball({
+            "repo-xyz/SKILL.md": "---\nname: orig\ndescription: d\n---\nb",
+        })
+        with self._patch(tar):
+            skill = manager.import_from_github(
+                "https://github.com/owner/repo",
+                scope="user",
+                name_override="renamed",
+            )
+        assert skill.name == "renamed"
+        assert (user_dir / "renamed").is_dir()
+        assert not (user_dir / "orig").exists()
+
+    def test_import_collision_without_overwrite_raises(self, manager):
+        manager.create_skill("user", "dup", "existing", [], "orig")
+        tar = build_tarball({
+            "repo-xyz/SKILL.md": "---\nname: dup\ndescription: new\n---\nnew body",
+        })
+        with self._patch(tar):
+            with pytest.raises(FileExistsError):
+                manager.import_from_github(
+                    "https://github.com/owner/repo", scope="user"
+                )
+
+    def test_import_collision_with_overwrite_replaces(self, manager, skill_dirs):
+        user_dir, _ = skill_dirs
+        manager.create_skill("user", "dup", "existing", [], "orig")
+        (user_dir / "dup" / "old_file.txt").write_text("old")
+        tar = build_tarball({
+            "repo-xyz/SKILL.md": "---\nname: dup\ndescription: new\n---\nnew body",
+            "repo-xyz/new_file.txt": "new",
+        })
+        with self._patch(tar):
+            skill = manager.import_from_github(
+                "https://github.com/owner/repo",
+                scope="user",
+                overwrite=True,
+            )
+        assert skill.description == "new"
+        assert (user_dir / "dup" / "new_file.txt").exists()
+        assert not (user_dir / "dup" / "old_file.txt").exists()
+
+    def test_import_invalid_name_override_raises(self, manager):
+        tar = build_tarball({
+            "repo-xyz/SKILL.md": "---\nname: ok\ndescription: d\n---\nb",
+        })
+        with self._patch(tar):
+            with pytest.raises(ValueError, match="Invalid skill name"):
+                manager.import_from_github(
+                    "https://github.com/owner/repo",
+                    scope="user",
+                    name_override="INVALID NAME!!",
+                )
+
+    def test_import_fires_change_listener(self, manager):
+        tar = build_tarball({
+            "repo-xyz/SKILL.md": "---\nname: gh-skill\ndescription: d\n---\nb",
+        })
+        calls = []
+        manager.on_skills_changed(lambda: calls.append(1))
+        with self._patch(tar):
+            manager.import_from_github(
+                "https://github.com/owner/repo", scope="user"
+            )
+        assert calls == [1]

--- a/tests/test_skill_manifest.py
+++ b/tests/test_skill_manifest.py
@@ -1,0 +1,195 @@
+import io
+from unittest.mock import patch
+
+import pytest
+
+from notebook_intelligence.skill_manifest import (
+    ManifestError,
+    MAX_MANIFEST_BYTES,
+    load_manifest,
+)
+
+
+class TestFileLoading:
+    def test_loads_yaml_from_file(self, tmp_path):
+        p = tmp_path / "m.yaml"
+        p.write_text(
+            "skills:\n"
+            "  - url: https://github.com/org/repo/tree/main/a\n"
+            "  - url: https://github.com/org/repo/tree/main/b\n"
+            "    name: beta\n"
+            "    scope: project\n",
+            encoding="utf-8",
+        )
+        manifest = load_manifest(str(p))
+        assert len(manifest.entries) == 2
+        assert manifest.entries[0].url == "https://github.com/org/repo/tree/main/a"
+        assert manifest.entries[0].name is None
+        assert manifest.entries[0].scope == "user"
+        assert manifest.entries[1].name == "beta"
+        assert manifest.entries[1].scope == "project"
+
+    def test_loads_json_from_file(self, tmp_path):
+        # yaml.safe_load handles JSON as a subset of YAML.
+        p = tmp_path / "m.json"
+        p.write_text(
+            '{"skills": [{"url": "https://github.com/org/repo/tree/main/a"}]}',
+            encoding="utf-8",
+        )
+        manifest = load_manifest(str(p))
+        assert len(manifest.entries) == 1
+
+    def test_expands_tilde_in_path(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        p = tmp_path / "m.yaml"
+        p.write_text("skills: []\n", encoding="utf-8")
+        manifest = load_manifest("~/m.yaml")
+        assert manifest.entries == []
+
+    def test_missing_file_raises(self, tmp_path):
+        with pytest.raises(ManifestError, match="not found"):
+            load_manifest(str(tmp_path / "nope.yaml"))
+
+    def test_size_cap_enforced(self, tmp_path):
+        p = tmp_path / "big.yaml"
+        p.write_bytes(b"a" * (MAX_MANIFEST_BYTES + 10))
+        with pytest.raises(ManifestError, match="exceeds"):
+            load_manifest(str(p))
+
+
+class TestValidation:
+    def test_rejects_empty_source(self):
+        with pytest.raises(ManifestError, match="empty"):
+            load_manifest("")
+
+    def test_rejects_non_mapping_root(self, tmp_path):
+        p = tmp_path / "m.yaml"
+        p.write_text("- url: foo\n", encoding="utf-8")
+        with pytest.raises(ManifestError, match="mapping"):
+            load_manifest(str(p))
+
+    def test_rejects_missing_skills_key(self, tmp_path):
+        p = tmp_path / "m.yaml"
+        p.write_text("other: []\n", encoding="utf-8")
+        with pytest.raises(ManifestError, match="skills"):
+            load_manifest(str(p))
+
+    def test_rejects_non_list_skills(self, tmp_path):
+        p = tmp_path / "m.yaml"
+        p.write_text("skills:\n  foo: bar\n", encoding="utf-8")
+        with pytest.raises(ManifestError, match="must be a list"):
+            load_manifest(str(p))
+
+    def test_rejects_entry_missing_url(self, tmp_path):
+        p = tmp_path / "m.yaml"
+        p.write_text("skills:\n  - name: nope\n", encoding="utf-8")
+        with pytest.raises(ManifestError, match="url is required"):
+            load_manifest(str(p))
+
+    def test_rejects_invalid_scope(self, tmp_path):
+        p = tmp_path / "m.yaml"
+        p.write_text(
+            "skills:\n  - url: https://x/y\n    scope: global\n", encoding="utf-8"
+        )
+        with pytest.raises(ManifestError, match="scope"):
+            load_manifest(str(p))
+
+    def test_rejects_invalid_name(self, tmp_path):
+        p = tmp_path / "m.yaml"
+        p.write_text(
+            "skills:\n  - url: https://x/y\n    name: Bad Name\n", encoding="utf-8"
+        )
+        with pytest.raises(ManifestError, match="not a valid skill name"):
+            load_manifest(str(p))
+
+    def test_rejects_malformed_yaml(self, tmp_path):
+        p = tmp_path / "m.yaml"
+        p.write_text("skills: [\n", encoding="utf-8")
+        with pytest.raises(ManifestError, match="not valid YAML"):
+            load_manifest(str(p))
+
+
+class TestUrlLoading:
+    @staticmethod
+    def _fake_response(body: bytes):
+        resp = io.BytesIO(body)
+        resp.__enter__ = lambda self: self  # type: ignore[attr-defined]
+        resp.__exit__ = lambda self, *a: False  # type: ignore[attr-defined]
+        return resp
+
+    def test_fetches_over_https(self):
+        body = b"skills:\n  - url: https://github.com/org/repo/tree/main/a\n"
+        with patch(
+            "notebook_intelligence.skill_manifest.urllib.request.urlopen"
+        ) as mock_open:
+            mock_open.return_value = self._fake_response(body)
+            manifest = load_manifest("https://example.com/manifest.yaml")
+        assert len(manifest.entries) == 1
+        # Verify auth header not set when no token.
+        req = mock_open.call_args[0][0]
+        assert "Authorization" not in req.headers
+
+    def test_adds_bearer_token_header(self):
+        body = b"skills: []\n"
+        with patch(
+            "notebook_intelligence.skill_manifest.urllib.request.urlopen"
+        ) as mock_open:
+            mock_open.return_value = self._fake_response(body)
+            load_manifest("https://example.com/manifest.yaml", token="abc123")
+        req = mock_open.call_args[0][0]
+        assert req.headers.get("Authorization") == "Bearer abc123"
+
+    def test_url_size_cap_enforced(self):
+        big = b"a" * (MAX_MANIFEST_BYTES + 10)
+        with patch(
+            "notebook_intelligence.skill_manifest.urllib.request.urlopen"
+        ) as mock_open:
+            mock_open.return_value = self._fake_response(big)
+            with pytest.raises(ManifestError, match="exceeds"):
+                load_manifest("https://example.com/manifest.yaml")
+
+    def test_github_host_uses_gh_token_fallback(self):
+        body = b"skills: []\n"
+        with patch(
+            "notebook_intelligence.skill_manifest._get_github_token",
+            return_value="gh_fallback",
+        ), patch(
+            "notebook_intelligence.skill_manifest.urllib.request.urlopen"
+        ) as mock_open:
+            mock_open.return_value = self._fake_response(body)
+            load_manifest(
+                "https://raw.githubusercontent.com/org/repo/main/manifest.yaml"
+            )
+        req = mock_open.call_args[0][0]
+        assert req.headers.get("Authorization") == "Bearer gh_fallback"
+
+    def test_non_github_host_skips_gh_token_fallback(self):
+        body = b"skills: []\n"
+        with patch(
+            "notebook_intelligence.skill_manifest._get_github_token",
+            return_value="gh_fallback",
+        ) as probe, patch(
+            "notebook_intelligence.skill_manifest.urllib.request.urlopen"
+        ) as mock_open:
+            mock_open.return_value = self._fake_response(body)
+            load_manifest("https://example.com/manifest.yaml")
+        req = mock_open.call_args[0][0]
+        assert "Authorization" not in req.headers
+        probe.assert_not_called()
+
+    def test_explicit_token_wins_over_gh_token_fallback(self):
+        body = b"skills: []\n"
+        with patch(
+            "notebook_intelligence.skill_manifest._get_github_token",
+            return_value="gh_fallback",
+        ) as probe, patch(
+            "notebook_intelligence.skill_manifest.urllib.request.urlopen"
+        ) as mock_open:
+            mock_open.return_value = self._fake_response(body)
+            load_manifest(
+                "https://raw.githubusercontent.com/org/repo/main/manifest.yaml",
+                token="explicit",
+            )
+        req = mock_open.call_args[0][0]
+        assert req.headers.get("Authorization") == "Bearer explicit"
+        probe.assert_not_called()

--- a/tests/test_skill_reconciler.py
+++ b/tests/test_skill_reconciler.py
@@ -1,0 +1,332 @@
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+
+from notebook_intelligence.skill_manager import SkillManager
+from notebook_intelligence.skill_reconciler import SkillReconciler
+from notebook_intelligence.skillset import SKILL_ENTRY_FILE, Skill, serialize_skill_md
+from tests.conftest import build_tarball
+
+
+@pytest.fixture
+def skill_dirs(tmp_path):
+    user_dir = tmp_path / "user_skills"
+    project_dir = tmp_path / "project_skills"
+    user_dir.mkdir()
+    project_dir.mkdir()
+    return user_dir, project_dir
+
+
+@pytest.fixture
+def manager(skill_dirs):
+    user_dir, project_dir = skill_dirs
+    return SkillManager(user_dir, project_dir)
+
+
+def _write_manifest(tmp_path, entries_yaml):
+    p = tmp_path / "manifest.yaml"
+    body = f"skills:\n{entries_yaml}" if entries_yaml else "skills: []\n"
+    p.write_text(body, encoding="utf-8")
+    return str(p)
+
+
+def _patch_tarball(tar: bytes):
+    return patch(
+        "notebook_intelligence.skill_github_import._fetch_tarball",
+        return_value=tar,
+    )
+
+
+def _patch_sha(sha):
+    return patch(
+        "notebook_intelligence.skill_reconciler.get_latest_commit_sha",
+        return_value=sha,
+    )
+
+
+class TestReconcileInstall:
+    def test_installs_missing_managed_skill(self, manager, tmp_path, skill_dirs):
+        user_dir, _ = skill_dirs
+        manifest = _write_manifest(
+            tmp_path,
+            "  - url: https://github.com/org/repo/tree/main/alpha\n",
+        )
+        tar = build_tarball({
+            "repo-xyz/alpha/SKILL.md": "---\nname: alpha\ndescription: a\n---\nbody",
+        })
+        reconciler = SkillReconciler(manager, manifest, interval_seconds=60)
+
+        with _patch_sha("abc123"), _patch_tarball(tar):
+            result = reconciler.reconcile()
+
+        assert result.added == 1
+        assert result.updated == 0
+        assert result.removed == 0
+        assert result.errors == []
+        skill = Skill.from_path(user_dir / "alpha", "user")
+        assert skill.managed is True
+        assert skill.managed_ref == "abc123"
+        assert skill.managed_source == "https://github.com/org/repo/tree/main/alpha"
+
+    def test_skips_when_sha_matches(self, manager, tmp_path, skill_dirs):
+        user_dir, _ = skill_dirs
+        manifest = _write_manifest(
+            tmp_path,
+            "  - url: https://github.com/org/repo/tree/main/alpha\n",
+        )
+        # Pre-install a managed skill with a known SHA.
+        bundle = user_dir / "alpha"
+        bundle.mkdir()
+        (bundle / SKILL_ENTRY_FILE).write_text(
+            serialize_skill_md(
+                "alpha", "a", [], "body",
+                managed_source="https://github.com/org/repo/tree/main/alpha",
+                managed_ref="sha_match",
+            ),
+            encoding="utf-8",
+        )
+        reconciler = SkillReconciler(manager, manifest, interval_seconds=60)
+
+        with _patch_sha("sha_match"), patch(
+            "notebook_intelligence.skill_github_import._fetch_tarball"
+        ) as fetch:
+            result = reconciler.reconcile()
+
+        assert result.unchanged == 1
+        assert result.updated == 0
+        # Crucial: tarball never fetched when SHA matches.
+        fetch.assert_not_called()
+
+    def test_updates_when_sha_differs(self, manager, tmp_path, skill_dirs):
+        user_dir, _ = skill_dirs
+        manifest = _write_manifest(
+            tmp_path,
+            "  - url: https://github.com/org/repo/tree/main/alpha\n",
+        )
+        bundle = user_dir / "alpha"
+        bundle.mkdir()
+        (bundle / SKILL_ENTRY_FILE).write_text(
+            serialize_skill_md(
+                "alpha", "old", [], "old body",
+                managed_source="https://github.com/org/repo/tree/main/alpha",
+                managed_ref="sha_old",
+            ),
+            encoding="utf-8",
+        )
+        tar = build_tarball({
+            "repo-xyz/alpha/SKILL.md": "---\nname: alpha\ndescription: new\n---\nnew body",
+        })
+        reconciler = SkillReconciler(manager, manifest, interval_seconds=60)
+
+        with _patch_sha("sha_new"), _patch_tarball(tar):
+            result = reconciler.reconcile()
+
+        assert result.updated == 1
+        reloaded = Skill.from_path(bundle, "user")
+        assert reloaded.description == "new"
+        assert reloaded.managed_ref == "sha_new"
+
+    def test_full_sha_in_url_skips_probe(self, manager, tmp_path):
+        full_sha = "a" * 40
+        manifest = _write_manifest(
+            tmp_path,
+            f"  - url: https://github.com/org/repo/tree/{full_sha}/alpha\n",
+        )
+        tar = build_tarball({
+            "repo-xyz/alpha/SKILL.md": "---\nname: alpha\ndescription: a\n---\nbody",
+        })
+        reconciler = SkillReconciler(manager, manifest, interval_seconds=60)
+
+        with _patch_tarball(tar), patch(
+            "notebook_intelligence.skill_reconciler.get_latest_commit_sha"
+        ) as probe:
+            result = reconciler.reconcile()
+
+        probe.assert_not_called()
+        assert result.added == 1
+
+
+class TestReconcileDelete:
+    def test_removes_managed_skill_missing_from_manifest(
+        self, manager, tmp_path, skill_dirs
+    ):
+        user_dir, _ = skill_dirs
+        bundle = user_dir / "gone"
+        bundle.mkdir()
+        (bundle / SKILL_ENTRY_FILE).write_text(
+            serialize_skill_md(
+                "gone", "d", [], "b",
+                managed_source="https://github.com/org/repo/tree/main/gone",
+                managed_ref="sha",
+            ),
+            encoding="utf-8",
+        )
+        manifest = _write_manifest(tmp_path, "")  # empty manifest
+        reconciler = SkillReconciler(manager, manifest, interval_seconds=60)
+
+        result = reconciler.reconcile()
+
+        assert result.removed == 1
+        assert not bundle.exists()
+
+    def test_preserves_user_authored_skill(self, manager, tmp_path, skill_dirs):
+        user_dir, _ = skill_dirs
+        manager.create_skill("user", "mine", "my skill", [], "body")
+        manifest = _write_manifest(tmp_path, "")  # empty
+        reconciler = SkillReconciler(manager, manifest, interval_seconds=60)
+
+        result = reconciler.reconcile()
+
+        assert result.removed == 0
+        assert (user_dir / "mine" / SKILL_ENTRY_FILE).exists()
+
+
+class TestReconcileErrors:
+    def test_tarball_error_isolated_per_entry(self, manager, tmp_path, skill_dirs):
+        user_dir, _ = skill_dirs
+        manifest = _write_manifest(
+            tmp_path,
+            "  - url: https://github.com/org/repo/tree/main/broken\n"
+            "  - url: https://github.com/org/repo/tree/main/good\n",
+        )
+        tar_good = build_tarball({
+            "repo-xyz/good/SKILL.md": "---\nname: good\ndescription: g\n---\nbody",
+        })
+
+        call_count = {"n": 0}
+
+        def fake_fetch(owner, repo, ref):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise ValueError("network flake")
+            return tar_good
+
+        reconciler = SkillReconciler(manager, manifest, interval_seconds=60)
+        with _patch_sha("sha"), patch(
+            "notebook_intelligence.skill_github_import._fetch_tarball",
+            side_effect=fake_fetch,
+        ):
+            result = reconciler.reconcile()
+
+        assert result.added == 1  # second entry still installed
+        assert len(result.errors) == 1
+        assert "network flake" in result.errors[0]
+        assert (user_dir / "good" / SKILL_ENTRY_FILE).exists()
+
+    def test_malformed_manifest_logs_and_skips_removals(
+        self, manager, tmp_path, skill_dirs
+    ):
+        user_dir, _ = skill_dirs
+        bundle = user_dir / "prev"
+        bundle.mkdir()
+        (bundle / SKILL_ENTRY_FILE).write_text(
+            serialize_skill_md(
+                "prev", "d", [], "b",
+                managed_source="https://github.com/org/repo/tree/main/prev",
+                managed_ref="sha",
+            ),
+            encoding="utf-8",
+        )
+        # Malformed — missing required `skills:` list.
+        bad = tmp_path / "m.yaml"
+        bad.write_text("other: []\n", encoding="utf-8")
+        reconciler = SkillReconciler(manager, str(bad), interval_seconds=60)
+
+        result = reconciler.reconcile()
+
+        assert len(result.errors) == 1
+        assert result.removed == 0
+        # Managed skill left in place — safer than mass-deleting on transient error.
+        assert bundle.exists()
+
+    def test_commits_api_error_keeps_existing_install(
+        self, manager, tmp_path, skill_dirs
+    ):
+        user_dir, _ = skill_dirs
+        bundle = user_dir / "alpha"
+        bundle.mkdir()
+        (bundle / SKILL_ENTRY_FILE).write_text(
+            serialize_skill_md(
+                "alpha", "old", [], "old",
+                managed_source="https://github.com/org/repo/tree/main/alpha",
+                managed_ref="sha_old",
+            ),
+            encoding="utf-8",
+        )
+        manifest = _write_manifest(
+            tmp_path,
+            "  - url: https://github.com/org/repo/tree/main/alpha\n",
+        )
+        reconciler = SkillReconciler(manager, manifest, interval_seconds=60)
+
+        with _patch_sha(None), patch(
+            "notebook_intelligence.skill_github_import._fetch_tarball"
+        ) as fetch:
+            result = reconciler.reconcile()
+
+        # Probe failed but the skill is already installed — don't re-download;
+        # wait for a later cycle that produces a concrete SHA.
+        assert result.unchanged == 1
+        assert result.updated == 0
+        fetch.assert_not_called()
+        reloaded = Skill.from_path(bundle, "user")
+        assert reloaded.description == "old"
+        assert reloaded.managed_ref == "sha_old"
+
+    def test_name_collision_with_user_skill_reports_error(
+        self, manager, tmp_path, skill_dirs
+    ):
+        user_dir, _ = skill_dirs
+        manager.create_skill("user", "alpha", "user bundle", [], "mine")
+        manifest = _write_manifest(
+            tmp_path,
+            "  - url: https://github.com/org/repo/tree/main/alpha\n",
+        )
+        tar = build_tarball({
+            "repo-xyz/alpha/SKILL.md": "---\nname: alpha\ndescription: gh\n---\nb",
+        })
+        reconciler = SkillReconciler(manager, manifest, interval_seconds=60)
+
+        with _patch_sha("sha"), _patch_tarball(tar):
+            result = reconciler.reconcile()
+
+        assert result.added == 0
+        assert any("user-authored" in e for e in result.errors)
+        # User skill untouched.
+        assert Skill.from_path(user_dir / "alpha", "user").body.strip() == "mine"
+
+
+class TestBackgroundThread:
+    def test_runs_once_at_start_and_on_interval(self, manager, tmp_path):
+        manifest = _write_manifest(tmp_path, "")
+        reconciler = SkillReconciler(manager, manifest, interval_seconds=1)
+        call_times = []
+
+        orig_reconcile = reconciler.reconcile
+
+        def tracking_reconcile():
+            call_times.append(time.monotonic())
+            return orig_reconcile()
+
+        reconciler.reconcile = tracking_reconcile  # type: ignore[assignment]
+        # Tight interval for the test.
+        reconciler._interval_seconds = 0.05
+
+        reconciler.start()
+        try:
+            # Wait for at least two passes.
+            deadline = time.monotonic() + 2.0
+            while len(call_times) < 2 and time.monotonic() < deadline:
+                time.sleep(0.05)
+        finally:
+            reconciler.stop()
+
+        assert len(call_times) >= 2
+
+    def test_stop_is_idempotent(self, manager, tmp_path):
+        manifest = _write_manifest(tmp_path, "")
+        reconciler = SkillReconciler(manager, manifest, interval_seconds=60)
+        reconciler.stop()
+        reconciler.stop()

--- a/tests/test_skill_reconciler.py
+++ b/tests/test_skill_reconciler.py
@@ -197,7 +197,7 @@ class TestReconcileErrors:
 
         call_count = {"n": 0}
 
-        def fake_fetch(owner, repo, ref):
+        def fake_fetch(owner, repo, ref, *, token=None):
             call_count["n"] += 1
             if call_count["n"] == 1:
                 raise ValueError("network flake")
@@ -296,6 +296,68 @@ class TestReconcileErrors:
         assert any("user-authored" in e for e in result.errors)
         # User skill untouched.
         assert Skill.from_path(user_dir / "alpha", "user").body.strip() == "mine"
+
+
+class TestManagedToken:
+    def test_managed_token_threaded_to_tarball_and_probe(
+        self, manager, tmp_path, skill_dirs
+    ):
+        user_dir, _ = skill_dirs
+        manifest = _write_manifest(
+            tmp_path,
+            "  - url: https://github.com/org/repo/tree/main/alpha\n",
+        )
+        tar = build_tarball({
+            "repo-xyz/alpha/SKILL.md": "---\nname: alpha\ndescription: a\n---\nbody",
+        })
+        reconciler = SkillReconciler(
+            manager, manifest, interval_seconds=60, managed_token="scoped-org-token"
+        )
+
+        with patch(
+            "notebook_intelligence.skill_reconciler.get_latest_commit_sha",
+            return_value="abc123",
+        ) as probe, patch(
+            "notebook_intelligence.skill_github_import._fetch_tarball",
+            return_value=tar,
+        ) as fetch:
+            reconciler.reconcile()
+
+        # Probe and tarball fetch both see the scoped managed token, not the
+        # user's GITHUB_TOKEN chain.
+        assert probe.call_args.kwargs.get("token") == "scoped-org-token"
+        assert fetch.call_args.kwargs.get("token") == "scoped-org-token"
+
+    def test_managed_token_failure_is_not_retried_with_fallback(
+        self, manager, tmp_path, skill_dirs
+    ):
+        """Option A: if the deployment's scoped token is rejected by GitHub, the
+        error surfaces — we don't silently retry with the user's GITHUB_TOKEN.
+        Hiding a misconfigured scoped token would let admins miss expirations.
+        """
+        manifest = _write_manifest(
+            tmp_path,
+            "  - url: https://github.com/org/repo/tree/main/alpha\n",
+        )
+        call_count = {"n": 0}
+
+        def fake_fetch(owner, repo, ref, *, token=None):
+            call_count["n"] += 1
+            raise ValueError("GitHub rejected the token (HTTP 401)")
+
+        reconciler = SkillReconciler(
+            manager, manifest, interval_seconds=60, managed_token="expired-token"
+        )
+        with _patch_sha("abc123"), patch(
+            "notebook_intelligence.skill_github_import._fetch_tarball",
+            side_effect=fake_fetch,
+        ):
+            result = reconciler.reconcile()
+
+        # Single attempt, error surfaced — no silent retry.
+        assert call_count["n"] == 1
+        assert result.added == 0
+        assert any("rejected the token" in e for e in result.errors)
 
 
 class TestBackgroundThread:

--- a/tests/test_skills_handlers.py
+++ b/tests/test_skills_handlers.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from unittest.mock import MagicMock, patch
 
@@ -14,9 +15,12 @@ from notebook_intelligence.extension import (
     SkillsImportHandler,
     SkillsImportPreviewHandler,
     SkillsListHandler,
+    SkillsReconcileHandler,
 )
+from notebook_intelligence.skill_reconciler import ReconcileResult
 from notebook_intelligence.skill_manager import SkillManager
 from notebook_intelligence.skillset import SKILL_ENTRY_FILE
+from tests.conftest import build_tarball
 
 
 @pytest.fixture
@@ -212,21 +216,8 @@ class TestSkillsContextHandler:
 
 
 class TestSkillsImportHandlers:
-    @staticmethod
-    def _tar(files: dict) -> bytes:
-        import io
-        import tarfile
-        buf = io.BytesIO()
-        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-            for name, content in files.items():
-                data = content.encode("utf-8")
-                info = tarfile.TarInfo(name=name)
-                info.size = len(data)
-                tar.addfile(info, io.BytesIO(data))
-        return buf.getvalue()
-
     def test_preview_returns_metadata(self, skill_manager):
-        tar = self._tar({
+        tar = build_tarball({
             "repo-x/SKILL.md": "---\nname: imported\ndescription: d\n---\nbody",
         })
         handler = _make_handler(
@@ -258,7 +249,7 @@ class TestSkillsImportHandlers:
         handler.set_status.assert_called_with(400)
 
     def test_import_installs_skill(self, skill_manager):
-        tar = self._tar({
+        tar = build_tarball({
             "repo-x/SKILL.md": "---\nname: gh-skill\ndescription: d\n---\nhello",
         })
         handler = _make_handler(
@@ -290,7 +281,7 @@ class TestSkillsImportHandlers:
 
     def test_import_collision_returns_409(self, skill_manager):
         skill_manager.create_skill("user", "dup", "d", [], "")
-        tar = self._tar({
+        tar = build_tarball({
             "repo-x/SKILL.md": "---\nname: dup\ndescription: d\n---\nb",
         })
         handler = _make_handler(
@@ -410,3 +401,30 @@ class TestSkillBundleFileRenameHandler:
         )
         SkillBundleFileRenameHandler.post(handler, "user", "bun")
         handler.set_status.assert_called_with(404)
+
+
+class TestSkillsReconcileHandler:
+    def test_returns_409_when_reconciler_not_configured(self, skill_manager):
+        ext_module.ai_service_manager.get_skill_reconciler.return_value = None
+        handler = _make_handler(SkillsReconcileHandler)
+        asyncio.run(SkillsReconcileHandler.post(handler))
+        handler.set_status.assert_called_with(409)
+        body = _parse_response(handler)
+        assert "manifest" in body["error"].lower()
+
+    def test_returns_reconcile_result(self, skill_manager):
+        reconciler = MagicMock()
+        reconciler.reconcile.return_value = ReconcileResult(
+            added=2, updated=1, removed=0, unchanged=3, errors=["boom"]
+        )
+        ext_module.ai_service_manager.get_skill_reconciler.return_value = reconciler
+        handler = _make_handler(SkillsReconcileHandler)
+        asyncio.run(SkillsReconcileHandler.post(handler))
+        body = _parse_response(handler)
+        assert body == {
+            "added": 2,
+            "updated": 1,
+            "removed": 0,
+            "unchanged": 3,
+            "errors": ["boom"],
+        }

--- a/tests/test_skills_handlers.py
+++ b/tests/test_skills_handlers.py
@@ -1,0 +1,412 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import notebook_intelligence.extension as ext_module
+from notebook_intelligence.extension import (
+    SkillBundleFileHandler,
+    SkillBundleFileRenameHandler,
+    SkillDetailHandler,
+    SkillRenameHandler,
+    SkillsBaseHandler,
+    SkillsContextHandler,
+    SkillsImportHandler,
+    SkillsImportPreviewHandler,
+    SkillsListHandler,
+)
+from notebook_intelligence.skill_manager import SkillManager
+from notebook_intelligence.skillset import SKILL_ENTRY_FILE
+
+
+@pytest.fixture
+def skill_manager(tmp_path):
+    user_dir = tmp_path / "user"
+    project_dir = tmp_path / "project"
+    user_dir.mkdir()
+    project_dir.mkdir()
+    manager = SkillManager(user_dir, project_dir)
+    with patch.object(ext_module, "ai_service_manager") as mock_asm:
+        mock_asm.get_skill_manager.return_value = manager
+        yield manager
+
+
+def _make_handler(handler_cls, body: bytes = b"", query_args: dict | None = None):
+    handler = MagicMock(spec=handler_cls)
+    handler.request = MagicMock()
+    handler.request.body = body
+    query_args = query_args or {}
+
+    def get_query_argument(name, default=None):
+        return query_args.get(name, default)
+
+    handler.get_query_argument = get_query_argument
+    # The `skill_manager` property on SkillsBaseHandler is shadowed by the spec'd mock,
+    # so resolve it explicitly via the patched ai_service_manager.
+    handler.skill_manager = ext_module.ai_service_manager.get_skill_manager()
+    # Bind real helper implementations so handler logic exercises actual code paths.
+    handler._parse_json_body = lambda: SkillsBaseHandler._parse_json_body(handler)
+    handler._bundle_rel_path = lambda: SkillsBaseHandler._bundle_rel_path(handler)
+    handler._error = lambda exc: SkillsBaseHandler._error(handler, exc)
+    return handler
+
+
+def _parse_response(handler) -> dict:
+    return json.loads(handler.finish.call_args[0][0])
+
+
+class TestSkillsListHandler:
+    def test_list_empty(self, skill_manager):
+        handler = _make_handler(SkillsListHandler)
+        SkillsListHandler.get(handler)
+        body = _parse_response(handler)
+        assert body == {"skills": []}
+
+    def test_list_includes_both_scopes(self, skill_manager):
+        skill_manager.create_skill("user", "u-skill", "d", [], "")
+        skill_manager.create_skill("project", "p-skill", "d", [], "")
+        handler = _make_handler(SkillsListHandler)
+        SkillsListHandler.get(handler)
+        body = _parse_response(handler)
+        names = {(s["name"], s["scope"]) for s in body["skills"]}
+        assert names == {("u-skill", "user"), ("p-skill", "project")}
+
+
+class TestSkillsCreate:
+    def test_create_skill(self, skill_manager):
+        handler = _make_handler(
+            SkillsListHandler,
+            body=json.dumps({
+                "scope": "user",
+                "name": "new-skill",
+                "description": "d",
+                "allowed_tools": ["Read"],
+                "body": "# body",
+            }).encode(),
+        )
+        SkillsListHandler.post(handler)
+        body = _parse_response(handler)
+        assert body["skill"]["name"] == "new-skill"
+        assert body["skill"]["allowed_tools"] == ["Read"]
+        assert "# body" in body["skill"]["body"]
+
+    def test_create_rejects_invalid_name(self, skill_manager):
+        handler = _make_handler(
+            SkillsListHandler,
+            body=json.dumps({"scope": "user", "name": "UPPER"}).encode(),
+        )
+        SkillsListHandler.post(handler)
+        handler.set_status.assert_called_with(400)
+        body = _parse_response(handler)
+        assert "Invalid skill name" in body["error"]
+
+    def test_create_rejects_duplicate(self, skill_manager):
+        skill_manager.create_skill("user", "dup", "d", [], "")
+        handler = _make_handler(
+            SkillsListHandler,
+            body=json.dumps({"scope": "user", "name": "dup"}).encode(),
+        )
+        SkillsListHandler.post(handler)
+        handler.set_status.assert_called_with(400)
+
+
+class TestSkillDetail:
+    def test_get_existing(self, skill_manager):
+        skill_manager.create_skill("user", "x", "desc", ["Read"], "body")
+        handler = _make_handler(SkillDetailHandler)
+        SkillDetailHandler.get(handler, "user", "x")
+        body = _parse_response(handler)
+        assert body["skill"]["name"] == "x"
+        assert body["skill"]["allowed_tools"] == ["Read"]
+        assert "body" in body["skill"]["body"]
+
+    def test_get_missing_returns_404(self, skill_manager):
+        handler = _make_handler(SkillDetailHandler)
+        SkillDetailHandler.get(handler, "user", "nope")
+        handler.set_status.assert_called_with(404)
+
+    def test_update_persists_changes(self, skill_manager):
+        skill_manager.create_skill("user", "x", "old", [], "body")
+        handler = _make_handler(
+            SkillDetailHandler,
+            body=json.dumps({"description": "new"}).encode(),
+        )
+        SkillDetailHandler.put(handler, "user", "x")
+        body = _parse_response(handler)
+        assert body["skill"]["description"] == "new"
+
+    def test_update_missing_returns_404(self, skill_manager):
+        handler = _make_handler(
+            SkillDetailHandler,
+            body=json.dumps({"description": "new"}).encode(),
+        )
+        SkillDetailHandler.put(handler, "user", "nope")
+        handler.set_status.assert_called_with(404)
+
+    def test_delete_removes_skill(self, skill_manager):
+        skill_manager.create_skill("user", "gone", "d", [], "")
+        handler = _make_handler(SkillDetailHandler)
+        SkillDetailHandler.delete(handler, "user", "gone")
+        body = _parse_response(handler)
+        assert body["success"] is True
+        assert skill_manager.get_skill("user", "gone") is None
+
+    def test_delete_missing_returns_404(self, skill_manager):
+        handler = _make_handler(SkillDetailHandler)
+        SkillDetailHandler.delete(handler, "user", "nope")
+        handler.set_status.assert_called_with(404)
+
+
+class TestSkillRenameHandler:
+    def test_rename_success(self, skill_manager):
+        skill_manager.create_skill("user", "old", "d", [], "body")
+        handler = _make_handler(
+            SkillRenameHandler, body=json.dumps({"new_name": "new"}).encode()
+        )
+        SkillRenameHandler.post(handler, "user", "old")
+        body = _parse_response(handler)
+        assert body["skill"]["name"] == "new"
+        assert skill_manager.get_skill("user", "old") is None
+
+    def test_rename_missing_new_name_returns_400(self, skill_manager):
+        skill_manager.create_skill("user", "old", "d", [], "")
+        handler = _make_handler(SkillRenameHandler, body=json.dumps({}).encode())
+        SkillRenameHandler.post(handler, "user", "old")
+        handler.set_status.assert_called_with(400)
+
+    def test_rename_duplicate_returns_409(self, skill_manager):
+        skill_manager.create_skill("user", "a", "d", [], "")
+        skill_manager.create_skill("user", "b", "d", [], "")
+        handler = _make_handler(
+            SkillRenameHandler, body=json.dumps({"new_name": "b"}).encode()
+        )
+        SkillRenameHandler.post(handler, "user", "a")
+        handler.set_status.assert_called_with(409)
+
+    def test_rename_missing_source_returns_404(self, skill_manager):
+        handler = _make_handler(
+            SkillRenameHandler, body=json.dumps({"new_name": "new"}).encode()
+        )
+        SkillRenameHandler.post(handler, "user", "nope")
+        handler.set_status.assert_called_with(404)
+
+    def test_rename_invalid_new_name_returns_400(self, skill_manager):
+        skill_manager.create_skill("user", "old", "d", [], "")
+        handler = _make_handler(
+            SkillRenameHandler, body=json.dumps({"new_name": "UPPER"}).encode()
+        )
+        SkillRenameHandler.post(handler, "user", "old")
+        handler.set_status.assert_called_with(400)
+
+
+class TestSkillsContextHandler:
+    def test_returns_configured_dirs(self, skill_manager, tmp_path, monkeypatch):
+        monkeypatch.setattr(ext_module, "get_jupyter_root_dir", lambda: str(tmp_path))
+        handler = _make_handler(SkillsContextHandler)
+        SkillsContextHandler.get(handler)
+        body = _parse_response(handler)
+        assert body["project_root"] == str(tmp_path)
+        assert body["project_name"] == tmp_path.name
+        assert body["user_skills_dir"] == str(skill_manager.scope_dir("user"))
+        assert body["project_skills_dir"] == str(skill_manager.scope_dir("project"))
+
+
+class TestSkillsImportHandlers:
+    @staticmethod
+    def _tar(files: dict) -> bytes:
+        import io
+        import tarfile
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            for name, content in files.items():
+                data = content.encode("utf-8")
+                info = tarfile.TarInfo(name=name)
+                info.size = len(data)
+                tar.addfile(info, io.BytesIO(data))
+        return buf.getvalue()
+
+    def test_preview_returns_metadata(self, skill_manager):
+        tar = self._tar({
+            "repo-x/SKILL.md": "---\nname: imported\ndescription: d\n---\nbody",
+        })
+        handler = _make_handler(
+            SkillsImportPreviewHandler,
+            body=json.dumps({"url": "https://github.com/owner/repo"}).encode(),
+        )
+        with patch(
+            "notebook_intelligence.skill_github_import._fetch_tarball",
+            return_value=tar,
+        ):
+            SkillsImportPreviewHandler.post(handler)
+        body = _parse_response(handler)
+        assert body["preview"]["name"] == "imported"
+        assert body["preview"]["exists_in_user_scope"] is False
+
+    def test_preview_missing_url_returns_400(self, skill_manager):
+        handler = _make_handler(
+            SkillsImportPreviewHandler, body=json.dumps({}).encode()
+        )
+        SkillsImportPreviewHandler.post(handler)
+        handler.set_status.assert_called_with(400)
+
+    def test_preview_invalid_url_returns_400(self, skill_manager):
+        handler = _make_handler(
+            SkillsImportPreviewHandler,
+            body=json.dumps({"url": "https://gitlab.com/owner/repo"}).encode(),
+        )
+        SkillsImportPreviewHandler.post(handler)
+        handler.set_status.assert_called_with(400)
+
+    def test_import_installs_skill(self, skill_manager):
+        tar = self._tar({
+            "repo-x/SKILL.md": "---\nname: gh-skill\ndescription: d\n---\nhello",
+        })
+        handler = _make_handler(
+            SkillsImportHandler,
+            body=json.dumps({
+                "url": "https://github.com/owner/repo",
+                "scope": "user",
+            }).encode(),
+        )
+        with patch(
+            "notebook_intelligence.skill_github_import._fetch_tarball",
+            return_value=tar,
+        ):
+            SkillsImportHandler.post(handler)
+        body = _parse_response(handler)
+        assert body["skill"]["name"] == "gh-skill"
+        assert body["skill"]["source"] == "https://github.com/owner/repo"
+
+    def test_import_invalid_scope_returns_400(self, skill_manager):
+        handler = _make_handler(
+            SkillsImportHandler,
+            body=json.dumps({
+                "url": "https://github.com/owner/repo",
+                "scope": "bogus",
+            }).encode(),
+        )
+        SkillsImportHandler.post(handler)
+        handler.set_status.assert_called_with(400)
+
+    def test_import_collision_returns_409(self, skill_manager):
+        skill_manager.create_skill("user", "dup", "d", [], "")
+        tar = self._tar({
+            "repo-x/SKILL.md": "---\nname: dup\ndescription: d\n---\nb",
+        })
+        handler = _make_handler(
+            SkillsImportHandler,
+            body=json.dumps({
+                "url": "https://github.com/owner/repo",
+                "scope": "user",
+            }).encode(),
+        )
+        with patch(
+            "notebook_intelligence.skill_github_import._fetch_tarball",
+            return_value=tar,
+        ):
+            SkillsImportHandler.post(handler)
+        handler.set_status.assert_called_with(409)
+
+
+class TestSkillBundleFileHandler:
+    def test_write_and_read_bundle_file(self, skill_manager):
+        skill_manager.create_skill("user", "bun", "d", [], "")
+        put_handler = _make_handler(
+            SkillBundleFileHandler,
+            body=json.dumps({"content": "print(1)"}).encode(),
+            query_args={"path": "helper.py"},
+        )
+        SkillBundleFileHandler.put(put_handler, "user", "bun")
+        assert _parse_response(put_handler)["success"] is True
+
+        get_handler = _make_handler(SkillBundleFileHandler, query_args={"path": "helper.py"})
+        SkillBundleFileHandler.get(get_handler, "user", "bun")
+        assert _parse_response(get_handler)["content"] == "print(1)"
+
+    def test_missing_path_param_returns_400(self, skill_manager):
+        skill_manager.create_skill("user", "bun", "d", [], "")
+        handler = _make_handler(SkillBundleFileHandler, query_args={})
+        SkillBundleFileHandler.get(handler, "user", "bun")
+        handler.set_status.assert_called_with(400)
+
+    def test_path_traversal_rejected(self, skill_manager):
+        skill_manager.create_skill("user", "bun", "d", [], "")
+        handler = _make_handler(
+            SkillBundleFileHandler,
+            body=json.dumps({"content": "x"}).encode(),
+            query_args={"path": "../escape.py"},
+        )
+        SkillBundleFileHandler.put(handler, "user", "bun")
+        handler.set_status.assert_called_with(400)
+
+    def test_absolute_path_rejected(self, skill_manager):
+        skill_manager.create_skill("user", "bun", "d", [], "")
+        handler = _make_handler(
+            SkillBundleFileHandler,
+            body=json.dumps({"content": "x"}).encode(),
+            query_args={"path": "/etc/passwd"},
+        )
+        SkillBundleFileHandler.put(handler, "user", "bun")
+        handler.set_status.assert_called_with(400)
+
+    def test_delete_skill_md_rejected(self, skill_manager):
+        skill_manager.create_skill("user", "bun", "d", [], "")
+        handler = _make_handler(SkillBundleFileHandler, query_args={"path": SKILL_ENTRY_FILE})
+        SkillBundleFileHandler.delete(handler, "user", "bun")
+        handler.set_status.assert_called_with(400)
+
+    def test_delete_missing_file_returns_404(self, skill_manager):
+        skill_manager.create_skill("user", "bun", "d", [], "")
+        handler = _make_handler(SkillBundleFileHandler, query_args={"path": "missing.py"})
+        SkillBundleFileHandler.delete(handler, "user", "bun")
+        handler.set_status.assert_called_with(404)
+
+
+class TestSkillBundleFileRenameHandler:
+    def test_rename_success(self, skill_manager):
+        skill_manager.create_skill("user", "bun", "d", [], "")
+        skill_manager.write_bundle_file("user", "bun", "old.txt", "x")
+        handler = _make_handler(
+            SkillBundleFileRenameHandler,
+            body=json.dumps({"from": "old.txt", "to": "new.txt"}).encode(),
+        )
+        SkillBundleFileRenameHandler.post(handler, "user", "bun")
+        assert _parse_response(handler)["success"] is True
+        assert skill_manager.read_bundle_file("user", "bun", "new.txt") == "x"
+
+    def test_rename_missing_body_fields_returns_400(self, skill_manager):
+        skill_manager.create_skill("user", "bun", "d", [], "")
+        handler = _make_handler(
+            SkillBundleFileRenameHandler, body=json.dumps({"from": "a"}).encode()
+        )
+        SkillBundleFileRenameHandler.post(handler, "user", "bun")
+        handler.set_status.assert_called_with(400)
+
+    def test_rename_to_existing_returns_409(self, skill_manager):
+        skill_manager.create_skill("user", "bun", "d", [], "")
+        skill_manager.write_bundle_file("user", "bun", "a.txt", "x")
+        skill_manager.write_bundle_file("user", "bun", "b.txt", "y")
+        handler = _make_handler(
+            SkillBundleFileRenameHandler,
+            body=json.dumps({"from": "a.txt", "to": "b.txt"}).encode(),
+        )
+        SkillBundleFileRenameHandler.post(handler, "user", "bun")
+        handler.set_status.assert_called_with(409)
+
+    def test_rename_skill_md_rejected(self, skill_manager):
+        skill_manager.create_skill("user", "bun", "d", [], "")
+        handler = _make_handler(
+            SkillBundleFileRenameHandler,
+            body=json.dumps({"from": SKILL_ENTRY_FILE, "to": "x.md"}).encode(),
+        )
+        SkillBundleFileRenameHandler.post(handler, "user", "bun")
+        handler.set_status.assert_called_with(400)
+
+    def test_rename_missing_source_returns_404(self, skill_manager):
+        skill_manager.create_skill("user", "bun", "d", [], "")
+        handler = _make_handler(
+            SkillBundleFileRenameHandler,
+            body=json.dumps({"from": "nope.txt", "to": "yep.txt"}).encode(),
+        )
+        SkillBundleFileRenameHandler.post(handler, "user", "bun")
+        handler.set_status.assert_called_with(404)


### PR DESCRIPTION
  Description                                                                                                               
                                                                                                                          
  ## Summary                                                                                                              

  Adds a UI for managing [Claude skill bundles](https://docs.claude.com/en/docs/claude-code/skills) (SKILL.md + supporting files) alongside the existing Rules panel. Skills are discovered from both user (`~/.claude/skills/`, or
  `$CLAUDE_CONFIG_DIR/skills`) and project (`<project>/.claude/skills/`) scopes — matching Claude Code's own resolution — so skills authored here are picked up by Claude automatically, and skills authored for Claude directly show up here.      
                                                                                                                          
  ## Motivation

  Skills are increasingly how users extend Claude's behavior for domain-specific work (notebooks, data pipelines, internal tooling, etc.), but today authoring and curating them means hand-editing files on disk. Bringing first-class skill management into the extension makes the authoring loop a lot tighter for data scientists already living inside JupyterLab, and gives a discoverable entry point for the growing library of community skills on GitHub.                            
                                                                                                                          
  ## What's included                                                                                                        
   
  - **CRUD + undo.** List, create, edit, rename, duplicate, and delete skills. Delete snapshots the bundle client-side so undo fully restores SKILL.md and every helper file.                                                                     
  - **Inline editor.** Edit frontmatter (name, description, allowed-tools) and body, with lazy-loaded tabs for helper files so large bundles stay responsive.                                                                                         
  - **Import from GitHub.** Fetches a public repo via the GitHub tarball API — no auth, no `git` binary required, although auth also supported. URLs can point at a repo root, a branch, or a subpath containing `SKILL.md`. A two-phase flow shows a preview (name, description,  files, resolved source URL), supports a name override, and requires an explicit checkbox to overwrite an existing skill. Extraction enforces size caps, rejects path traversal, and skips symlinks. The canonical source URL is stamped into the skill's `source:` frontmatter so provenance is traceable.                                                               
  - **Live reload.** An mtime-based background watcher on both scope directories notifies the active chat when skills change on disk, so edits (including those made outside the panel) apply to the in-flight conversation without a reconnect.      
   
  ## Implementation notes                                                                                                   
                                                                                                                          
  - Backend exposes a REST API under `/notebook-intelligence/skills/…`; handler ordering is load-bearing because the `{scope}/{name}` catch-all would otherwise shadow `/import`, `/context`, etc.
  - Wire format is snake_case; the TypeScript client translates to camelCase at the boundary (`skillFromWire`).             
  - `SKILL_NAME_REGEX` lives in `skillset.py` and is mirrored into the TS validator and the Tornado routes; the comment in each location points back to the source of truth.                                                                         
  - Frontmatter parsing and the bundle file walk are shared between `Skill` and the GitHub importer.                        
                                                                                                                            
  ## Test plan                                                                                                            
                                                                                                                            
  Adds 106 tests covering URL parsing, archive safety (traversal, symlink, size), name derivation, the full `SkillManager` lifecycle (including GitHub import with mocked tarballs), and every HTTP handler.                                       
                                                                                                                            
  - [x] `pytest tests/test_skill_manager.py tests/test_skill_github_import.py tests/test_skills_handlers.py` — 106 passing  
  - [x] `tsc --noEmit` clean                                                                                              
  - [x] Manual: create, edit, rename, duplicate, delete (+ undo) in both scopes                                             
  - [x] Manual: import a repo-root skill, a subpath skill, and a skill with a name collision (with and without overwrite)   
  - [x] Manual: edit a SKILL.md outside the panel and confirm the active chat picks it up          

  ## Screenshots

<img width="576" height="593" alt="skills-panel" src="https://github.com/user-attachments/assets/64cc638c-eedd-4305-8431-1dbe75be073e" />

<img width="506" height="455" alt="skill-editor-2" src="https://github.com/user-attachments/assets/5fdde45f-db8f-4e36-a429-442595dcaeff" />

<img width="517" height="594" alt="skill-editor-1" src="https://github.com/user-attachments/assets/871ed16a-cd62-40af-94a7-ab4b7fd49fa1" />

<img width="479" height="277" alt="import-from-github" src="https://github.com/user-attachments/assets/e5842fc3-cf87-43d4-a56b-d7d8a8750a2e" />