### PR TITLE
Retry connect() in ClaudeCodeClient.query() when the worker thread has died

### DIFF
--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import sys
 import asyncio
 from enum import Enum
 from queue import Queue
@@ -331,9 +332,8 @@ class ClaudeCodeClient():
         try:
             self._client_thread = threading.Thread(
                 name="Claude Agent Client Thread",
-                target=asyncio.run,
+                target=self._run_client_thread,
                 daemon=True,
-                args=(self._client_thread_func(),)
             )
             self._client_thread.start()
             # Block until the worker has either finished the SDK handshake or
@@ -395,6 +395,23 @@ class ClaudeCodeClient():
                     })
             except Exception as e:
                 log.error(f"Error occurred while sending status message to websocket: {str(e)}")
+
+    def _run_client_thread(self):
+        # The Claude Agent SDK spawns claude.exe via asyncio.create_subprocess_exec.
+        # On Windows the SelectorEventLoop raises NotImplementedError for subprocess
+        # creation; only ProactorEventLoop supports it. Python's default policy on
+        # Windows varies across versions and distributions (e.g. uv's 3.14 builds
+        # hand out Selector), so force Proactor here for this thread's loop
+        # instead of relying on the ambient policy. See #147.
+        if sys.platform == "win32":
+            loop = asyncio.ProactorEventLoop()
+            try:
+                asyncio.set_event_loop(loop)
+                loop.run_until_complete(self._client_thread_func())
+            finally:
+                loop.close()
+        else:
+            asyncio.run(self._client_thread_func())
 
     async def _client_thread_func(self):
         try:

--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -52,6 +52,7 @@ class ClaudeAgentClientStatus(str, Enum):
 CLAUDE_AGENT_CLIENT_RESPONSE_WAIT_TIME = float(os.getenv("NBI_CLAUDE_AGENT_CLIENT_RESPONSE_WAIT_TIME", "0.5"))
 CLAUDE_AGENT_CLIENT_RESPONSE_TIMEOUT = float(os.getenv("NBI_CLAUDE_AGENT_CLIENT_RESPONSE_TIMEOUT", "1800"))
 CLAUDE_AGENT_CLIENT_UPDATE_WAIT_TIME = float(os.getenv("NBI_CLAUDE_AGENT_CLIENT_UPDATE_WAIT_TIME", "0.5"))
+CLAUDE_AGENT_CONNECT_TIMEOUT = float(os.getenv("NBI_CLAUDE_AGENT_CONNECT_TIMEOUT", "15"))
 
 _current_request = None
 _current_response = None
@@ -278,6 +279,7 @@ class ClaudeCodeClient():
         self._client_queue = None
         self._client_thread_signal = None
         self._client_thread = None
+        self._connect_resolved = threading.Event()
         self._status = ClaudeAgentClientStatus.NotConnected
         self._server_info: dict[str, Any] | None = None
         self._server_info_lock = threading.Lock()
@@ -325,6 +327,7 @@ class ClaudeCodeClient():
         self._reconnect_required = False
         self._client_queue = Queue()
         self._client_thread_signal: SignalImpl = SignalImpl()
+        self._connect_resolved.clear()
         try:
             self._client_thread = threading.Thread(
                 name="Claude Agent Client Thread",
@@ -333,10 +336,23 @@ class ClaudeCodeClient():
                 args=(self._client_thread_func(),)
             )
             self._client_thread.start()
-            self._update_server_info_async()
+            # Block until the worker has either finished the SDK handshake or
+            # failed — otherwise callers that check is_connected() afterwards
+            # see a momentarily-alive thread that's about to die on spawn
+            # failure, and never reach the "not connected" error branch (#147).
+            if not self._connect_resolved.wait(timeout=CLAUDE_AGENT_CONNECT_TIMEOUT):
+                log.warning(
+                    f"Claude agent did not reach a terminal connect state within "
+                    f"{CLAUDE_AGENT_CONNECT_TIMEOUT}s"
+                )
+            if self.is_connected():
+                self._update_server_info_async()
         except Exception as e:
             self._client_thread = None
