### PR TITLE
docs: restructure README and add operator/security/privacy guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ For each release we list user-facing changes grouped as **Added**, **Changed**, 
 
 - Chat feedback mechanism for AI responses, configurable via the `enable_chat_feedback` traitlet, with a `telemetry` event hook.
 - Attach files as context in chat.
-- Newline in chat input on Shift+Enter.
+- `Shift+Enter` inserts a newline in the chat input.
+- Disable LLM providers via the `disabled_providers` traitlet, with optional per-pod re-enable via `NBI_ENABLED_PROVIDERS`.
 
 ### Changed
 
@@ -32,8 +33,7 @@ For each release we list user-facing changes grouped as **Added**, **Changed**, 
 
 ### Added
 
-- Configurable Claude CLI path via Claude settings (`claude_cli_path`).
-- Disable LLM providers via `disabled_providers` and re-enable via `NBI_ENABLED_PROVIDERS`.
+- Configurable Claude Code CLI path via the `NBI_CLAUDE_CLI_PATH` environment variable.
 
 ### Changed
 
@@ -57,12 +57,12 @@ For each release we list user-facing changes grouped as **Added**, **Changed**, 
 
 - Auto-complete debounce delay configuration.
 - Additional inline-completion options in Claude mode.
+- Conversation continuation in Claude mode.
 
 ### Changed
 
 - Settings dialog hides Claude-specific options when Claude mode is off.
 - NBI sidebar moved to the left side of the JupyterLab UI.
-- "Remember GitHub Copilot login" support, encrypted at rest with `NBI_GH_ACCESS_TOKEN_PASSWORD`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,150 @@
 # Changelog
 
+All notable changes to Notebook Intelligence are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) starting with 4.0.0.
+
+For each release we list user-facing changes grouped as **Added**, **Changed**, **Fixed**, and **Removed**. Commits are squashed into the change that motivated them; the full git log remains the source of truth for low-level history.
+
 <!-- <START NEW CHANGELOG ENTRY> -->
 
 <!-- <END NEW CHANGELOG ENTRY> -->
