### PR TITLE
fix(ui): disconnect configChanged handlers on component unmount

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,8 @@
             "@typescript-eslint/no-unused-vars": [
                 "warn",
                 {
-                    "args": "none"
+                    "args": "none",
+                    "varsIgnorePattern": "^_"
                 }
             ],
             "@typescript-eslint/no-explicit-any": "off",

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -1423,7 +1423,7 @@ function SidebarComponent(props: any) {
   }, [mcpServerEnabledState]);
 
   useEffect(() => {
-    NBIAPI.configChanged.connect(() => {
+    const handler = () => {
       toolConfigRef.current = NBIAPI.config.toolConfig;
       mcpServerSettingsRef.current = NBIAPI.config.mcpServerSettings;
       const newMcpServerEnabledState = mcpServerSettingsToEnabledState(
@@ -1432,7 +1432,11 @@ function SidebarComponent(props: any) {
       );
       setMCPServerEnabledState(newMcpServerEnabledState);
       setRenderCount(renderCount => renderCount + 1);
-    });
+    };
+    NBIAPI.configChanged.connect(handler);
+    return () => {
+      NBIAPI.configChanged.disconnect(handler);
+    };
   }, []);
 
   useEffect(() => {
@@ -2615,10 +2619,14 @@ function SidebarComponent(props: any) {
   const [skillsReloadedVisible, setSkillsReloadedVisible] = useState(false);
 
   useEffect(() => {
-    NBIAPI.configChanged.connect(() => {
+    const handler = () => {
       setGHLoginRequired(NBIAPI.getGHLoginRequired());
       setChatEnabled(NBIAPI.getChatEnabled());
-    });
+    };
+    NBIAPI.configChanged.connect(handler);
+    return () => {
+      NBIAPI.configChanged.disconnect(handler);
+    };
   }, []);
 
   useEffect(() => {

--- a/src/components/settings-panel.tsx
+++ b/src/components/settings-panel.tsx
@@ -93,9 +93,13 @@ function SettingsPanelTabsComponent(props: any) {
   );
 
   useEffect(() => {
-    NBIAPI.configChanged.connect(() => {
+    const handler = () => {
       setIsInClaudeCodeMode(NBIAPI.config.isInClaudeCodeMode);
-    });
+    };
+    NBIAPI.configChanged.connect(handler);
+    return () => {
+      NBIAPI.configChanged.disconnect(handler);
+    };
   }, []);
 
   return (
@@ -737,11 +741,15 @@ function SettingsPanelComponentMCPServers(props: any) {
   };
 
   useEffect(() => {
-    NBIAPI.configChanged.connect(() => {
+    const handler = () => {
       mcpServersRef.current = nbiConfig.toolConfig.mcpServers;
       mcpServerSettingsRef.current = nbiConfig.mcpServerSettings;
       setRenderCount(renderCount => renderCount + 1);
-    });
+    };
+    NBIAPI.configChanged.connect(handler);
+    return () => {
+      NBIAPI.configChanged.disconnect(handler);
+    };
   }, []);
 
   return (
@@ -905,11 +913,15 @@ function SettingsPanelComponentClaude(props: any) {
   const [loadingModels, setLoadingModels] = useState(false);
 
   useEffect(() => {
-    NBIAPI.configChanged.connect(() => {
+    const handler = () => {
       claudeSettingsRef.current = nbiConfig.claudeSettings;
       setClaudeModels(nbiConfig.claudeModels);
       setRenderCount(renderCount => renderCount + 1);
-    });
+    };
+    NBIAPI.configChanged.connect(handler);
+    return () => {
+      NBIAPI.configChanged.disconnect(handler);
+    };
   }, []);
 
   const refreshClaudeModels = async () => {


### PR DESCRIPTION
## Issue

Five `useEffect` hooks across `settings-panel.tsx` and `chat-sidebar.tsx` connect to `NBIAPI.configChanged` but don't return a cleanup function. The signal is on the static `NBIAPI` singleton, so handlers from unmounted components stay subscribed for the rest of the session. Opening and closing the settings panel a few times leaves multiple stale handlers firing on every config change, each calling `setState` on a dead component (React then warns).

## Fix

Each affected `useEffect` now binds the handler to a local variable and returns a cleanup that calls `NBIAPI.configChanged.disconnect(handler)`. Same pattern the codebase already uses for `skillsReloaded` listeners.

## Testing

- `jlpm lint:check`, `tsc --noEmit`, and `jlpm build` clean.
- Manually verified by opening/closing the settings panel repeatedly; no React "setState on unmounted component" warnings, and the configChanged listener count stays bounded.