-            log.error(f"Error occurred while connecting to Claude agent client: {str(e)}")
+            log.error(
+                f"Error occurred while connecting to Claude agent client: {str(e)}",
+                exc_info=True,
+            )
             self._set_status(ClaudeAgentClientStatus.FailedToConnect)
 
     def disconnect(self):
@@ -384,6 +400,7 @@ class ClaudeCodeClient():
         try:
             async with await self._get_client() as client:
                 self._set_status(ClaudeAgentClientStatus.Connected)
+                self._connect_resolved.set()
                 set_current_claude_client(client)
 
                 while True:
@@ -484,8 +501,12 @@ class ClaudeCodeClient():
                         log.error(f"Unknown event type {event}")
         except Exception as e:
             self._client_thread = None
-            log.error(f"Error occurred while running MCP server thread: {str(e)}")
+            log.error(
+                f"Error occurred while running MCP server thread: {str(e)}",
+                exc_info=True,
+            )
             self._set_status(ClaudeAgentClientStatus.FailedToConnect)
+            self._connect_resolved.set()
 
     def _create_client(self) -> ClaudeSDKClient:
         continue_conversation_cfg = self._host.nbi_config.claude_settings.get('continue_conversation', False)
@@ -574,10 +595,14 @@ class ClaudeCodeClient():
         finally:
             signal.disconnect(_on_client_response)
 
-    def update_server_info(self):
-        if self._reconnect_required:
+    def _ensure_connected(self) -> bool:
+        """Reconnect if the worker thread is missing or the SDK flagged a retry."""
+        if self._reconnect_required or not self.is_connected():
             self.connect()
-        if not self.is_connected():
+        return self.is_connected()
+
+    def update_server_info(self):
+        if not self._ensure_connected():
             return
         self._set_status(ClaudeAgentClientStatus.UpdatingServerInfo)
         response = self._send_claude_agent_request(ClaudeAgentEventType.GetServerInfo)
@@ -592,10 +617,8 @@ class ClaudeCodeClient():
         return self._server_info
 
     def query(self, request: ChatRequest, response: ChatResponse):
-        if self._reconnect_required:
-            self.connect()
-        if not self.is_connected():
-            return f"Claude agent is not connected"
+        if not self._ensure_connected():
+            return "Claude agent is not connected. Check the server log for the underlying startup error."
 
         response = self._send_claude_agent_request(ClaudeAgentEventType.Query, {
             "request": request,
@@ -609,9 +632,7 @@ class ClaudeCodeClient():
             return response["error"]
 
     def clear_chat_history(self):
-        if self._reconnect_required:
-            self.connect()
-        if not self.is_connected():
+        if not self._ensure_connected():
             return
         response = self._send_claude_agent_request(ClaudeAgentEventType.ClearChatHistory)
 

--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -349,10 +349,7 @@ class ClaudeCodeClient():
                 self._update_server_info_async()
         except Exception as e:
             self._client_thread = None
-            log.error(
-                f"Error occurred while connecting to Claude agent client: {str(e)}",
-                exc_info=True,
-            )
+            log.error(f"Error occurred while connecting to Claude agent client: {str(e)}")
             self._set_status(ClaudeAgentClientStatus.FailedToConnect)
 
     def disconnect(self):
@@ -518,10 +515,7 @@ class ClaudeCodeClient():
                         log.error(f"Unknown event type {event}")
         except Exception as e:
             self._client_thread = None
-            log.error(
-                f"Error occurred while running MCP server thread: {str(e)}",
-                exc_info=True,
-            )
+            log.error(f"Error occurred while running MCP server thread: {str(e)}")
             self._set_status(ClaudeAgentClientStatus.FailedToConnect)
             self._connect_resolved.set()
 
@@ -643,7 +637,9 @@ class ClaudeCodeClient():
         })
 
         if response["success"]:
-            return response["data"]
+            # Query results are streamed to `response` as they arrive; the
+            # success payload is just a sentinel, not something to surface.
+            return None
         else:
             log.error(f"Claude agent query failed: {response['error']}")
             return response["error"]

