### PR TITLE
  fix: repair integration tests broken by claude_settings mock + async setup

### DIFF
--- a/tests/test_ai_service_manager_integration.py
+++ b/tests/test_ai_service_manager_integration.py
@@ -4,6 +4,10 @@ from notebook_intelligence.ai_service_manager import AIServiceManager
 from notebook_intelligence.rule_manager import RuleManager
 
 
+# AIServiceManager.__init__ constructs a ClaudeCodeChatParticipant whose own __init__
+# reads nbi_config.claude_settings and does `ToolType in settings.get('tools', [])`.
+# A bare Mock() returns another Mock from .get(), which isn't iterable — so every
+# mock_config in this file sets `claude_settings = {}` to keep that check happy.
 class TestAIServiceManagerIntegration:
     def test_init_with_rules_enabled(self):
         """Test AIServiceManager initialization with rules enabled."""
@@ -12,6 +16,7 @@ class TestAIServiceManagerIntegration:
             mock_config.rules_enabled = True
             mock_config.rules_directory = "/test/rules"
             mock_config.mcp = {"mcpServers": {}, "participants": {}}
+            mock_config.claude_settings = {}
             mock_config_class.return_value = mock_config
             
             with patch('notebook_intelligence.ai_service_manager.RuleManager') as mock_rule_manager_class:
@@ -29,6 +34,7 @@ class TestAIServiceManagerIntegration:
             mock_config = Mock()
             mock_config.rules_enabled = False
             mock_config.mcp = {"mcpServers": {}, "participants": {}}
+            mock_config.claude_settings = {}
             mock_config_class.return_value = mock_config
             
             manager = AIServiceManager({"server_root_dir": "/test"})
@@ -42,6 +48,7 @@ class TestAIServiceManagerIntegration:
             mock_config.rules_enabled = True
             mock_config.rules_directory = "/test/rules"
             mock_config.mcp = {"mcpServers": {}, "participants": {}}
+            mock_config.claude_settings = {}
             mock_config_class.return_value = mock_config
             
             with patch('notebook_intelligence.ai_service_manager.RuleManager') as mock_rule_manager_class:
@@ -59,6 +66,7 @@ class TestAIServiceManagerIntegration:
             mock_config = Mock()
             mock_config.rules_enabled = False
             mock_config.mcp = {"mcpServers": {}, "participants": {}}
+            mock_config.claude_settings = {}
             mock_config_class.return_value = mock_config
             
             manager = AIServiceManager({"server_root_dir": "/test"})
@@ -73,6 +81,7 @@ class TestAIServiceManagerIntegration:
             mock_config.rules_enabled = True
             mock_config.rules_directory = "/test/rules"
             mock_config.mcp = {"mcpServers": {}, "participants": {}}
+            mock_config.claude_settings = {}
             mock_config_class.return_value = mock_config
             
             with patch('notebook_intelligence.ai_service_manager.RuleManager') as mock_rule_manager_class:
@@ -91,6 +100,7 @@ class TestAIServiceManagerIntegration:
             mock_config = Mock()
             mock_config.rules_enabled = False
             mock_config.mcp = {"mcpServers": {}, "participants": {}}
+            mock_config.claude_settings = {}
             mock_config_class.return_value = mock_config
             
             manager = AIServiceManager({"server_root_dir": "/test"})

--- a/tests/test_base_chat_participant_integration.py
+++ b/tests/test_base_chat_participant_integration.py
@@ -1,5 +1,5 @@
-import pytest
-from unittest.mock import Mock, MagicMock, AsyncMock
+import asyncio
+from unittest.mock import Mock, AsyncMock
 from notebook_intelligence.base_chat_participant import BaseChatParticipant
 from notebook_intelligence.api import ChatRequest, ChatResponse, ChatMode, CancelToken
 from notebook_intelligence.ruleset import RuleContext
@@ -35,31 +35,30 @@ class TestBaseChatParticipantIntegration:
         assert result == "Enhanced prompt with rules"
         mock_injector.inject_rules.assert_called_once_with(base_prompt, request)
     