+
+## [4.5.0] — 2026-04-09
+
+### Added
+
+- Chat feedback mechanism for AI responses, configurable via the `enable_chat_feedback` traitlet, with a `telemetry` event hook.
+- Attach files as context in chat.
+- Newline in chat input on Shift+Enter.
+
+### Changed
+
+- Inline completion for the OpenAI-compatible provider now uses the Chat Completions API.
+
+### Fixed
+
+- OpenAI-compatible provider now correctly handles `tool` and `tool_choice` parameters.
+- File-attach popover styling.
+- Newlines in user input are preserved.
+
+## [4.4.0] — 2026-03-13
+
+### Added
+
+- Configurable Claude CLI path via Claude settings (`claude_cli_path`).
+- Disable LLM providers via `disabled_providers` and re-enable via `NBI_ENABLED_PROVIDERS`.
+
+### Changed
+
+- Subprocess invocations no longer use `shell=True`.
+
+## [4.3.2] — 2026-03-13
+
+### Fixed
+
+- Refresh-models button in Claude settings; model list pulled from the Anthropic SDK.
+
+## [4.3.1] — 2026-01-12
+
+### Fixed
+
+- Inline-chat autocomplete popover position.
+
+## [4.3.0] — 2026-01-11
+
+### Added
+
+- Auto-complete debounce delay configuration.
+- Additional inline-completion options in Claude mode.
+
+### Changed
+
+- Settings dialog hides Claude-specific options when Claude mode is off.
+- NBI sidebar moved to the left side of the JupyterLab UI.
+- "Remember GitHub Copilot login" support, encrypted at rest with `NBI_GH_ACCESS_TOKEN_PASSWORD`.
+
+### Fixed
+
+- Auto-complete tab-state handling.
+
+## [4.2.1] — 2026-01-06
+
+### Changed
+
+- Project rebrand from "JUI" to "NBI" (`@notebook-intelligence/notebook-intelligence`).
+
+## [4.2.0] — 2026-01-06
+
+### Changed
+
+- Notebook tool calls (e.g., cell execution) now require explicit user approval instead of being auto-allowed.
+
+### Fixed
+
+- Improved error handling and message-handler disconnect.
+- Claude settings font color and UI state when toggling Claude mode.
+
+## [4.1.2] — 2026-01-05
+
+### Fixed
+
+- Lock-handling in long-running Claude sessions.
+
+## [4.1.1] — 2026-01-04
+
+### Fixed
+
+- Claude mode reliability (multiple cleanup commits).
+
+## [4.1.0] — 2026-01-03
+
+### Added
+
+- Plan mode for Claude.
+- Custom message for the Bash tool.
+
+### Changed
+
+- Claude session timeout raised to 30 minutes.
+- Improved AskUserQuestion styling.
+
+### Fixed
+
+- Current-directory context and chat-history handling.
+
+## [4.0.0] — 2026-01-01
+
+### Added
+
+- **Claude mode** — first-class integration with [Claude Code](https://code.claude.com/), including:
+  - Claude Code-backed Agent Chat UI, inline chat, and auto-complete.
+  - Claude Code tools, skills, MCP servers, and custom commands available inside JupyterLab.
+  - Claude session resume from `~/.claude/projects/`.
+- Honor `c.ServerApp.base_url` for all extension routes.
+
+### Changed
+
+- Settings UI restructured around Claude vs default mode.
+- WebSocket connection reliability improvements.
+
+[unreleased]: https://github.com/notebook-intelligence/notebook-intelligence/compare/v4.5.0...HEAD
+[4.5.0]: https://github.com/notebook-intelligence/notebook-intelligence/compare/v4.4.0...v4.5.0
+[4.4.0]: https://github.com/notebook-intelligence/notebook-intelligence/compare/v4.3.2...v4.4.0
+[4.3.2]: https://github.com/notebook-intelligence/notebook-intelligence/compare/v4.3.1...v4.3.2
+[4.3.1]: https://github.com/notebook-intelligence/notebook-intelligence/compare/v4.3.0...v4.3.1
+[4.3.0]: https://github.com/notebook-intelligence/notebook-intelligence/compare/v4.2.1...v4.3.0
+[4.2.1]: https://github.com/notebook-intelligence/notebook-intelligence/compare/v4.2.0...v4.2.1
+[4.2.0]: https://github.com/notebook-intelligence/notebook-intelligence/compare/v4.1.2...v4.2.0
+[4.1.2]: https://github.com/notebook-intelligence/notebook-intelligence/compare/v4.1.1...v4.1.2
+[4.1.1]: https://github.com/notebook-intelligence/notebook-intelligence/compare/v4.1.0...v4.1.1
+[4.1.0]: https://github.com/notebook-intelligence/notebook-intelligence/compare/v4.0.0...v4.1.0
+[4.0.0]: https://github.com/notebook-intelligence/notebook-intelligence/releases/tag/v4.0.0
+
+## Versioning policy
+
+- **Major (X.0.0)** — backward-incompatible changes to traitlets, environment variables, REST routes, or on-disk file formats. Major releases are accompanied by a migration note in this file.
+- **Minor (4.Y.0)** — new features and traitlets. Existing configuration continues to work.
+- **Patch (4.5.Z)** — bug fixes only.
+
+Deprecations land in a minor release with a warning at startup, and are removed no earlier than the next major release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,22 +2,22 @@
 
 Thanks for considering a contribution to Notebook Intelligence!
 
-> **Just want to use NBI?** You don't need to read this file. `pip install notebook-intelligence` and the [README](README.md) Quick Start are all you need.
+> **Just want to use NBI?** You don't need to read this file. `pip install notebook-intelligence` and the [README](README.md) quick start are all you need.
 
 ## Filing a good bug report
 
-Please include the following so we can reproduce the issue:
+Include the following so we can reproduce the issue:
 
 - **NBI version** — output of `pip show notebook-intelligence`.
 - **JupyterLab version** — output of `jupyter --version`.
-- **Python version and OS** — `python --version`; macOS / Linux / Windows + version.
-- **Browser** — Chrome / Firefox / Safari + version, if the issue is in the chat sidebar or settings UI.
-- **LLM provider** — GitHub Copilot, Claude, OpenAI-compatible, LiteLLM-compatible, or Ollama, plus the model name.
+- **Python version and OS** — `python --version`; macOS, Linux, or Windows plus version.
+- **Browser** — Chrome, Firefox, or Safari plus version, if the issue is in the chat sidebar or settings UI.
+- **LLM provider** — GitHub Copilot, OpenAI-compatible, LiteLLM-compatible, Ollama, or Claude mode, plus the model name.
 - **Claude mode** — on or off.
-- **Reproduction steps** — minimum sequence of clicks/messages.
+- **Reproduction steps** — minimum sequence of clicks and messages.
 - **Logs** — relevant excerpts from the JupyterLab terminal (server-side errors), the browser DevTools console (frontend errors), and any redacted contents of `~/.jupyter/nbi/config.json` if the issue is configuration-related.
 
-See [`docs/troubleshooting.md`](docs/troubleshooting.md) for common problems with copy-pasteable fixes — please check there first.
+See [`docs/troubleshooting.md`](docs/troubleshooting.md) for common problems with copy-pasteable fixes — check there first.
 
 ## Reporting a security issue
 
@@ -42,13 +42,14 @@ NBI has two halves:
   - `src/chat-sidebar.tsx` — chat sidebar React tree.
   - `src/components/settings-panel.tsx` — settings dialog.
   - `src/components/skills-panel.tsx` — Claude Skills management UI.
-  - `src/api.ts` — HTTP client for the server extension.
+  - `src/api.ts` — high-level client for the server extension (chat WebSocket, capabilities, config).
+  - `src/handler.ts` — thin wrapper over Jupyter's `ServerConnection.makeRequest`.
 
-The two halves communicate over the routes registered in `extension.py` (REST + WebSocket). All routes live under `/notebook-intelligence/`. See [`docs/admin-guide.md`](docs/admin-guide.md#http-api-surface) for the full list.
+The two halves communicate over the routes registered in `extension.py` (REST and WebSocket). All routes live under `/notebook-intelligence/`. See [`docs/admin-guide.md`](docs/admin-guide.md#http-api-surface) for the full list.
 
 ## Development install
 
-You will need Node.js 18+ to build the frontend. The `jlpm` command is JupyterLab's pinned version of [yarn](https://yarnpkg.com/) that ships with JupyterLab — install JupyterLab first to get it.
+You'll need Node.js 18 or newer to build the frontend. The `jlpm` command is JupyterLab's pinned version of [yarn](https://yarnpkg.com/) — install JupyterLab first to get it.
 
 ```bash
 # Clone the repo and change into the directory.
@@ -103,12 +104,12 @@ There is no Python test suite at the moment. Manual end-to-end verification is d
 
 ```bash
 jlpm lint:check   # check, no fixes
-jlpm lint         # check + auto-fix prettier/eslint/stylelint
+jlpm lint         # check and auto-fix prettier, eslint, and stylelint
 ```
 
-CI runs `lint:check`. Identifiers prefixed with `_` are treated as intentionally unused and are excluded from the unused-vars rule.
+CI runs `lint:check`. Identifiers prefixed with `_` are treated as intentionally unused and excluded from the unused-vars rule.
 
-If `jlpm install` produces lockfile changes you didn't expect, your local Yarn version probably differs from the one bundled with JupyterLab. `jlpm` ships with JupyterLab (currently Yarn 3.5.0) — use it directly instead of a system-wide `yarn`.
+If `jlpm install` produces unexpected lockfile changes, your local Yarn version probably differs from the one bundled with JupyterLab. `jlpm` ships with JupyterLab — use it directly instead of a system-wide `yarn`.
 
 ## Packaging
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,38 +1,80 @@
-## Contributing
+# Contributing
 
-### Development install
+Thanks for considering a contribution to Notebook Intelligence!
 
-Note: You will need NodeJS to build the extension package.
+> **Just want to use NBI?** You don't need to read this file. `pip install notebook-intelligence` and the [README](README.md) Quick Start are all you need.
 
-The `jlpm` command is JupyterLab's pinned version of
-[yarn](https://yarnpkg.com/) that is installed with JupyterLab. You may use
-`yarn` or `npm` in lieu of `jlpm` below.
+## Filing a good bug report
+
+Please include the following so we can reproduce the issue:
+
+- **NBI version** — output of `pip show notebook-intelligence`.
+- **JupyterLab version** — output of `jupyter --version`.
+- **Python version and OS** — `python --version`; macOS / Linux / Windows + version.
+- **Browser** — Chrome / Firefox / Safari + version, if the issue is in the chat sidebar or settings UI.
+- **LLM provider** — GitHub Copilot, Claude, OpenAI-compatible, LiteLLM-compatible, or Ollama, plus the model name.
+- **Claude mode** — on or off.
+- **Reproduction steps** — minimum sequence of clicks/messages.
+- **Logs** — relevant excerpts from the JupyterLab terminal (server-side errors), the browser DevTools console (frontend errors), and any redacted contents of `~/.jupyter/nbi/config.json` if the issue is configuration-related.
+
+See [`docs/troubleshooting.md`](docs/troubleshooting.md) for common problems with copy-pasteable fixes — please check there first.
+
+## Reporting a security issue
+
+Do not open a public GitHub issue. See [SECURITY.md](SECURITY.md) for the private-disclosure address.
+
+## Architecture overview
+
+NBI has two halves:
+
+- **Server extension** — Python package `notebook_intelligence/`. Runs inside Jupyter Server. Key entry points:
+  - `notebook_intelligence/extension.py` — tornado handlers, traitlets, route registration, server lifecycle.
+  - `notebook_intelligence/ai_service_manager.py` — composes LLM providers, MCP, skills, and rules into the request pipeline.
+  - `notebook_intelligence/llm_providers/` — provider adapters (GitHub Copilot, OpenAI-compatible, LiteLLM-compatible, Ollama).
+  - `notebook_intelligence/claude.py` + `notebook_intelligence/claude_sessions.py` — Claude Code integration via [`claude-agent-sdk`](https://pypi.org/project/claude-agent-sdk/).
+  - `notebook_intelligence/mcp_manager.py` — MCP server management via [`fastmcp`](https://pypi.org/project/fastmcp/).
+  - `notebook_intelligence/skill_manager.py`, `skill_github_import.py`, `skill_manifest.py`, `skill_reconciler.py`, `skillset.py` — Claude Skills storage, GitHub import, and managed-manifest reconciliation.
+  - `notebook_intelligence/rule_manager.py`, `rule_injector.py`, `ruleset.py` — ruleset discovery and prompt injection.
+  - `notebook_intelligence/built_in_toolsets.py` — built-in tool implementations (`nbi-notebook-edit`, `nbi-command-execute`, etc.).
+  - `notebook_intelligence/github_copilot.py` — GitHub Copilot device-flow auth and token storage.
+- **Frontend extension** — TypeScript package `src/`. Compiled to a JupyterLab labextension. Key entry points:
+  - `src/index.ts` — JupyterLab plugin registration.
+  - `src/chat-sidebar.tsx` — chat sidebar React tree.
+  - `src/components/settings-panel.tsx` — settings dialog.
+  - `src/components/skills-panel.tsx` — Claude Skills management UI.
+  - `src/api.ts` — HTTP client for the server extension.
+
+The two halves communicate over the routes registered in `extension.py` (REST + WebSocket). All routes live under `/notebook-intelligence/`. See [`docs/admin-guide.md`](docs/admin-guide.md#http-api-surface) for the full list.
+
+## Development install
+
+You will need Node.js 18+ to build the frontend. The `jlpm` command is JupyterLab's pinned version of [yarn](https://yarnpkg.com/) that ships with JupyterLab — install JupyterLab first to get it.
 
 ```bash
-# Clone the repo to your local environment
-# Change directory to the notebook_intelligence directory
-# Install package in development mode
+# Clone the repo and change into the directory.
+# Install the package in development mode.
 pip install -e "."
-# Link your development version of the extension with JupyterLab
+
+# Link the development version of the extension with JupyterLab.
 jupyter labextension develop . --overwrite
-# Server extension must be manually installed in develop mode
+
+# Server extension must be manually installed in develop mode.
 jupyter server extension enable notebook_intelligence
-# Rebuild extension Typescript source after making changes
+
+# Build the TypeScript source.
 jlpm build
 ```
 
-You can watch the source directory and run JupyterLab at the same time in different terminals to watch for changes in the extension's source and automatically rebuild the extension.
+Run JupyterLab and the watch loop in two terminals to pick up source changes automatically:
 
 ```bash
-# Watch the source directory in one terminal, automatically rebuilding when needed
+# Terminal 1
 jlpm watch
-# Run JupyterLab in another terminal
+# Terminal 2
 jupyter lab
 ```
 
-With the watch command running, every saved change will immediately be built locally and available in your running JupyterLab. Refresh JupyterLab to load the change in your browser (you may need to wait several seconds for the extension to be rebuilt).
-
-By default, the `jlpm build` command generates the source maps for this extension to make it easier to debug using the browser dev tools. To also generate source maps for the JupyterLab core extensions, you can run the following command:
+Refresh the browser tab to load the rebuilt frontend. To get source maps for JupyterLab core extensions as well:
 
 ```bash
 jupyter lab build --minimize=False
@@ -41,36 +83,52 @@ jupyter lab build --minimize=False
 ### Development uninstall
 
 ```bash
-# Server extension must be manually disabled in develop mode
 jupyter server extension disable notebook_intelligence
 pip uninstall notebook_intelligence
 ```
 
-In development mode, you will also need to remove the symlink created by `jupyter labextension develop`
-command. To find its location, you can run `jupyter labextension list` to figure out where the `labextensions`
-folder is located. Then you can remove the symlink named `@notebook-intelligence/notebook-intelligence` within that folder.
+The `jupyter labextension develop` command leaves a symlink behind. Run `jupyter labextension list` to find the labextensions directory, then remove the `@notebook-intelligence/notebook-intelligence` symlink there.
 
-### Packaging the extension
+## Running tests
 
-See [RELEASE](RELEASE.md)
+TypeScript unit tests:
 
-### Troubleshoot
+```bash
+jlpm test
+```
 
-If you are seeing the frontend extension, but it is not working, check
-that the server extension is enabled:
+There is no Python test suite at the moment. Manual end-to-end verification is documented per change in pull request descriptions.
+
+## Linting
+
+```bash
+jlpm lint:check   # check, no fixes
+jlpm lint         # check + auto-fix prettier/eslint/stylelint
+```
+
+CI runs `lint:check`. Identifiers prefixed with `_` are treated as intentionally unused and are excluded from the unused-vars rule.
+
+If `jlpm install` produces lockfile changes you didn't expect, your local Yarn version probably differs from the one bundled with JupyterLab. `jlpm` ships with JupyterLab (currently Yarn 3.5.0) — use it directly instead of a system-wide `yarn`.
+
+## Packaging
+
+See [RELEASE.md](RELEASE.md).
+
+## Frontend extension layout sanity check
+
+If you see the frontend extension but it isn't working, check the server extension is enabled:
 
 ```bash
 jupyter server extension list
 ```
 
-If the server extension is installed and enabled, but you are not seeing
-the frontend extension, check the frontend extension is installed:
+If the server extension is enabled but the frontend isn't loading:
 
 ```bash
 jupyter labextension list
 ```
 
-### Resources I used as reference
+## Resources
 
 - [Copilot Internals blog post](https://thakkarparth007.github.io/copilot-explorer/posts/copilot-internals.html)
-- [B00TK1D/copilot-api for GitHub auth and inline completions](https://github.com/B00TK1D/copilot-api)
+- [B00TK1D/copilot-api](https://github.com/B00TK1D/copilot-api) — GitHub Copilot auth and inline completions

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -4,41 +4,41 @@ This page documents what NBI sends to external services, when, and how administr
 
 ## What NBI sends, by provider
 
-The table below describes what each LLM provider receives **when you actively use a feature** (chat message, inline completion, agent action). Idle JupyterLab does not contact the provider.
+The table below describes what each LLM provider receives **when you actively use a feature** (chat message, inline completion, agent action). An idle JupyterLab does not contact the provider.
 
-| Provider                   | What is sent                                                                                            | When                                                 | Destination                                                                           |
-| -------------------------- | ------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| **GitHub Copilot**         | Prompt, surrounding cell source, attached files (when you click "attach")                               | Per request (chat) and as you type (inline-complete) | `api.githubcopilot.com`, `api.github.com` (auth)                                      |
-| **Anthropic / Claude API** | Prompt, surrounding cell source, attached files, tool-call results from agent mode                      | Per request and per agent step                       | `api.anthropic.com` (or your configured Base URL)                                     |
-| **Claude Code (CLI)**      | Prompt, working-directory file reads requested by Claude, shell-command output for tools Claude invokes | Per agent turn                                       | Whatever the Claude Code CLI is configured to talk to (typically `api.anthropic.com`) |
-| **OpenAI-compatible**      | Prompt, surrounding cell source, attached files                                                         | Per request and inline-complete                      | The Base URL you configured (`api.openai.com` by default)                             |
-| **LiteLLM-compatible**     | Same as OpenAI-compatible; LiteLLM proxy forwards to the upstream model you configured                  | Per request                                          | The Base URL of your LiteLLM proxy                                                    |
-| **Ollama (local)**         | Prompt, surrounding cell source, attached files                                                         | Per request                                          | Localhost (or the host you configured); **no external network**                       |
+| Provider                          | What is sent                                                                                            | When                                                 | Destination                                                                           |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| **GitHub Copilot**                | Prompt, surrounding cell source, attached files (when you click _attach_)                               | Per request (chat) and as you type (inline complete) | `api.githubcopilot.com`, `api.github.com` (auth)                                      |
+| **OpenAI-compatible**             | Prompt, surrounding cell source, attached files                                                         | Per request and per inline-completion request        | The Base URL you configured (`api.openai.com` by default)                             |
+| **LiteLLM-compatible**            | Same as OpenAI-compatible; the LiteLLM proxy forwards to the upstream model you configured              | Per request                                          | The Base URL of your LiteLLM proxy                                                    |
+| **Ollama (local)**                | Prompt, surrounding cell source, attached files                                                         | Per request                                          | Localhost (or the host you configured); **no external network**                       |
+| **Anthropic API** (Claude mode)   | Prompt, surrounding cell source, attached files                                                         | Per inline-chat or auto-complete request             | `api.anthropic.com` (or your configured Base URL)                                     |
+| **Claude Code CLI** (Claude mode) | Prompt, working-directory file reads requested by Claude, shell-command output for tools Claude invokes | Per agent turn in the chat panel                     | Whatever the Claude Code CLI is configured to talk to (typically `api.anthropic.com`) |
 
 ### Cell outputs are included when the cell is attached
 
-NBI does **not** automatically include rendered cell outputs in every prompt. Outputs are sent only when:
+NBI does **not** automatically include rendered cell outputs in every prompt. Outputs go out only when:
 
-- You attach a notebook or cell explicitly via the "attach files" UI.
-- The active context references a notebook and the agent (or inline chat) reads its source — the source view in `.ipynb` JSON includes any saved outputs in the file.
+- You attach a notebook or cell explicitly via the _attach files_ UI.
+- The active context references a notebook and the agent (or inline chat) reads its source — the `.ipynb` JSON includes any saved outputs.
 
-If your cells contain sensitive outputs (PHI, PII, secrets), clear them before invoking AI features, or use a local-only provider (Ollama). Inline completion is keystroke-driven and only sends the cell source; it does not transmit unrelated cells or outputs.
+If your cells contain sensitive outputs (PHI, PII, secrets), clear them before invoking AI features, or use a local-only provider (Ollama). Inline completion is keystroke-driven and sends only the cell source; it does not transmit unrelated cells or outputs.
 
 ## Egress allowlist
 
 Hosts NBI may contact, depending on which features are enabled:
 
-| Host                                            | Purpose                                                                                                    |
-| ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `api.githubcopilot.com`                         | GitHub Copilot chat and inline completion                                                                  |
-| `api.github.com`                                | GitHub Copilot device-flow login; managed-skills manifest fetches when hosted on github.com; skill imports |
-| `github.com` / `codeload.github.com`            | Skill tarball downloads (`Import from GitHub` and managed-skills reconciler)                               |
-| `raw.githubusercontent.com`                     | Manifest fetches when `NBI_SKILLS_MANIFEST` points at a `raw.githubusercontent.com` URL                    |
-| `api.anthropic.com`                             | Claude API and Claude Code (default)                                                                       |
-| `api.openai.com`                                | OpenAI-compatible provider (default Base URL)                                                              |
-| Your configured Base URL                        | OpenAI-compatible / LiteLLM-compatible / Claude when redirected to a self-hosted endpoint                  |
-| `localhost:11434` (or your Ollama host)         | Ollama local model serving                                                                                 |
-| `registry.npmjs.org` and configured npm mirrors | Only if MCP servers are configured to launch via `npx -y` — `npx` fetches the package on first run         |
+| Host                                            | Purpose                                                                                                          |
+| ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `api.githubcopilot.com`                         | GitHub Copilot chat and inline completion                                                                        |
+| `api.github.com`                                | GitHub Copilot device-flow login; managed-skills manifest fetches when hosted on github.com; skill imports       |
+| `github.com`, `codeload.github.com`             | Skill tarball downloads (Import from GitHub and the managed-skills reconciler)                                   |
+| `raw.githubusercontent.com`                     | Manifest fetches when `NBI_SKILLS_MANIFEST` points at a `raw.githubusercontent.com` URL                          |
+| `api.anthropic.com`                             | Anthropic API for Claude-mode inline chat and auto-complete; also the default destination of the Claude Code CLI |
+| `api.openai.com`                                | OpenAI-compatible provider (default Base URL)                                                                    |
+| Your configured Base URL                        | OpenAI-compatible, LiteLLM-compatible, or Claude when pointed at a self-hosted endpoint                          |
+| `localhost:11434` (or your Ollama host)         | Ollama local model serving                                                                                       |
+| `registry.npmjs.org` and configured npm mirrors | Only if MCP servers are configured to launch via `npx -y` — `npx` fetches the package on first run               |
 
 For the configurable destinations above (Base URLs, Ollama host, MCP `npx` packages), the destination is whatever you or your admin set. There is no other implicit network activity.
 
@@ -64,11 +64,11 @@ The encrypted GitHub token uses a default password (`nbi-access-token-password`)
 
 NBI does not collect telemetry, send analytics, or report usage.
 
-The `enable_chat_feedback` traitlet (off by default) emits an internal `telemetry` event when a user gives thumbs-up/down feedback in chat. The event is **emitted in-process only** — nothing leaves the pod unless you write a custom handler that listens for it. See [`docs/admin-guide.md`](docs/admin-guide.md#chat-feedback-event-hook).
+The `enable_chat_feedback` traitlet (off by default) emits an internal `telemetry` event when a user gives thumbs-up/down feedback in chat. The event is **emitted in-process only** — nothing leaves the process unless you write a custom handler that listens for it. See [`docs/admin-guide.md`](docs/admin-guide.md#chat-feedback-event-hook).
 
 ## Reproducibility caveat
 
-LLM outputs are non-deterministic. Pinning the model name, temperature, and seed does **not** guarantee identical output across runs — provider-side updates, load-balancing, and silent model deprecation can all shift behavior. Treat AI-generated code as a draft to be reviewed, tested, and committed like any other contribution. For research artifacts that need reproducibility, save the exact prompt, model name, and date alongside the generated output.
+LLM outputs are non-deterministic. Pinning the model name, temperature, and seed does **not** guarantee identical output across runs — provider-side updates, load balancing, and silent model deprecation can all shift behavior. Treat AI-generated code as a draft to be reviewed, tested, and committed like any other contribution. For research artifacts that need reproducibility, save the exact prompt, model name, and date alongside the generated output.
 
 ## Privacy-sensitive deployment recipes
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,84 @@
+# Privacy and Data Flow
+
+This page documents what NBI sends to external services, when, and how administrators can restrict it. NBI is a per-user tool that runs inside your Jupyter Server process — it has no central server of its own and collects no telemetry by default.
+
+## What NBI sends, by provider
+
+The table below describes what each LLM provider receives **when you actively use a feature** (chat message, inline completion, agent action). Idle JupyterLab does not contact the provider.
+
+| Provider                   | What is sent                                                                                            | When                                                 | Destination                                                                           |
+| -------------------------- | ------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| **GitHub Copilot**         | Prompt, surrounding cell source, attached files (when you click "attach")                               | Per request (chat) and as you type (inline-complete) | `api.githubcopilot.com`, `api.github.com` (auth)                                      |
+| **Anthropic / Claude API** | Prompt, surrounding cell source, attached files, tool-call results from agent mode                      | Per request and per agent step                       | `api.anthropic.com` (or your configured Base URL)                                     |
+| **Claude Code (CLI)**      | Prompt, working-directory file reads requested by Claude, shell-command output for tools Claude invokes | Per agent turn                                       | Whatever the Claude Code CLI is configured to talk to (typically `api.anthropic.com`) |
+| **OpenAI-compatible**      | Prompt, surrounding cell source, attached files                                                         | Per request and inline-complete                      | The Base URL you configured (`api.openai.com` by default)                             |
+| **LiteLLM-compatible**     | Same as OpenAI-compatible; LiteLLM proxy forwards to the upstream model you configured                  | Per request                                          | The Base URL of your LiteLLM proxy                                                    |
+| **Ollama (local)**         | Prompt, surrounding cell source, attached files                                                         | Per request                                          | Localhost (or the host you configured); **no external network**                       |
+
+### Cell outputs are included when the cell is attached
+
+NBI does **not** automatically include rendered cell outputs in every prompt. Outputs are sent only when:
+
+- You attach a notebook or cell explicitly via the "attach files" UI.
+- The active context references a notebook and the agent (or inline chat) reads its source — the source view in `.ipynb` JSON includes any saved outputs in the file.
+
+If your cells contain sensitive outputs (PHI, PII, secrets), clear them before invoking AI features, or use a local-only provider (Ollama). Inline completion is keystroke-driven and only sends the cell source; it does not transmit unrelated cells or outputs.
+
+## Egress allowlist
+
+Hosts NBI may contact, depending on which features are enabled:
+
+| Host                                            | Purpose                                                                                                    |
+| ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `api.githubcopilot.com`                         | GitHub Copilot chat and inline completion                                                                  |
+| `api.github.com`                                | GitHub Copilot device-flow login; managed-skills manifest fetches when hosted on github.com; skill imports |
+| `github.com` / `codeload.github.com`            | Skill tarball downloads (`Import from GitHub` and managed-skills reconciler)                               |
+| `raw.githubusercontent.com`                     | Manifest fetches when `NBI_SKILLS_MANIFEST` points at a `raw.githubusercontent.com` URL                    |
+| `api.anthropic.com`                             | Claude API and Claude Code (default)                                                                       |
+| `api.openai.com`                                | OpenAI-compatible provider (default Base URL)                                                              |
+| Your configured Base URL                        | OpenAI-compatible / LiteLLM-compatible / Claude when redirected to a self-hosted endpoint                  |
+| `localhost:11434` (or your Ollama host)         | Ollama local model serving                                                                                 |
+| `registry.npmjs.org` and configured npm mirrors | Only if MCP servers are configured to launch via `npx -y` — `npx` fetches the package on first run         |
+
+For the configurable destinations above (Base URLs, Ollama host, MCP `npx` packages), the destination is whatever you or your admin set. There is no other implicit network activity.
+
+For air-gapped or egress-restricted environments, see [`docs/admin-guide.md`](docs/admin-guide.md#air-gap-deployment).
+
+## Data NBI stores locally
+
+| Path                            | Contents                                                                   |
+| ------------------------------- | -------------------------------------------------------------------------- |
+| `~/.jupyter/nbi/config.json`    | Provider selection, model choices, API keys (plaintext), MCP server config |
+| `~/.jupyter/nbi/user-data.json` | Encrypted GitHub Copilot token (when "remember login" is enabled)          |
+| `~/.jupyter/nbi/rules/`         | Your ruleset markdown files                                                |
+| `~/.jupyter/nbi/mcp.json`       | MCP server config (if you used the file-based config)                      |
+| `~/.claude/skills/`             | User-scope Claude skills                                                   |
+| `<project>/.claude/skills/`     | Project-scope Claude skills                                                |
+| `~/.claude/projects/`           | Claude Code session transcripts (managed by Claude CLI, not NBI)           |
+
+> Treat `~/.jupyter/nbi/config.json` and `~/.jupyter/nbi/user-data.json` as secrets. They contain your API keys and (encrypted) GitHub token. Do not commit them to git, share them, or sync them across users. If a key leaks, rotate it at the provider immediately.
+
+The encrypted GitHub token uses a default password (`nbi-access-token-password`) unless you set `NBI_GH_ACCESS_TOKEN_PASSWORD`. The default is **shared across installs** and provides obfuscation, not real protection. Set a custom password before enabling "remember login" on any shared or multi-tenant system.
+
+## Telemetry
+
+NBI does not collect telemetry, send analytics, or report usage.
+
+The `enable_chat_feedback` traitlet (off by default) emits an internal `telemetry` event when a user gives thumbs-up/down feedback in chat. The event is **emitted in-process only** — nothing leaves the pod unless you write a custom handler that listens for it. See [`docs/admin-guide.md`](docs/admin-guide.md#chat-feedback-event-hook).
+
+## Reproducibility caveat
+
+LLM outputs are non-deterministic. Pinning the model name, temperature, and seed does **not** guarantee identical output across runs — provider-side updates, load-balancing, and silent model deprecation can all shift behavior. Treat AI-generated code as a draft to be reviewed, tested, and committed like any other contribution. For research artifacts that need reproducibility, save the exact prompt, model name, and date alongside the generated output.
+
+## Privacy-sensitive deployment recipes
+
+For HIPAA, FedRAMP, classroom, or otherwise restricted environments:
+
+- **Force local-only models.** Disable every cloud provider via `disabled_providers` and use Ollama. See the [HIPAA / sensitive-data preset](docs/admin-guide.md#hipaa--sensitive-data-preset) in the admin guide.
+- **Restrict skill imports.** Block egress to `github.com` and serve managed skills from an internal manifest URL.
+- **Disable "remember GitHub Copilot login"** for shared systems where users share home directories.
+- **Pre-pull MCP servers** rather than allowing `npx -y` (which downloads from npmjs).
+
+## Reporting privacy issues
+
+Email `mbektasgh@outlook.com` with details. Privacy concerns are treated like security issues — see [SECURITY.md](SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -1,51 +1,84 @@
 # Notebook Intelligence
 
-Notebook Intelligence (NBI) is an AI coding assistant and extensible AI framework for JupyterLab. It can use GitHub Copilot or AI models from any other LLM Provider, including local models from [Ollama](https://ollama.com/). NBI greatly boosts the productivity of JupyterLab users with AI assistance.
+Notebook Intelligence (NBI) is an AI coding assistant and extensible AI framework for JupyterLab. It adds chat, inline edit, auto-complete, and an agent that can drive notebooks — backed by GitHub Copilot, Anthropic Claude, OpenAI-compatible, LiteLLM-compatible, or local [Ollama](https://ollama.com/) models.
 
-## Feature Highlights
+## What it costs
 
-### Claude Mode
+NBI is free and open-source. Connect it to a free or paid LLM provider of your choice — GitHub Copilot, Anthropic Claude, OpenAI, Ollama (local), or any OpenAI- or LiteLLM-compatible endpoint. Provider charges, when applicable, are paid directly to the provider.
 
-Notebook Intelligence provides a dedicated mode for [Claude Code](https://code.claude.com/) integration. In **Claude mode**, NBI uses Claude Code for AI Agent Chat UI and Claude models for inline chat (in editors) and auto-complete suggestions.
+## Requirements
 
-This integration brings the AI tools and features supported by Claude Code such as built-in tools, skills, MCP servers, custom commands and many more to JupyterLab.
+- Python 3.10+
+- JupyterLab 4.x
+- Node.js — only required for [Claude mode](#claude-mode) (the Claude Code CLI) and for MCP servers that launch via `npx`.
+- A fresh virtualenv or conda env is recommended so NBI doesn't conflict with system Python.
+
+## Quick start
+
+```bash
+pip install notebook-intelligence
+jupyter lab     # restart JupyterLab if it was already running
+```
+
+After restart:
+
+1. Click the NBI icon in the left sidebar to open the chat panel.
+2. Open NBI Settings (gear icon in the chat panel, or _Settings → Notebook Intelligence Settings_).
+3. Sign into your provider — for GitHub Copilot, click _Sign in_; for Claude/OpenAI, paste an API key; for Ollama, point at your local daemon.
+4. Type a message in the chat panel and press Enter.
+
+If the panel stays empty or login does nothing, see [Troubleshooting](docs/troubleshooting.md).
+
+## Concepts
+
+A short glossary you'll see referenced throughout these docs.
+
+- **LLM Provider** — the service that runs the model. NBI ships with adapters for GitHub Copilot, Anthropic Claude, OpenAI-compatible, LiteLLM-compatible, and Ollama.
+- **Chat Participant** — a `@mention`-able persona inside the chat panel (`@workspace`, `@mcp`, …). Participants route the request to a specific tool surface.
+- **Default mode vs Claude mode** — _Default_ uses the configured LLM Provider for chat, inline chat, and auto-complete. _Claude mode_ uses the Claude Code CLI for the chat panel (gaining its tools/skills/MCP/custom-commands ecosystem) and Claude models via the Anthropic API for inline chat and auto-complete. Requires the Claude Code CLI on `PATH`.
+- **Claude Code vs the Anthropic API** — the _Anthropic API_ (selected as a regular LLM Provider) sends prompts to `api.anthropic.com`. _Claude Code_ is Anthropic's local CLI agent that NBI shells out to in Claude mode; it talks to Anthropic itself.
+- **MCP** — [Model Context Protocol](https://modelcontextprotocol.io/). A way for the LLM to call out to external tools (read files, hit APIs, run scripts).
+- **Ruleset** — markdown files in `~/.jupyter/nbi/rules/` that get injected into the system prompt to enforce conventions, coding standards, or domain rules.
+
+## Feature highlights
+
+### Claude mode
+
+NBI provides a dedicated mode for [Claude Code](https://code.claude.com/) integration. In **Claude mode**, NBI uses Claude Code for the Agent Chat UI, and Claude models for inline chat (in editors) and auto-complete suggestions. This brings Claude Code's tools, skills, MCP servers, and custom commands into JupyterLab.
 
 <img src="media/claude-chat.png" alt="Claude mode" width=500 />
 
-#### Claude Configuration
+Configure via the NBI Settings dialog (gear icon in the chat panel, or _Settings → Notebook Intelligence Settings_). Toggle _Enable Claude mode_, then:
 
-You can configure the Claude settings in the NBI Settings dialog. You can access this dialog by using the gear icon in the NBI Chat UI or from JupyterLab Settings menu -> Notebook Intelligence Settings. Toggle the `Enable Claude mode` option to enable Claude mode. The other options are as follows:
-
-- **Chat model**: Select the Claude model to use for Agent Chat UI and inline chat.
-- **Auto-complete model**: Select the Claude model to use for auto-complete suggestions.
-- **Chat Agent setting sources**: Select the setting sources to use for Claude Code. You can choose to use user settings, project settings or both. These settings are the standard Claude Code settings such as tools, skills, MCP servers, custom commands and many more that are saved in the user's home directory and project directory. See [Claude Code documentation](https://code.claude.com/docs/en/settings) for more details.
-- **Chat Agent tools**: Select the tools to activate in the Agent Chat UI. `Claude Code tools` are always activated. `Jupyter UI tools` are the tools that are provided by NBI to interact with JupyterLab UI (authoring notebooks, running cells, etc.).
-- **API key**: Enter your Claude API key.
-- **Base URL**: Enter your Claude base URL.
+- **Chat model** — the Claude model used for the Agent Chat UI and inline chat.
+- **Auto-complete model** — the Claude model used for auto-complete suggestions.
+- **Chat Agent setting sources** — user / project / both, mirroring [Claude Code's settings](https://code.claude.com/docs/en/settings).
+- **Chat Agent tools** — which tool sets to activate. _Claude Code tools_ are always on. _Jupyter UI tools_ are NBI's own (authoring notebooks, running cells, etc.).
+- **API key** and **Base URL** — point at Anthropic or a self-hosted endpoint.
 
 <img src="media/claude-settings.png" alt="Claude settings" width=700 />
 
 #### Resuming a previous Claude session
 
-When Claude mode is enabled, the NBI chat sidebar shows a history icon next to the settings gear. Clicking it opens a picker listing Claude Code sessions recorded for the current JupyterLab working directory (the same transcripts Claude CLI stores under `~/.claude/projects/`). Selecting a session reconnects the Claude client with `resume`, so the next message you send continues that transcript with full prior context.
+When Claude mode is on, the chat sidebar shows a history icon next to the gear. Clicking it lists the Claude Code sessions recorded for the current working directory (the same transcripts Claude CLI stores under `~/.claude/projects/`). Selecting a session reconnects via `resume`, so the next message you send continues that transcript with full prior context.
 
-### Agent Mode
+### Agent mode
 
-In Agent Mode, built-in AI agent creates, edits and executes notebooks for you interactively. It can detect issues in the cells and fix for you.
+In Agent Mode, the built-in AI agent creates, edits, and executes notebooks for you interactively. It can detect issues in the cells and fix them.
 
 ![Agent mode](media/agent-mode.gif)
 
 ### Code generation with inline chat
 
-Use the sparkle icon on cell toolbar or the keyboard shortcuts to show the inline chat popover.
+Use the sparkle icon on the cell toolbar or the keyboard shortcut to show the inline chat popover.
 
-Keyboard shortcuts: `Ctrl + G` / `Cmd + G` is the shortcut to show the inline chat popover and `Ctrl + Enter` / `Cmd + Enter` is the shortcut to accept the suggestion. Clicking `Escape` key closes the popover.
+`Ctrl+G` / `Cmd+G` opens the popover. `Ctrl+Enter` / `Cmd+Enter` accepts the suggestion. `Esc` closes it. The accept shortcut overrides JupyterLab's default _run cell_ binding **only while the popover is open** — outside the popover, `Cmd+Enter` still runs the active cell.
 
 ![Generate code](media/generate-code.gif)
 
 ### Auto-complete
 
-Auto-complete suggestions are shown as you type. Clicking `Tab` key accepts the suggestion. NBI provides auto-complete suggestions in code cells and Python file editors.
+Auto-complete suggestions are shown as you type. `Tab` accepts. NBI provides auto-complete in code cells and Python file editors.
 
 <img src="media/inline-completion.gif" alt="Auto-complete" width=700 />
 
@@ -53,148 +86,72 @@ Auto-complete suggestions are shown as you type. Clicking `Tab` key accepts the 
 
 <img src="media/copilot-chat.gif" alt="Chat interface" width=600 />
 
-See blog posts for more features and usage.
+See blog posts for more features and usage:
 
 - [Introducing Notebook Intelligence!](https://notebook-intelligence.github.io/notebook-intelligence/blog/2025/01/08/introducing-notebook-intelligence.html)
 - [Building AI Extensions for JupyterLab](https://notebook-intelligence.github.io/notebook-intelligence/blog/2025/02/05/building-ai-extensions-for-jupyterlab.html)
 - [Building AI Agents for JupyterLab](https://notebook-intelligence.github.io/notebook-intelligence/blog/2025/02/09/building-ai-agents-for-jupyterlab.html)
 - [Notebook Intelligence now supports any LLM Provider and AI Model!](https://notebook-intelligence.github.io/notebook-intelligence/blog/2025/03/05/support-for-any-llm-provider.html)
 
-## Installation
+## Configuring providers and models
 
-NBI requires JupyterLab >= 4.0.0. To install the extension, run the command below and restart JupyterLab.
-
-```bash
-pip install notebook-intelligence
-```
-
-## Configuration options
-
-### Configuring LLM Provider and models
-
-You can configure the model provider and model options using the Notebook Intelligence Settings dialog. You can access this dialog from JupyterLab Settings menu -> Notebook Intelligence Settings, using `/settings` command in NBI Chat or by using the command palette. For more details, see the [blog post](https://notebook-intelligence.github.io/notebook-intelligence/blog/2025/03/05/support-for-any-llm-provider.html).
+Configure your provider, model, and API key from NBI Settings — the gear icon in the chat panel, the `/settings` chat command, or the JupyterLab command palette. For background, see the [provider blog post](https://notebook-intelligence.github.io/notebook-intelligence/blog/2025/03/05/support-for-any-llm-provider.html).
 
 <img src="media/provider-list.png" alt="Settings dialog" width=500 />
 
-Notebook Intelligence extension for JupyterLab
+### Configuration files
 
-This extension is composed of a Python package named `notebook_intelligence`
-for the server extension and a NPM package named `@notebook-intelligence/notebook-intelligence`
-for the frontend extension.
+NBI saves configuration at `~/.jupyter/nbi/config.json`. It also supports an environment-wide base configuration at `<env-prefix>/share/jupyter/nbi/config.json` — organizations can ship default configuration there and user changes will be saved as overrides on top.
 
-### Disabling LLM Providers
+These config files store provider, model, and MCP configuration. **API keys for custom LLM providers are also stored here in plaintext** — never commit `~/.jupyter/nbi/config.json` to git, share it, or sync it across users. If a key leaks, rotate it at the provider immediately.
 
-By default, all LLM providers can be selected by user dropdown. However, you can disable them and make them controlled by an environment variable.
-
-In order to disable any LLM provider use the `disabled_providers` config:
-
-```python
-c.NotebookIntelligence.disabled_providers = ["ollama","litellm-compatible","openai-compatible"]
-```
-
-Valid built-in provider values are `github-copilot`, `ollama`, `litellm-compatible`, `openai-compatible`.
-
-In order to disable a built-in provider by default but allow re-enabling using an environment variable use the `allow_enabling_providers_with_env` config:
-
-```python
-c.NotebookIntelligence.allow_enabling_providers_with_env = True
-```
-
-Then the environment variable `NBI_ENABLED_PROVIDERS` can be used to re-enable specific built-in tools.
-
-```bash
-export NBI_ENABLED_PROVIDERS=github-copilot,ollama
-```
-
-### Enabling Chat Feedback
-
-<img src="media/chat-feedback.png" alt="Chat feedback" width=500 />
-
-You can enable chat feedback by setting the `enable_chat_feedback` config to `true`. You can handle feedback events in your Notebook Intelligence extension code by listening to the `telemetry` events.
-
-```python
-c.NotebookIntelligence.enable_chat_feedback = True
-```
-
-or by using the command line.
-
-```bash
-jupyter lab --NotebookIntelligence.enable_chat_feedback=true
-```
+> Manual edits to `config.json` require a JupyterLab restart to take effect. Edits via the Settings dialog are picked up live.
 
 ### Remembering GitHub Copilot login
 
-Notebook Intelligence can remember your GitHub Copilot login so that you don't need to re-login after a JupyterLab or system restart. Please be aware of the security implications of using this feature.
+NBI can remember your GitHub Copilot login so you don't need to re-login after a JupyterLab or system restart.
 
 > [!CAUTION]
-> If you configure NBI to remember your GitHub Copilot login, it will encrypt the token and store into a data file at `~/.jupyter/nbi/user-data.json`. You should never share this file with others as they can access your tokens.
-> Even though the token is encrypted, it is done so by using a default password and that's why it can be decrypted by others. In order to prevent that you can specify a custom password using the environment variable `NBI_GH_ACCESS_TOKEN_PASSWORD`.
+> If you enable this, NBI encrypts the token and stores it in `~/.jupyter/nbi/user-data.json`. Never share this file. The encryption uses a default password unless you set `NBI_GH_ACCESS_TOKEN_PASSWORD` to a custom value — on shared or multi-tenant systems, set a custom password before enabling this option.
 
 ```bash
 NBI_GH_ACCESS_TOKEN_PASSWORD=my_custom_password
 ```
 
-To let Notebook Intelligence remember your GitHub access token, go to Notebook Intelligence Settings dialog and check the option `Remember my GitHub Copilot access token` as shown below.
+To enable, check _Remember my GitHub Copilot access token_ in the Settings dialog.
 
 <img src="media/remember-gh-access-token.png" alt="Remember access token" width=500 />
 
-If your stored access token fails to login (due to expiration or other reasons), you will be prompted to relogin on the UI.
+If the stored token fails to log in (expired, revoked, password mismatch), you'll be prompted to re-login.
 
-## Built-in Tools
+## Built-in tools
 
-- **Notebook Edit** (nbi-notebook-edit): Edit notebook using the JupyterLab notebook editor.
-- **Notebook Execute** (nbi-notebook-execute): Run notebooks in JupyterLab UI.
-- **Python File Edit** (nbi-python-file-edit): Edit Python files using the JupyterLab file editor.
-- **File Edit** (nbi-file-edit): Edit files in the Jupyter root directory.
-- **File Read** (nbi-file-read): Read files in the Jupyter root directory.
-- **Command Execute** (nbi-command-execute): Execute shell commands using embedded terminal in Agent UI or JupyterLab terminal.
+These tools are available in Agent Mode and to MCP-enabled chats.
 
-### Disabling Built-in tools
+| Tool                                          | What it does                                                                           |
+| --------------------------------------------- | -------------------------------------------------------------------------------------- |
+| **Notebook Edit** (`nbi-notebook-edit`)       | Edit notebooks via the JupyterLab notebook editor.                                     |
+| **Notebook Execute** (`nbi-notebook-execute`) | Run notebooks in the JupyterLab UI.                                                    |
+| **Python File Edit** (`nbi-python-file-edit`) | Edit Python files via the JupyterLab file editor.                                      |
+| **File Edit** (`nbi-file-edit`)               | Edit files in the Jupyter root directory.                                              |
+| **File Read** (`nbi-file-read`)               | Read files in the Jupyter root directory.                                              |
+| **Command Execute** (`nbi-command-execute`)   | Execute shell commands using the embedded terminal in Agent UI or JupyterLab terminal. |
 
-All built-in toolas are enabled by default in Agent Mode. However, you can disable them and make them controlled by an environment variable.
+In multi-tenant deployments, `nbi-command-execute` and `nbi-file-edit` are effectively arbitrary code execution as the user. See [`docs/admin-guide.md`](docs/admin-guide.md#security-model) for guidance on disabling them.
 
-In order to disable any built-in tool use the `disabled_tools` config:
+## Model Context Protocol (MCP) support
 
-```python
-c.NotebookIntelligence.disabled_tools = ["nbi-notebook-execute","nbi-python-file-edit"]
-```
+NBI integrates with [MCP](https://modelcontextprotocol.io) servers. It supports both stdio and Streamable HTTP transports. **MCP server tools are supported; resources and prompts are not yet supported.**
 
-Valid built-in tool values are `nbi-notebook-edit`, `nbi-notebook-execute`, `nbi-python-file-edit`, `nbi-file-edit`, `nbi-file-read`, `nbi-command-execute`.
-
-In order to disable a built-in tool by default but allow re-enabling using an environment variable use the `allow_enabling_tools_with_env` config:
-
-```python
-c.NotebookIntelligence.allow_enabling_tools_with_env = True
-```
-
-Then the environment variable `NBI_ENABLED_BUILTIN_TOOLS` can be used to re-enable specific built-in tools.
-
-```bash
-export NBI_ENABLED_BUILTIN_TOOLS=nbi-notebook-execute,nbi-python-file-edit
-```
-
-### Configuration files
-
-NBI saves configuration at `~/.jupyter/nbi/config.json`. It also supports environment wide base configuration at `<env-prefix>/share/jupyter/nbi/config.json`. Organizations can ship default configuration at this environment wide config path. User's changes will be stored as overrides at `~/.jupyter/nbi/config.json`.
-
-These config files are used for saving LLM provider, model and MCP configuration. Note that API keys you enter for your custom LLM providers will also be stored in these config files.
-
-> [!IMPORTANT]
-> Note that updating config.json manually requires restarting JupyterLab to take effect.
-
-### Model Context Protocol ([MCP](https://modelcontextprotocol.io)) Support
-
-NBI seamlessly integrates with MCP servers. It supports servers with both Standard Input/Output (stdio) and Server-Sent Events (SSE) transports. The MCP support is limited to server tools at the moment.
-
-You can easily add MCP servers to NBI by editing the configuration file [~/.jupyter/nbi/mcp.json](#configuration-files). Environment wide base configuration is also support using the file at `<env-prefix>/share/jupyter/nbi/mcp.json`.
+Add MCP servers by editing `~/.jupyter/nbi/mcp.json`. An environment-wide base file at `<env-prefix>/share/jupyter/nbi/mcp.json` is also supported.
 
 > [!NOTE]
-> Using MCP servers requires an LLM model with tool calling capabilities. All of the GitHub Copilot models provided in NBI support this feature. If you are using other providers make sure you choose a tool calling capable model.
+> MCP requires an LLM model with tool-calling capability. All GitHub Copilot models in NBI support this. For other providers, choose a tool-calling-capable model.
 
 > [!CAUTION]
-> Note that most MCP servers are run on the same computer as your JupyterLab installation and they can make irreversible changes to your computer and/or access private data. Make sure that you only install MCP servers from trusted sources.
+> Most MCP servers run on the same machine as JupyterLab and can make irreversible changes or access private data. Only install MCP servers from trusted sources.
 
-### MCP Config file example
+### MCP config example
 
 ```json
 {
@@ -211,9 +168,7 @@ You can easily add MCP servers to NBI by editing the configuration file [~/.jupy
 }
 ```
 
-You can use Agent mode to access tools provided by MCP servers you configured.
-
-For servers with stdio transport, you can also set additional environment variables by using the `env` key. Environment variables are specified as key value pairs.
+For stdio servers you can pass extra environment variables under `env`:
 
 ```json
 "mcpServers": {
@@ -223,200 +178,93 @@ For servers with stdio transport, you can also set additional environment variab
         "env": {
             "ENV_VAR_NAME": "ENV_VAR_VALUE"
         }
-    },
+    }
 }
 ```
 
-Below is an example of a server configuration with Streamable HTTP transport. For Streamable HTTP transport servers, you can also specify headers to be sent as part of the requests.
+For Streamable HTTP servers you can also specify request headers:
 
 ```json
 "mcpServers": {
-    "remoterservername": {
+    "remoteservername": {
         "url": "http://127.0.0.1:8080/mcp",
         "headers": {
             "Authorization": "Bearer mysecrettoken"
         }
-    },
+    }
 }
 ```
 
-If you have multiple servers configured but you would like to disable some for a while, you can do so by using the `disabled` key. `servername2` will be disabled and not available in `@mcp` chat participant.
+To temporarily disable a configured server without removing it, set `"disabled": true`:
 
 ```json
 "mcpServers": {
-    "servername1": {
-        "command": "",
-        "args": [],
-    },
     "servername2": {
         "command": "",
         "args": [],
         "disabled": true
-    },
+    }
 }
 ```
 
-### Ruleset System
+## Rulesets
 
-NBI includes a powerful ruleset system that allows you to define custom guidelines and best practices that are automatically injected into AI prompts. This helps ensure consistent coding standards, project-specific conventions, and domain knowledge across all AI interactions.
+NBI's ruleset system lets you define guidelines and best practices that get injected into AI prompts automatically — for consistent coding standards, project conventions, or domain knowledge. Rules are markdown files in `~/.jupyter/nbi/rules/` and can scope by file pattern, kernel, directory, or chat mode.
 
-#### How It Works
-
-Rules are markdown files with optional YAML frontmatter stored in `~/.jupyter/nbi/rules/`. They are automatically discovered and applied based on context (file type, notebook kernel, chat mode).
-
-#### Creating Rules
-
-**Global Rules** - Apply to all contexts:
-
-Create a file like `~/.jupyter/nbi/rules/01-coding-standards.md`:
+A two-line example:
 
 ```markdown
 ---
 priority: 10
 ---
 
-# Coding Standards
-
-- Always use type hints in Python functions
-- Prefer list comprehensions over loops when appropriate
-- Add docstrings to all public functions
+- Always use type hints in Python functions.
+- Add docstrings to all public functions.
 ```
 
-**Mode-Specific Rules** - Apply only to specific chat modes:
+For full details (frontmatter reference, mode-specific rules, auto-reload), see [`docs/rulesets.md`](docs/rulesets.md).
 
-NBI supports mode-specific rules for three modes:
+## Claude Skills
 
-- **ask** - Question/answer mode
-- **agent** - Autonomous agent mode with tool access
-- **inline-chat** - Inline code generation and editing
+When Claude mode is enabled, the Settings panel exposes a **Skills** tab for managing the skills that Claude can invoke. Skills are stored under `~/.claude/skills/` (user) or `<project>/.claude/skills/` (project). You can create and edit skills inline, duplicate, rename, delete (with undo), or import from a public GitHub repo.
 
-Create a file like `~/.jupyter/nbi/rules/modes/agent/01-testing.md`:
+For organization-wide deployments, NBI can install and keep a curated set of skills in sync from a YAML manifest pointed at by `NBI_SKILLS_MANIFEST`. Managed skills are read-only in the UI and refreshed on a schedule.
 
-```markdown
----
-priority: 20
-scope:
-  kernels: ['python3']
----
+For full details, see [`docs/skills.md`](docs/skills.md).
 
-# Testing Guidelines
+## Chat feedback
 
-When writing code in agent mode:
+Enable thumbs-up/down feedback on AI responses by setting:
 
-- Always include error handling
-- Add logging for debugging
-- Test edge cases
+```python
+c.NotebookIntelligence.enable_chat_feedback = True
 ```
 
-#### Rule Frontmatter Options
-
-```yaml
----
-apply: always # 'always', 'auto', or 'manual'
-active: true # Enable/disable the rule
-priority: 10 # Lower numbers = higher priority
-scope:
-  file_patterns: # Apply to specific file patterns
-    - '*.py'
-    - 'test_*.ipynb'
-  kernels: # Apply to specific notebook kernels
-    - 'python3'
-    - 'ir'
-  directories: # Apply to specific directories
-    - '/projects/ml'
----
-```
-
-#### Configuration
-
-**Enable/Disable Rules System:**
-
-Edit `~/.jupyter/nbi/config.json`:
-
-```json
-{
-  "rules_enabled": true
-}
-```
-
-**Auto-Reload Configuration:**
-
-Rules are automatically reloaded when changed (enabled by default). This behavior is controlled by the `NBI_RULES_AUTO_RELOAD` environment variable.
-
-To disable auto-reload:
+…or via CLI:
 
 ```bash
-export NBI_RULES_AUTO_RELOAD=false
-jupyter lab
+jupyter lab --NotebookIntelligence.enable_chat_feedback=true
 ```
 
-Or to enable (default):
+The feedback fires an in-process `telemetry` event. Nothing leaves the pod by default — see the [admin guide](docs/admin-guide.md#chat-feedback-event-hook) for how to wire it into your observability stack.
 
-```bash
-export NBI_RULES_AUTO_RELOAD=true
-jupyter lab
-```
+<img src="media/chat-feedback.png" alt="Chat feedback" width=500 />
 
-#### Managing Rules
+## Documentation
 
-Rules are automatically discovered from:
+- [`docs/admin-guide.md`](docs/admin-guide.md) — deployment, env vars, security model, air-gap, multi-tenancy.
+- [`docs/skills.md`](docs/skills.md) — Claude Skills management and the org-manifest reconciler.
+- [`docs/rulesets.md`](docs/rulesets.md) — ruleset frontmatter and discovery.
+- [`docs/troubleshooting.md`](docs/troubleshooting.md) — common problems with copy-pasteable fixes.
+- [`PRIVACY.md`](PRIVACY.md) — what NBI sends to which provider, and the egress allowlist.
+- [`SECURITY.md`](SECURITY.md) — how to report a vulnerability.
+- [`CHANGELOG.md`](CHANGELOG.md) — release history.
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — building NBI from source. Skip this if you just want to use NBI.
 
-- **Global rules**: `~/.jupyter/nbi/rules/*.md`
-- **Mode-specific rules**: `~/.jupyter/nbi/rules/modes/{mode}/*.md` where `{mode}` can be:
-  - `ask` - For question/answer interactions
-  - `agent` - For autonomous agent operations
-  - `inline-chat` - For inline code generation
+## License
 
-Rules are applied in priority order (lower numbers first) and can be toggled on/off without deleting the files.
+Licensed under [GPL-3.0](LICENSE).
 
-### Managing Claude Skills
+## Roadmap
 
-When Claude mode is enabled, the NBI settings panel shows a **Skills** tab for viewing, creating, editing, and deleting the skills that Claude can invoke. Skills are Claude Agent SDK artifacts stored on disk:
-
-- **User skills**: `~/.claude/skills/`
-- **Project skills**: `<project_root>/.claude/skills/`
-
-Skills live in a directory named `<name>/` containing a `SKILL.md` entry file (with YAML frontmatter for `name`, `description`, `allowed-tools`) plus any helper files the skill references.
-
-The Skills tab lets you:
-
-- Add new skills in either scope, editing `SKILL.md` and helper files inline
-- **Rename** a skill (updates the bundle directory and frontmatter)
-- **Duplicate** a skill into the same or opposite scope under a new name
-- **Delete** a skill, with an undo toast that restores the full bundle contents if clicked within 8 seconds
-- Open or delete additional files in the bundle (`SKILL.md` itself is protected from deletion)
-
-**Importing from GitHub.** Click **Import from GitHub** to install a skill from a public repo. Paste any `https://github.com/<owner>/<repo>` URL — or a deep link like `/tree/<ref>/<subpath>` pointing at the directory that contains `SKILL.md` — pick the target scope, and the bundle is fetched, validated, and installed. The canonical source URL is recorded in the skill's frontmatter as `source:` so you can trace where each imported skill came from.
-
-When a skill is saved, added, or removed — either through the UI or directly on disk — the Claude SDK session is transparently reloaded (preserving conversation history via the session's resume behavior), and a **"Skills reloaded"** banner briefly appears in the chat sidebar.
-
-#### Managed skills via an org manifest
-
-For organization-wide deployments (e.g., Kubeflow notebooks), NBI can install and keep a curated set of Claude skills in sync from a YAML/JSON manifest. Skills installed this way are marked **Managed** in the UI — they are read-only (edit/rename/delete disabled) and are refreshed on a schedule.
-
-Configure via environment variables (also available as traitlets on `NotebookIntelligence`):
-
-- `NBI_SKILLS_MANIFEST` — URL (`https://...`) or local filesystem path to the manifest. Empty/unset disables the feature.
-- `NBI_SKILLS_MANIFEST_INTERVAL` — seconds between reconciles. Default `86400` (24h). Reconciliation also runs once at startup.
-- `NBI_MANAGED_SKILLS_TOKEN` — optional bearer token used for **all** managed-skills GitHub operations: fetching the manifest, probing commits, and downloading skill tarballs. Lets an org deploy a minimal-privilege scoped token covering the whole managed pathway — user-initiated imports (the Import-from-GitHub dialog, `POST /skills/import`) do **not** see this token and continue to use `GITHUB_TOKEN` / `GH_TOKEN` / `gh auth`. When unset, managed operations fall back to the same chain. If set and a managed operation fails with an auth error, it fails loudly (no retry with the fallback chain) so misconfigured or expired scoped tokens stay visible to the admin.
-
-Manifest schema:
-
-```yaml
-skills:
-  - url: https://github.com/org/repo/tree/main/skills/data-eda
-    name: data-eda # optional: override the installed skill name
-    scope: user # optional: "user" (default) or "project"
-  - url: https://github.com/org/repo/tree/main/skills/ml-recipes
-```
-
-Behavior:
-
-- The reconciler probes GitHub's commits API for each entry's `subpath`/`ref` and skips fetching the tarball when the installed `managed_ref` already matches the latest SHA. Full-SHA URLs skip the probe.
-- Managed skills present in the install but missing from the manifest are **removed**. User-authored skills are never touched; if a user-authored skill has the same name as a manifest entry, the reconciler leaves it alone and reports a per-entry error.
-- A manual **Sync managed skills** button appears in the Skills panel when any managed skill is installed, and a `POST /notebook-intelligence/skills/reconcile` endpoint is available for scripted triggers.
-- If the manifest cannot be loaded (network, bad YAML, missing `skills:` list), the reconciler logs the error and leaves all managed skills in place rather than mass-deleting on a transient failure.
-
-### Developer documentation
-
-For building locally and contributing see the [developer documentatation](CONTRIBUTING.md).
+NBI 4.x is stable. New features land in minor releases (4.5, 4.6, …); breaking changes are reserved for the next major (5.x) and will be announced in the [changelog](CHANGELOG.md).

--- a/README.md
+++ b/README.md
@@ -1,10 +1,36 @@
 # Notebook Intelligence
 
-Notebook Intelligence (NBI) is an AI coding assistant and extensible AI framework for JupyterLab. It adds chat, inline edit, auto-complete, and an agent that can drive notebooks — backed by GitHub Copilot, Anthropic Claude, OpenAI-compatible, LiteLLM-compatible, or local [Ollama](https://ollama.com/) models.
+Notebook Intelligence (NBI) is an AI coding assistant and extensible AI framework for JupyterLab. It adds chat, inline edit, auto-complete, and an agent that can drive notebooks — backed by GitHub Copilot, an OpenAI-compatible or LiteLLM-compatible endpoint, local [Ollama](https://ollama.com/) models, or Anthropic's Claude Code CLI.
+
+## Contents
+
+- [What it costs](#what-it-costs)
+- [Requirements](#requirements)
+- [Quick start](#quick-start)
+- [Concepts](#concepts)
+- [Feature highlights](#feature-highlights)
+  - [Claude mode](#claude-mode)
+  - [Agent mode](#agent-mode)
+  - [Code generation with inline chat](#code-generation-with-inline-chat)
+  - [Auto-complete](#auto-complete)
+  - [Chat interface](#chat-interface)
+- [Configuration](#configuration)
+  - [Configuration files](#configuration-files)
+  - [Remembering GitHub Copilot login](#remembering-github-copilot-login)
+- [Built-in tools](#built-in-tools)
+- [Model Context Protocol (MCP) support](#model-context-protocol-mcp-support)
+  - [MCP config example](#mcp-config-example)
+- [Rulesets](#rulesets)
+- [Claude Skills](#claude-skills)
+- [Chat feedback](#chat-feedback)
+- [Documentation](#documentation)
+- [Further reading](#further-reading)
+- [Roadmap](#roadmap)
+- [License](#license)
 
 ## What it costs
 
-NBI is free and open-source. Connect it to a free or paid LLM provider of your choice — GitHub Copilot, Anthropic Claude, OpenAI, Ollama (local), or any OpenAI- or LiteLLM-compatible endpoint. Provider charges, when applicable, are paid directly to the provider.
+NBI is free and open-source. Connect it to a free or paid LLM provider of your choice — GitHub Copilot, any OpenAI- or LiteLLM-compatible endpoint, Ollama (local), or Anthropic Claude (via the Claude Code CLI). Provider charges, when applicable, are paid directly to the provider.
 
 ## Requirements
 
@@ -24,7 +50,7 @@ After restart:
 
 1. Click the NBI icon in the left sidebar to open the chat panel.
 2. Open NBI Settings (gear icon in the chat panel, or _Settings → Notebook Intelligence Settings_).
-3. Sign into your provider — for GitHub Copilot, click _Sign in_; for Claude/OpenAI, paste an API key; for Ollama, point at your local daemon.
+3. Sign into your provider — for GitHub Copilot, click _Sign in_; for an OpenAI- or LiteLLM-compatible endpoint, paste an API key; for Ollama, point at your local daemon. To use Claude, enable Claude mode (see below).
 4. Type a message in the chat panel and press Enter.
 
 If the panel stays empty or login does nothing, see [Troubleshooting](docs/troubleshooting.md).
@@ -33,10 +59,10 @@ If the panel stays empty or login does nothing, see [Troubleshooting](docs/troub
 
 A short glossary you'll see referenced throughout these docs.
 
-- **LLM Provider** — the service that runs the model. NBI ships with adapters for GitHub Copilot, Anthropic Claude, OpenAI-compatible, LiteLLM-compatible, and Ollama.
+- **LLM Provider** — the service that runs the model. NBI ships with four provider adapters: GitHub Copilot, OpenAI-compatible, LiteLLM-compatible, and Ollama. Anthropic Claude is available through [Claude mode](#claude-mode), not as a top-level provider.
 - **Chat Participant** — a `@mention`-able persona inside the chat panel (`@workspace`, `@mcp`, …). Participants route the request to a specific tool surface.
-- **Default mode vs Claude mode** — _Default_ uses the configured LLM Provider for chat, inline chat, and auto-complete. _Claude mode_ uses the Claude Code CLI for the chat panel (gaining its tools/skills/MCP/custom-commands ecosystem) and Claude models via the Anthropic API for inline chat and auto-complete. Requires the Claude Code CLI on `PATH`.
-- **Claude Code vs the Anthropic API** — the _Anthropic API_ (selected as a regular LLM Provider) sends prompts to `api.anthropic.com`. _Claude Code_ is Anthropic's local CLI agent that NBI shells out to in Claude mode; it talks to Anthropic itself.
+- **Default mode vs Claude mode** — _Default_ uses the configured LLM Provider for chat, inline chat, and auto-complete. _Claude mode_ uses the Claude Code CLI for the chat panel (gaining its tools, skills, MCP servers, and custom commands) and Claude models via the Anthropic API for inline chat and auto-complete. Requires the Claude Code CLI on `PATH`.
+- **Claude Code vs the Anthropic API** — the _Anthropic API_ (`api.anthropic.com`) is the HTTPS endpoint NBI calls directly for inline chat and auto-complete in Claude mode. _Claude Code_ is Anthropic's local CLI agent that NBI shells out to for the chat panel; it talks to Anthropic itself.
 - **MCP** — [Model Context Protocol](https://modelcontextprotocol.io/). A way for the LLM to call out to external tools (read files, hit APIs, run scripts).
 - **Ruleset** — markdown files in `~/.jupyter/nbi/rules/` that get injected into the system prompt to enforce conventions, coding standards, or domain rules.
 
@@ -44,27 +70,29 @@ A short glossary you'll see referenced throughout these docs.
 
 ### Claude mode
 
-NBI provides a dedicated mode for [Claude Code](https://code.claude.com/) integration. In **Claude mode**, NBI uses Claude Code for the Agent Chat UI, and Claude models for inline chat (in editors) and auto-complete suggestions. This brings Claude Code's tools, skills, MCP servers, and custom commands into JupyterLab.
+NBI provides a dedicated mode for [Claude Code](https://code.claude.com/) integration. In **Claude mode**, NBI uses the Claude Code CLI for the chat panel, and Claude models (via the Anthropic API) for inline chat and auto-complete suggestions. This brings Claude Code's tools, skills, MCP servers, and custom commands into JupyterLab.
 
 <img src="media/claude-chat.png" alt="Claude mode" width=500 />
 
 Configure via the NBI Settings dialog (gear icon in the chat panel, or _Settings → Notebook Intelligence Settings_). Toggle _Enable Claude mode_, then:
 
-- **Chat model** — the Claude model used for the Agent Chat UI and inline chat.
+- **Chat model** — the Claude model used for the chat panel and inline chat.
 - **Auto-complete model** — the Claude model used for auto-complete suggestions.
-- **Chat Agent setting sources** — user / project / both, mirroring [Claude Code's settings](https://code.claude.com/docs/en/settings).
+- **Chat Agent setting sources** — user, project, or both, mirroring [Claude Code's settings](https://code.claude.com/docs/en/settings).
 - **Chat Agent tools** — which tool sets to activate. _Claude Code tools_ are always on. _Jupyter UI tools_ are NBI's own (authoring notebooks, running cells, etc.).
 - **API key** and **Base URL** — point at Anthropic or a self-hosted endpoint.
+
+If the Claude Code CLI is on `PATH`, NBI launches it automatically. To override the location, set the `NBI_CLAUDE_CLI_PATH` environment variable before starting JupyterLab.
 
 <img src="media/claude-settings.png" alt="Claude settings" width=700 />
 
 #### Resuming a previous Claude session
 
-When Claude mode is on, the chat sidebar shows a history icon next to the gear. Clicking it lists the Claude Code sessions recorded for the current working directory (the same transcripts Claude CLI stores under `~/.claude/projects/`). Selecting a session reconnects via `resume`, so the next message you send continues that transcript with full prior context.
+When Claude mode is on, the chat sidebar shows a history icon next to the gear. Click it to list the Claude Code sessions recorded for the current working directory (the same transcripts the Claude Code CLI stores under `~/.claude/projects/`). Selecting a session reconnects via `resume`, so the next message you send continues that transcript with full prior context.
 
 ### Agent mode
 
-In Agent Mode, the built-in AI agent creates, edits, and executes notebooks for you interactively. It can detect issues in the cells and fix them.
+In Agent mode, the built-in AI agent creates, edits, and executes notebooks for you interactively. It can detect issues in cells and fix them.
 
 ![Agent mode](media/agent-mode.gif)
 
@@ -72,7 +100,7 @@ In Agent Mode, the built-in AI agent creates, edits, and executes notebooks for 
 
 Use the sparkle icon on the cell toolbar or the keyboard shortcut to show the inline chat popover.
 
-`Ctrl+G` / `Cmd+G` opens the popover. `Ctrl+Enter` / `Cmd+Enter` accepts the suggestion. `Esc` closes it. The accept shortcut overrides JupyterLab's default _run cell_ binding **only while the popover is open** — outside the popover, `Cmd+Enter` still runs the active cell.
+`Ctrl+G` / `Cmd+G` opens the popover. `Ctrl+Enter` / `Cmd+Enter` accepts the suggestion. `Esc` closes it. The accept shortcut overrides JupyterLab's default _run cell_ binding **only while the popover is open** — outside the popover, `Ctrl+Enter` / `Cmd+Enter` still runs the active cell.
 
 ![Generate code](media/generate-code.gif)
 
@@ -86,14 +114,7 @@ Auto-complete suggestions are shown as you type. `Tab` accepts. NBI provides aut
 
 <img src="media/copilot-chat.gif" alt="Chat interface" width=600 />
 
-See blog posts for more features and usage:
-
-- [Introducing Notebook Intelligence!](https://notebook-intelligence.github.io/notebook-intelligence/blog/2025/01/08/introducing-notebook-intelligence.html)
-- [Building AI Extensions for JupyterLab](https://notebook-intelligence.github.io/notebook-intelligence/blog/2025/02/05/building-ai-extensions-for-jupyterlab.html)
-- [Building AI Agents for JupyterLab](https://notebook-intelligence.github.io/notebook-intelligence/blog/2025/02/09/building-ai-agents-for-jupyterlab.html)
-- [Notebook Intelligence now supports any LLM Provider and AI Model!](https://notebook-intelligence.github.io/notebook-intelligence/blog/2025/03/05/support-for-any-llm-provider.html)
-
-## Configuring providers and models
+## Configuration
 
 Configure your provider, model, and API key from NBI Settings — the gear icon in the chat panel, the `/settings` chat command, or the JupyterLab command palette. For background, see the [provider blog post](https://notebook-intelligence.github.io/notebook-intelligence/blog/2025/03/05/support-for-any-llm-provider.html).
 
@@ -101,7 +122,7 @@ Configure your provider, model, and API key from NBI Settings — the gear icon 
 
 ### Configuration files
 
-NBI saves configuration at `~/.jupyter/nbi/config.json`. It also supports an environment-wide base configuration at `<env-prefix>/share/jupyter/nbi/config.json` — organizations can ship default configuration there and user changes will be saved as overrides on top.
+NBI saves configuration at `~/.jupyter/nbi/config.json`. It also supports an environment-wide base configuration at `<env-prefix>/share/jupyter/nbi/config.json` — organizations can ship default configuration there, and user changes save as overrides on top.
 
 These config files store provider, model, and MCP configuration. **API keys for custom LLM providers are also stored here in plaintext** — never commit `~/.jupyter/nbi/config.json` to git, share it, or sync it across users. If a key leaks, rotate it at the provider immediately.
 
@@ -109,7 +130,7 @@ These config files store provider, model, and MCP configuration. **API keys for 
 
 ### Remembering GitHub Copilot login
 
-NBI can remember your GitHub Copilot login so you don't need to re-login after a JupyterLab or system restart.
+NBI can remember your GitHub Copilot login so you don't have to sign in again after a JupyterLab or system restart.
 
 > [!CAUTION]
 > If you enable this, NBI encrypts the token and stores it in `~/.jupyter/nbi/user-data.json`. Never share this file. The encryption uses a default password unless you set `NBI_GH_ACCESS_TOKEN_PASSWORD` to a custom value — on shared or multi-tenant systems, set a custom password before enabling this option.
@@ -122,11 +143,11 @@ To enable, check _Remember my GitHub Copilot access token_ in the Settings dialo
 
 <img src="media/remember-gh-access-token.png" alt="Remember access token" width=500 />
 
-If the stored token fails to log in (expired, revoked, password mismatch), you'll be prompted to re-login.
+If the stored token fails to authenticate (expired, revoked, password mismatch), NBI prompts you to sign in again.
 
 ## Built-in tools
 
-These tools are available in Agent Mode and to MCP-enabled chats.
+These tools are available in Agent mode and to MCP-enabled chats.
 
 | Tool                                          | What it does                                                                           |
 | --------------------------------------------- | -------------------------------------------------------------------------------------- |
@@ -246,7 +267,7 @@ c.NotebookIntelligence.enable_chat_feedback = True
 jupyter lab --NotebookIntelligence.enable_chat_feedback=true
 ```
 
-The feedback fires an in-process `telemetry` event. Nothing leaves the pod by default — see the [admin guide](docs/admin-guide.md#chat-feedback-event-hook) for how to wire it into your observability stack.
+The feedback fires an in-process `telemetry` event. Nothing leaves the process by default — see the [admin guide](docs/admin-guide.md#chat-feedback-event-hook) for how to wire it into your observability stack.
 
 <img src="media/chat-feedback.png" alt="Chat feedback" width=500 />
 
@@ -261,10 +282,17 @@ The feedback fires an in-process `telemetry` event. Nothing leaves the pod by de
 - [`CHANGELOG.md`](CHANGELOG.md) — release history.
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — building NBI from source. Skip this if you just want to use NBI.
 
-## License
+## Further reading
 
-Licensed under [GPL-3.0](LICENSE).
+- [Introducing Notebook Intelligence!](https://notebook-intelligence.github.io/notebook-intelligence/blog/2025/01/08/introducing-notebook-intelligence.html)
+- [Building AI Extensions for JupyterLab](https://notebook-intelligence.github.io/notebook-intelligence/blog/2025/02/05/building-ai-extensions-for-jupyterlab.html)
+- [Building AI Agents for JupyterLab](https://notebook-intelligence.github.io/notebook-intelligence/blog/2025/02/09/building-ai-agents-for-jupyterlab.html)
+- [Notebook Intelligence now supports any LLM Provider and AI Model!](https://notebook-intelligence.github.io/notebook-intelligence/blog/2025/03/05/support-for-any-llm-provider.html)
 
 ## Roadmap
 
 NBI 4.x is stable. New features land in minor releases (4.5, 4.6, …); breaking changes are reserved for the next major (5.x) and will be announced in the [changelog](CHANGELOG.md).
+
+## License
+
+Licensed under [GPL-3.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 Notebook Intelligence (NBI) is an AI coding assistant and extensible AI framework for JupyterLab. It adds chat, inline edit, auto-complete, and an agent that can drive notebooks — backed by GitHub Copilot, an OpenAI-compatible or LiteLLM-compatible endpoint, local [Ollama](https://ollama.com/) models, or Anthropic's Claude Code CLI.
 
+NBI is free and open-source. Connect it to a free or paid LLM provider of your choice — GitHub Copilot, any OpenAI- or LiteLLM-compatible endpoint, Ollama (local), or Anthropic Claude (via the Claude Code CLI). Provider charges, when applicable, are paid directly to the provider.
+
 ## Contents
 
-- [What it costs](#what-it-costs)
 - [Requirements](#requirements)
 - [Quick start](#quick-start)
 - [Concepts](#concepts)
@@ -27,10 +28,6 @@ Notebook Intelligence (NBI) is an AI coding assistant and extensible AI framewor
 - [Further reading](#further-reading)
 - [Roadmap](#roadmap)
 - [License](#license)
-
-## What it costs
-
-NBI is free and open-source. Connect it to a free or paid LLM provider of your choice — GitHub Copilot, any OpenAI- or LiteLLM-compatible endpoint, Ollama (local), or Anthropic Claude (via the Claude Code CLI). Provider charges, when applicable, are paid directly to the provider.
 
 ## Requirements
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,15 +2,15 @@
 
 ## Reporting a vulnerability
 
-Please **do not** open a public GitHub issue for security vulnerabilities.
+**Do not** open a public GitHub issue for security vulnerabilities.
 
 Email the maintainer directly at **mbektasgh@outlook.com** with:
 
-- A description of the vulnerability and the impact you have observed.
+- A description of the vulnerability and the impact you observed.
 - Steps to reproduce, including affected versions of NBI, JupyterLab, and Python.
 - Any proof-of-concept code or logs (redact secrets).
 
-You should expect an acknowledgement within five business days. We will work with you on a coordinated disclosure timeline once we confirm the issue.
+Expect an acknowledgement within five business days. Once we confirm the issue, we'll work with you on a coordinated disclosure timeline.
 
 ## Supported versions
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Email the maintainer directly at **mbektasgh@outlook.com** with:
+
+- A description of the vulnerability and the impact you have observed.
+- Steps to reproduce, including affected versions of NBI, JupyterLab, and Python.
+- Any proof-of-concept code or logs (redact secrets).
+
+You should expect an acknowledgement within five business days. We will work with you on a coordinated disclosure timeline once we confirm the issue.
+
+## Supported versions
+
+NBI follows semantic versioning starting with 4.0.0. Security fixes land on the latest minor release of the current major line. Earlier major lines are not actively maintained.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 4.x     | Yes (latest minor) |
+| < 4.0   | No                 |
+
+## Scope
+
+In-scope:
+
+- The `notebook_intelligence` server extension and its HTTP handlers.
+- The `@notebook-intelligence/notebook-intelligence` JupyterLab frontend.
+- Built-in tools (`nbi-notebook-edit`, `nbi-notebook-execute`, `nbi-python-file-edit`, `nbi-file-edit`, `nbi-file-read`, `nbi-command-execute`).
+- The Claude Skills import and managed-manifest reconciler.
+
+Out of scope:
+
+- Vulnerabilities in upstream dependencies (`litellm`, `anthropic`, `openai`, `ollama`, `claude-agent-sdk`, `fastmcp`) — please report those upstream. We will pick up patched releases when they ship.
+- Vulnerabilities in MCP servers users install from third-party sources.
+- Vulnerabilities in LLM providers themselves (data handling at OpenAI, Anthropic, GitHub Copilot, etc.).
+
+## Security model
+
+NBI is a **per-user** tool. The server extension runs inside the user's Jupyter Server process and inherits that user's permissions. Built-in tools shell out as the user, MCP stdio servers run as the user, and the Claude Code CLI inherits the user's environment. There is no privilege boundary between the extension and the user's account.
+
+For multi-tenant deployments, see [`docs/admin-guide.md`](docs/admin-guide.md) for guidance on disabling features that are unsafe to expose without additional sandboxing (notably `nbi-command-execute` and `nbi-file-edit`).

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -1,0 +1,462 @@
+# Administrator Guide
+
+This guide covers deploying Notebook Intelligence at scale — JupyterHub, KubeSpawner, Kubeflow, multi-tenant clusters, regulated environments. For end-user documentation see the [README](../README.md).
+
+> NBI is a per-user tool. Every section below assumes the extension is running inside a per-user Jupyter Server, not a shared one. Server-side state is per-user; there is no central NBI service.
+
+---
+
+## Table of contents
+
+- [Install layout and config precedence](#install-layout-and-config-precedence)
+- [Persistent-volume layout](#persistent-volume-layout)
+- [Shared filesystem and multi-user notes](#shared-filesystem-and-multi-user-notes)
+- [Environment variables and traitlets](#environment-variables-and-traitlets)
+- [Security model](#security-model)
+- [API-key handling](#api-key-handling)
+- [Self-hosted LLM endpoints](#self-hosted-llm-endpoints)
+- [Custom CA certs and corporate proxies](#custom-ca-certs-and-corporate-proxies)
+- [Air-gap deployment](#air-gap-deployment)
+- [HIPAA / sensitive-data preset](#hipaa--sensitive-data-preset)
+- [Restricting features for managed deployments](#restricting-features-for-managed-deployments)
+- [Multi-tenancy and per-team scoping](#multi-tenancy-and-per-team-scoping)
+- [Managed Claude Skills token](#managed-claude-skills-token)
+- [Chat feedback event hook](#chat-feedback-event-hook)
+- [HTTP API surface](#http-api-surface)
+- [Failure modes](#failure-modes)
+- [Version matrix](#version-matrix)
+- [FIPS posture](#fips-posture)
+- [Resource footprint](#resource-footprint)
+
+---
+
+## Install layout and config precedence
+
+NBI reads configuration from three layers, listed in order of precedence (later wins):
+
+1. **Environment-wide base config** — `<env-prefix>/share/jupyter/nbi/config.json` and `<env-prefix>/share/jupyter/nbi/mcp.json`. Bake into your image. Read once at startup.
+2. **User config** — `~/.jupyter/nbi/config.json` and `~/.jupyter/nbi/mcp.json`. Mutated by the user via the Settings dialog. Per-user PVC.
+3. **Environment variables** — `NBI_*` and certain provider variables (see the [reference table](#environment-variables-and-traitlets)). Override at pod startup time.
+
+Traitlets configured via JupyterLab CLI flags or `jupyter_server_config.py` (e.g., `c.NotebookIntelligence.disabled_providers = [...]`) are evaluated at server startup. Where a traitlet has a corresponding env var (e.g., `NBI_ENABLED_PROVIDERS` for `disabled_providers`/`allow_enabling_providers_with_env`), the env var is read at request time.
+
+Manual edits to `config.json` while JupyterLab is running require a JupyterLab restart to take effect. Edits via the Settings dialog are picked up live.
+
+---
+
+## Persistent-volume layout
+
+| Path                                      | Persist?    | Notes                                                                                                                           |
+| ----------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `~/.jupyter/nbi/config.json`              | Yes         | User's chosen provider, models, MCP servers, plus plaintext API keys. Treat as a secret.                                        |
+| `~/.jupyter/nbi/user-data.json`           | Yes         | Encrypted GitHub Copilot access token, written when "remember login" is enabled. Encrypted with `NBI_GH_ACCESS_TOKEN_PASSWORD`. |
+| `~/.jupyter/nbi/rules/`                   | Yes         | User's ruleset markdown files.                                                                                                  |
+| `~/.jupyter/nbi/mcp.json`                 | Yes         | User's MCP server config (alternative to managing via the Settings dialog).                                                     |
+| `~/.claude/skills/`                       | Yes         | User-scope Claude skills (including managed skills).                                                                            |
+| `~/.claude/projects/`                     | Yes         | Claude Code session transcripts. Required for "Resume previous Claude session". Managed by Claude CLI, not NBI.                 |
+| `<env-prefix>/share/jupyter/nbi/`         | No (image)  | Org-wide base config. Bake into your container image.                                                                           |
+| Project-scope `<project>/.claude/skills/` | Per project | Lives in the user's working directory. Persists if the working directory does.                                                  |
+
+For Kubeflow / KubeSpawner: mount the user's home directory on a PVC and ensure `~/.jupyter`, `~/.claude` are inside that mount. Anything else (`/tmp`, `~/.cache`) can be ephemeral.
+
+---
+
+## Shared filesystem and multi-user notes
+
+If users share a home directory across nodes (NFS-backed shared HPC, classroom labs):
+
+- **Race conditions in `~/.jupyter/nbi/`.** Concurrent writes from two login nodes can corrupt `config.json`. NBI does not file-lock. Either pin each user to one node, or use a per-node config-prefix.
+- **`NBI_GH_ACCESS_TOKEN_PASSWORD` default is unsafe.** The default password (`nbi-access-token-password`) is shared across installs. On a multi-tenant cluster, anyone with read access to another user's `~/.jupyter/nbi/user-data.json` can decrypt their Copilot token. Set a per-user password (e.g., derived from the Hub user secret), or disable "remember login" entirely (see [Restricting features](#restricting-features-for-managed-deployments)).
+- **Skill collisions.** Two users sharing `~/.claude/skills/` will see each other's skills. Make sure each user has a unique home.
+
+---
+
+## Environment variables and traitlets
+
+The full surface, in one table.
+
+| Name                                | Type | Default                     | Source                             | Purpose                                                                                                                      |
+| ----------------------------------- | ---- | --------------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `disabled_providers`                | List | `[]`                        | traitlet on `NotebookIntelligence` | Hide providers from the user dropdown. Values: `github-copilot`, `ollama`, `litellm-compatible`, `openai-compatible`.        |
+| `allow_enabling_providers_with_env` | Bool | `False`                     | traitlet                           | If true, `NBI_ENABLED_PROVIDERS` re-enables hidden providers per pod.                                                        |
+| `NBI_ENABLED_PROVIDERS`             | csv  | unset                       | env                                | Comma-separated provider IDs to re-enable. Effective only when `allow_enabling_providers_with_env=True`.                     |
+| `disabled_tools`                    | List | `[]`                        | traitlet                           | Hide built-in tools from agent mode. Values listed in [Restricting features](#restricting-features-for-managed-deployments). |
+| `allow_enabling_tools_with_env`     | Bool | `False`                     | traitlet                           | If true, `NBI_ENABLED_BUILTIN_TOOLS` re-enables hidden tools per pod.                                                        |
+| `NBI_ENABLED_BUILTIN_TOOLS`         | csv  | unset                       | env                                | Comma-separated tool IDs to re-enable. Effective only when `allow_enabling_tools_with_env=True`.                             |
+| `enable_chat_feedback`              | Bool | `False`                     | traitlet                           | Enables thumbs-up/down UI in chat and emits in-process `telemetry` events.                                                   |
+| `skills_manifest`                   | str  | `""`                        | traitlet                           | URL or filesystem path to a managed-skills manifest. See [`docs/skills.md`](skills.md#managed-skills-via-an-org-manifest).   |
+| `NBI_SKILLS_MANIFEST`               | str  | unset                       | env (overrides traitlet)           | Same as above; env takes precedence.                                                                                         |
+| `skills_manifest_interval`          | int  | `86400`                     | traitlet                           | Seconds between reconciles.                                                                                                  |
+| `NBI_SKILLS_MANIFEST_INTERVAL`      | int  | unset                       | env (overrides traitlet)           | Same as above; env takes precedence.                                                                                         |
+| `managed_skills_token`              | str  | `""`                        | traitlet                           | Bearer token for managed-skills GitHub fetches.                                                                              |
+| `NBI_MANAGED_SKILLS_TOKEN`          | str  | unset                       | env (overrides traitlet)           | Same as above; env takes precedence.                                                                                         |
+| `NBI_GH_ACCESS_TOKEN_PASSWORD`      | str  | `nbi-access-token-password` | env                                | Password used to encrypt the stored Copilot token in `user-data.json`. **Change in multi-tenant deployments.**               |
+| `NBI_RULES_AUTO_RELOAD`             | bool | `true`                      | env                                | When `false`, ruleset edits require a JupyterLab restart to take effect.                                                     |
+| `GITHUB_TOKEN` / `GH_TOKEN`         | str  | unset                       | env                                | Used (in that order) by user-initiated skill imports for GitHub auth. Falls back to `gh` CLI auth.                           |
+
+Configure traitlets in `jupyter_server_config.py`:
+
+```python
+c.NotebookIntelligence.disabled_providers = ["openai-compatible", "litellm-compatible"]
+c.NotebookIntelligence.allow_enabling_providers_with_env = True
+c.NotebookIntelligence.disabled_tools = ["nbi-command-execute"]
+c.NotebookIntelligence.skills_manifest = "https://internal.example.com/manifests/data-science-team.yaml"
+```
+
+---
+
+## Security model
+
+NBI runs entirely inside the user's Jupyter Server process. There is no privilege boundary between NBI and the user. In particular:
+
+- **Built-in tools execute as the user.**
+  - `nbi-command-execute` runs arbitrary shell commands.
+  - `nbi-file-edit` and `nbi-file-read` read and write any file the user can.
+  - `nbi-notebook-edit` and `nbi-notebook-execute` modify and run notebooks.
+- **MCP stdio servers** are launched as user subprocesses with the user's environment. NBI does not sandbox them.
+- **Claude Code CLI** inherits the user's environment, including filesystem permissions and any auth tokens in `~/.claude/`.
+
+For regulated tenants:
+
+1. Disable the most powerful tools — minimally `nbi-command-execute` and `nbi-file-edit`. See [Restricting features](#restricting-features-for-managed-deployments).
+2. Restrict the providers the user can pick. Force a single self-hosted endpoint with `disabled_providers` plus the org's base config.
+3. Disable user-initiated skill imports (currently network-layer only — see [`docs/skills.md`](skills.md#disabling-user-initiated-github-imports)).
+4. Run with a non-root container user, with no host-network access and no host-path mounts beyond the user's PVC.
+
+---
+
+## API-key handling
+
+By default, custom-provider API keys (Anthropic, OpenAI-compatible, LiteLLM-compatible) are stored plaintext in `~/.jupyter/nbi/config.json`. This is acceptable for single-tenant developer workstations and unacceptable for multi-tenant clusters.
+
+Recommended approach for clusters:
+
+- **Inject the org's keys via env vars at pod startup.** Set the provider's expected env var (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.) on the pod. Configure the provider in `<env-prefix>/share/jupyter/nbi/config.json` without a key — NBI will pick up the provider's standard env var.
+- **Source secrets from your secret manager.** Vault, External Secrets Operator, AWS Secrets Manager, GCP Secret Manager, or KubeSpawner's `c.KubeSpawner.environment` callback can all populate the pod env from a secret backend at spawn time.
+- **Do not commit `config.json`.** Even the env-prefix base config should not contain keys; pull keys from env at spawn.
+
+`${ENV_VAR}`-style interpolation directly inside `config.json` is not currently supported. Tracked as a feature request.
+
+---
+
+## Self-hosted LLM endpoints
+
+NBI's `openai-compatible` and `litellm-compatible` providers can target any endpoint that speaks the respective wire format.
+
+**Azure OpenAI** (via the OpenAI-compatible provider):
+
+```json
+{
+  "providers": {
+    "openai-compatible": {
+      "base_url": "https://my-resource.openai.azure.com/openai/deployments/gpt-4-deployment",
+      "api_key": "${AZURE_OPENAI_KEY}",
+      "default_chat_model": "gpt-4",
+      "default_inline_completion_model": "gpt-4"
+    }
+  }
+}
+```
+
+**vLLM / TGI / any local OpenAI-compatible server**:
+
+```json
+{
+  "providers": {
+    "openai-compatible": {
+      "base_url": "http://internal-vllm.example.com:8000/v1",
+      "api_key": "any-string-the-server-accepts",
+      "default_chat_model": "meta-llama/Meta-Llama-3-70B-Instruct"
+    }
+  }
+}
+```
+
+**LiteLLM proxy** (so you can route to many upstream models from one place, including Bedrock, Vertex, etc.):
+
+```json
+{
+  "providers": {
+    "litellm-compatible": {
+      "base_url": "https://litellm.internal.example.com",
+      "api_key": "${LITELLM_TOKEN}"
+    }
+  }
+}
+```
+
+Bake the base config into your image and let users select their model from the dropdown.
+
+---
+
+## Custom CA certs and corporate proxies
+
+NBI's HTTP requests use Python's `requests` and `httpx`, plus `litellm`/`openai`/`anthropic` SDKs. All honor standard Python TLS and proxy environment variables:
+
+```bash
+REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
+SSL_CERT_FILE=/etc/pki/tls/certs/ca-bundle.crt
+HTTPS_PROXY=http://corp-proxy.example.com:3128
+HTTP_PROXY=http://corp-proxy.example.com:3128
+NO_PROXY=localhost,127.0.0.1,.cluster.local
+```
+
+Set these on the pod (`c.KubeSpawner.environment` for Hub; environment in your Dockerfile or compose file otherwise). The Claude Code CLI is a separate Node.js process and reads the same `HTTPS_PROXY` / `NODE_EXTRA_CA_CERTS` conventions.
+
+The frontend talks only to its own Jupyter Server backend, which proxies the LLM calls. The browser does not need a corporate-CA trust.
+
+---
+
+## Air-gap deployment
+
+Steps for deploying to a network with no general internet egress:
+
+1. **Pre-build the Docker image** with NBI installed, the Claude Code CLI binary baked in, and any MCP server packages pre-installed (do **not** rely on `npx -y` at runtime).
+2. **Manifest hosting.** Set `NBI_SKILLS_MANIFEST` to either a `file://` path (a manifest baked into the image) or an internal `https://` URL on a network the pod can reach.
+3. **Skill bundles.** Either bake the skills into the image under `~/.claude/skills/` (managed-status will be reset since they aren't from the manifest), or host the GitHub-style tarballs at an internal mirror and write the manifest URLs to point at it.
+4. **Disable user-initiated GitHub imports** at the network layer — block `github.com`, `codeload.github.com`, `raw.githubusercontent.com`. Users can still install skills from the local filesystem by dropping bundles into `~/.claude/skills/`.
+5. **MCP `npx -y` is incompatible** with air-gap. Pre-install the server binary and reference it directly:
+
+   ```json
+   {
+     "mcpServers": {
+       "filesystem": {
+         "command": "/opt/mcp/bin/mcp-server-filesystem",
+         "args": ["/home/user/work"]
+       }
+     }
+   }
+   ```
+
+6. **LLM endpoint.** Air-gap means a self-hosted endpoint (vLLM, TGI, LiteLLM proxy in front of Bedrock-via-VPC-endpoint, etc.). See [Self-hosted LLM endpoints](#self-hosted-llm-endpoints).
+
+---
+
+## HIPAA / sensitive-data preset
+
+For deployments that must not transmit PHI to cloud LLM providers, force local-only models:
+
+```python
+# jupyter_server_config.py
+c.NotebookIntelligence.disabled_providers = [
+    "github-copilot",
+    "openai-compatible",
+    "litellm-compatible",
+]
+c.NotebookIntelligence.allow_enabling_providers_with_env = False  # users cannot override
+c.NotebookIntelligence.disabled_tools = ["nbi-command-execute", "nbi-file-edit"]
+c.NotebookIntelligence.allow_enabling_tools_with_env = False
+```
+
+Pair with `<env-prefix>/share/jupyter/nbi/config.json` shipping an Ollama provider preconfigured against your local model:
+
+```json
+{
+  "default_provider": "ollama",
+  "providers": {
+    "ollama": {
+      "base_url": "http://ollama-internal.example.com:11434",
+      "default_chat_model": "llama3:70b",
+      "default_inline_completion_model": "codellama:7b"
+    }
+  }
+}
+```
+
+Block egress to all external LLM hosts at the network layer as defense in depth (see [`PRIVACY.md`](../PRIVACY.md#egress-allowlist) for the full list).
+
+This is a **starting point**, not a HIPAA-compliance certification. Run a security review of the full stack (Ollama, your Jupyter image, KubeSpawner, network policy) before treating any data as protected.
+
+---
+
+## Restricting features for managed deployments
+
+NBI's denylist for providers and tools follows the same shape:
+
+### Disabling LLM providers
+
+```python
+c.NotebookIntelligence.disabled_providers = ["ollama", "litellm-compatible", "openai-compatible"]
+```
+
+Valid IDs: `github-copilot`, `ollama`, `litellm-compatible`, `openai-compatible`.
+
+To allow per-pod re-enable via env var:
+
+```python
+c.NotebookIntelligence.allow_enabling_providers_with_env = True
+```
+
+```bash
+NBI_ENABLED_PROVIDERS=github-copilot,ollama
+```
+
+### Disabling built-in tools
+
+```python
+c.NotebookIntelligence.disabled_tools = ["nbi-notebook-execute", "nbi-python-file-edit"]
+```
+
+Valid IDs: `nbi-notebook-edit`, `nbi-notebook-execute`, `nbi-python-file-edit`, `nbi-file-edit`, `nbi-file-read`, `nbi-command-execute`.
+
+To allow per-pod re-enable:
+
+```python
+c.NotebookIntelligence.allow_enabling_tools_with_env = True
+```
+
+```bash
+NBI_ENABLED_BUILTIN_TOOLS=nbi-notebook-execute,nbi-python-file-edit
+```
+
+NBI does not currently support an explicit allowlist mode (`allowed_providers`, `allowed_tools`). A new built-in provider added in a minor release would auto-enable for users on `disabled_providers=[]`. If this matters for your compliance posture, pin to specific NBI versions and review changelog entries before upgrading. Tracked as a feature request.
+
+---
+
+## Multi-tenancy and per-team scoping
+
+JupyterHub spawn-time profiles can carry per-team config:
+
+```python
+c.KubeSpawner.profile_list = [
+    {
+        "display_name": "Data Science (managed skills)",
+        "kubespawner_override": {
+            "environment": {
+                "NBI_SKILLS_MANIFEST": "https://manifests.internal/team-ds.yaml",
+                "NBI_MANAGED_SKILLS_TOKEN": {"valueFrom": {"secretKeyRef": {...}}},
+            },
+        },
+    },
+    {
+        "display_name": "ML Research (no managed skills)",
+        "kubespawner_override": {"environment": {"NBI_SKILLS_MANIFEST": ""}},
+    },
+]
+```
+
+Skill name collisions between manifests and user-authored skills are handled per-entry by the reconciler (managed entries skip user-authored skills with the same name). Across teams, if a user moves between profiles that ship different `data-eda` skills, they will see whichever team's skill the active profile reconciled most recently. Keep team skill names distinct (`team-ds-data-eda`, `team-ml-data-eda`) to avoid surprises.
+
+---
+
+## Managed Claude Skills token
+
+`NBI_MANAGED_SKILLS_TOKEN` (or the `managed_skills_token` traitlet) authenticates managed-skills GitHub operations (manifest fetch when hosted on github.com, commits-API probing, tarball downloads).
+
+- **Minimum scope:** `contents:read` on the org/repos that host the manifest and skill bundles.
+- **Rotation:** tokens are read from env on every reconcile cycle. Restart the pod (or reissue the env, if your KubeSpawner re-reads on resume) to rotate.
+- **401/403 behavior:** a single auth failure on a managed operation is logged and **not retried with the fallback token chain** when `NBI_MANAGED_SKILLS_TOKEN` is set. This keeps misconfiguration visible. The reconciler continues with remaining entries.
+- **User-initiated imports do not see this token.** They use `GITHUB_TOKEN` → `GH_TOKEN` → `gh` CLI auth. Keep these separate so a misconfigured org token can't unintentionally be applied to user imports.
+
+---
+
+## Chat feedback event hook
+
+When `enable_chat_feedback = True`, NBI emits a `telemetry` event in-process whenever a user gives thumbs-up/down feedback in chat. The event payload includes the rating, the prompt, the response, and the model.
+
+The event is **emitted in-process only**. Nothing leaves the pod unless you write a custom handler that listens for it. The shape of the payload is not currently considered stable API; if you build on it, pin to a specific NBI version.
+
+To pipe feedback into your internal observability stack (Kafka, OTel collector), write an extension that registers a listener for the `telemetry` event and forwards it.
+
+---
+
+## HTTP API surface
+
+All routes live under `/notebook-intelligence/`. All require Jupyter authentication (XSRF token + Jupyter login token) — the labextension obtains these automatically. There is no admin-only route; access control is via Jupyter Server itself.
+
+| Route                                                       | Method          | Purpose                                                                           |
+| ----------------------------------------------------------- | --------------- | --------------------------------------------------------------------------------- |
+| `/notebook-intelligence/capabilities`                       | GET             | Capabilities + tool/provider gate state.                                          |
+| `/notebook-intelligence/config`                             | GET/POST        | Read or update user-scope config.                                                 |
+| `/notebook-intelligence/update-provider-models`             | POST            | Refresh model list for a provider (e.g., Anthropic SDK refresh).                  |
+| `/notebook-intelligence/mcp-config-file`                    | GET/POST        | Read or write `~/.jupyter/nbi/mcp.json`.                                          |
+| `/notebook-intelligence/reload-mcp-servers`                 | POST            | Re-discover MCP servers without restarting JupyterLab.                            |
+| `/notebook-intelligence/emit-telemetry-event`               | POST            | Used by the frontend to emit `telemetry` events (e.g., chat feedback).            |
+| `/notebook-intelligence/gh-login-status`                    | GET             | GitHub Copilot login state.                                                       |
+| `/notebook-intelligence/gh-login`                           | POST            | Begin GitHub Copilot device-flow login.                                           |
+| `/notebook-intelligence/gh-logout`                          | GET             | Sign out of GitHub Copilot.                                                       |
+| `/notebook-intelligence/copilot`                            | WS              | Streaming chat / inline-completion WebSocket.                                     |
+| `/notebook-intelligence/rules`                              | GET             | List discovered rules.                                                            |
+| `/notebook-intelligence/rules/<id>/toggle`                  | POST            | Toggle a rule's `active` field.                                                   |
+| `/notebook-intelligence/rules/reload`                       | POST            | Manually reload all rules.                                                        |
+| `/notebook-intelligence/skills`                             | GET/POST        | List or create skills.                                                            |
+| `/notebook-intelligence/skills/context`                     | GET             | Skill context info for the active workspace.                                      |
+| `/notebook-intelligence/skills/import/preview`              | POST            | Preview a GitHub-hosted skill before installing.                                  |
+| `/notebook-intelligence/skills/import`                      | POST            | Install a GitHub-hosted skill (user-initiated).                                   |
+| `/notebook-intelligence/skills/reconcile`                   | POST            | Run the managed-skills reconciler. Returns 409 if `NBI_SKILLS_MANIFEST` is unset. |
+| `/notebook-intelligence/skills/<scope>/<name>`              | GET/PUT/DELETE  | Skill detail; managed skills are read-only.                                       |
+| `/notebook-intelligence/skills/<scope>/<name>/rename`       | POST            | Rename a skill (denied for managed skills).                                       |
+| `/notebook-intelligence/skills/<scope>/<name>/files`        | GET/POST/DELETE | Skill bundle file ops.                                                            |
+| `/notebook-intelligence/skills/<scope>/<name>/files/rename` | POST            | Rename a file inside a skill bundle.                                              |
+| `/notebook-intelligence/upload-file`                        | POST            | Upload a file to attach as chat context.                                          |
+| `/notebook-intelligence/claude-sessions`                    | GET             | List Claude Code sessions for the working directory.                              |
+| `/notebook-intelligence/claude-sessions/resume`             | POST            | Resume a Claude session.                                                          |
+
+The extension respects `c.ServerApp.base_url`. Behind JupyterHub at `/user/<name>/` everything still works because JupyterLab proxies routes through the per-user base URL automatically.
+
+---
+
+## Failure modes
+
+| Condition                                      | User-visible behavior                                                     | Where to look in logs                                     |
+| ---------------------------------------------- | ------------------------------------------------------------------------- | --------------------------------------------------------- |
+| LLM provider unreachable                       | Chat shows "Thinking…" then a connection error toast.                     | JupyterLab terminal (server stderr).                      |
+| LLM 401 (bad / expired key)                    | Chat shows the provider's error message.                                  | JupyterLab terminal; provider's own SDK logs.             |
+| Claude CLI missing                             | Chat hangs on "Thinking…" in Claude mode; never returns.                  | JupyterLab terminal — `claude-agent-sdk` connect failure. |
+| Claude CLI fails to start (path mismatch)      | Same as above.                                                            | Same — set Claude CLI path in NBI Settings.               |
+| MCP stdio server crashes                       | The server's tools disappear from `@mcp` chat participant.                | JupyterLab terminal — server's stderr.                    |
+| MCP `npx -y` package fetch fails (offline)     | Server fails to start; tools missing.                                     | JupyterLab terminal.                                      |
+| Managed-skills manifest 5xx / DNS failure      | Reconciler logs the error; existing managed skills remain installed.      | JupyterLab terminal — `skill_reconciler` warning/error.   |
+| Managed-skills tarball fetch fails (per entry) | That entry stays at the previous installed version; others succeed.       | JupyterLab terminal — per-entry error.                    |
+| `NBI_MANAGED_SKILLS_TOKEN` 401/403             | Reconcile fails; loud log; does not fall back to user GITHUB_TOKEN chain. | JupyterLab terminal.                                      |
+| Ruleset frontmatter is invalid YAML            | Rule is skipped; others load.                                             | JupyterLab terminal — `rule_manager` warning.             |
+| Encrypted token decrypt fails                  | User is prompted to re-login on the chat sidebar.                         | JupyterLab terminal.                                      |
+
+---
+
+## Version matrix
+
+NBI is tested against the JupyterLab and `jupyter_server` versions declared in [`pyproject.toml`](../pyproject.toml).
+
+| NBI version | JupyterLab | jupyter_server | Python    |
+| ----------- | ---------- | -------------- | --------- |
+| 4.5.x       | 4.x        | 2.x            | 3.10–3.12 |
+| 4.4.x       | 4.x        | 2.x            | 3.10–3.12 |
+| 4.3.x       | 4.x        | 2.x            | 3.10–3.12 |
+
+Upper bounds for `litellm`, `claude-agent-sdk`, `anthropic`, and `fastmcp` are not pinned in `pyproject.toml`. For production deployments, pin these in your image build:
+
+```bash
+pip install \
+  "notebook-intelligence==4.5.*" \
+  "litellm==1.62.*" \
+  "claude-agent-sdk==0.x.*" \
+  "anthropic==0.x.*" \
+  "fastmcp==2.x.*"
+```
+
+Substitute the versions you've validated. The NBI test suite is currently TypeScript-only (`jlpm test`); end-to-end Python testing is a future work item.
+
+---
+
+## FIPS posture
+
+NBI's `cryptography` dependency is used solely to encrypt the stored GitHub Copilot token. The default password (`nbi-access-token-password`) and the encryption are intended for at-rest obfuscation, **not** as a FIPS-validated secret store.
+
+If you operate under FIPS:
+
+- Run with the FIPS-mode OpenSSL build of Python. NBI's `cryptography` calls (Fernet under the hood, AES-128-CBC + HMAC-SHA256) work under FIPS-mode OpenSSL.
+- Set a per-user `NBI_GH_ACCESS_TOKEN_PASSWORD` so the encryption key is not derivable.
+- For higher assurance, disable "remember GitHub Copilot login" entirely so no encrypted-at-rest token exists.
+
+NBI itself does not assert FIPS compliance.
+
+---
+
+## Resource footprint
+
+NBI's per-user memory cost depends on which Python deps actually get imported. A clean Jupyter Server with NBI installed but no LLM activity uses roughly the baseline of `notebook_intelligence` plus its server-imported dependencies.
+
+We have not published measured numbers. If you size pods aggressively, profile your image: import everything NBI imports lazily (run a chat turn, trigger inline completion, exercise `claude-agent-sdk`) and measure RSS before sizing your pod-memory request. Inline completion under load is the most chatty path; consider provider-side rate limits if you have hundreds of simultaneous users on a paid endpoint.
+
+A measured-baseline doc is on the roadmap. If you have numbers from a production deployment, please share them in a GitHub issue.

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -1,8 +1,8 @@
 # Administrator Guide
 
-This guide covers deploying Notebook Intelligence at scale — JupyterHub, KubeSpawner, Kubeflow, multi-tenant clusters, regulated environments. For end-user documentation see the [README](../README.md).
+This guide covers deploying Notebook Intelligence at scale — JupyterHub, KubeSpawner, Kubeflow, multi-tenant clusters, regulated environments. For end-user documentation, see the [README](../README.md).
 
-> NBI is a per-user tool. Every section below assumes the extension is running inside a per-user Jupyter Server, not a shared one. Server-side state is per-user; there is no central NBI service.
+> NBI is a per-user tool. Every section below assumes the extension runs inside a per-user Jupyter Server, not a shared one. Server-side state is per-user; there is no central NBI service.
 
 ---
 
@@ -35,10 +35,10 @@ This guide covers deploying Notebook Intelligence at scale — JupyterHub, KubeS
 NBI reads configuration from three layers, listed in order of precedence (later wins):
 
 1. **Environment-wide base config** — `<env-prefix>/share/jupyter/nbi/config.json` and `<env-prefix>/share/jupyter/nbi/mcp.json`. Bake into your image. Read once at startup.
-2. **User config** — `~/.jupyter/nbi/config.json` and `~/.jupyter/nbi/mcp.json`. Mutated by the user via the Settings dialog. Per-user PVC.
+2. **User config** — `~/.jupyter/nbi/config.json` and `~/.jupyter/nbi/mcp.json`. The user mutates these via the Settings dialog. Lives on the per-user PVC.
 3. **Environment variables** — `NBI_*` and certain provider variables (see the [reference table](#environment-variables-and-traitlets)). Override at pod startup time.
 
-Traitlets configured via JupyterLab CLI flags or `jupyter_server_config.py` (e.g., `c.NotebookIntelligence.disabled_providers = [...]`) are evaluated at server startup. Where a traitlet has a corresponding env var (e.g., `NBI_ENABLED_PROVIDERS` for `disabled_providers`/`allow_enabling_providers_with_env`), the env var is read at request time.
+Traitlets configured via JupyterLab CLI flags or `jupyter_server_config.py` (e.g., `c.NotebookIntelligence.disabled_providers = [...]`) are evaluated at server startup. Where a traitlet has a corresponding env var (e.g., `NBI_ENABLED_PROVIDERS` for `disabled_providers` and `allow_enabling_providers_with_env`), NBI reads the env var at request time.
 
 Manual edits to `config.json` while JupyterLab is running require a JupyterLab restart to take effect. Edits via the Settings dialog are picked up live.
 
@@ -57,7 +57,7 @@ Manual edits to `config.json` while JupyterLab is running require a JupyterLab r
 | `<env-prefix>/share/jupyter/nbi/`         | No (image)  | Org-wide base config. Bake into your container image.                                                                           |
 | Project-scope `<project>/.claude/skills/` | Per project | Lives in the user's working directory. Persists if the working directory does.                                                  |
 
-For Kubeflow / KubeSpawner: mount the user's home directory on a PVC and ensure `~/.jupyter`, `~/.claude` are inside that mount. Anything else (`/tmp`, `~/.cache`) can be ephemeral.
+For Kubeflow or KubeSpawner: mount the user's home directory on a PVC and ensure `~/.jupyter` and `~/.claude` are inside that mount. Anything else (`/tmp`, `~/.cache`) can be ephemeral.
 
 ---
 
@@ -65,7 +65,7 @@ For Kubeflow / KubeSpawner: mount the user's home directory on a PVC and ensure 
 
 If users share a home directory across nodes (NFS-backed shared HPC, classroom labs):
 
-- **Race conditions in `~/.jupyter/nbi/`.** Concurrent writes from two login nodes can corrupt `config.json`. NBI does not file-lock. Either pin each user to one node, or use a per-node config-prefix.
+- **Race conditions in `~/.jupyter/nbi/`.** Concurrent writes from two login nodes can corrupt `config.json`. NBI does not file-lock. Pin each user to one node, or use a per-node config prefix.
 - **`NBI_GH_ACCESS_TOKEN_PASSWORD` default is unsafe.** The default password (`nbi-access-token-password`) is shared across installs. On a multi-tenant cluster, anyone with read access to another user's `~/.jupyter/nbi/user-data.json` can decrypt their Copilot token. Set a per-user password (e.g., derived from the Hub user secret), or disable "remember login" entirely (see [Restricting features](#restricting-features-for-managed-deployments)).
 - **Skill collisions.** Two users sharing `~/.claude/skills/` will see each other's skills. Make sure each user has a unique home.
 
@@ -92,7 +92,10 @@ The full surface, in one table.
 | `NBI_MANAGED_SKILLS_TOKEN`          | str  | unset                       | env (overrides traitlet)           | Same as above; env takes precedence.                                                                                         |
 | `NBI_GH_ACCESS_TOKEN_PASSWORD`      | str  | `nbi-access-token-password` | env                                | Password used to encrypt the stored Copilot token in `user-data.json`. **Change in multi-tenant deployments.**               |
 | `NBI_RULES_AUTO_RELOAD`             | bool | `true`                      | env                                | When `false`, ruleset edits require a JupyterLab restart to take effect.                                                     |
-| `GITHUB_TOKEN` / `GH_TOKEN`         | str  | unset                       | env                                | Used (in that order) by user-initiated skill imports for GitHub auth. Falls back to `gh` CLI auth.                           |
+| `NBI_CLAUDE_CLI_PATH`               | str  | unset                       | env                                | Absolute path to the Claude Code CLI binary. When unset, NBI looks up `claude` on `PATH`.                                    |
+| `NBI_GHE_SUBDOMAIN`                 | str  | `""`                        | env                                | GitHub Enterprise subdomain for GitHub Copilot users on a GHE tenant. Empty selects github.com.                              |
+| `NBI_LOG_LEVEL`                     | str  | `INFO`                      | env                                | Python logging level for the `notebook_intelligence` logger.                                                                 |
+| `GITHUB_TOKEN`, `GH_TOKEN`          | str  | unset                       | env                                | Used (in that order) by user-initiated skill imports for GitHub auth. Falls back to `gh` CLI auth.                           |
 
 Configure traitlets in `jupyter_server_config.py`:
 
@@ -118,9 +121,9 @@ NBI runs entirely inside the user's Jupyter Server process. There is no privileg
 
 For regulated tenants:
 
-1. Disable the most powerful tools — minimally `nbi-command-execute` and `nbi-file-edit`. See [Restricting features](#restricting-features-for-managed-deployments).
+1. Disable the most powerful tools — at minimum `nbi-command-execute` and `nbi-file-edit`. See [Restricting features](#restricting-features-for-managed-deployments).
 2. Restrict the providers the user can pick. Force a single self-hosted endpoint with `disabled_providers` plus the org's base config.
-3. Disable user-initiated skill imports (currently network-layer only — see [`docs/skills.md`](skills.md#disabling-user-initiated-github-imports)).
+3. Disable user-initiated skill imports (currently network-layer only — see [`skills.md`](skills.md#disabling-user-initiated-github-imports)).
 4. Run with a non-root container user, with no host-network access and no host-path mounts beyond the user's PVC.
 
 ---
@@ -131,11 +134,11 @@ By default, custom-provider API keys (Anthropic, OpenAI-compatible, LiteLLM-comp
 
 Recommended approach for clusters:
 
-- **Inject the org's keys via env vars at pod startup.** Set the provider's expected env var (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.) on the pod. Configure the provider in `<env-prefix>/share/jupyter/nbi/config.json` without a key — NBI will pick up the provider's standard env var.
+- **Inject the org's keys via env vars at pod startup.** Set the provider's expected env var (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.) on the pod. Configure the provider in `<env-prefix>/share/jupyter/nbi/config.json` without a key — NBI picks up the provider's standard env var.
 - **Source secrets from your secret manager.** Vault, External Secrets Operator, AWS Secrets Manager, GCP Secret Manager, or KubeSpawner's `c.KubeSpawner.environment` callback can all populate the pod env from a secret backend at spawn time.
-- **Do not commit `config.json`.** Even the env-prefix base config should not contain keys; pull keys from env at spawn.
+- **Don't commit `config.json`.** Even the env-prefix base config should not contain keys; pull keys from env at spawn.
 
-`${ENV_VAR}`-style interpolation directly inside `config.json` is not currently supported. Tracked as a feature request.
+`${ENV_VAR}`-style interpolation inside `config.json` is not currently supported. Tracked as a feature request.
 
 ---
 
@@ -143,7 +146,7 @@ Recommended approach for clusters:
 
 NBI's `openai-compatible` and `litellm-compatible` providers can target any endpoint that speaks the respective wire format.
 
-**Azure OpenAI** (via the OpenAI-compatible provider):
+**Azure OpenAI** (via the `openai-compatible` provider):
 
 ```json
 {
@@ -158,7 +161,7 @@ NBI's `openai-compatible` and `litellm-compatible` providers can target any endp
 }
 ```
 
-**vLLM / TGI / any local OpenAI-compatible server**:
+**vLLM, TGI, or any local OpenAI-compatible server**:
 
 ```json
 {
@@ -191,7 +194,7 @@ Bake the base config into your image and let users select their model from the d
 
 ## Custom CA certs and corporate proxies
 
-NBI's HTTP requests use Python's `requests` and `httpx`, plus `litellm`/`openai`/`anthropic` SDKs. All honor standard Python TLS and proxy environment variables:
+NBI's HTTP requests use Python's `requests` and `httpx`, plus the `litellm`, `openai`, and `anthropic` SDKs. All honor standard Python TLS and proxy environment variables:
 
 ```bash
 REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
@@ -201,9 +204,9 @@ HTTP_PROXY=http://corp-proxy.example.com:3128
 NO_PROXY=localhost,127.0.0.1,.cluster.local
 ```
 
-Set these on the pod (`c.KubeSpawner.environment` for Hub; environment in your Dockerfile or compose file otherwise). The Claude Code CLI is a separate Node.js process and reads the same `HTTPS_PROXY` / `NODE_EXTRA_CA_CERTS` conventions.
+Set these on the pod (`c.KubeSpawner.environment` for Hub; environment in your Dockerfile or compose file otherwise). The Claude Code CLI is a separate Node.js process and reads the same `HTTPS_PROXY` and `NODE_EXTRA_CA_CERTS` conventions.
 
-The frontend talks only to its own Jupyter Server backend, which proxies the LLM calls. The browser does not need a corporate-CA trust.
+The frontend talks only to its own Jupyter Server backend, which proxies the LLM calls. The browser does not need a corporate CA trust.
 
 ---
 
@@ -213,9 +216,9 @@ Steps for deploying to a network with no general internet egress:
 
 1. **Pre-build the Docker image** with NBI installed, the Claude Code CLI binary baked in, and any MCP server packages pre-installed (do **not** rely on `npx -y` at runtime).
 2. **Manifest hosting.** Set `NBI_SKILLS_MANIFEST` to either a `file://` path (a manifest baked into the image) or an internal `https://` URL on a network the pod can reach.
-3. **Skill bundles.** Either bake the skills into the image under `~/.claude/skills/` (managed-status will be reset since they aren't from the manifest), or host the GitHub-style tarballs at an internal mirror and write the manifest URLs to point at it.
-4. **Disable user-initiated GitHub imports** at the network layer — block `github.com`, `codeload.github.com`, `raw.githubusercontent.com`. Users can still install skills from the local filesystem by dropping bundles into `~/.claude/skills/`.
-5. **MCP `npx -y` is incompatible** with air-gap. Pre-install the server binary and reference it directly:
+3. **Skill bundles.** Either bake the skills into the image under `~/.claude/skills/` (managed status will reset since they aren't from the manifest), or host the GitHub-style tarballs at an internal mirror and write the manifest URLs to point at it.
+4. **Disable user-initiated GitHub imports** at the network layer — block `github.com`, `codeload.github.com`, and `raw.githubusercontent.com`. Users can still install skills from the local filesystem by dropping bundles into `~/.claude/skills/`.
+5. **MCP `npx -y` is incompatible with air-gap.** Pre-install the server binary and reference it directly:
 
    ```json
    {
@@ -228,7 +231,7 @@ Steps for deploying to a network with no general internet egress:
    }
    ```
 
-6. **LLM endpoint.** Air-gap means a self-hosted endpoint (vLLM, TGI, LiteLLM proxy in front of Bedrock-via-VPC-endpoint, etc.). See [Self-hosted LLM endpoints](#self-hosted-llm-endpoints).
+6. **LLM endpoint.** Air-gap requires a self-hosted endpoint (vLLM, TGI, or a LiteLLM proxy in front of a VPC-endpoint Bedrock, etc.). See [Self-hosted LLM endpoints](#self-hosted-llm-endpoints).
 
 ---
 
@@ -265,7 +268,7 @@ Pair with `<env-prefix>/share/jupyter/nbi/config.json` shipping an Ollama provid
 
 Block egress to all external LLM hosts at the network layer as defense in depth (see [`PRIVACY.md`](../PRIVACY.md#egress-allowlist) for the full list).
 
-This is a **starting point**, not a HIPAA-compliance certification. Run a security review of the full stack (Ollama, your Jupyter image, KubeSpawner, network policy) before treating any data as protected.
+This is a **starting point**, not a HIPAA compliance certification. Run a security review of the full stack (Ollama, your Jupyter image, KubeSpawner, network policy) before treating any data as protected.
 
 ---
 
@@ -309,7 +312,7 @@ c.NotebookIntelligence.allow_enabling_tools_with_env = True
 NBI_ENABLED_BUILTIN_TOOLS=nbi-notebook-execute,nbi-python-file-edit
 ```
 
-NBI does not currently support an explicit allowlist mode (`allowed_providers`, `allowed_tools`). A new built-in provider added in a minor release would auto-enable for users on `disabled_providers=[]`. If this matters for your compliance posture, pin to specific NBI versions and review changelog entries before upgrading. Tracked as a feature request.
+NBI does not currently support an explicit allowlist mode (`allowed_providers`, `allowed_tools`). A new built-in provider added in a minor release would auto-enable for users with `disabled_providers=[]`. If this matters for your compliance posture, pin to specific NBI versions and review changelog entries before upgrading. Tracked as a feature request.
 
 ---
 
@@ -335,7 +338,7 @@ c.KubeSpawner.profile_list = [
 ]
 ```
 
-Skill name collisions between manifests and user-authored skills are handled per-entry by the reconciler (managed entries skip user-authored skills with the same name). Across teams, if a user moves between profiles that ship different `data-eda` skills, they will see whichever team's skill the active profile reconciled most recently. Keep team skill names distinct (`team-ds-data-eda`, `team-ml-data-eda`) to avoid surprises.
+The reconciler handles skill name collisions between manifests and user-authored skills per entry (managed entries skip user-authored skills with the same name). Across teams, if a user moves between profiles that ship different `data-eda` skills, they see whichever team's skill the active profile reconciled most recently. Keep team skill names distinct (`team-ds-data-eda`, `team-ml-data-eda`) to avoid surprises.
 
 ---
 
@@ -344,9 +347,9 @@ Skill name collisions between manifests and user-authored skills are handled per
 `NBI_MANAGED_SKILLS_TOKEN` (or the `managed_skills_token` traitlet) authenticates managed-skills GitHub operations (manifest fetch when hosted on github.com, commits-API probing, tarball downloads).
 
 - **Minimum scope:** `contents:read` on the org/repos that host the manifest and skill bundles.
-- **Rotation:** tokens are read from env on every reconcile cycle. Restart the pod (or reissue the env, if your KubeSpawner re-reads on resume) to rotate.
+- **Rotation:** NBI reads the token from env on every reconcile cycle. Restart the pod (or reissue the env, if your KubeSpawner re-reads on resume) to rotate.
 - **401/403 behavior:** a single auth failure on a managed operation is logged and **not retried with the fallback token chain** when `NBI_MANAGED_SKILLS_TOKEN` is set. This keeps misconfiguration visible. The reconciler continues with remaining entries.
-- **User-initiated imports do not see this token.** They use `GITHUB_TOKEN` → `GH_TOKEN` → `gh` CLI auth. Keep these separate so a misconfigured org token can't unintentionally be applied to user imports.
+- **User-initiated imports do not see this token.** They use `GITHUB_TOKEN` → `GH_TOKEN` → `gh` CLI auth. Keep these separate so a misconfigured org token can't unintentionally apply to user imports.
 
 ---
 
@@ -354,7 +357,7 @@ Skill name collisions between manifests and user-authored skills are handled per
 
 When `enable_chat_feedback = True`, NBI emits a `telemetry` event in-process whenever a user gives thumbs-up/down feedback in chat. The event payload includes the rating, the prompt, the response, and the model.
 
-The event is **emitted in-process only**. Nothing leaves the pod unless you write a custom handler that listens for it. The shape of the payload is not currently considered stable API; if you build on it, pin to a specific NBI version.
+The event is **emitted in-process only**. Nothing leaves the process unless you write a custom handler that listens for it. The payload shape is not currently considered stable API; if you build on it, pin to a specific NBI version.
 
 To pipe feedback into your internal observability stack (Kafka, OTel collector), write an extension that registers a listener for the `telemetry` event and forwards it.
 
@@ -362,7 +365,7 @@ To pipe feedback into your internal observability stack (Kafka, OTel collector),
 
 ## HTTP API surface
 
-All routes live under `/notebook-intelligence/`. All require Jupyter authentication (XSRF token + Jupyter login token) — the labextension obtains these automatically. There is no admin-only route; access control is via Jupyter Server itself.
+All routes live under `/notebook-intelligence/`. All require Jupyter authentication (XSRF token plus Jupyter login token) — the labextension obtains these automatically. There is no admin-only route; access control runs through Jupyter Server itself.
 
 | Route                                                       | Method          | Purpose                                                                           |
 | ----------------------------------------------------------- | --------------- | --------------------------------------------------------------------------------- |
@@ -377,7 +380,7 @@ All routes live under `/notebook-intelligence/`. All require Jupyter authenticat
 | `/notebook-intelligence/gh-logout`                          | GET             | Sign out of GitHub Copilot.                                                       |
 | `/notebook-intelligence/copilot`                            | WS              | Streaming chat / inline-completion WebSocket.                                     |
 | `/notebook-intelligence/rules`                              | GET             | List discovered rules.                                                            |
-| `/notebook-intelligence/rules/<id>/toggle`                  | POST            | Toggle a rule's `active` field.                                                   |
+| `/notebook-intelligence/rules/<id>/toggle`                  | PUT             | Toggle a rule's `active` field.                                                   |
 | `/notebook-intelligence/rules/reload`                       | POST            | Manually reload all rules.                                                        |
 | `/notebook-intelligence/skills`                             | GET/POST        | List or create skills.                                                            |
 | `/notebook-intelligence/skills/context`                     | GET             | Skill context info for the active workspace.                                      |
@@ -398,19 +401,19 @@ The extension respects `c.ServerApp.base_url`. Behind JupyterHub at `/user/<name
 
 ## Failure modes
 
-| Condition                                      | User-visible behavior                                                     | Where to look in logs                                     |
-| ---------------------------------------------- | ------------------------------------------------------------------------- | --------------------------------------------------------- |
-| LLM provider unreachable                       | Chat shows "Thinking…" then a connection error toast.                     | JupyterLab terminal (server stderr).                      |
-| LLM 401 (bad / expired key)                    | Chat shows the provider's error message.                                  | JupyterLab terminal; provider's own SDK logs.             |
-| Claude CLI missing                             | Chat hangs on "Thinking…" in Claude mode; never returns.                  | JupyterLab terminal — `claude-agent-sdk` connect failure. |
-| Claude CLI fails to start (path mismatch)      | Same as above.                                                            | Same — set Claude CLI path in NBI Settings.               |
-| MCP stdio server crashes                       | The server's tools disappear from `@mcp` chat participant.                | JupyterLab terminal — server's stderr.                    |
-| MCP `npx -y` package fetch fails (offline)     | Server fails to start; tools missing.                                     | JupyterLab terminal.                                      |
-| Managed-skills manifest 5xx / DNS failure      | Reconciler logs the error; existing managed skills remain installed.      | JupyterLab terminal — `skill_reconciler` warning/error.   |
-| Managed-skills tarball fetch fails (per entry) | That entry stays at the previous installed version; others succeed.       | JupyterLab terminal — per-entry error.                    |
-| `NBI_MANAGED_SKILLS_TOKEN` 401/403             | Reconcile fails; loud log; does not fall back to user GITHUB_TOKEN chain. | JupyterLab terminal.                                      |
-| Ruleset frontmatter is invalid YAML            | Rule is skipped; others load.                                             | JupyterLab terminal — `rule_manager` warning.             |
-| Encrypted token decrypt fails                  | User is prompted to re-login on the chat sidebar.                         | JupyterLab terminal.                                      |
+| Condition                                      | User-visible behavior                                                      | Where to look in logs                                     |
+| ---------------------------------------------- | -------------------------------------------------------------------------- | --------------------------------------------------------- |
+| LLM provider unreachable                       | Chat shows "Thinking…", then a connection-error toast.                     | JupyterLab terminal (server stderr).                      |
+| LLM 401 (bad or expired key)                   | Chat shows the provider's error message.                                   | JupyterLab terminal; the provider's own SDK logs.         |
+| Claude CLI missing                             | Chat hangs on "Thinking…" in Claude mode; never returns.                   | JupyterLab terminal — `claude-agent-sdk` connect failure. |
+| Claude CLI fails to start (path mismatch)      | Same as above.                                                             | Same — set `NBI_CLAUDE_CLI_PATH` and restart JupyterLab.  |
+| MCP stdio server crashes                       | The server's tools disappear from `@mcp` chat participant.                 | JupyterLab terminal — server's stderr.                    |
+| MCP `npx -y` package fetch fails (offline)     | Server fails to start; tools missing.                                      | JupyterLab terminal.                                      |
+| Managed-skills manifest 5xx / DNS failure      | Reconciler logs the error; existing managed skills remain installed.       | JupyterLab terminal — `skill_reconciler` warning/error.   |
+| Managed-skills tarball fetch fails (per entry) | That entry stays at the previously installed version; others succeed.      | JupyterLab terminal — per-entry error.                    |
+| `NBI_MANAGED_SKILLS_TOKEN` 401/403             | Reconcile fails; loud log; does not fall back to the `GITHUB_TOKEN` chain. | JupyterLab terminal.                                      |
+| Ruleset frontmatter is invalid YAML            | Rule is skipped; others load.                                              | JupyterLab terminal — `rule_manager` warning.             |
+| Encrypted token decrypt fails                  | The chat sidebar prompts the user to sign in again.                        | JupyterLab terminal.                                      |
 
 ---
 
@@ -445,7 +448,7 @@ NBI's `cryptography` dependency is used solely to encrypt the stored GitHub Copi
 
 If you operate under FIPS:
 
-- Run with the FIPS-mode OpenSSL build of Python. NBI's `cryptography` calls (Fernet under the hood, AES-128-CBC + HMAC-SHA256) work under FIPS-mode OpenSSL.
+- Run with the FIPS-mode OpenSSL build of Python. NBI's `cryptography` calls (Fernet under the hood — AES-128-CBC plus HMAC-SHA256) work under FIPS-mode OpenSSL.
 - Set a per-user `NBI_GH_ACCESS_TOKEN_PASSWORD` so the encryption key is not derivable.
 - For higher assurance, disable "remember GitHub Copilot login" entirely so no encrypted-at-rest token exists.
 
@@ -455,8 +458,8 @@ NBI itself does not assert FIPS compliance.
 
 ## Resource footprint
 
-NBI's per-user memory cost depends on which Python deps actually get imported. A clean Jupyter Server with NBI installed but no LLM activity uses roughly the baseline of `notebook_intelligence` plus its server-imported dependencies.
+NBI's per-user memory cost depends on which Python dependencies actually get imported. A clean Jupyter Server with NBI installed but no LLM activity uses roughly the baseline of `notebook_intelligence` plus its server-imported dependencies.
 
-We have not published measured numbers. If you size pods aggressively, profile your image: import everything NBI imports lazily (run a chat turn, trigger inline completion, exercise `claude-agent-sdk`) and measure RSS before sizing your pod-memory request. Inline completion under load is the most chatty path; consider provider-side rate limits if you have hundreds of simultaneous users on a paid endpoint.
+We have not published measured numbers. If you size pods aggressively, profile your image: import everything NBI imports lazily (run a chat turn, trigger inline completion, exercise `claude-agent-sdk`) and measure RSS before sizing your pod memory request. Inline completion under load is the chattiest path; consider provider-side rate limits if you have hundreds of simultaneous users on a paid endpoint.
 
-A measured-baseline doc is on the roadmap. If you have numbers from a production deployment, please share them in a GitHub issue.
+A measured-baseline document is on the roadmap. If you have numbers from a production deployment, share them in a GitHub issue.

--- a/docs/rulesets.md
+++ b/docs/rulesets.md
@@ -1,0 +1,108 @@
+# Ruleset System
+
+NBI's ruleset system lets you inject custom guidelines into AI prompts so the assistant follows project conventions, coding standards, or domain knowledge consistently. Rules are markdown files with optional YAML frontmatter, discovered automatically and applied based on context.
+
+## How it works
+
+Rules are stored in `~/.jupyter/nbi/rules/`. NBI loads them at startup, watches the directory for changes, and selects which rules apply to each chat turn based on the file frontmatter and current context (file type, notebook kernel, chat mode).
+
+Selected rules are concatenated in priority order and prepended to the system prompt sent to the LLM.
+
+## Creating rules
+
+### Global rules — apply to all contexts
+
+Create `~/.jupyter/nbi/rules/01-coding-standards.md`:
+
+```markdown
+---
+priority: 10
+---
+
+# Coding Standards
+
+- Always use type hints in Python functions.
+- Prefer list comprehensions over loops when appropriate.
+- Add docstrings to all public functions.
+```
+
+### Mode-specific rules — apply only to a chat mode
+
+NBI has three chat modes: `ask` (Q&A), `agent` (autonomous tool use), `inline-chat` (cell-level code generation/edit).
+
+Create `~/.jupyter/nbi/rules/modes/agent/01-testing.md`:
+
+```markdown
+---
+priority: 20
+scope:
+  kernels: ['python3']
+---
+
+# Testing Guidelines
+
+When writing code in agent mode:
+
+- Always include error handling.
+- Add logging for debugging.
+- Test edge cases.
+```
+
+## Frontmatter reference
+
+```yaml
+---
+apply: always # 'always', 'auto', or 'manual'. Default: 'always'.
+active: true # Set false to disable without deleting. Default: true.
+priority: 10 # Lower numbers apply first. Default: 100.
+scope:
+  file_patterns: # Apply only when the active file matches.
+    - '*.py'
+    - 'test_*.ipynb'
+  kernels: # Apply only for these notebook kernels.
+    - 'python3'
+    - 'ir'
+  directories: # Apply only when working under these paths.
+    - '/projects/ml'
+---
+```
+
+All `scope` fields are optional. A rule with no `scope` applies to every context (subject to mode and `apply`).
+
+## Discovery layout
+
+```
+~/.jupyter/nbi/rules/
+├── *.md                          # global rules
+└── modes/
+    ├── ask/*.md                  # apply only in ask mode
+    ├── agent/*.md                # apply only in agent mode
+    └── inline-chat/*.md          # apply only in inline-chat mode
+```
+
+## Enabling, disabling, and managing rules
+
+The Settings dialog has a Rules tab listing every discovered rule with a toggle. Toggling marks the rule inactive for the current session — it does not delete the file or rewrite the frontmatter. To persistently disable a rule, set `active: false` in its frontmatter.
+
+To disable the system entirely, edit `~/.jupyter/nbi/config.json`:
+
+```json
+{
+  "rules_enabled": false
+}
+```
+
+## Auto-reload
+
+By default, NBI watches `~/.jupyter/nbi/rules/` and reloads rules on change without requiring a JupyterLab restart. This is controlled by `NBI_RULES_AUTO_RELOAD`:
+
+```bash
+export NBI_RULES_AUTO_RELOAD=false   # disable; restart JupyterLab to pick up rule changes
+export NBI_RULES_AUTO_RELOAD=true    # default
+```
+
+## Tips
+
+- Use `priority` to break ties when multiple rules cover the same topic. Lower number wins.
+- Keep individual rules short and focused. The LLM benefits more from five concise rules than one sprawling one.
+- For machine-generated rules (e.g., committed to a project repo), set `apply: manual` so users must explicitly enable them in the Rules tab.

--- a/docs/rulesets.md
+++ b/docs/rulesets.md
@@ -4,7 +4,7 @@ NBI's ruleset system lets you inject custom guidelines into AI prompts so the as
 
 ## How it works
 
-Rules are stored in `~/.jupyter/nbi/rules/`. NBI loads them at startup, watches the directory for changes, and selects which rules apply to each chat turn based on the file frontmatter and current context (file type, notebook kernel, chat mode).
+Rules live in `~/.jupyter/nbi/rules/`. NBI loads them at startup, watches the directory for changes, and selects which rules apply to each chat turn based on the file frontmatter and the current context (file type, notebook kernel, chat mode).
 
 Selected rules are concatenated in priority order and prepended to the system prompt sent to the LLM.
 
@@ -28,7 +28,7 @@ priority: 10
 
 ### Mode-specific rules — apply only to a chat mode
 
-NBI has three chat modes: `ask` (Q&A), `agent` (autonomous tool use), `inline-chat` (cell-level code generation/edit).
+NBI has three chat modes: `ask` (Q&A), `agent` (autonomous tool use), and `inline-chat` (cell-level code generation and edit).
 
 Create `~/.jupyter/nbi/rules/modes/agent/01-testing.md`:
 
@@ -94,7 +94,7 @@ To disable the system entirely, edit `~/.jupyter/nbi/config.json`:
 
 ## Auto-reload
 
-By default, NBI watches `~/.jupyter/nbi/rules/` and reloads rules on change without requiring a JupyterLab restart. This is controlled by `NBI_RULES_AUTO_RELOAD`:
+By default, NBI watches `~/.jupyter/nbi/rules/` and reloads rules on change without requiring a JupyterLab restart. The `NBI_RULES_AUTO_RELOAD` environment variable controls this:
 
 ```bash
 export NBI_RULES_AUTO_RELOAD=false   # disable; restart JupyterLab to pick up rule changes

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,80 @@
+# Claude Skills
+
+When [Claude mode](../README.md#claude-mode) is enabled, NBI exposes a **Skills** tab in the settings panel for viewing, creating, editing, and deleting the skills that Claude can invoke.
+
+Skills are Claude Agent SDK artifacts stored on disk:
+
+- **User skills**: `~/.claude/skills/`
+- **Project skills**: `<project_root>/.claude/skills/`
+
+Each skill lives in a directory named after the skill, containing a `SKILL.md` entry file (with YAML frontmatter for `name`, `description`, `allowed-tools`) and any helper files the skill references.
+
+## The Skills tab
+
+From the tab you can:
+
+- **Add** a new skill in either scope, editing `SKILL.md` and helper files inline.
+- **Rename** a skill — updates both the bundle directory and the frontmatter `name`.
+- **Duplicate** a skill into the same or opposite scope under a new name.
+- **Delete** a skill, with an undo toast that restores the full bundle if clicked within 8 seconds.
+- Open or delete additional files in the bundle (`SKILL.md` itself is protected from deletion).
+
+When a skill is saved, added, or removed — through the UI or directly on disk — the Claude SDK session is transparently reloaded (preserving conversation history via session resume), and a **"Skills reloaded"** banner briefly appears in the chat sidebar.
+
+## Importing from GitHub
+
+Click **Import from GitHub** in the Skills tab to install a skill from a public repository.
+
+Paste either:
+
+- A repository URL: `https://github.com/<owner>/<repo>` — imports the repo root if it contains `SKILL.md`.
+- A deep link: `https://github.com/<owner>/<repo>/tree/<ref>/<subpath>` — imports the directory at `<subpath>`.
+
+Pick the target scope (user or project), and the bundle is fetched, validated, and installed. The canonical source URL is recorded in the skill's frontmatter as `source:` so you can trace where each imported skill came from.
+
+GitHub auth for imports uses, in order: `GITHUB_TOKEN` → `GH_TOKEN` → the `gh` CLI auth, if any are set. Public-repo imports work without auth.
+
+## Managed skills via an org manifest
+
+For organization-wide deployments (e.g., Kubeflow notebooks), NBI can install and keep a curated set of Claude skills in sync from a YAML/JSON manifest. Skills installed this way are marked **Managed** in the UI — they are read-only (edit/rename/delete disabled) and refreshed on a schedule.
+
+### Configuration
+
+Configure via environment variables (also available as traitlets on `NotebookIntelligence`):
+
+| Variable                       | Description                                                                                     |
+| ------------------------------ | ----------------------------------------------------------------------------------------------- |
+| `NBI_SKILLS_MANIFEST`          | URL (`https://...`) or local filesystem path to the manifest. Empty/unset disables the feature. |
+| `NBI_SKILLS_MANIFEST_INTERVAL` | Seconds between reconciles. Default `86400` (24h). Reconciliation also runs once at startup.    |
+| `NBI_MANAGED_SKILLS_TOKEN`     | Optional bearer token used for **all** managed-skills GitHub operations (see below).            |
+
+`NBI_MANAGED_SKILLS_TOKEN`, when set, scopes to: fetching the manifest, probing commits, and downloading skill tarballs. User-initiated imports (the Import-from-GitHub dialog, `POST /skills/import`) do **not** see this token and continue to use `GITHUB_TOKEN` / `GH_TOKEN` / `gh` CLI auth. When `NBI_MANAGED_SKILLS_TOKEN` is unset, managed operations fall back to that same chain. When it is set and a managed operation fails with an auth error, it fails loudly (no retry with the fallback chain) so misconfigured or expired tokens stay visible to the admin. The minimum required GitHub scope is `contents:read`.
+
+### Manifest schema
+
+```yaml
+skills:
+  - url: https://github.com/org/repo/tree/main/skills/data-eda
+    name: data-eda # optional: override the installed skill name
+    scope: user # optional: "user" (default) or "project"
+  - url: https://github.com/org/repo/tree/main/skills/ml-recipes
+```
+
+JSON is also accepted (the parser is `yaml.safe_load`).
+
+### Reconciler behavior
+
+- The reconciler probes GitHub's commits API for each entry's `subpath` / `ref` and skips fetching the tarball when the installed `managed_ref` matches the latest SHA. Full-SHA URLs skip the probe.
+- Managed skills present in the install but missing from the manifest are **removed**.
+- User-authored skills are never touched. If a user-authored skill has the same name as a manifest entry, the reconciler leaves it alone and reports a per-entry error.
+- A manual **Sync managed skills** button appears in the Skills panel when any managed skill is installed.
+- A `POST /notebook-intelligence/skills/reconcile` endpoint is available for scripted triggers.
+- If the manifest cannot be loaded (network, bad YAML, missing `skills:` list), the reconciler logs the error and leaves all managed skills in place rather than mass-deleting on a transient failure.
+
+### Multi-tenant scoping
+
+Different JupyterHub profiles or spawner configurations can point at different manifests by setting `NBI_SKILLS_MANIFEST` per profile. Within a single user's install, skills are namespaced by name — so two profiles that both install a skill called `data-eda` will collide if a user moves between them. Use distinct skill names across teams to avoid this.
+
+### Disabling user-initiated GitHub imports
+
+There is currently no flag that disables the **Import from GitHub** button. If your deployment cannot allow users to pull arbitrary public repos, the workaround is to gate egress to `github.com` and `api.github.com` at the network layer and rely on `NBI_SKILLS_MANIFEST` with a private internal manifest URL. Tracking this as a future feature.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -5,21 +5,21 @@ When [Claude mode](../README.md#claude-mode) is enabled, NBI exposes a **Skills*
 Skills are Claude Agent SDK artifacts stored on disk:
 
 - **User skills**: `~/.claude/skills/`
-- **Project skills**: `<project_root>/.claude/skills/`
+- **Project skills**: `<project>/.claude/skills/`
 
-Each skill lives in a directory named after the skill, containing a `SKILL.md` entry file (with YAML frontmatter for `name`, `description`, `allowed-tools`) and any helper files the skill references.
+Each skill lives in a directory named after the skill, containing a `SKILL.md` entry file (with YAML frontmatter for `name`, `description`, and `allowed-tools`) plus any helper files the skill references.
 
 ## The Skills tab
 
 From the tab you can:
 
 - **Add** a new skill in either scope, editing `SKILL.md` and helper files inline.
-- **Rename** a skill — updates both the bundle directory and the frontmatter `name`.
+- **Rename** a skill — NBI updates both the bundle directory and the frontmatter `name`.
 - **Duplicate** a skill into the same or opposite scope under a new name.
-- **Delete** a skill, with an undo toast that restores the full bundle if clicked within 8 seconds.
+- **Delete** a skill, with an undo toast that restores the full bundle if clicked within eight seconds.
 - Open or delete additional files in the bundle (`SKILL.md` itself is protected from deletion).
 
-When a skill is saved, added, or removed — through the UI or directly on disk — the Claude SDK session is transparently reloaded (preserving conversation history via session resume), and a **"Skills reloaded"** banner briefly appears in the chat sidebar.
+When a skill is saved, added, or removed — through the UI or directly on disk — NBI transparently reloads the Claude SDK session (preserving conversation history via session resume), and a **"Skills reloaded"** banner briefly appears in the chat sidebar.
 
 ## Importing from GitHub
 
@@ -30,25 +30,25 @@ Paste either:
 - A repository URL: `https://github.com/<owner>/<repo>` — imports the repo root if it contains `SKILL.md`.
 - A deep link: `https://github.com/<owner>/<repo>/tree/<ref>/<subpath>` — imports the directory at `<subpath>`.
 
-Pick the target scope (user or project), and the bundle is fetched, validated, and installed. The canonical source URL is recorded in the skill's frontmatter as `source:` so you can trace where each imported skill came from.
+Pick the target scope (user or project) and NBI fetches, validates, and installs the bundle. The canonical source URL is recorded in the skill's frontmatter as `source:` so you can trace where each imported skill came from.
 
-GitHub auth for imports uses, in order: `GITHUB_TOKEN` → `GH_TOKEN` → the `gh` CLI auth, if any are set. Public-repo imports work without auth.
+GitHub auth for imports uses, in order: `GITHUB_TOKEN` → `GH_TOKEN` → `gh` CLI auth. Public-repo imports work without auth.
 
 ## Managed skills via an org manifest
 
-For organization-wide deployments (e.g., Kubeflow notebooks), NBI can install and keep a curated set of Claude skills in sync from a YAML/JSON manifest. Skills installed this way are marked **Managed** in the UI — they are read-only (edit/rename/delete disabled) and refreshed on a schedule.
+For organization-wide deployments (e.g., Kubeflow notebooks), NBI can install and keep a curated set of Claude skills in sync from a YAML or JSON manifest. Skills installed this way are marked **Managed** in the UI — they are read-only (edit, rename, and delete are disabled) and refreshed on a schedule.
 
 ### Configuration
 
 Configure via environment variables (also available as traitlets on `NotebookIntelligence`):
 
-| Variable                       | Description                                                                                     |
-| ------------------------------ | ----------------------------------------------------------------------------------------------- |
-| `NBI_SKILLS_MANIFEST`          | URL (`https://...`) or local filesystem path to the manifest. Empty/unset disables the feature. |
-| `NBI_SKILLS_MANIFEST_INTERVAL` | Seconds between reconciles. Default `86400` (24h). Reconciliation also runs once at startup.    |
-| `NBI_MANAGED_SKILLS_TOKEN`     | Optional bearer token used for **all** managed-skills GitHub operations (see below).            |
+| Variable                       | Description                                                                                        |
+| ------------------------------ | -------------------------------------------------------------------------------------------------- |
+| `NBI_SKILLS_MANIFEST`          | URL (`https://...`) or local filesystem path to the manifest. Empty or unset disables the feature. |
+| `NBI_SKILLS_MANIFEST_INTERVAL` | Seconds between reconciles. Default `86400` (24 hours). Reconciliation also runs once at startup.  |
+| `NBI_MANAGED_SKILLS_TOKEN`     | Optional bearer token used for **all** managed-skills GitHub operations (see below).               |
 
-`NBI_MANAGED_SKILLS_TOKEN`, when set, scopes to: fetching the manifest, probing commits, and downloading skill tarballs. User-initiated imports (the Import-from-GitHub dialog, `POST /skills/import`) do **not** see this token and continue to use `GITHUB_TOKEN` / `GH_TOKEN` / `gh` CLI auth. When `NBI_MANAGED_SKILLS_TOKEN` is unset, managed operations fall back to that same chain. When it is set and a managed operation fails with an auth error, it fails loudly (no retry with the fallback chain) so misconfigured or expired tokens stay visible to the admin. The minimum required GitHub scope is `contents:read`.
+When set, `NBI_MANAGED_SKILLS_TOKEN` scopes to fetching the manifest, probing commits, and downloading skill tarballs. User-initiated imports (the Import-from-GitHub dialog, `POST /skills/import`) do **not** see this token and continue to use `GITHUB_TOKEN` → `GH_TOKEN` → `gh` CLI auth. When `NBI_MANAGED_SKILLS_TOKEN` is unset, managed operations fall back to that same chain. When it is set and a managed operation fails with an auth error, it fails loudly (no retry with the fallback chain) so misconfigured or expired tokens stay visible to the admin. The minimum required GitHub scope is `contents:read`.
 
 ### Manifest schema
 
@@ -64,12 +64,12 @@ JSON is also accepted (the parser is `yaml.safe_load`).
 
 ### Reconciler behavior
 
-- The reconciler probes GitHub's commits API for each entry's `subpath` / `ref` and skips fetching the tarball when the installed `managed_ref` matches the latest SHA. Full-SHA URLs skip the probe.
+- The reconciler probes GitHub's commits API for each entry's `subpath` and `ref`, and skips fetching the tarball when the installed `managed_ref` matches the latest SHA. Full-SHA URLs skip the probe.
 - Managed skills present in the install but missing from the manifest are **removed**.
 - User-authored skills are never touched. If a user-authored skill has the same name as a manifest entry, the reconciler leaves it alone and reports a per-entry error.
 - A manual **Sync managed skills** button appears in the Skills panel when any managed skill is installed.
 - A `POST /notebook-intelligence/skills/reconcile` endpoint is available for scripted triggers.
-- If the manifest cannot be loaded (network, bad YAML, missing `skills:` list), the reconciler logs the error and leaves all managed skills in place rather than mass-deleting on a transient failure.
+- If the manifest cannot be loaded (network failure, bad YAML, missing `skills:` list), the reconciler logs the error and leaves all managed skills in place rather than mass-deleting on a transient failure.
 
 ### Multi-tenant scoping
 
@@ -77,4 +77,4 @@ Different JupyterHub profiles or spawner configurations can point at different m
 
 ### Disabling user-initiated GitHub imports
 
-There is currently no flag that disables the **Import from GitHub** button. If your deployment cannot allow users to pull arbitrary public repos, the workaround is to gate egress to `github.com` and `api.github.com` at the network layer and rely on `NBI_SKILLS_MANIFEST` with a private internal manifest URL. Tracking this as a future feature.
+There is currently no flag that disables the **Import from GitHub** button. If your deployment cannot allow users to pull arbitrary public repos, gate egress to `github.com` and `api.github.com` at the network layer and rely on `NBI_SKILLS_MANIFEST` with a private internal manifest URL. Tracked as a future feature.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,109 @@
+# Troubleshooting
+
+Common problems with copy-pasteable fixes. If your problem isn't listed, open an issue with the information requested in [CONTRIBUTING.md](../CONTRIBUTING.md#filing-a-good-bug-report).
+
+## "Extension installed but I don't see anything in JupyterLab"
+
+After `pip install notebook-intelligence`, you must restart JupyterLab. If a restart doesn't help, verify both halves of the extension are enabled:
+
+```bash
+jupyter server extension list   # look for "notebook_intelligence  enabled"
+jupyter labextension list       # look for "@notebook-intelligence/notebook-intelligence ... enabled"
+```
+
+If either is disabled or missing:
+
+```bash
+jupyter server extension enable notebook_intelligence
+pip install --force-reinstall notebook-intelligence   # if the labextension is missing
+```
+
+The chat sidebar appears as a left-rail icon in the JupyterLab UI. Click it to open the panel.
+
+## "GitHub login window doesn't open" / Copilot login does nothing
+
+NBI uses GitHub's device-flow login. The server extension prints the URL and one-time code to the JupyterLab terminal. Look there first.
+
+If the popup is blocked by your browser, copy the URL from the terminal output and paste it into a new tab.
+
+If the device-flow request itself fails (timeout, network error), check that your network allows outbound HTTPS to `github.com` and `api.githubcopilot.com`. See [`PRIVACY.md`](../PRIVACY.md#egress-allowlist) for the full egress list.
+
+## "It says 'no models available'"
+
+This means NBI started successfully but the configured provider returned an empty model list. Check, in order:
+
+1. **Provider auth** — open the NBI Settings dialog. For GitHub Copilot, sign in. For Claude, OpenAI-compatible, or LiteLLM-compatible, paste an API key. For Ollama, ensure the daemon is running locally.
+2. **Custom Base URL** — if you set one, confirm it points at the provider's chat-completions endpoint and that it's reachable from the JupyterLab process.
+3. **Provider gating** — if your admin disabled the provider via `disabled_providers`, the dropdown won't list its models. See [`docs/admin-guide.md`](admin-guide.md#restricting-features-for-managed-deployments).
+4. **Model refresh** — for Claude, click the refresh button in the Claude settings panel.
+
+## "I'm getting a 401"
+
+A 401 from the LLM provider almost always means an expired or invalid API key.
+
+- **GitHub Copilot** — sign out and sign in again from NBI Settings → GitHub Copilot.
+- **Claude / OpenAI / LiteLLM** — paste a fresh key in NBI Settings → respective provider.
+- **Stored Copilot token corrupted** — delete `~/.jupyter/nbi/user-data.json` and sign in again.
+
+A 401 from a managed-skills manifest fetch means `NBI_MANAGED_SKILLS_TOKEN` is missing or expired. The reconciler logs the failure and leaves installed managed skills in place.
+
+## Claude mode does nothing / hangs on "Thinking…"
+
+Claude mode requires the [Claude Code CLI](https://code.claude.com/) on the user's `PATH`. If the CLI is missing or fails to start, the chat sidebar will hang.
+
+```bash
+which claude   # should print a path
+claude --version
+```
+
+If `claude` is installed but in a non-default location, set the **Claude CLI path** in NBI Settings → Claude.
+
+If Claude mode worked previously but is now stuck, check the JupyterLab terminal for `claude-agent-sdk` errors. A failed-to-start agent thread is the usual culprit; restart JupyterLab to retry.
+
+## MCP server crashes / tools missing in `@mcp`
+
+MCP stdio servers run as subprocesses of the user's Jupyter Server. If a server crashes at startup:
+
+1. Check the JupyterLab terminal for the server's stderr output.
+2. Verify the `command` and `args` in `~/.jupyter/nbi/mcp.json` are correct and that the binary is on `PATH`.
+3. For `npx -y` servers, confirm Node.js is installed (`node --version`).
+4. Use the **Reload MCP servers** action from NBI Settings → MCP after fixing the config — this re-runs the discovery without restarting JupyterLab.
+
+If the LLM is connected but tools aren't being called, confirm the model supports tool calling. All GitHub Copilot models do; for other providers, check the provider's docs.
+
+## Where do logs live and how do I turn on debug?
+
+NBI does not have a separate log file. Server-side messages go to **stderr of the JupyterLab process** — the terminal where you ran `jupyter lab`.
+
+To see more detail:
+
+```bash
+jupyter lab --debug
+```
+
+Frontend errors go to the **browser DevTools console** (Cmd+Option+I on macOS, Ctrl+Shift+I on Linux/Windows). Look for messages tagged `[NBI]`.
+
+For configuration inspection:
+
+```bash
+cat ~/.jupyter/nbi/config.json
+cat ~/.jupyter/nbi/mcp.json
+ls ~/.jupyter/nbi/rules/         # ruleset files
+ls ~/.claude/skills/             # Claude skills
+ls ~/.claude/projects/           # Claude session transcripts
+```
+
+> Do not share the contents of `~/.jupyter/nbi/config.json` or `~/.jupyter/nbi/user-data.json` — they may contain API keys or your encrypted GitHub token.
+
+## "Skills reloaded" banner keeps appearing
+
+The Claude SDK session is reloaded whenever a skill changes on disk. If you have a script or editor that frequently rewrites files under `~/.claude/skills/` (autoformatter, sync tool), it will trigger this. Pause the writer or move the skill out of `~/.claude/skills/` while editing.
+
+## Inline completion is too aggressive / too quiet
+
+Tune the debounce delay in NBI Settings → Inline completion. Lower delays = more requests = higher cost on paid providers. The default balances responsiveness against cost.
+
+## Still stuck?
+
+- Check [GitHub issues](https://github.com/notebook-intelligence/notebook-intelligence/issues) for similar reports.
+- Open a new issue including the information listed in [CONTRIBUTING.md](../CONTRIBUTING.md#filing-a-good-bug-report).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,7 +4,7 @@ Common problems with copy-pasteable fixes. If your problem isn't listed, open an
 
 ## "Extension installed but I don't see anything in JupyterLab"
 
-After `pip install notebook-intelligence`, you must restart JupyterLab. If a restart doesn't help, verify both halves of the extension are enabled:
+After `pip install notebook-intelligence`, restart JupyterLab. If a restart doesn't help, verify both halves of the extension are enabled:
 
 ```bash
 jupyter server extension list   # look for "notebook_intelligence  enabled"
@@ -20,21 +20,21 @@ pip install --force-reinstall notebook-intelligence   # if the labextension is m
 
 The chat sidebar appears as a left-rail icon in the JupyterLab UI. Click it to open the panel.
 
-## "GitHub login window doesn't open" / Copilot login does nothing
+## "GitHub login window doesn't open" or Copilot login does nothing
 
 NBI uses GitHub's device-flow login. The server extension prints the URL and one-time code to the JupyterLab terminal. Look there first.
 
-If the popup is blocked by your browser, copy the URL from the terminal output and paste it into a new tab.
+If your browser blocks the popup, copy the URL from the terminal output and paste it into a new tab.
 
 If the device-flow request itself fails (timeout, network error), check that your network allows outbound HTTPS to `github.com` and `api.githubcopilot.com`. See [`PRIVACY.md`](../PRIVACY.md#egress-allowlist) for the full egress list.
 
 ## "It says 'no models available'"
 
-This means NBI started successfully but the configured provider returned an empty model list. Check, in order:
+NBI started successfully but the configured provider returned an empty model list. Check, in order:
 
-1. **Provider auth** — open the NBI Settings dialog. For GitHub Copilot, sign in. For Claude, OpenAI-compatible, or LiteLLM-compatible, paste an API key. For Ollama, ensure the daemon is running locally.
+1. **Provider auth** — open the NBI Settings dialog. For GitHub Copilot, sign in. For OpenAI-compatible or LiteLLM-compatible, paste an API key. For Ollama, ensure the daemon is running locally. For Claude mode, paste an Anthropic API key in the Claude tab.
 2. **Custom Base URL** — if you set one, confirm it points at the provider's chat-completions endpoint and that it's reachable from the JupyterLab process.
-3. **Provider gating** — if your admin disabled the provider via `disabled_providers`, the dropdown won't list its models. See [`docs/admin-guide.md`](admin-guide.md#restricting-features-for-managed-deployments).
+3. **Provider gating** — if your admin disabled the provider via `disabled_providers`, the dropdown won't list its models. See [`admin-guide.md`](admin-guide.md#restricting-features-for-managed-deployments).
 4. **Model refresh** — for Claude, click the refresh button in the Claude settings panel.
 
 ## "I'm getting a 401"
@@ -42,36 +42,36 @@ This means NBI started successfully but the configured provider returned an empt
 A 401 from the LLM provider almost always means an expired or invalid API key.
 
 - **GitHub Copilot** — sign out and sign in again from NBI Settings → GitHub Copilot.
-- **Claude / OpenAI / LiteLLM** — paste a fresh key in NBI Settings → respective provider.
+- **OpenAI-compatible, LiteLLM-compatible, or Claude** — paste a fresh key in NBI Settings under the respective provider.
 - **Stored Copilot token corrupted** — delete `~/.jupyter/nbi/user-data.json` and sign in again.
 
 A 401 from a managed-skills manifest fetch means `NBI_MANAGED_SKILLS_TOKEN` is missing or expired. The reconciler logs the failure and leaves installed managed skills in place.
 
-## Claude mode does nothing / hangs on "Thinking…"
+## Claude mode does nothing or hangs on "Thinking…"
 
-Claude mode requires the [Claude Code CLI](https://code.claude.com/) on the user's `PATH`. If the CLI is missing or fails to start, the chat sidebar will hang.
+Claude mode requires the [Claude Code CLI](https://code.claude.com/) on the user's `PATH`. If the CLI is missing or fails to start, the chat sidebar hangs.
 
 ```bash
 which claude   # should print a path
 claude --version
 ```
 
-If `claude` is installed but in a non-default location, set the **Claude CLI path** in NBI Settings → Claude.
+If `claude` is installed in a non-default location, set the `NBI_CLAUDE_CLI_PATH` environment variable to its absolute path before starting JupyterLab.
 
 If Claude mode worked previously but is now stuck, check the JupyterLab terminal for `claude-agent-sdk` errors. A failed-to-start agent thread is the usual culprit; restart JupyterLab to retry.
 
-## MCP server crashes / tools missing in `@mcp`
+## MCP server crashes or tools missing in `@mcp`
 
 MCP stdio servers run as subprocesses of the user's Jupyter Server. If a server crashes at startup:
 
 1. Check the JupyterLab terminal for the server's stderr output.
-2. Verify the `command` and `args` in `~/.jupyter/nbi/mcp.json` are correct and that the binary is on `PATH`.
+2. Verify the `command` and `args` in `~/.jupyter/nbi/mcp.json` are correct and the binary is on `PATH`.
 3. For `npx -y` servers, confirm Node.js is installed (`node --version`).
-4. Use the **Reload MCP servers** action from NBI Settings → MCP after fixing the config — this re-runs the discovery without restarting JupyterLab.
+4. Use the **Reload MCP servers** action from NBI Settings → MCP after fixing the config — this re-runs discovery without restarting JupyterLab.
 
 If the LLM is connected but tools aren't being called, confirm the model supports tool calling. All GitHub Copilot models do; for other providers, check the provider's docs.
 
-## Where do logs live and how do I turn on debug?
+## Where do logs live, and how do I turn on debug?
 
 NBI does not have a separate log file. Server-side messages go to **stderr of the JupyterLab process** — the terminal where you ran `jupyter lab`.
 
@@ -81,7 +81,7 @@ To see more detail:
 jupyter lab --debug
 ```
 
-Frontend errors go to the **browser DevTools console** (Cmd+Option+I on macOS, Ctrl+Shift+I on Linux/Windows). Look for messages tagged `[NBI]`.
+Frontend errors go to the **browser DevTools console** (`Cmd+Option+I` on macOS, `Ctrl+Shift+I` on Linux or Windows). Look for messages from `notebook-intelligence`.
 
 For configuration inspection:
 
@@ -93,15 +93,15 @@ ls ~/.claude/skills/             # Claude skills
 ls ~/.claude/projects/           # Claude session transcripts
 ```
 
-> Do not share the contents of `~/.jupyter/nbi/config.json` or `~/.jupyter/nbi/user-data.json` — they may contain API keys or your encrypted GitHub token.
+> Do not share the contents of `~/.jupyter/nbi/config.json` or `~/.jupyter/nbi/user-data.json` — they contain API keys or your encrypted GitHub token.
 
 ## "Skills reloaded" banner keeps appearing
 
-The Claude SDK session is reloaded whenever a skill changes on disk. If you have a script or editor that frequently rewrites files under `~/.claude/skills/` (autoformatter, sync tool), it will trigger this. Pause the writer or move the skill out of `~/.claude/skills/` while editing.
+NBI reloads the Claude SDK session whenever a skill changes on disk. If a script or editor frequently rewrites files under `~/.claude/skills/` (autoformatter, sync tool), it triggers the banner. Pause the writer or move the skill out of `~/.claude/skills/` while editing.
 
-## Inline completion is too aggressive / too quiet
+## Inline completion is too aggressive or too quiet
 
-Tune the debounce delay in NBI Settings → Inline completion. Lower delays = more requests = higher cost on paid providers. The default balances responsiveness against cost.
+Tune the debounce delay in NBI Settings → Inline completion. Lower delays mean more requests, which means higher cost on paid providers. The default balances responsiveness against cost.
 
 ## Still stuck?
 


### PR DESCRIPTION
_**You are going to want to review this carefully and probably make many changes (if you even decide to merge it). It was just a stab at improving the docs for different types of users.**_

## Summary

Restructure NBI's documentation into three tiers — user-facing in the README, top-level files for changelog/security/privacy/contributing, and a `docs/` tree for operator-facing material.

### What changed

- **README.md**: Added a generated table of contents. Tightened the intro, fixed an internal contradiction in the Claude mode description (the chat panel uses Claude Code; inline chat and auto-complete use Claude models via the Anthropic API). Moved blog-post links out of the "Chat interface" subsection into a dedicated "Further reading" section. Moved ruleset and skills detail into their own docs.
- **SECURITY.md** *(new)*: Private-disclosure address, supported versions, scope.
- **PRIVACY.md** *(new)*: Per-provider data-flow table, egress allowlist, local-storage paths, privacy-sensitive deployment recipes.
- **CHANGELOG.md**: Rewritten in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format, backfilled v4.0.0 through v4.5.0 from `git log`.
- **CONTRIBUTING.md**: Added a bug-report checklist, an architecture overview pointing at the load-bearing modules on both halves of the extension, and a pointer to `SECURITY.md`.
- **docs/admin-guide.md** *(new)*: Deployment-focused — env vars + traitlets master table, security model, self-hosted endpoints, custom CA / corporate proxy, air-gap recipe, HIPAA preset, multi-tenancy, full HTTP API surface, FIPS posture, failure modes.
- **docs/skills.md** *(new)*: Skills tab UI, Import-from-GitHub auth chain, managed-skills manifest schema and reconciler behavior.
- **docs/rulesets.md** *(new)*: Discovery layout, frontmatter reference, auto-reload.
- **docs/troubleshooting.md** *(new)*: Common problems with copy-pasteable fixes.

### Why

NBI's deployment story (JupyterHub, KubeSpawner, multi-tenant, regulated environments) was undocumented, and the prior README mixed user-facing material with ruleset/skills detail that operators wanted to consume in isolation. Splitting by audience keeps each surface concise and lets the README focus on the install-and-go path.

## Test plan

- [x] `jlpm lint:check` — prettier clean; the three pre-existing eslint warnings in `src/` are unrelated.
- [x] All TOC anchors resolve to real H2/H3 headings (verified programmatically).
- [x] All cross-doc links (`docs/...`, `../...`, `#anchor`) resolve.
- [x] Spot-check rendering on GitHub before merging.