### PR TITLE
fix: connect Claude agent in background to unblock startup (#163)

### DIFF
--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -296,9 +296,14 @@ class ClaudeCodeClient():
         self._status = ClaudeAgentClientStatus.NotConnected
         self._server_info: dict[str, Any] | None = None
         self._server_info_lock = threading.Lock()
+        self._connect_lock = threading.Lock()
         self._reconnect_required = False
         self._continue_conversation: bool | None = None
-        self.connect()
+        # Connect on a background thread so JupyterLab's startup path isn't
+        # blocked by the synchronous SDK handshake (#163). Callers that need
+        # to wait for readiness (e.g. _ensure_connected from a chat request)
+        # still call connect() directly and get the blocking behavior.
+        self.connect_in_background()
 
     @property
     def client_options(self) -> ClaudeAgentOptions:
@@ -349,39 +354,78 @@ class ClaudeCodeClient():
             asyncio.set_event_loop(None)
             loop.close()
 
-    def connect(self):
+    def _start_worker_thread(self) -> bool:
+        """Spawn the worker thread without waiting for the handshake to resolve.
+
+        Returns True if a thread was started (or was already running), False if
+        spawning raised. Must be called with ``_connect_lock`` held to prevent
+        two callers from racing and double-spawning the worker.
+        """
         if self.is_connected():
-            return
+            return True
 
         self._set_status(ClaudeAgentClientStatus.Connecting)
 
         self._reconnect_required = False
         self._client_queue = Queue()
-        self._client_thread_signal: SignalImpl = SignalImpl()
+        self._client_thread_signal = SignalImpl()
         self._connect_resolved.clear()
         try:
-            self._client_thread = threading.Thread(
+            thread = threading.Thread(
                 name="Claude Agent Client Thread",
                 target=self._run_client_thread,
                 daemon=True,
                 args=(self._client_thread_func(),),
             )
-            self._client_thread.start()
-            # Block until the worker has either finished the SDK handshake or
-            # failed — otherwise callers that check is_connected() afterwards
-            # see a momentarily-alive thread that's about to die on spawn
-            # failure, and never reach the "not connected" error branch (#147).
-            if not self._connect_resolved.wait(timeout=CLAUDE_AGENT_CONNECT_TIMEOUT):
-                log.warning(
-                    f"Claude agent did not reach a terminal connect state within "
-                    f"{CLAUDE_AGENT_CONNECT_TIMEOUT}s"
-                )
-            if self.is_connected():
-                self._update_server_info_async()
+            thread.start()
+            # Only publish the thread after start() succeeds so observers
+            # (including test cleanup) never see an un-started Thread object.
+            self._client_thread = thread
+            return True
         except Exception as e:
             self._client_thread = None
             log.error(f"Error occurred while connecting to Claude agent client: {str(e)}")
             self._set_status(ClaudeAgentClientStatus.FailedToConnect)
+            self._connect_resolved.set()
+            return False
+
+    def connect(self):
+        # Serialise concurrent connects so a chat handler hitting
+        # _ensure_connected() while the background __init__ connect is still
+        # in flight doesn't double-spawn the worker thread.
+        with self._connect_lock:
+            if self.is_connected() and self._connect_resolved.is_set():
+                return
+            started = self._start_worker_thread()
+        if not started:
+            return
+        # Block until the worker has either finished the SDK handshake or
+        # failed — otherwise callers that check is_connected() afterwards
+        # see a momentarily-alive thread that's about to die on spawn
+        # failure, and never reach the "not connected" error branch (#147).
+        if not self._connect_resolved.wait(timeout=CLAUDE_AGENT_CONNECT_TIMEOUT):
+            log.warning(
+                f"Claude agent did not reach a terminal connect state within "
+                f"{CLAUDE_AGENT_CONNECT_TIMEOUT}s"
+            )
+        if self.is_connected():
+            self._update_server_info_async()
+
+    def connect_in_background(self):
+        """Kick off ``connect()`` on a daemon thread and return immediately.
+
+        Used from ``__init__`` so JupyterLab's server startup isn't blocked by
+        the SDK handshake (#163). The status reflects ``Connecting`` until the
+        background thread resolves, and any caller that needs the synchronous
+        guarantee can call ``connect()`` directly — the lock makes them wait
+        for the in-flight handshake instead of double-spawning.
+        """
+        thread = threading.Thread(
+            name="Claude Agent Connect Thread",
+            target=self.connect,
+            daemon=True,
+        )
+        thread.start()
 
     def disconnect(self):
         if not self.is_connected():

--- a/tests/test_claude_client.py
+++ b/tests/test_claude_client.py
@@ -43,6 +43,7 @@ def _make_client():
     client._status = ClaudeAgentClientStatus.NotConnected
     client._server_info = None
     client._server_info_lock = threading.Lock()
+    client._connect_lock = threading.Lock()
     client._reconnect_required = False
     client._continue_conversation = None
     return client
@@ -394,6 +395,161 @@ class TestConnectWaitsForReadiness:
 
         assert "not connected" in result
         assert "server log" in result
+
+
+class TestConnectInBackground:
+    """``__init__`` must return promptly even when the SDK handshake is slow,
+    so JupyterLab's server startup isn't blocked for the
+    ``CLAUDE_AGENT_CONNECT_TIMEOUT`` window (#163). The synchronous
+    ``connect()`` is preserved for chat-request callers that need readiness
+    state before issuing a query.
+    """
+
+    def test_connect_in_background_returns_immediately_when_worker_slow(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "notebook_intelligence.claude.CLAUDE_AGENT_CONNECT_TIMEOUT", 5
+        )
+        client = _make_client()
+        client._update_server_info_async = Mock()
+
+        stop_worker = threading.Event()
+
+        async def slow_worker():
+            # Worker takes 0.3s to "handshake" — far longer than the budget
+            # we'd accept on the JupyterLab startup path.
+            await asyncio.sleep(0.3)
+            client._status = ClaudeAgentClientStatus.Connected
+            client._connect_resolved.set()
+            while not stop_worker.is_set():
+                await asyncio.sleep(0.01)
+
+        client._client_thread_func = slow_worker
+
+        try:
+            start = time.monotonic()
+            client.connect_in_background()
+            elapsed = time.monotonic() - start
+            # The connect dispatch should return well under the worker's own
+            # delay. 100ms is generous for a thread-spawn and lock-acquire.
+            assert elapsed < 0.1, (
+                f"connect_in_background blocked for {elapsed:.3f}s; expected "
+                f"non-blocking dispatch"
+            )
+        finally:
+            stop_worker.set()
+            if client._client_thread is not None:
+                client._client_thread.join(timeout=1)
+
+    def test_init_returns_quickly_even_when_handshake_hangs(self, monkeypatch):
+        """End-to-end of the #163 fix: constructing a ``ClaudeCodeClient`` no
+        longer blocks the caller for the full connect timeout when the
+        worker takes longer than expected."""
+        monkeypatch.setattr(
+            "notebook_intelligence.claude.CLAUDE_AGENT_CONNECT_TIMEOUT", 5
+        )
+
+        # Replace the worker entrypoint with a slow stub before constructing
+        # the client. _start_worker_thread reads
+        # ``self._client_thread_func`` lazily via ``self._client_thread_func()``,
+        # so monkey-patching the bound name on the instance is enough.
+        original_init = ClaudeCodeClient.__init__
+        slow_func_holders = {}
+
+        def patched_init(self, host, options):
+            stop = threading.Event()
+            slow_func_holders[id(self)] = stop
+
+            async def slow():
+                # Check the stop flag frequently so cleanup doesn't have to
+                # wait the full 2-second handshake delay.
+                deadline = time.monotonic() + 2.0
+                while time.monotonic() < deadline and not stop.is_set():
+                    await asyncio.sleep(0.05)
+                while not stop.is_set():
+                    await asyncio.sleep(0.05)
+
+            # Stub out the bits that touch real infrastructure.
+            self._client_thread_func = slow
+            original_init(self, host, options)
+
+        monkeypatch.setattr(ClaudeCodeClient, "__init__", patched_init)
+
+        host = MagicMock()
+        host.websocket_connector = None
+        options = MagicMock()
+
+        start = time.monotonic()
+        client = ClaudeCodeClient(host, options)
+        elapsed = time.monotonic() - start
+
+        try:
+            # 500ms is the budget called out in the issue: well under the
+            # 15s default timeout, generous enough to absorb thread-start
+            # overhead on a loaded CI runner.
+            assert elapsed < 0.5, (
+                f"__init__ blocked for {elapsed:.3f}s; should dispatch the "
+                f"handshake to a background thread"
+            )
+            # Status reflects the in-flight connect, not a completed one.
+            assert client._status in (
+                ClaudeAgentClientStatus.Connecting,
+                ClaudeAgentClientStatus.NotConnected,
+            )
+        finally:
+            stop = slow_func_holders.get(id(client))
+            if stop is not None:
+                stop.set()
+            # Give the background connect dispatcher a beat to finish spawning
+            # the worker before we try to join it.
+            for _ in range(50):
+                if client._client_thread is not None:
+                    break
+                time.sleep(0.05)
+            if client._client_thread is not None:
+                client._client_thread.join(timeout=5)
+
+    def test_concurrent_connect_does_not_double_spawn(self, monkeypatch):
+        """If a chat handler hits ``_ensure_connected()`` while the background
+        ``__init__`` connect is mid-handshake, the lock must serialise them
+        so we don't end up with two worker threads racing on ``self._client``.
+        """
+        monkeypatch.setattr(
+            "notebook_intelligence.claude.CLAUDE_AGENT_CONNECT_TIMEOUT", 5
+        )
+        client = _make_client()
+        client._update_server_info_async = Mock()
+
+        spawn_count = {"n": 0}
+        stop_worker = threading.Event()
+
+        async def counting_worker():
+            spawn_count["n"] += 1
+            await asyncio.sleep(0.05)
+            client._status = ClaudeAgentClientStatus.Connected
+            client._connect_resolved.set()
+            while not stop_worker.is_set():
+                await asyncio.sleep(0.01)
+
+        client._client_thread_func = counting_worker
+
+        try:
+            t1 = threading.Thread(target=client.connect)
+            t2 = threading.Thread(target=client.connect)
+            t1.start()
+            t2.start()
+            t1.join(timeout=3)
+            t2.join(timeout=3)
+
+            assert spawn_count["n"] == 1, (
+                f"expected 1 worker thread, got {spawn_count['n']}"
+            )
+            assert client.is_connected()
+        finally:
+            stop_worker.set()
+            if client._client_thread is not None:
+                client._client_thread.join(timeout=1)
 
 
 class TestOtherCallersEnsureConnected:


### PR DESCRIPTION
## Summary
- `ClaudeCodeClient.__init__` calls `connect()` synchronously, and `connect()` blocks the caller for up to `CLAUDE_AGENT_CONNECT_TIMEOUT` (15s) waiting on the SDK handshake. Because `AIServiceManager.initialize()` constructs the client on the Tornado server thread, JupyterLab startup stalls while the Claude subprocess comes up — the symptom in #163.
- This PR splits the connect path so `__init__` dispatches to a worker via a new `connect_in_background()`, while `connect()` keeps its synchronous wait for callers that need readiness state (the `_ensure_connected` / reconnect / `update_client` paths preserved by #147).
- Adds a `_connect_lock` so a chat handler hitting `_ensure_connected()` during the in-flight startup handshake doesn't double-spawn the worker thread.

Closes #163

## Test plan
- [x] `pytest tests/test_claude_client.py::TestConnectInBackground` — covers (1) `connect_in_background` returning under 100ms when the worker is slow, (2) `ClaudeCodeClient.__init__` returning under 500ms when the handshake hangs, (3) two concurrent `connect()` calls spawning only one worker thread.
- [x] Manual: launch JupyterLab with Claude mode enabled and confirm the UI is interactive immediately rather than hanging on the spinner; then send a chat message and verify the agent connects on demand.