### PR TITLE
IMPORTANT: Deduplicate Windows ProactorEventLoop code left over from PR #148 + #149 merge

### DIFF
--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -4,7 +4,6 @@ import json
 import os
 import sys
 import asyncio
-import sys
 from enum import Enum
 from queue import Queue
 import threading
@@ -353,6 +352,7 @@ class ClaudeCodeClient():
                 name="Claude Agent Client Thread",
                 target=self._run_client_thread,
                 daemon=True,
+                args=(self._client_thread_func(),),
             )
             self._client_thread.start()
             # Block until the worker has either finished the SDK handshake or
@@ -411,23 +411,6 @@ class ClaudeCodeClient():
                     })
             except Exception as e:
                 log.error(f"Error occurred while sending status message to websocket: {str(e)}")
-
-    def _run_client_thread(self):
-        # The Claude Agent SDK spawns claude.exe via asyncio.create_subprocess_exec.
-        # On Windows the SelectorEventLoop raises NotImplementedError for subprocess
-        # creation; only ProactorEventLoop supports it. Python's default policy on
-        # Windows varies across versions and distributions (e.g. uv's 3.14 builds
-        # hand out Selector), so force Proactor here for this thread's loop
-        # instead of relying on the ambient policy. See #147.
-        if sys.platform == "win32":
-            loop = asyncio.ProactorEventLoop()
-            try:
-                asyncio.set_event_loop(loop)
-                loop.run_until_complete(self._client_thread_func())
-            finally:
-                loop.close()
-        else:
-            asyncio.run(self._client_thread_func())
 
     async def _client_thread_func(self):
         try:

--- a/tests/test_claude_client.py
+++ b/tests/test_claude_client.py
@@ -86,13 +86,21 @@ class TestClientThreadEventLoop:
             def new_event_loop(self):
                 return created_loop
 
-        monkeypatch.setattr(claude_module.sys, "platform", "win32", raising=False)
+        # Patch the policy attribute before sys.platform: on Python 3.14+
+        # non-Windows platforms, asyncio.__getattr__'s shim for
+        # WindowsProactorEventLoopPolicy is guarded by a sys.platform check
+        # and references a windows_events module that wasn't imported. If
+        # sys.platform is patched to "win32" first, monkeypatch's getattr
+        # (to save the old value) triggers that branch and raises NameError,
+        # which raising=False doesn't catch. Ordering the policy patch first
+        # lets the shim fall through to AttributeError cleanly.
         monkeypatch.setattr(
             claude_module.asyncio,
             "WindowsProactorEventLoopPolicy",
             lambda: FakeProactorPolicy(),
             raising=False,
         )
