### PR TITLE
fix(ui): preserve undo for inline chat edits

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -187,13 +187,33 @@ export function applyCodeToSelectionInEditor(
   code: string
 ) {
   const selection = editor.getSelection();
-  const startOffset = editor.getOffsetAt(selection.start);
-  const endOffset = editor.getOffsetAt(selection.end);
+  const selectionStartOffset = editor.getOffsetAt(selection.start);
+  const selectionEndOffset = editor.getOffsetAt(selection.end);
+  const startOffset = Math.min(selectionStartOffset, selectionEndOffset);
+  const endOffset = Math.max(selectionStartOffset, selectionEndOffset);
+  const cursorOffset = startOffset + code.length;
+  const codeMirrorEditor = editor as CodeEditor.IEditor & {
+    editor?: {
+      dispatch: (spec: {
+        changes: { from: number; to: number; insert: string };
+        selection: { anchor: number };
+        scrollIntoView: boolean;
+      }) => void;
+    };
+  };
 
-  editor.model.sharedModel.updateSource(startOffset, endOffset, code);
-  const numAddedLines = code.split('\n').length;
+  if (codeMirrorEditor.editor?.dispatch) {
+    codeMirrorEditor.editor.dispatch({
+      changes: { from: startOffset, to: endOffset, insert: code },
+      selection: { anchor: cursorOffset },
+      scrollIntoView: true
+    });
+  } else {
+    editor.model.sharedModel.updateSource(startOffset, endOffset, code);
+  }
+
   const cursorLine = Math.min(
-    selection.start.line + numAddedLines - 1,
+    editor.getPositionAt(cursorOffset).line,
     editor.lineCount - 1
   );
   const cursorColumn = editor.getLine(cursorLine)?.length || 0;

--- a/tests/ts/utils.test.ts
+++ b/tests/ts/utils.test.ts
@@ -10,7 +10,8 @@ import {
   isSelectionEmpty,
   isDarkTheme,
   getTokenCount,
-  cellOutputAsText
+  cellOutputAsText,
+  applyCodeToSelectionInEditor
 } from '../../src/utils';
 
 describe('removeAnsiChars', () => {
@@ -179,6 +180,59 @@ describe('isSelectionEmpty', () => {
         end: { line: 4, column: 5 }
       })
     ).toBe(false);
+  });
+});
+
+describe('applyCodeToSelectionInEditor', () => {
+  const makeEditor = (dispatch?: jest.Mock) => {
+    const updateSource = jest.fn();
+    const setCursorPosition = jest.fn();
+    const editor: any = {
+      getSelection: jest.fn(() => ({
+        start: { line: 0, column: 1 },
+        end: { line: 0, column: 4 }
+      })),
+      getOffsetAt: jest.fn(position => position.column),
+      getPositionAt: jest.fn(offset => ({ line: 0, column: offset })),
+      lineCount: 1,
+      getLine: jest.fn(() => 'abcXYZdef'),
+      setCursorPosition,
+      model: {
+        sharedModel: {
+          updateSource
+        }
+      }
+    };
+    if (dispatch) {
+      editor.editor = { dispatch };
+    }
+    return { editor, updateSource, setCursorPosition };
+  };
+
+  it('uses CodeMirror dispatch when available so edits enter the undo path', () => {
+    const dispatch = jest.fn();
+    const { editor, updateSource, setCursorPosition } = makeEditor(dispatch);
+
+    applyCodeToSelectionInEditor(editor, 'XYZ');
+
+    expect(dispatch).toHaveBeenCalledWith({
+      changes: { from: 1, to: 4, insert: 'XYZ' },
+      selection: { anchor: 4 },
+      scrollIntoView: true
+    });
+    expect(updateSource).not.toHaveBeenCalled();
+    expect(setCursorPosition).toHaveBeenCalledWith({
+      line: 0,
+      column: 'abcXYZdef'.length
+    });
+  });
+
+  it('falls back to shared model updates for non-CodeMirror editors', () => {
+    const { editor, updateSource } = makeEditor();
+
+    applyCodeToSelectionInEditor(editor, 'XYZ');
+
+    expect(updateSource).toHaveBeenCalledWith(1, 4, 'XYZ');
   });
 });
 


### PR DESCRIPTION
﻿## Summary

Replacing selected cell text through `sharedModel.updateSource` bypassed the editor undo stack. That made accepted inline-chat results impossible to undo, even though the visible edit succeeded.

## Changes

- Accepted inline-chat edits now go through the active editor dispatch path when available, so applying a suggestion behaves like a normal editor edit and can be undone with Ctrl+Z.
- The existing shared-model update path is kept as a fallback for editor types that do not expose the CodeMirror dispatch API.

## Validation

- `jlpm build:lib`
- `jlpm test --runTestsByPath tests/ts/utils.test.ts --runInBand --modulePathIgnorePatterns "<rootDir>/notebook_intelligence/labextension" "<rootDir>/.venv"`
- Manual local JupyterLab test of accepting an inline-chat edit and undoing it with Ctrl+Z
