### PR TITLE
fix(skill_github_import): reject tarball entries with absolute paths

### DIFF
--- a/notebook_intelligence/skill_github_import.py
+++ b/notebook_intelligence/skill_github_import.py
@@ -22,7 +22,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Optional
 
 from notebook_intelligence.skillset import (
@@ -240,9 +240,10 @@ def _extract_skill(
             if m.issym() or m.islnk():
                 # Skip symlinks for safety — they can escape the extraction dir.
                 continue
-            name = m.name.lstrip("/")
-            parts = Path(name).parts
-            if any(p == ".." for p in parts):
+            # Tar names are POSIX by spec, so use PurePosixPath to keep the
+            # absolute-path check platform-independent.
+            path = PurePosixPath(m.name)
+            if path.is_absolute() or any(p == ".." for p in path.parts):
                 raise ValueError(f"Unsafe path in archive: {m.name}")
             if m.isfile():
                 total_bytes += m.size
@@ -252,7 +253,15 @@ def _extract_skill(
                         f"({MAX_EXTRACTED_BYTES // (1024 * 1024)} MB)"
                     )
             safe_members.append(m)
-        tar.extractall(into, members=safe_members)
+        # `filter="data"` (PEP 706, available on Python 3.12+ and patch-level
+        # backports of 3.10/3.11) blocks absolute paths, traversal, device
+        # files, and unsafe permission bits at the tarfile layer. Our explicit
+        # checks above remain the safety net for older Python patch levels
+        # that lack `tarfile.data_filter`.
+        extract_kwargs = {}
+        if hasattr(tarfile, "data_filter"):
+            extract_kwargs["filter"] = "data"
+        tar.extractall(into, members=safe_members, **extract_kwargs)
 
     extracted = into / top_dir
     if not extracted.is_dir():

--- a/tests/test_skill_github_import.py
+++ b/tests/test_skill_github_import.py
@@ -120,6 +120,22 @@ class TestExtractSkill:
         with pytest.raises(ValueError, match="Unsafe path"):
             _extract_skill(buf.getvalue(), "", tmp_path)
 
+    def test_rejects_absolute_path(self, tmp_path):
+        """An entry with an absolute name (e.g. /etc/passwd) must be rejected
+        even though it contains no '..' segments."""
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            # Wrapper directory so _extract_skill sees a top_dir.
+            wrapper = tarfile.TarInfo(name="repo-abc/")
+            wrapper.type = tarfile.DIRTYPE
+            tar.addfile(wrapper)
+            data = b"evil"
+            info = tarfile.TarInfo(name="/tmp/nbi-pwn")
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+        with pytest.raises(ValueError, match="Unsafe path"):
+            _extract_skill(buf.getvalue(), "", tmp_path)
+
     def test_skips_symlinks(self, tmp_path):
         buf = io.BytesIO()
         with tarfile.open(fileobj=buf, mode="w:gz") as tar:


### PR DESCRIPTION
## Issue

`stage_skill_from_github` extracts a GitHub tarball into a temp dir, but the path-safety check is broken:

```python
if os.path.isabs(m.name.lstrip("/")) or ".." in m.name.split("/"):
```

`lstrip("/")` strips the leading slash before `isabs` runs, so `/tmp/evil` becomes `tmp/evil` and passes the check. On Python versions before the `tarfile.data_filter` default (3.12+, or 3.10.12 / 3.11.4 with the backport), this lets a malicious skill repo write files anywhere the Jupyter process can write.

## Fix

- Validate paths with `PurePosixPath` (tar names are POSIX by spec, so this works the same on every platform).
- Reject any member whose path is absolute or contains a `..` component.
- Pass `filter="data"` to `extractall` when available, so newer Pythons get defense-in-depth on top of the manual check.

## Testing

- New test `test_rejects_absolute_path` confirms a tarball with an absolute-path entry raises `ValueError("Unsafe path...")`.
- Empirically confirmed without the fix that `filter="fully_trusted"` (the legacy default) writes the file outside the extraction dir; with the fix it raises before extraction.
- Full backend suite: 355/355 pass.