### PR TITLE
fix(api): disconnect WebSocket message handlers when request ends

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -682,6 +682,28 @@ export class NBIAPI {
     );
   }
 
+  /**
+   * Subscribe to inbound websocket messages for a single request, forwarding
+   * them to `responseEmitter`. The subscription auto-disconnects when the
+   * server emits StreamEnd, preventing per-request listener accumulation.
+   */
+  private static _subscribeUntilStreamEnd(
+    messageId: string,
+    responseEmitter: IChatCompletionResponseEmitter
+  ): void {
+    const handler = (_: unknown, msg: any) => {
+      const parsed = JSON.parse(msg);
+      if (parsed.id !== messageId) {
+        return;
+      }
+      responseEmitter.emit(parsed);
+      if (parsed.type === BackendMessageType.StreamEnd) {
+        this._messageReceived.disconnect(handler);
+      }
+    };
+    this._messageReceived.connect(handler);
+  }
+
   static async chatRequest(
     messageId: string,
     chatId: string,
@@ -694,12 +716,7 @@ export class NBIAPI {
     toolSelections: IToolSelections,
     responseEmitter: IChatCompletionResponseEmitter
   ) {
-    this._messageReceived.connect((_, msg) => {
-      msg = JSON.parse(msg);
-      if (msg.id === messageId) {
-        responseEmitter.emit(msg);
-      }
-    });
+    this._subscribeUntilStreamEnd(messageId, responseEmitter);
     this._webSocket.send(
       JSON.stringify({
         id: messageId,
@@ -743,12 +760,7 @@ export class NBIAPI {
     responseEmitter: IChatCompletionResponseEmitter
   ) {
     const messageId = UUID.uuid4();
-    this._messageReceived.connect((_, msg) => {
-      msg = JSON.parse(msg);
-      if (msg.id === messageId) {
-        responseEmitter.emit(msg);
-      }
-    });
+    this._subscribeUntilStreamEnd(messageId, responseEmitter);
     this._webSocket.send(
       JSON.stringify({
         id: messageId,
@@ -795,12 +807,7 @@ export class NBIAPI {
     filename: string,
     responseEmitter: IChatCompletionResponseEmitter
   ) {
-    this._messageReceived.connect((_, msg) => {
-      msg = JSON.parse(msg);
-      if (msg.id === messageId) {
-        responseEmitter.emit(msg);
-      }
-    });
+    this._subscribeUntilStreamEnd(messageId, responseEmitter);
     this._webSocket.send(
       JSON.stringify({
         id: messageId,


### PR DESCRIPTION
## Issue

`NBIAPI.chatRequest`, `generateCode`, and `inlineCompletionsRequest` each connect a handler to the static `_messageReceived` signal but never disconnect it. Every chat message, code generation, and inline completion permanently adds a listener. Over a long session the signal accumulates dead handlers — each one parses every incoming WebSocket message before short-circuiting on a non-matching `id`. Memory and per-message CPU both grow unboundedly.

## Fix

Added a `_subscribeUntilStreamEnd` helper that disconnects the handler once the response's terminal `StreamEnd` message arrives. The three call sites now share it.

`StreamEnd` is the right trigger because `ChatResponse.finish()` in the backend always emits it at the end of a request, including error paths.

## Testing

- `jlpm lint:check` and `tsc --noEmit` clean
- `jlpm build` clean
- Manually verified in a running JupyterLab session that listener count stays flat across many chat turns (previously grew by 1 per turn)