### PR TITLE
fix(claude): use ProactorEventLoop on Windows for Claude agent thread

### DIFF
--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -3,6 +3,7 @@
 import json
 import os
 import asyncio
+import sys
 from enum import Enum
 from queue import Queue
 import threading
@@ -316,6 +317,24 @@ class ClaudeCodeClient():
     def is_connected(self):
         return self._client_thread is not None and self._client_thread.is_alive()
 
+    def _create_client_thread_event_loop(self) -> asyncio.AbstractEventLoop:
+        if sys.platform == 'win32' and hasattr(asyncio, "WindowsProactorEventLoopPolicy"):
+            return asyncio.WindowsProactorEventLoopPolicy().new_event_loop()
+        return asyncio.new_event_loop()
+
+    def _run_client_thread(self, coro):
+        loop = self._create_client_thread_event_loop()
+        try:
+            asyncio.set_event_loop(loop)
+            loop.run_until_complete(coro)
+        finally:
+            try:
+                loop.run_until_complete(loop.shutdown_asyncgens())
+            except Exception:
+                pass
+            asyncio.set_event_loop(None)
+            loop.close()
+
     def connect(self):
         if self.is_connected():
             return
@@ -328,7 +347,7 @@ class ClaudeCodeClient():
         try:
             self._client_thread = threading.Thread(
                 name="Claude Agent Client Thread",
-                target=asyncio.run,
+                target=self._run_client_thread,
                 daemon=True,
                 args=(self._client_thread_func(),)
             )

--- a/tests/test_claude_client.py
+++ b/tests/test_claude_client.py
@@ -17,6 +17,7 @@ import time
 from queue import Queue
 from unittest.mock import AsyncMock, MagicMock, Mock
 
+import notebook_intelligence.claude as claude_module
 from notebook_intelligence.api import ChatResponse, MarkdownData
 from notebook_intelligence.claude import (
     ClaudeAgentClientStatus,
@@ -72,6 +73,42 @@ class TestIsConnected:
         finally:
             stop.set()
             thread.join(timeout=1)
+
+
+class TestClientThreadEventLoop:
+    def test_windows_uses_proactor_loop_without_changing_global_policy(self, monkeypatch):
+        client = _make_client()
+        created_loop = asyncio.new_event_loop()
+        set_policy_calls = []
+
+        class FakeProactorPolicy:
+            def new_event_loop(self):
+                return created_loop
+
+        monkeypatch.setattr(claude_module.sys, "platform", "win32", raising=False)
+        monkeypatch.setattr(
+            claude_module.asyncio,
+            "WindowsProactorEventLoopPolicy",
+            lambda: FakeProactorPolicy(),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            claude_module.asyncio,
+            "set_event_loop_policy",
+            lambda *args, **kwargs: set_policy_calls.append((args, kwargs)),
+        )
+
+        observed_loop = None
+
+        async def sample():
+            nonlocal observed_loop
+            observed_loop = asyncio.get_running_loop()
+
+        client._run_client_thread(sample())
+
+        assert observed_loop is created_loop
+        assert created_loop.is_closed()
+        assert set_policy_calls == []
 
 
 class TestSendClaudeAgentRequestDeadThread:


### PR DESCRIPTION
Set WindowsProactorEventLoopPolicy for the background thread to resolve an issue where the Claude Code subprocess could not be spawned on Windows due to Jupyter/Tornado using SelectorEventLoop by default.

Fixes #112