--- a/tests/test_claude_client.py
+++ b/tests/test_claude_client.py
@@ -195,7 +195,7 @@ class TestQueryReconnect:
 
         client.connect.assert_called_once()
         client._send_claude_agent_request.assert_called_once()
-        assert result == "ok"
+        assert result is None
 
     def test_returns_informative_error_when_reconnect_fails(self):
         client = _make_client()

--- a/tests/test_claude_client.py
+++ b/tests/test_claude_client.py
@@ -37,6 +37,7 @@ def _make_client():
     client._client_queue = Queue()
     client._client_thread_signal = SignalImpl()
     client._client_thread = None
+    client._connect_resolved = threading.Event()
     client._status = ClaudeAgentClientStatus.NotConnected
     client._server_info = None
     client._server_info_lock = threading.Lock()
@@ -126,6 +127,240 @@ class TestSendClaudeAgentRequestDeadThread:
         # locally-captured signal in _send_claude_agent_request should still
         # have had its listener removed.
         assert len(signal_before._listeners) == listeners_before
+
+
+class TestEnsureConnected:
+    """The helper the three callers (query, update_server_info, clear_chat_history)
+    all share. Before this refactor each had its own slightly-different guard."""
+
+    def test_noop_when_already_connected(self):
+        client = _make_client()
+        live = Mock()
+        live.is_alive.return_value = True
+        client._client_thread = live
+        client.connect = Mock()
+
+        assert client._ensure_connected() is True
+        client.connect.assert_not_called()
+
+    def test_calls_connect_when_thread_dead(self):
+        client = _make_client()
+        client._client_thread = None
+
+        live = Mock()
+        live.is_alive.return_value = True
+        client.connect = Mock(
+            side_effect=lambda: setattr(client, "_client_thread", live)
+        )
+
+        assert client._ensure_connected() is True
+        client.connect.assert_called_once()
+
+    def test_calls_connect_when_reconnect_required_even_if_thread_alive(self):
+        # _reconnect_required is set from inside the worker thread when the
+        # SDK reports an error but before the thread has fully exited.
+        client = _make_client()
+        live = Mock()
+        live.is_alive.return_value = True
+        client._client_thread = live
+        client._reconnect_required = True
+        client.connect = Mock()
+
+        client._ensure_connected()
+        client.connect.assert_called_once()
+
+
+class TestQueryReconnect:
+    def test_reconnects_when_thread_has_died(self):
+        # Dead thread: caller observed it as "not connected" and couldn't
+        # recover without restarting JupyterLab (#147).
+        client = _make_client()
+        dead_thread = threading.Thread(target=lambda: None)
+        dead_thread.start()
+        dead_thread.join()
+        client._client_thread = dead_thread
+
+        live_thread = Mock()
+        live_thread.is_alive.return_value = True
+
+        def revive_thread():
+            client._client_thread = live_thread
+
+        client.connect = Mock(side_effect=revive_thread)
+        client._send_claude_agent_request = Mock(
+            return_value={"data": "ok", "success": True, "error": None}
+        )
+
+        result = client.query(MagicMock(), MagicMock())
+
+        client.connect.assert_called_once()
+        client._send_claude_agent_request.assert_called_once()
+        assert result == "ok"
+
+    def test_returns_informative_error_when_reconnect_fails(self):
+        client = _make_client()
+        client._client_thread = None
+        client.connect = Mock()
+        client._send_claude_agent_request = Mock()
+
+        result = client.query(MagicMock(), MagicMock())
+
+        client.connect.assert_called_once()
+        client._send_claude_agent_request.assert_not_called()
+        assert "not connected" in result
+        assert "server log" in result
+
+
+class TestConnectWaitsForReadiness:
+    """``connect()`` must not return until the worker thread has reached a
+    terminal state (Connected or FailedToConnect). Otherwise the caller's
+    post-connect ``is_connected()`` check sees a momentarily-alive thread
+    that's about to die on subprocess-spawn failure — exactly the #147 race
+    that made PR #148's first attempt ineffective for the reporter.
+    """
+
+    def test_waits_for_connected_signal(self, monkeypatch):
+        monkeypatch.setattr(
+            "notebook_intelligence.claude.CLAUDE_AGENT_CONNECT_TIMEOUT", 5
+        )
+        client = _make_client()
+        client._update_server_info_async = Mock()
+
+        worker_started = threading.Event()
+        stop_worker = threading.Event()
+
+        async def fake_worker():
+            # Simulate a slow handshake so connect() must actually wait.
+            await asyncio.sleep(0.05)
+            client._status = ClaudeAgentClientStatus.Connected
+            client._connect_resolved.set()
+            worker_started.set()
+            # Keep thread alive so is_connected() stays True after connect().
+            while not stop_worker.is_set():
+                await asyncio.sleep(0.01)
+
+        client._client_thread_func = fake_worker
+
+        try:
+            start = time.monotonic()
+            client.connect()
+            elapsed = time.monotonic() - start
+            assert worker_started.is_set()
+            assert elapsed >= 0.05
+            assert client.is_connected()
+            client._update_server_info_async.assert_called_once()
+        finally:
+            stop_worker.set()
+            if client._client_thread is not None:
+                client._client_thread.join(timeout=1)
+
+    def test_returns_promptly_on_spawn_failure(self, monkeypatch):
+        # The #147 race: _get_client() raises (SDK subprocess spawn failed).
+        # The outer except in _client_thread_func must set _connect_resolved
+        # so connect() returns immediately instead of waiting the full
+        # CLAUDE_AGENT_CONNECT_TIMEOUT.
+        monkeypatch.setattr(
+            "notebook_intelligence.claude.CLAUDE_AGENT_CONNECT_TIMEOUT", 5
+        )
+        client = _make_client()
+        client._update_server_info_async = Mock()
+
+        async def spawn_failure():
+            raise RuntimeError("SDK spawn failed")
+
+        client._get_client = spawn_failure
+
+        start = time.monotonic()
+        client.connect()
+        elapsed = time.monotonic() - start
+
+        # Well under the 5s timeout — the except branch signals promptly.
+        assert elapsed < 2
+        assert not client.is_connected()
+        assert client._status == ClaudeAgentClientStatus.FailedToConnect
+        # No server-info fetch when the handshake failed.
+        client._update_server_info_async.assert_not_called()
+
+    def test_returns_after_timeout_when_worker_hangs(self, monkeypatch):
+        # Defensive: if the worker hangs in the async setup without raising
+        # or setting the event, connect() still returns after the timeout.
+        monkeypatch.setattr(
+            "notebook_intelligence.claude.CLAUDE_AGENT_CONNECT_TIMEOUT", 0.1
+        )
+        client = _make_client()
+        client._update_server_info_async = Mock()
+
+        stop_worker = threading.Event()
+
+        async def hanging_worker():
+            while not stop_worker.is_set():
+                await asyncio.sleep(0.01)
+
+        client._client_thread_func = hanging_worker
+
+        try:
+            start = time.monotonic()
+            client.connect()
+            elapsed = time.monotonic() - start
+            assert 0.1 <= elapsed < 2
+        finally:
+            stop_worker.set()
+            if client._client_thread is not None:
+                client._client_thread.join(timeout=1)
+
+    def test_query_surfaces_server_log_error_when_spawn_fails(self, monkeypatch):
+        """End-to-end of the #147 scenario raffaelemancuso hit after PR #148
+        commit 1: with only the naive retry, query()'s post-connect
+        is_connected() check passed while the worker thread was momentarily
+        alive, so the user saw the stale 'Claude agent is not running'
+        error from _send_claude_agent_request's dead-thread path. With
+        connect() now blocking until readiness resolves, query() returns
+        the informative 'Check the server log' error instead.
+        """
+        monkeypatch.setattr(
+            "notebook_intelligence.claude.CLAUDE_AGENT_CONNECT_TIMEOUT", 2
+        )
+        client = _make_client()
+        client._update_server_info_async = Mock()
+
+        async def spawn_failure():
+            raise RuntimeError("SDK spawn failed")
+
+        client._get_client = spawn_failure
+
+        result = client.query(MagicMock(), MagicMock())
+
+        assert "not connected" in result
+        assert "server log" in result
+
+
+class TestOtherCallersEnsureConnected:
+    """update_server_info / clear_chat_history used to check only
+    _reconnect_required, not is_connected(), so a dead thread without the
+    flag set left them silently no-op'd. Now they route through
+    _ensure_connected() and pick up the same recovery behavior as query()."""
+
+    def test_update_server_info_reconnects_on_dead_thread(self):
+        client = _make_client()
+        client._client_thread = None
+        client.connect = Mock()
+        client._send_claude_agent_request = Mock()
+
+        client.update_server_info()
+
+        client.connect.assert_called_once()
+        client._send_claude_agent_request.assert_not_called()
+
+    def test_clear_chat_history_reconnects_on_dead_thread(self):
+        client = _make_client()
+        client._client_thread = None
+        client.connect = Mock()
+        client._send_claude_agent_request = Mock()
+
+        client.clear_chat_history()
+
+        client.connect.assert_called_once()
+        client._send_claude_agent_request.assert_not_called()
 
 
 def _make_participant():


