### PR TITLE
Fix chat hanging on "Thinking…" when Claude agent fails to start

### DIFF
--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -512,57 +512,59 @@ class ClaudeCodeClient():
             if data['id'] == event_id:
                 resp["data"] = data['data']
 
-        self._client_thread_signal.connect(_on_client_response)
+        # Capture the signal locally so the finally-disconnect is safe even if
+        # _mark_as_disconnected() nulls self._client_thread_signal mid-loop.
+        signal = self._client_thread_signal
+        signal.connect(_on_client_response)
 
         start_time = time.time()
 
-        while True:
-            self._reconnect_required = False
-            nbi_request_obj = get_current_request()
-            if nbi_request_obj is not None and nbi_request_obj.cancel_token.is_cancel_requested:
-                try:
-                    process: Process = self._client._transport._process
-                    process.kill()
+        try:
+            while True:
+                self._reconnect_required = False
+                nbi_request_obj = get_current_request()
+                if nbi_request_obj is not None and nbi_request_obj.cancel_token.is_cancel_requested:
+                    try:
+                        process: Process = self._client._transport._process
+                        process.kill()
 
-                    self._reconnect_required = True
-                    self._continue_conversation = True
-                except Exception as e:
-                    log.error(f"Error occurred while setting current request and response to None: {str(e)}")
-                self._client_thread_signal.disconnect(_on_client_response)
-                if self._reconnect_required:
+                        self._reconnect_required = True
+                        self._continue_conversation = True
+                    except Exception as e:
+                        log.error(f"Error occurred while setting current request and response to None: {str(e)}")
+                    if self._reconnect_required:
+                        self._mark_as_disconnected()
+                    return {
+                        "data": None,
+                        "success": False,
+                        "error": "Cancel requested by user"
+                    }
+                if resp["data"] is not None:
+                    return {
+                        "data": resp["data"],
+                        "success": True,
+                        "error": None
+                    }
+                # Bail out immediately if the worker thread has died (e.g. Claude
+                # Code failed to start on a previous event). Without this we'd
+                # poll for the full CLAUDE_AGENT_CLIENT_RESPONSE_TIMEOUT window
+                # (30 min default) while the UI sits on "Thinking…".
+                if self._client_thread is None or not self._client_thread.is_alive():
                     self._mark_as_disconnected()
-                return {
-                    "data": None,
-                    "success": False,
-                    "error": "Cancel requested by user"
-                }
-            if resp["data"] is not None:
-                self._client_thread_signal.disconnect(_on_client_response)
-                return {
-                    "data": resp["data"],
-                    "success": True,
-                    "error": None
-                }
-            # Bail out immediately if the worker thread has died (e.g. Claude Code
-            # failed to start on a previous event). Without this we'd poll the
-            # response queue for the full CLAUDE_AGENT_CLIENT_RESPONSE_TIMEOUT
-            # window (30 min default) while the UI sits on "Thinking…".
-            if self._client_thread is None or not self._client_thread.is_alive():
-                self._client_thread_signal.disconnect(_on_client_response)
-                self._mark_as_disconnected()
-                return {
-                    "data": None,
-                    "success": False,
-                    "error": "Claude agent client is not running",
-                }
-            if time.time() - start_time > CLAUDE_AGENT_CLIENT_RESPONSE_TIMEOUT:
-                self._client_thread_signal.disconnect(_on_client_response)
-                return {
-                    "data": None,
-                    "success": False,
-                    "error": f"Claude agent client response timeout"
-                }
-            time.sleep(CLAUDE_AGENT_CLIENT_RESPONSE_WAIT_TIME)
+                    return {
+                        "data": None,
+                        "success": False,
+                        "error": "Claude agent is not running",
+                    }
+                if time.time() - start_time > CLAUDE_AGENT_CLIENT_RESPONSE_TIMEOUT:
+                    return {
+                        "data": None,
+                        "success": False,
+                        "error": "Claude agent response timeout",
+                    }
+                time.sleep(CLAUDE_AGENT_CLIENT_RESPONSE_WAIT_TIME)
+        finally:
+            signal.disconnect(_on_client_response)
 
     def update_server_info(self):
         if self._reconnect_required:
@@ -968,8 +970,8 @@ class ClaudeCodeChatParticipant(BaseChatParticipant):
             log.error(f"Error while handling Claude chat request: {e}", exc_info=True)
             try:
                 response.stream(MarkdownData(f"**Error:** {e}"))
-            except Exception:
-                pass
+            except Exception as stream_err:
+                log.debug(f"Could not stream error to client (likely closed websocket): {stream_err}")
         finally:
             try:
                 response.finish()

