### PR TITLE
feat(claude): stream inline-chat responses

### DIFF
--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -189,22 +189,57 @@ class ClaudeChatModel(ChatModel):
         return self._supports_tools
 
     def completions(self, messages: list[dict], tools: list[dict] = None, response: ChatResponse = None, cancel_token: CancelToken = None, options: dict = {}) -> Any:
-        resp = self._client.messages.create(
-            model=self._model_id,
-            max_tokens=10000,
-            messages=messages
-        )
-
-        for block in resp.content:
-            if isinstance(block, AnthropicTextBlock):
+        # Use the streaming endpoint so the inline-chat diff pane fills in
+        # progressively instead of staying empty until the whole response
+        # lands. Each text delta is forwarded as its own LLMRaw payload so the
+        # front-end accumulator (chat-sidebar.tsx InlinePopoverComponent)
+        # appends it directly to the modified-code state.
+        if cancel_token is not None and cancel_token.is_cancel_requested:
+            # A fast CancelChatRequest can flip the token before the worker
+            # thread reaches us. Bail out before opening the stream so we
+            # don't burn an Anthropic request whose output has nowhere to go.
+            response.finish()
+            return
+        try:
+            with self._client.messages.stream(
+                model=self._model_id,
+                max_tokens=10000,
+                messages=messages
+            ) as stream:
+                for chunk in stream.text_stream:
+                    if cancel_token is not None and cancel_token.is_cancel_requested:
+                        break
+                    if not chunk:
+                        continue
+                    response.stream({
+                        "choices": [{
+                            "delta": {
+                                "role": "assistant",
+                                "content": chunk
+                            }
+                        }]
+                    })
+        except Exception as e:
+            # The outer inline-chat handler reports failures as MarkdownData,
+            # but the diff pane only consumes payloads with delta.content, so
+            # that error never reaches the user — they'd see partial code
+            # silently fence-stripped on StreamEnd and assume it was final.
+            # Push a plain-text marker into the same channel so the partial
+            # output is visibly annotated, plus a structured nbi_stream_error
+            # field so the fresh-generation auto-insert path in index.ts can
+            # detect the failure and skip writing the partial buffer to the
+            # user's cell. Re-raise so the caller logs and runs finish().
+            if response is not None:
                 response.stream({
                     "choices": [{
                         "delta": {
                             "role": "assistant",
-                            "content": block.text
+                            "content": f"\n\n[Stream interrupted: {e}]"
                         }
-                    }]
+                    }],
+                    "nbi_stream_error": str(e)
                 })
+            raise
 
         response.finish()
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -3,7 +3,6 @@
 import { ServerConnection } from '@jupyterlab/services';
 import { requestAPI } from './handler';
 import { URLExt } from '@jupyterlab/coreutils';
