### PR TITLE
fix(claude): guard _send_claude_agent_request against disconnect race

### DIFF
--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -547,16 +547,26 @@ class ClaudeCodeClient():
             "args": event_args,
         }
         set_current_request(None)
-        self._client_queue.put(event)
+
+        # _mark_as_disconnected() nulls both fields, so snapshot them once
+        # rather than dereferencing through `self` repeatedly and racing with
+        # a concurrent disconnect.
+        queue = self._client_queue
+        signal = self._client_thread_signal
+        if queue is None or signal is None:
+            return {
+                "data": None,
+                "success": False,
+                "error": "Claude agent is not connected",
+            }
+
+        queue.put(event)
 
         resp = {"data": None}
         def _on_client_response(data: dict):
             if data['id'] == event_id:
                 resp["data"] = data['data']
 
-        # Capture the signal locally so the finally-disconnect is safe even if
-        # _mark_as_disconnected() nulls self._client_thread_signal mid-loop.
-        signal = self._client_thread_signal
         signal.connect(_on_client_response)
 
         start_time = time.time()

--- a/tests/test_claude_client.py
+++ b/tests/test_claude_client.py
@@ -173,6 +173,22 @@ class TestSendClaudeAgentRequestDeadThread:
         # have had its listener removed.
         assert len(signal_before._listeners) == listeners_before
 
+    def test_returns_error_when_queue_or_signal_is_none(self):
+        """If _mark_as_disconnected ran before us (queue/signal both None),
+        the request must surface a "not connected" error rather than crash
+        with AttributeError on `None.put` or `None.connect`."""
+        client = _make_client()
+        client._client_queue = None
+        client._client_thread_signal = None
+
+        result = client._send_claude_agent_request(ClaudeAgentEventType.Query, {})
+
+        assert result == {
+            "data": None,
+            "success": False,
+            "error": "Claude agent is not connected",
+        }
+
 
 class TestEnsureConnected:
     """The helper the three callers (query, update_server_info, clear_chat_history)


### PR DESCRIPTION
## Issue

`_send_claude_agent_request` reads `self._client_queue` and `self._client_thread_signal` and uses them without checking for `None`. `_mark_as_disconnected` nulls both fields when the agent thread exits. If a request comes in during or just after disconnect, the call raises `AttributeError: 'NoneType' object has no attribute 'put'` instead of returning a clean error, and the chat hangs on "Thinking…".

## Fix

Snapshot both fields once at the top of the method. If either is `None`, return the standard error response shape (`{"data": None, "success": False, "error": "Claude agent is not connected"}`). The snapshot avoids re-reading through `self` and racing with a concurrent `_mark_as_disconnected`.

## Testing

- New test `test_returns_error_when_queue_or_signal_is_none` covers both fields being `None`.
- Full backend suite: 355/355 pass.