--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -306,7 +306,7 @@ class ClaudeCodeClient():
         return self._status
 
     def is_connected(self):
-        return self._client_thread is not None
+        return self._client_thread is not None and self._client_thread.is_alive()
 
     def connect(self):
         if self.is_connected():
@@ -542,6 +542,18 @@ class ClaudeCodeClient():
                     "data": resp["data"],
                     "success": True,
                     "error": None
+                }
+            # Bail out immediately if the worker thread has died (e.g. Claude Code
+            # failed to start on a previous event). Without this we'd poll the
+            # response queue for the full CLAUDE_AGENT_CLIENT_RESPONSE_TIMEOUT
+            # window (30 min default) while the UI sits on "Thinking…".
+            if self._client_thread is None or not self._client_thread.is_alive():
+                self._client_thread_signal.disconnect(_on_client_response)
+                self._mark_as_disconnected()
+                return {
+                    "data": None,
+                    "success": False,
+                    "error": "Claude agent client is not running",
                 }
             if time.time() - start_time > CLAUDE_AGENT_CLIENT_RESPONSE_TIMEOUT:
                 self._client_thread_signal.disconnect(_on_client_response)
@@ -943,9 +955,28 @@ class ClaudeCodeChatParticipant(BaseChatParticipant):
             return await self.handle_inline_chat_request(request, response, options)
         self._current_chat_request = request
 
-        response.stream(ProgressData("Thinking..."))
-        self._client.query(request, response)
-        response.finish()
+        try:
+            response.stream(ProgressData("Thinking..."))
+            result = self._client.query(request, response)
+            # query() returns a string when it bails early without dispatching —
+            # e.g. the agent isn't connected, a response timeout elapsed, or the
+            # worker thread died. Surface it so the user sees why instead of a
+            # silent spinner stop.
+            if isinstance(result, str) and result:
+                response.stream(MarkdownData(f"**Claude agent error:** {result}"))
+        except Exception as e:
+            log.error(f"Error while handling Claude chat request: {e}", exc_info=True)
+            try:
+                response.stream(MarkdownData(f"**Error:** {e}"))
+            except Exception:
+                pass
+        finally:
+            try:
+                response.finish()
+            except Exception as e:
+                # Most common cause: the user's websocket closed mid-request.
+                # Nothing useful to send back; just keep the task from dying.
+                log.warning(f"Could not finalize Claude chat response: {e}")
 
     async def handle_inline_chat_request(self, request: ChatRequest, response: ChatResponse, options: dict = {}) -> None:
         try:

--- a/tests/test_claude_client.py
+++ b/tests/test_claude_client.py
@@ -1,0 +1,208 @@
+"""Regression tests for the "Claude hangs on Thinking..." fix.
+
+Covers three defects that combined to produce the 30-minute spinner when the
+Claude agent failed to start or a query failed:
+
+1. ``ClaudeCodeClient.is_connected`` considered a zombie thread "connected".
+2. ``_send_claude_agent_request`` polled for the full response timeout even
+   when the worker thread had died.
+3. ``ClaudeCodeChatParticipant.handle_chat_request`` swallowed error-string
+   returns from ``_client.query`` and never streamed error info or guaranteed
+   ``response.finish()`` ran on exceptions.
+"""
+
+import asyncio
+import threading
+import time
+from queue import Queue
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+from notebook_intelligence.api import ChatResponse, MarkdownData
+from notebook_intelligence.claude import (
+    ClaudeAgentClientStatus,
+    ClaudeAgentEventType,
+    ClaudeCodeChatParticipant,
+    ClaudeCodeClient,
+    SignalImpl,
+)
+
+
+def _make_client():
+    """Build a ``ClaudeCodeClient`` without invoking ``__init__`` / ``connect``."""
+    client = ClaudeCodeClient.__new__(ClaudeCodeClient)
+    client._host = None
+    client._client_options = None
+    client._websocket_connector = None
+    client._client = None
+    client._client_queue = Queue()
+    client._client_thread_signal = SignalImpl()
+    client._client_thread = None
+    client._status = ClaudeAgentClientStatus.NotConnected
+    client._server_info = None
+    client._server_info_lock = threading.Lock()
+    client._reconnect_required = False
+    client._continue_conversation = None
+    return client
+
+
+class TestIsConnected:
+    def test_returns_false_when_thread_is_none(self):
+        client = _make_client()
+        client._client_thread = None
+        assert client.is_connected() is False
+
+    def test_returns_false_when_thread_has_exited(self):
+        client = _make_client()
+        thread = threading.Thread(target=lambda: None)
+        thread.start()
+        thread.join()
+        client._client_thread = thread
+        # Without the is_alive() check this returned True for a zombie thread,
+        # causing query() to push events into a queue nobody was reading.
+        assert client.is_connected() is False
+
+    def test_returns_true_for_live_thread(self):
+        client = _make_client()
+        stop = threading.Event()
+        thread = threading.Thread(target=stop.wait, daemon=True)
+        thread.start()
+        try:
+            client._client_thread = thread
+            assert client.is_connected() is True
+        finally:
+            stop.set()
+            thread.join(timeout=1)
+
+
+class TestSendClaudeAgentRequestDeadThread:
+    def test_bails_out_quickly_when_worker_thread_dead(self, monkeypatch):
+        # Make the poll loop's sleep a no-op so a slow test host doesn't mask
+        # the bug: the behavior we're guarding is structural (returns without
+        # waiting for the 30-min timeout), not microsecond-level.
+        monkeypatch.setattr(
+            "notebook_intelligence.claude.CLAUDE_AGENT_CLIENT_RESPONSE_WAIT_TIME",
+            0,
+        )
+
+        client = _make_client()
+        dead_thread = threading.Thread(target=lambda: None)
+        dead_thread.start()
+        dead_thread.join()
+        client._client_thread = dead_thread
+
+        start = time.monotonic()
+        result = client._send_claude_agent_request(ClaudeAgentEventType.Query, {})
+        elapsed = time.monotonic() - start
+
+        assert result == {
+            "data": None,
+            "success": False,
+            "error": "Claude agent is not running",
+        }
+        # Should return on the first loop iteration, long before the 1800s
+        # response timeout. A generous 5s ceiling keeps CI noise from flaking.
+        assert elapsed < 5
+        # Dead-thread branch must mark the client disconnected so subsequent
+        # requests don't block waiting on the same corpse.
+        assert client._status == ClaudeAgentClientStatus.NotConnected
+        assert client._client_thread is None
+
+    def test_signal_disconnect_runs_on_dead_thread_exit(self, monkeypatch):
+        """The try/finally must disconnect even when the loop short-circuits."""
+        monkeypatch.setattr(
+            "notebook_intelligence.claude.CLAUDE_AGENT_CLIENT_RESPONSE_WAIT_TIME",
+            0,
+        )
+        client = _make_client()
+        dead_thread = threading.Thread(target=lambda: None)
+        dead_thread.start()
+        dead_thread.join()
+        client._client_thread = dead_thread
+
+        signal_before = client._client_thread_signal
+        listeners_before = len(signal_before._listeners)
+        client._send_claude_agent_request(ClaudeAgentEventType.Query, {})
+        # _mark_as_disconnected nulls the signal ref on the client, but the
+        # locally-captured signal in _send_claude_agent_request should still
+        # have had its listener removed.
+        assert len(signal_before._listeners) == listeners_before
+
+
+def _make_participant():
+    """Build a ``ClaudeCodeChatParticipant`` without spinning up a real client."""
+    participant = ClaudeCodeChatParticipant.__new__(ClaudeCodeChatParticipant)
+    participant._rule_injector = MagicMock()
+    participant._update_client_debounced_timer = None
+    participant._host = MagicMock()
+    participant._client_options = MagicMock()
+    participant._client = MagicMock()
+    return participant
+
+
+def _make_chat_request(mode_id="ask"):
+    request = MagicMock()
+    request.chat_mode.id = mode_id
+    return request
+
+
+class TestHandleChatRequestErrorHandling:
+    def test_finish_called_when_query_raises(self):
+        participant = _make_participant()
+        participant._client.query.side_effect = RuntimeError("boom")
+
+        response = Mock(spec=ChatResponse)
+        asyncio.run(participant.handle_chat_request(_make_chat_request(), response))
+
+        response.finish.assert_called_once()
+        # The exception path should have streamed a user-visible error.
+        stream_calls = [c.args[0] for c in response.stream.call_args_list]
+        markdown_messages = [
+            d.content for d in stream_calls if isinstance(d, MarkdownData)
+        ]
+        assert any("boom" in m for m in markdown_messages)
+
+    def test_error_string_from_query_is_surfaced(self):
+        participant = _make_participant()
+        participant._client.query.return_value = "Claude agent is not connected"
+
+        response = Mock(spec=ChatResponse)
+        asyncio.run(participant.handle_chat_request(_make_chat_request(), response))
+
+        response.finish.assert_called_once()
+        stream_calls = [c.args[0] for c in response.stream.call_args_list]
+        markdown_messages = [
+            d.content for d in stream_calls if isinstance(d, MarkdownData)
+        ]
+        # The string-return bail-out path must reach the user instead of
+        # leaving a silent "Thinking..." spinner.
+        assert any(
+            "Claude agent error" in m and "not connected" in m
+            for m in markdown_messages
+        )
+
+    def test_finish_swallows_closed_websocket(self):
+        """A closed socket at finish() must not propagate into the task loop."""
+        participant = _make_participant()
+        participant._client.query.return_value = None
+        response = Mock(spec=ChatResponse)
+        response.finish.side_effect = RuntimeError("WebSocketClosedError")
+
+        # Must not raise — the whole point of the finally-wrapped finish().
+        asyncio.run(participant.handle_chat_request(_make_chat_request(), response))
+        response.finish.assert_called_once()
+
+    def test_inline_chat_mode_delegates_without_wrapping(self):
+        """Sanity check: the ask/agent try/finally block is skipped for inline."""
+        participant = _make_participant()
+        participant.handle_inline_chat_request = AsyncMock()
+
+        response = Mock(spec=ChatResponse)
+        asyncio.run(
+            participant.handle_chat_request(_make_chat_request("inline-chat"), response)
+        )
+
+        participant.handle_inline_chat_request.assert_awaited_once()
+        # Inline path owns its own response lifecycle; the outer handler
+        # shouldn't have touched the response.
+        response.finish.assert_not_called()
+        response.stream.assert_not_called()