-import { UUID } from '@lumino/coreutils';
 import { Signal } from '@lumino/signaling';
 import {
   GITHUB_COPILOT_PROVIDER_ID,
@@ -750,6 +749,7 @@ export class NBIAPI {
   }
 
   static async generateCode(
+    messageId: string,
     chatId: string,
     prompt: string,
     prefix: string,
@@ -759,7 +759,6 @@ export class NBIAPI {
     filename: string,
     responseEmitter: IChatCompletionResponseEmitter
   ) {
-    const messageId = UUID.uuid4();
     this._subscribeUntilStreamEnd(messageId, responseEmitter);
     this._webSocket.send(
       JSON.stringify({

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -139,7 +139,10 @@ export interface IInlinePromptWidgetOptions {
   onRequestSubmitted: (prompt: string) => void;
   onRequestCancelled: () => void;
   onContentStream: (content: string) => void;
-  onContentStreamEnd: () => void;
+  // streamError is the backend's structured nbi_stream_error field, set
+  // when ClaudeChatModel.completions interrupts mid-stream. Auto-insert
+  // callers should skip applying generated content when it is non-null.
+  onContentStreamEnd: (streamError?: string | null) => void;
   onUpdatedCodeChange: (content: string) => void;
   onUpdatedCodeAccepted: () => void;
   telemetryEmitter: ITelemetryEmitter;
@@ -173,6 +176,12 @@ export class InlinePromptWidget extends ReactWidget {
 
   _onResponse(response: any) {
     if (response.type === BackendMessageType.StreamMessage) {
+      // Backend sets nbi_stream_error alongside the [Stream interrupted]
+      // marker delta. Capture it so onContentStreamEnd can tell the
+      // auto-insert path to skip writing the partial buffer.
+      if (typeof response.data?.nbi_stream_error === 'string') {
+        this._streamError = response.data.nbi_stream_error;
+      }
       const delta = response.data['choices']?.[0]?.['delta'];
       if (!delta) {
         return;
@@ -184,7 +193,8 @@ export class InlinePromptWidget extends ReactWidget {
       }
       this._options.onContentStream(responseMessage);
     } else if (response.type === BackendMessageType.StreamEnd) {
-      this._options.onContentStreamEnd();
+      this._options.onContentStreamEnd(this._streamError);
+      this._streamError = null;
       const timeElapsed =
         (new Date().getTime() - this._requestTime.getTime()) / 1000;
       this._options.telemetryEmitter.emitTelemetryEvent({
@@ -239,6 +249,7 @@ export class InlinePromptWidget extends ReactWidget {
 
   private _options: IInlinePromptWidgetOptions;
   private _requestTime: Date;
+  private _streamError: string | null = null;
 }
 
 export class GitHubCopilotStatusBarItem extends ReactWidget {
@@ -949,6 +960,7 @@ async function submitCompletionRequest(
     }
     case RunChatCompletionType.GenerateCode:
       return NBIAPI.generateCode(
+        request.messageId,
         request.chatId,
         request.content,
         request.prefix || '',
@@ -3217,17 +3229,48 @@ function SidebarComponent(props: any) {
 function InlinePopoverComponent(props: any) {
   const [modifiedCode, setModifiedCode] = useState<string>('');
   const [promptSubmitted, setPromptSubmitted] = useState(false);
+  // Tracks the in-flight backend request so Escape / Cancel / Accept can
+  // stop it via CancelChatRequest. Cleared on StreamEnd so a stale cancel
+  // doesn't fire after the response already finished.
+  const inflightMessageIdRef = useRef<string | null>(null);
+  // Mirrors InlinePromptWidget._streamError so this component can branch
+  // on it independently. Set when the backend tags a delta with
+  // nbi_stream_error; cleared on the next submit / StreamEnd.
+  const streamErrorRef = useRef<string | null>(null);
   const originalOnRequestSubmitted = props.onRequestSubmitted;
   const originalOnResponseEmit = props.onResponseEmit;
+  const originalOnRequestCancelled = props.onRequestCancelled;
+  const originalOnUpdatedCodeAccepted = props.onUpdatedCodeAccepted;
+
+  const cancelInflightRequest = () => {
+    const messageId = inflightMessageIdRef.current;
+    if (!messageId) {
+      return;
+    }
+    // Backend matches cancellations by websocket message id (see
+    // WebsocketCopilotHandler.on_message). Without this send the request
+    // keeps streaming server-side after the popover dismisses, burning
+    // tokens and wasting an inference.
+    NBIAPI.sendWebSocketMessage(
+      messageId,
+      RequestDataType.CancelChatRequest,
+      {}
+    );
+    inflightMessageIdRef.current = null;
+  };
 
   const onRequestSubmitted = (prompt: string) => {
     setModifiedCode('');
     setPromptSubmitted(true);
+    streamErrorRef.current = null;
     originalOnRequestSubmitted(prompt);
   };
 
   const onResponseEmit = (response: any) => {
     if (response.type === BackendMessageType.StreamMessage) {
+      if (typeof response.data?.nbi_stream_error === 'string') {
+        streamErrorRef.current = response.data.nbi_stream_error;
+      }
       const delta = response.data['choices']?.[0]?.['delta'];
       if (!delta) {
         return;
@@ -3239,12 +3282,45 @@ function InlinePopoverComponent(props: any) {
       }
       setModifiedCode((modifiedCode: string) => modifiedCode + responseMessage);
     } else if (response.type === BackendMessageType.StreamEnd) {
-      setModifiedCode((modifiedCode: string) =>
-        extractLLMGeneratedCode(modifiedCode)
-      );
+      // Only fence-strip on a clean stream. On error the marker has to
+      // stay visible in the diff pane so the modify-existing user has a
+      // persistent failure signal before deciding to Accept the
+      // truncated result.
+      if (!streamErrorRef.current) {
+        setModifiedCode((modifiedCode: string) =>
+          extractLLMGeneratedCode(modifiedCode)
+        );
+      }
+      // streamErrorRef intentionally outlives StreamEnd: Accept fires
+      // afterwards and needs to know the stream errored so it can
+      // dismiss instead of writing an empty buffer over the user's
+      // selection. Cleared on the next submit (see onRequestSubmitted).
+      inflightMessageIdRef.current = null;
     }
 
     originalOnResponseEmit(response);
+  };
+
+  const onRequestCancelled = () => {
+    cancelInflightRequest();
+    originalOnRequestCancelled();
+  };
+
+  // Accept on a partial diff used to leave the backend stream running
+  // off-screen, spending tokens on output the UI no longer used. Cancel
+  // the in-flight request before applying so a mid-stream Accept
+  // releases the upstream call too. When the stream errored the buffer
+  // is at best truncated and at worst marker-only, which would write an
+  // empty string over the user's selection — extractLLMGeneratedCode
+  // strips the marker and the remainder is just whitespace. Treat
+  // Accept as cancel in that case so the selection survives.
+  const onUpdatedCodeAccepted = () => {
+    if (streamErrorRef.current) {
+      onRequestCancelled();
+      return;
+    }
+    cancelInflightRequest();
+    originalOnUpdatedCodeAccepted();
   };
 
   return (
@@ -3253,7 +3329,11 @@ function InlinePopoverComponent(props: any) {
         {...props}
         onRequestSubmitted={onRequestSubmitted}
         onResponseEmit={onResponseEmit}
-        onUpdatedCodeAccepted={props.onUpdatedCodeAccepted}
+        onRequestCancelled={onRequestCancelled}
+        onMessageIdChange={(id: string) => {
+          inflightMessageIdRef.current = id;
+        }}
+        onUpdatedCodeAccepted={onUpdatedCodeAccepted}
         limitHeight={props.existingCode !== '' && promptSubmitted}
       />
       {props.existingCode !== '' && promptSubmitted && (
@@ -3263,7 +3343,7 @@ function InlinePopoverComponent(props: any) {
             <div>
               <button
                 className="jp-Button jp-mod-accept jp-mod-styled jp-mod-small"
-                onClick={() => props.onUpdatedCodeAccepted()}
+                onClick={() => onUpdatedCodeAccepted()}
               >
                 Accept
               </button>
@@ -3271,7 +3351,7 @@ function InlinePopoverComponent(props: any) {
             <div>
               <button
                 className="jp-Button jp-mod-reject jp-mod-styled jp-mod-small"
-                onClick={() => props.onRequestCancelled()}
+                onClick={() => onRequestCancelled()}
               >
                 Cancel
               </button>
@@ -3347,9 +3427,14 @@ function InlinePromptComponent(props: any) {
       }
     }
 
+    const messageId = UUID.uuid4();
+    // Hand the id back to the popover so its cancel handler can send a
+    // CancelChatRequest with the matching id.
+    props.onMessageIdChange?.(messageId);
+
     submitCompletionRequest(
       {
-        messageId: UUID.uuid4(),
+        messageId,
         chatId: UUID.uuid4(),
         type: RunChatCompletionType.GenerateCode,
         content: prompt,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1663,8 +1663,23 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
           }
           generatedContent += content;
         },
-        onContentStreamEnd: () => {
+        onContentStreamEnd: (streamError?: string | null) => {
           if (existingCode !== '') {
+            return;
+          }
+          if (streamError) {
+            // The backend tagged this stream as interrupted. Discard the
+            // partial buffer rather than auto-inserting truncated code (or
+            // worse, the [Stream interrupted] marker text itself) into the
+            // user's cell, and surface the failure as a toast.
+            generatedContent = '';
+            removePopover();
+            app.commands.execute('apputils:notify', {
+              message: `Inline chat failed: ${streamError}`,
+              type: 'error',
+              options: { autoClose: true }
+            });
+            editor.focus();
             return;
           }
           applyGeneratedCode();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -56,6 +56,20 @@ export function moveCodeSectionBoundaryMarkersToNewLine(
 }
 
 export function extractLLMGeneratedCode(code: string): string {
+  // Strip our backend-emitted stream-interruption marker. The Claude inline
+  // handler pushes it into the same text channel so the diff pane shows
+  // what went wrong, but we never want it landing verbatim in the user's
+  // file when fresh-generation auto-inserts the result (or when the user
+  // accepts a truncated diff). The pattern is anchored to end-of-string
+  // because the backend always emits the marker as the last delta, and
+  // its closing bracket is required so legitimate generated code that
+  // happens to contain the phrase mid-buffer (e.g.
+  // ``print("[Stream interrupted: demo]")``) is not stripped. Greedy
+  // ``[^\n]*\]`` backtracks to the last ``]`` on the marker line, so
+  // bracketed exception strings such as
+  // ``[SSL: CERTIFICATE_VERIFY_FAILED] unable to get local issuer certificate``
+  // and ``[Errno 11001] getaddrinfo failed`` are still matched in full.
+  code = code.replace(/\n*\[Stream interrupted:[^\n]*\]\n*$/, '');
   if (code.endsWith('```')) {
     code = code.slice(0, -3);
   }

--- a/tests/test_claude_client.py
+++ b/tests/test_claude_client.py
@@ -22,6 +22,7 @@ from notebook_intelligence.api import ChatResponse, MarkdownData
 from notebook_intelligence.claude import (
     ClaudeAgentClientStatus,
     ClaudeAgentEventType,
+    ClaudeChatModel,
     ClaudeCodeChatParticipant,
     ClaudeCodeClient,
     SignalImpl,
@@ -503,6 +504,286 @@ class TestHandleChatRequestErrorHandling:
         # shouldn't have touched the response.
         response.finish.assert_not_called()
         response.stream.assert_not_called()
+
+
+class _FakeMessageStream:
+    """Stand-in for the Anthropic SDK's MessageStreamManager.
+
+    The SDK returns a sync context manager whose ``text_stream`` attribute
+    yields decoded text deltas. ``ClaudeChatModel.completions`` only touches
+    those two pieces, so the fake mirrors exactly that surface."""
+
+    def __init__(self, chunks):
+        self.text_stream = iter(chunks)
+        self.entered = False
+        self.exited = False
+
+    def __enter__(self):
+        self.entered = True
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.exited = True
+        return False
+
+
+def _make_chat_model(chunks):
+    """Build a ``ClaudeChatModel`` without calling __init__ (avoids hitting
+    the live Anthropic API). The returned model has its ``_client.messages
+    .stream`` wired to a ``_FakeMessageStream`` that yields ``chunks``."""
+    model = ClaudeChatModel.__new__(ClaudeChatModel)
+    model._model_id = "claude-sonnet-test"
+    model._model_name = "Claude Sonnet (test)"
+    model._context_window = 200000
+    model._supports_tools = True
+    model._client = MagicMock()
+    fake_stream = _FakeMessageStream(chunks)
+    model._client.messages.stream = MagicMock(return_value=fake_stream)
+    return model, fake_stream
+
+
+class TestClaudeChatModelStreaming:
+    """``ClaudeChatModel.completions`` powers Claude-mode inline chat
+    (Ctrl+G). It must stream deltas as they arrive so the diff pane fills
+    in progressively, honour the cancel token between chunks, and always
+    end with ``response.finish()`` so the front-end stops the spinner."""
+
+    def test_each_chunk_is_streamed_as_its_own_delta(self):
+        # Three deltas in -> three response.stream calls out -> one finish.
+        # Proves we no longer buffer the whole response into a single delta.
+        model, fake_stream = _make_chat_model(["def ", "foo():", "\n    pass"])
+        response = MagicMock()
+
+        model.completions(messages=[{"role": "user", "content": "x"}], response=response)
+
+        assert response.stream.call_count == 3
+        emitted = [
+            call.args[0]["choices"][0]["delta"]["content"]
+            for call in response.stream.call_args_list
+        ]
+        assert emitted == ["def ", "foo():", "\n    pass"]
+        response.finish.assert_called_once()
+        # Context manager entered and exited cleanly so the SDK can release
+        # the underlying HTTP stream.
+        assert fake_stream.entered and fake_stream.exited
+
+    def test_uses_messages_stream_not_messages_create(self):
+        # Regression guard: if someone reverts this to messages.create the
+        # diff pane goes back to "empty until done". Easier to assert the
+        # API choice directly than to test the user-visible symptom.
+        model, _ = _make_chat_model(["hi"])
+        response = MagicMock()
+
+        model.completions(messages=[{"role": "user", "content": "x"}], response=response)
+
+        model._client.messages.stream.assert_called_once()
+        kwargs = model._client.messages.stream.call_args.kwargs
+        assert kwargs["model"] == "claude-sonnet-test"
+        assert kwargs["messages"] == [{"role": "user", "content": "x"}]
+        assert kwargs["max_tokens"] == 10000
+        model._client.messages.create.assert_not_called()
+
+    def test_empty_chunks_are_skipped(self):
+        # The Anthropic stream can occasionally yield empty strings between
+        # content blocks. Forwarding those wastes a websocket frame and
+        # creates an empty assistant turn in the front-end's accumulator.
+        model, _ = _make_chat_model(["hello", "", " world", ""])
+        response = MagicMock()
+
+        model.completions(messages=[{"role": "user", "content": "x"}], response=response)
+
+        assert response.stream.call_count == 2
+        emitted = [
+            call.args[0]["choices"][0]["delta"]["content"]
+            for call in response.stream.call_args_list
+        ]
+        assert emitted == ["hello", " world"]
+
+    def test_pre_cancelled_request_skips_anthropic_stream_open(self):
+        # A fast CancelChatRequest can flip the token before the worker
+        # thread reaches completions(). The check must run BEFORE the with
+        # block, otherwise the underlying messages.stream call still opens
+        # the HTTP request and burns an Anthropic call whose output has
+        # nowhere to go. finish() still runs so the websocket end event
+        # closes the front-end's spinner.
+        model, _ = _make_chat_model(["alpha", "beta"])
+        response = MagicMock()
+        cancel_token = MagicMock()
+        cancel_token.is_cancel_requested = True
+
+        model.completions(
+            messages=[{"role": "user", "content": "x"}],
+            response=response,
+            cancel_token=cancel_token,
+        )
+
+        # The actual API call must not have been opened — that's the whole
+        # point of the early-out. Asserting on response.stream alone (as an
+        # earlier version of this test did) was a false positive: a fake
+        # MessageStreamManager has no side effect analogous to opening the
+        # HTTP stream, so a missing emit doesn't prove the network was
+        # spared.
+        model._client.messages.stream.assert_not_called()
+        response.stream.assert_not_called()
+        response.finish.assert_called_once()
+
+    def test_cancel_token_short_circuits_mid_stream(self):
+        # User hits Escape while Claude is mid-response. The token flips on
+        # the next iteration so we stop emitting and let the with-block
+        # close the stream — abandoning the rest of the chunks.
+        model, _ = _make_chat_model(["alpha", "beta", "gamma"])
+        response = MagicMock()
+        cancel_token = MagicMock()
+        # Allow one chunk, then request cancel before the second.
+        cancel_token.is_cancel_requested = False
+
+        emit_count = {"n": 0}
+        original_stream = response.stream
+
+        def stream_then_cancel(payload):
+            original_stream(payload)
+            emit_count["n"] += 1
+            if emit_count["n"] == 1:
+                cancel_token.is_cancel_requested = True
+
+        response.stream = stream_then_cancel
+
+        model.completions(
+            messages=[{"role": "user", "content": "x"}],
+            response=response,
+            cancel_token=cancel_token,
+        )
+
+        # First chunk slipped through, second triggered the cancel check
+        # and broke the loop, third never reached the user.
+        emitted = [
+            payload["choices"][0]["delta"]["content"]
+            for (payload,), _ in original_stream.call_args_list
+        ]
+        assert emitted == ["alpha"]
+        # finish() still runs so the front-end's spinner closes — the user
+        # already saw the popover dismiss on Escape, but the websocket end
+        # event must arrive regardless.
+        response.finish.assert_called_once()
+
+    def test_no_cancel_token_is_safe(self):
+        # The non-Claude code paths still call completions without a cancel
+        # token. Defaulting to None must not crash.
+        model, _ = _make_chat_model(["a", "b"])
+        response = MagicMock()
+
+        model.completions(
+            messages=[{"role": "user", "content": "x"}],
+            response=response,
+            cancel_token=None,
+        )
+
+        assert response.stream.call_count == 2
+        response.finish.assert_called_once()
+
+    def test_mid_stream_exception_emits_error_marker_and_reraises(self):
+        # Anthropic raising mid-stream used to leave the diff pane showing
+        # silently truncated code (the outer handler's MarkdownData error
+        # never reaches the inline popover, which only consumes payloads with
+        # delta.content). The fix surfaces the failure as a final delta into
+        # the same channel and re-raises so the caller still finishes.
+        class ExplodingStream(_FakeMessageStream):
+            def __init__(self, before_chunks, exc):
+                super().__init__(before_chunks)
+                self._exc = exc
+
+                def gen():
+                    for c in before_chunks:
+                        yield c
+                    raise exc
+
+                self.text_stream = gen()
+
+        model = ClaudeChatModel.__new__(ClaudeChatModel)
+        model._model_id = "claude-sonnet-test"
+        model._model_name = "Claude Sonnet (test)"
+        model._context_window = 200000
+        model._supports_tools = True
+        model._client = MagicMock()
+        boom = RuntimeError("connection reset by peer")
+        model._client.messages.stream = MagicMock(
+            return_value=ExplodingStream(["def add(a, b):\n", "    return a + b"], boom)
+        )
+        response = MagicMock()
+
+        try:
+            model.completions(
+                messages=[{"role": "user", "content": "x"}], response=response
+            )
+        except RuntimeError as e:
+            assert e is boom
+        else:
+            raise AssertionError("expected the underlying stream error to propagate")
+
+        payloads = [call.args[0] for call in response.stream.call_args_list]
+        emitted = [p["choices"][0]["delta"]["content"] for p in payloads]
+        # Two real chunks, then a marker so the user sees the response was
+        # cut short instead of trusting the truncated code.
+        assert emitted[:2] == ["def add(a, b):\n", "    return a + b"]
+        assert "Stream interrupted" in emitted[-1]
+        assert "connection reset by peer" in emitted[-1]
+        # The marker payload must also carry the structured nbi_stream_error
+        # field so the front-end auto-insert path can detect the failure and
+        # skip writing the partial buffer to the user's cell.
+        assert payloads[-1].get("nbi_stream_error") == "connection reset by peer"
+        # finish() is the caller's responsibility on the error path; we must
+        # not double-finish here.
+        response.finish.assert_not_called()
+
+    def test_mid_stream_exception_with_bracketed_text_keeps_structured_field(self):
+        # Many real Anthropic / network errors contain bracketed fragments
+        # like ``[SSL: CERTIFICATE_VERIFY_FAILED]`` or ``[Errno 11001]``.
+        # The frontend marker-strip regex used to anchor on the first inner
+        # ``]`` and leak the suffix into the user's code; the popover and
+        # auto-insert paths now branch on nbi_stream_error rather than
+        # parsing the marker, so this asserts the contract the frontend
+        # depends on: the structured field carries the verbatim error text
+        # regardless of how many brackets it contains.
+        class ExplodingStream(_FakeMessageStream):
+            def __init__(self, before_chunks, exc):
+                super().__init__(before_chunks)
+
+                def gen():
+                    for c in before_chunks:
+                        yield c
+                    raise exc
+
+                self.text_stream = gen()
+
+        model = ClaudeChatModel.__new__(ClaudeChatModel)
+        model._model_id = "claude-sonnet-test"
+        model._model_name = "Claude Sonnet (test)"
+        model._context_window = 200000
+        model._supports_tools = True
+        model._client = MagicMock()
+        boom = RuntimeError(
+            "[SSL: CERTIFICATE_VERIFY_FAILED] unable to get local issuer certificate"
+        )
+        model._client.messages.stream = MagicMock(
+            return_value=ExplodingStream(["partial code"], boom)
+        )
+        response = MagicMock()
+
+        try:
+            model.completions(
+                messages=[{"role": "user", "content": "x"}], response=response
+            )
+        except RuntimeError:
+            pass
+
+        payloads = [call.args[0] for call in response.stream.call_args_list]
+        # Marker text contains the brackets verbatim — that's fine because
+        # the frontend strips by line, not by inner-bracket boundary.
+        assert "[SSL:" in payloads[-1]["choices"][0]["delta"]["content"]
+        # Structured field is the source of truth for the frontend's
+        # error-vs-success branch.
+        assert payloads[-1].get("nbi_stream_error") == str(boom)
+
 
 class TestNormalizeAnthropicCredential:
     """Settings panel saves unset string fields as ``""`` rather than ``None``.


### PR DESCRIPTION
### Summary

Claude inline chat currently buffers the full Anthropic response before updating the Ctrl+G diff pane, so the pane stays empty until the request completes. This change makes the diff fill progressively, and it hardens the request lifecycle so cancellation and interrupted-stream handling behave correctly under streaming.


### Changes
- Switch Claude-mode inline chat from Anthropic's buffered messages.create API to messages.stream so the Ctrl+G diff pane fills in as text arrives instead of staying empty until the full response lands.
- Also wire inline-chat cancellation to the active backend request, and mark interrupted streams so partial or errored output is shown clearly and never auto-inserted into the user's code.
- Add regression tests covering chunk-by-chunk streaming, pre-cancel and mid-stream cancel behavior, and interrupted streams including bracketed exception text.