+        monkeypatch.setattr(claude_module.sys, "platform", "win32", raising=False)
         monkeypatch.setattr(
             claude_module.asyncio,
             "set_event_loop_policy",

--- a/tests/test_claude_models.py
+++ b/tests/test_claude_models.py
@@ -1,6 +1,6 @@
 """Tests for Claude model fetching and caching in notebook_intelligence.claude."""
 
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import ANY, Mock, patch, MagicMock
 
 import pytest
 
@@ -172,4 +172,6 @@ class TestFetchClaudeModels:
 
         fetch_claude_models(api_key="  ", base_url="")
 
-        mock_anthropic_cls.assert_called_once_with(api_key=None, base_url=None)
+        mock_anthropic_cls.assert_called_once_with(
+            api_key=None, base_url=None, default_headers=ANY
+        )


### PR DESCRIPTION
## Summary

PRs #148 and #149 were merged back-to-back and both shipped Windows `ProactorEventLoop` fixes at different layers. GitHub's merge combined them syntactically without reconciling the overlap, leaving three artifacts in `notebook_intelligence/claude.py`:

1. `import sys` appearing twice at the top of the file.
2. Two `_run_client_thread` methods in `ClaudeCodeClient` — one from #149 taking `(self, coro)`, one from #148 taking `(self)`.
3. An orphaned `_create_client_thread_event_loop` helper from #149.

Python class bodies evaluate top-down, so #148's `_run_client_thread(self)` shadowed #149's `_run_client_thread(self, coro)`. Things ran because the merge kept #148's argumentless `threading.Thread(target=self._run_client_thread)` call, which happened to match the winning signature. But #149's better-engineered implementation was silently dropped, and its dedicated unit test (`TestClientThreadEventLoop::test_windows_uses_proactor_loop_without_changing_global_policy`) was validating a code path that never executed in production.

## Why keep Herik's (#149) implementation

@herikwebb's version is the better one, and this PR makes sure it's the one that actually runs:

- **Policy-based loop construction.** It uses \`asyncio.WindowsProactorEventLoopPolicy().new_event_loop()\` — the idiomatic way to obtain a Proactor loop. PR #148's version reached for \`asyncio.ProactorEventLoop()\` directly, which is less canonical and likely to be deprecated.
- **\`hasattr\` guard.** \`if sys.platform == 'win32' and hasattr(asyncio, "WindowsProactorEventLoopPolicy")\` defends against future Python versions that might remove the symbol. PR #148's version only checked \`sys.platform\`.
- **Proper async-generator shutdown.** The \`finally\` block runs \`loop.run_until_complete(loop.shutdown_asyncgens())\` before \`loop.close()\`, so any lingering async generators get \`aclose()\`'d cleanly. Without this, async generators that outlive their loop get GC'd with a \`RuntimeError: async generator ignored GeneratorExit\`. Relevant if the SDK \`async with\` bails out mid-stream.
- **Event-loop registry cleanup.** \`asyncio.set_event_loop(None)\` clears the thread-local loop reference after the loop closes. Minor but correct.
- **Dedicated unit test.** #149 added \`TestClientThreadEventLoop\`, which asserts the fix works without mutating the global event loop policy. Valuable coverage that's now actually exercising the live code path instead of the shadowed one.

## Changes

\`notebook_intelligence/claude.py\`:
- Remove duplicate \`import sys\`.
- Delete PR #148's shadowing \`_run_client_thread(self)\` method.
- Update \`threading.Thread(...)\` to pass \`args=(self._client_thread_func(),)\` so #149's \`_run_client_thread(self, coro)\` signature is satisfied.

\`tests/test_claude_client.py\`:
- Fix \`TestClientThreadEventLoop\` — reorder two \`monkeypatch.setattr\` calls so the \`WindowsProactorEventLoopPolicy\` patch runs *before* the \`sys.platform\` patch. On Python 3.14 non-Windows platforms, \`asyncio.__getattr__\`'s shim for \`WindowsProactorEventLoopPolicy\` is guarded by \`sys.platform == 'win32'\` and dereferences a \`windows_events\` module that wasn't imported. With the old ordering, pytest's getattr (to save the old value) triggered that branch and raised \`NameError\`, which \`raising=False\` doesn't catch. Comment in the test explains the ordering constraint.

\`tests/test_claude_models.py\`:
- Fix \`test_empty_api_key_passed_as_none\`. PR #140 added a default \`User-Agent\` header to the \`Anthropic\` client constructor but didn't update this test's strict \`assert_called_once_with(api_key=None, base_url=None)\`. It's been failing on \`main\` since #140 merged. Use \`unittest.mock.ANY\` for \`default_headers\` so the assertion stays focused on the empty-api-key-to-None normalization the test is actually covering.

## Test plan

- [x] \`pytest tests/\` — 354 passed (previously 352 passed, 2 failed)
- [x] \`prettier --check\`, \`stylelint\`, \`eslint\` all clean on touched files
- [ ] Confirm on a Windows machine that the Claude agent still starts correctly — the surviving code path is the one #149 was tested on, so this should be a no-op behaviorally on Windows