### PR DESCRIPTION
## Summary                                  
                                                                                                                   
  When the Claude Code SDK fails to spawn its subprocess, whether the bundled CLI is missing, a sandboxed environment blocks execution, or the user has the agent SDK misconfigured, the chat participant sat on "Thinking…" indefinitely (30 minutes, by default) instead of surfacing the error. This matches the symptom reported in #135, where the server log shows `Failed to start Claude Code:` at extension load but the user sees nothing but a silent spinner.                                
                                                                                                                   
  Three defects combined to produce the hang:                  

  1. `ClaudeCodeClient.is_connected()` returned `True` for a zombie worker thread, because it only checked `self._client_thread is not None` and not `is_alive()`. Callers then happily dispatched events into a queue nobody was reading.
  2. `_send_claude_agent_request` polled for the full `CLAUDE_AGENT_CLIENT_RESPONSE_TIMEOUT` window (30 minute default) with no liveness check on the worker. Even once the user's patience ran out, the failure bubbled up as a generic "response timeout" with no actionable detail.                                                           
  3. `ClaudeCodeChatParticipant.handle_chat_request` had no `try/except/finally`. Error-string returns from `_client.query()` were silently dropped, and an exception anywhere in the path skipped `response.finish()` — leaving the client's spinner stuck even after the task died.
                                                                                                                   
  ## Fix                                                                                                           
   
  - `is_connected()` now checks `is_alive()` so a dead worker correctly reports disconnected.                      
  - `_send_claude_agent_request` bails out of the poll loop immediately when the worker thread is dead, returning a concrete `"Claude agent is not running"` error instead of waiting for the full timeout. The signal handler is also now unregistered via `try/finally` so the short-circuit paths don't leak listeners on the shared `SignalImpl`.
  - `handle_chat_request` wraps dispatch in `try/except/finally`: error-string returns from `query()` are surfaced as `**Claude agent error:** …`, exceptions are logged and streamed as `**Error:** …`, and `response.finish()` always runs (with its own guard for already-closed websockets).                                                  
                                                               
  Net effect for the #135 reporter: the chat now displays a concrete error inside ~1s instead of hanging, and the server log already contains the underlying "Failed to start Claude Code" line for triage.
                                                                                                                   
  ## Test plan                                                                                                     
   
  - [x] New unit tests in `tests/test_claude_client.py` (9 tests) covering all three fix points:                   
    - `is_connected()` returns `False` for `None` / dead threads, `True` for live
    - `_send_claude_agent_request` returns in under 5s with `"Claude agent is not running"` when the worker is dead
   (previously 30 min)                                                                                             
    - `SignalImpl` listener is removed even on the dead-thread short-circuit path
    - `handle_chat_request` calls `response.finish()` when `query()` raises                                        
    - Error-string returns from `query()` are surfaced to the user                                                 
    - `response.finish()` errors (closed websocket) are logged, not propagated                                     
    - `inline-chat` mode still delegates cleanly without touching the outer response lifecycle                     
  - [x] Full test suite passes: `pytest tests/` — 169 passed (9 pre-existing unrelated failures on `main` unchanged)                                                                                                       
  - [x] Manual reproduction: launched JupyterLab with `NBI_CLAUDE_CLI_PATH=/nonexistent/claude`; confirmed error appears in the chat within ~1s instead of the old 30-minute hang. Server log shows the expected `Claude agent client failed to update server info: Claude agent is not running` in place of the old `response timeout`.        
                                                                                                                   
  Closes #135     