-    @pytest.mark.asyncio
-    async def test_handle_ask_mode_chat_request_with_rules(self):
+    def test_handle_ask_mode_chat_request_with_rules(self):
         """Test ask mode chat request handling with rule injection."""
         mock_injector = Mock(spec=RuleInjector)
         mock_injector.inject_rules.return_value = "Enhanced system prompt"
-        
+
         participant = BaseChatParticipant(rule_injector=mock_injector)
-        
+
         # Mock the chat model and host
         mock_chat_model = Mock()
         mock_chat_model.provider.name = "test-provider"
         mock_chat_model.provider.id = "test-provider"
         mock_chat_model.name = "test-model"
         mock_chat_model.completions = Mock()
-        
+
         mock_host = Mock()
         mock_host.chat_model = mock_chat_model
-        
+
         # Create request with rule context
         rule_context = RuleContext(
             filename="test.ipynb",
             kernel="python3",
             mode="ask"
         )
-        
+
         request = ChatRequest(
             host=mock_host,
             chat_mode=ChatMode("ask", "Ask"),
@@ -68,28 +67,27 @@ class TestBaseChatParticipantIntegration:
             cancel_token=Mock(spec=CancelToken),
             rule_context=rule_context
         )
-        
+
         response = Mock(spec=ChatResponse)
         response.stream = Mock()
-        
+
         # Call the method
-        await participant.handle_ask_mode_chat_request(request, response)
-        
+        asyncio.run(participant.handle_ask_mode_chat_request(request, response))
+
         # Verify rule injection was called
         mock_injector.inject_rules.assert_called_once()
-        
+
         # Verify chat model was called with enhanced prompt
         mock_chat_model.completions.assert_called_once()
         call_args = mock_chat_model.completions.call_args[0]
         messages = call_args[0]
-        
+
         # Check that the system message contains the enhanced prompt
         assert len(messages) >= 1
         assert messages[0]["role"] == "system"
         assert messages[0]["content"] == "Enhanced system prompt"
-    
-    @pytest.mark.asyncio
-    async def test_handle_chat_request_agent_mode_with_rules(self):
+
+    def test_handle_chat_request_agent_mode_with_rules(self):
         """Test agent mode chat request handling with rule injection."""
         mock_injector = Mock(spec=RuleInjector)
         mock_injector.inject_rules.return_value = "Enhanced agent prompt"
@@ -132,7 +130,7 @@ class TestBaseChatParticipantIntegration:
         participant.handle_chat_request_with_tools = AsyncMock()
         
         # Call the method
-        await participant.handle_chat_request(request, response)
+        asyncio.run(participant.handle_chat_request(request, response))
         
         # Verify rule injection was called
         mock_injector.inject_rules.assert_called_once()


### PR DESCRIPTION
## Summary

Repairs 8 pre-existing test failures on `main` (test-only changes; no production code touched).

### `tests/test_ai_service_manager_integration.py` — 6 failures

All six tests blew up with `TypeError: argument of type 'Mock' is not a container or iterable` at `claude.py:971`. `AIServiceManager.__init__` constructs a `ClaudeCodeChatParticipant`, whose `__init__` reads `nbi_config.claude_settings` and evaluates `ToolType in settings.get('tools', [])`. A bare `Mock()` returns another `Mock` from `.get()`, which isn't iterable.

**Fix:** set `mock_config.claude_settings = {}` in each test's mock setup so the membership check runs against an empty list (the natural "no tools configured" default). Added a class-level comment documenting the transitive coupling so future mocks don't regress.

### `tests/test_base_chat_participant_integration.py` — 2 failures

Two tests used `@pytest.mark.asyncio`, which requires the `pytest-asyncio` plugin that isn't in the project's dev dependencies. The tests were reported as `PytestUnknownMarkWarning` and then failed with `async def functions are not natively supported`.

**Fix:** run the coroutines through `asyncio.run(...)` directly, matching the existing pattern in `tests/test_feedback.py`. Removed newly-unused `pytest` and `MagicMock` imports.

## Test plan

  - [x] `pytest tests/` — 145 passed
  - [x] Confirmed all 8 failures reproduce on `main` before the fix
  - [x] No production code changes