### PR DESCRIPTION
## Summary

After #145, `ClaudeCodeClient.is_connected()` correctly returns `False` for a dead worker thread instead of reporting a zombie thread as "connected". That fix surfaced a latent recovery gap: once the Claude Agent SDK's subprocess fails to spawn (missing CLI, config issue, transient filesystem/permission error), `query()` hits `if not is_connected(): return "Claude agent is not connected"` on every subsequent user message — with no way to recover short of restarting JupyterLab.

This change makes `query()` try once to reconnect whenever it observes a dead worker, so the user gets a fresh shot if whatever caused the initial failure is resolved. If the reconnect also fails, the error message now points at the server log, where the underlying SDK startup error is already being logged.

## Motivation

Previously, a user whose Claude CLI setup was broken on first load would see:
- Before #145: 30-minute "Thinking…" hang, then generic response-timeout error.
- After #145: immediate "Claude agent is not connected" with no hint about where to look and no recovery path without restarting JupyterLab.

Neither is great. The silent 30-min hang is worse UX, but the fast error leaves users stuck even if the root cause (e.g., a CLI path they've since fixed) no longer applies on the next message.

This may resolve #147, where a user on `main` after #145 reported seeing "Claude Code is not running" and no clear path forward.

## Changes

**Commit 1 — the fix (`notebook_intelligence/claude.py`, `tests/test_claude_client.py`):**
- `ClaudeCodeClient.query()` now calls `self.connect()` whenever `not is_connected()` — previously only when `_reconnect_required` was set, which is only flipped by the cancel path.
- The fallback error string is now `"Claude agent is not connected. Check the server log for the underlying startup error."` so users know where the actual SDK failure was logged.
- Scope is deliberately narrow — `clear_chat_history()` and `update_server_info()` have similar `if self._reconnect_required:` guards but fail silently; they aren't in the reported issue and extending the change speculatively felt out of scope.

**Commit 2 — drive-by lint fix (`src/chat-sidebar.tsx`):**
The lint CI job was already failing on `main` before this PR: prettier wanted to reformat several JSX blocks introduced in #139, and eslint flagged `reasoningStartTime` as `prefer-const`. Both are mechanical (`prettier --write` + `eslint --fix`), no behavioral changes. Bundled here only so CI on this PR can go green — happy to split into a separate PR if preferred.

## Test plan

- [x] New tests in `tests/test_claude_client.py`:
  - `test_reconnects_when_thread_has_died` — asserts `query()` calls `connect()` and proceeds when the worker thread is dead on entry.
  - `test_returns_informative_error_when_reconnect_fails` — asserts the error message references "server log" so users get a pointer.
- [x] Full suite passes locally: `pytest tests/` — 179 pass (1 pre-existing unrelated failure in `test_claude_models.py::test_empty_api_key_passed_as_none` — fails on `main` too, caused by the user-agent default_headers change in #140 without a matching mock update).
- [x] `prettier --check` and `eslint` clean on the files this PR touches.
- [x] Manual repro on the reporter's scenario — appreciated if @raffaelemancuso can confirm.

Closes #147