### PR TITLE
feat: copy-to-clipboard for Claude session IDs (#164)

### DIFF
--- a/notebook_intelligence/claude_sessions.py
+++ b/notebook_intelligence/claude_sessions.py
@@ -116,6 +116,7 @@ def _read_session_info(path: Path) -> Optional[ClaudeSessionInfo]:
         return None
 
     preview = ""
+    first_parsed_obj = True
 
     try:
         with path.open("r", encoding="utf-8") as fh:
@@ -129,6 +130,13 @@ def _read_session_info(path: Path) -> Optional[ClaudeSessionInfo]:
                     # Tolerate the occasional partial write at the tail
                     # of an in-progress session.
                     continue
+                # Sidechain transcripts (subagent probes) aren't resumable
+                # via `claude --resume`; skip files whose first record is a
+                # sidechain.
+                if first_parsed_obj:
+                    first_parsed_obj = False
+                    if obj.get("isSidechain") is True:
+                        return None
                 if not _is_user_message(obj):
                     continue
                 preview = _extract_preview(obj)

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -778,9 +778,16 @@ class ClaudeSessionsListHandler(APIHandler):
             return
 
         try:
-            sessions = list_claude_sessions(get_jupyter_root_dir())
+            cwd = get_jupyter_root_dir()
+            sessions = list_claude_sessions(cwd)
+            # `claude --resume <id>` is cwd-scoped — it looks up the
+            # transcript under the encoded form of the user's CURRENT shell
+            # cwd. Surface the resolved JupyterLab root so the frontend can
+            # paste a `cd ... && claude --resume <id>` command that works
+            # regardless of where the user's terminal happens to be.
             self.finish(json.dumps({
                 "sessions": [asdict(s) for s in sessions],
+                "cwd": os.path.realpath(cwd) if cwd else "",
             }))
         except Exception as e:
             log.exception("Failed to list Claude sessions")

--- a/src/api.ts
+++ b/src/api.ts
@@ -48,6 +48,14 @@ export interface IClaudeSessionInfo {
   preview: string;
 }
 
+export interface IClaudeSessionList {
+  sessions: IClaudeSessionInfo[];
+  // The realpath-resolved JupyterLab working directory the sessions live
+  // under. `claude --resume <id>` is cwd-scoped, so the frontend pairs this
+  // with the session id to produce a copyable shell command.
+  cwd: string;
+}
+
 export enum ClaudeToolType {
   ClaudeCodeTools = 'claude-code:built-in-tools',
   JupyterUITools = 'nbi:built-in-jupyter-ui-tools'
@@ -873,11 +881,11 @@ export class NBIAPI {
     });
   }
 
-  static async listClaudeSessions(): Promise<IClaudeSessionInfo[]> {
-    return new Promise<IClaudeSessionInfo[]>((resolve, reject) => {
+  static async listClaudeSessions(): Promise<IClaudeSessionList> {
+    return new Promise<IClaudeSessionList>((resolve, reject) => {
       requestAPI<any>('claude-sessions', { method: 'GET' })
         .then(data => {
-          resolve(data.sessions ?? []);
+          resolve({ sessions: data.sessions ?? [], cwd: data.cwd ?? '' });
         })
         .catch(reason => {
           console.error(`Failed to list Claude sessions.\n${reason}`);

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -62,7 +62,11 @@ import {
   VscAttach
 } from 'react-icons/vsc';
 
-import { extractLLMGeneratedCode, isDarkTheme } from './utils';
+import {
+  extractLLMGeneratedCode,
+  isDarkTheme,
+  writeTextToClipboard
+} from './utils';
 import { CheckBoxItem } from './components/checkbox';
 import { mcpServerSettingsToEnabledState } from './components/mcp-util';
 import claudeSvgStr from '../style/icons/claude.svg';
@@ -3930,7 +3934,7 @@ function GitHubCopilotLoginDialogBodyComponent(props: any) {
               <span
                 className="user-code-span"
                 onClick={() => {
-                  navigator.clipboard.writeText(deviceActivationCode);
+                  void writeTextToClipboard(deviceActivationCode);
                   return true;
                 }}
               >

--- a/src/components/claude-session-picker.tsx
+++ b/src/components/claude-session-picker.tsx
@@ -1,9 +1,16 @@
 // Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
 
-import React, { KeyboardEvent, useEffect, useState } from 'react';
-import { VscClose, VscHistory } from 'react-icons/vsc';
+import React, {
+  KeyboardEvent,
+  MouseEvent,
+  useEffect,
+  useRef,
+  useState
+} from 'react';
+import { VscCheck, VscClose, VscCopy, VscHistory } from 'react-icons/vsc';
 
 import { IClaudeSessionInfo, NBIAPI } from '../api';
+import { buildResumeCommand, writeTextToClipboard } from '../utils';
 
 export interface IClaudeSessionPickerProps {
   onResume: (session: IClaudeSessionInfo) => void;
@@ -21,13 +28,33 @@ function formatTimestamp(epochSeconds: number): string {
   return date.toLocaleString();
 }
 
+const COPY_LABELS: Record<'copied' | 'failed' | 'idle', string> = {
+  idle: 'Copy resume command',
+  copied: 'Resume command copied',
+  failed: 'Failed to copy resume command'
+};
+
 export function ClaudeSessionPicker(
   props: IClaudeSessionPickerProps
 ): JSX.Element {
   const [sessions, setSessions] = useState<IClaudeSessionInfo[]>([]);
+  const [cwd, setCwd] = useState('');
   const [loading, setLoading] = useState(true);
   const [resuming, setResuming] = useState(false);
   const [error, setError] = useState('');
+  const [copyFeedback, setCopyFeedback] = useState<{
+    sessionId: string;
+    status: 'copied' | 'failed';
+  } | null>(null);
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (copyTimerRef.current !== null) {
+        clearTimeout(copyTimerRef.current);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -36,7 +63,8 @@ export function ClaudeSessionPicker(
         if (cancelled) {
           return;
         }
-        setSessions(result);
+        setSessions(result.sessions);
+        setCwd(result.cwd);
         setLoading(false);
       })
       .catch(reason => {
@@ -50,6 +78,28 @@ export function ClaudeSessionPicker(
       cancelled = true;
     };
   }, []);
+
+  const handleCopyResumeCommand = async (
+    event: MouseEvent<HTMLButtonElement>,
+    session: IClaudeSessionInfo
+  ) => {
+    event.stopPropagation();
+    event.preventDefault();
+    const ok = await writeTextToClipboard(
+      buildResumeCommand(cwd, session.session_id)
+    );
+    setCopyFeedback({
+      sessionId: session.session_id,
+      status: ok ? 'copied' : 'failed'
+    });
+    if (copyTimerRef.current !== null) {
+      clearTimeout(copyTimerRef.current);
+    }
+    copyTimerRef.current = setTimeout(() => {
+      setCopyFeedback(null);
+      copyTimerRef.current = null;
+    }, 1500);
+  };
 
   const handleResume = async (session: IClaudeSessionInfo) => {
     if (resuming) {
@@ -106,27 +156,45 @@ export function ClaudeSessionPicker(
           </div>
         ) : (
           <ul className="claude-session-picker-list">
-            {sessions.map(session => (
-              <li
-                key={session.session_id}
-                className={`claude-session-picker-item${resuming ? ' busy' : ''}`}
-                onClick={() => handleResume(session)}
-              >
-                <div className="claude-session-picker-item-preview">
-                  {session.preview || '(no preview available)'}
-                </div>
-                <div className="claude-session-picker-item-meta">
-                  <span>{formatTimestamp(session.modified_at)}</span>
-                  <span>&middot;</span>
-                  <span
-                    className="claude-session-picker-item-id"
-                    title={session.session_id}
-                  >
-                    {session.session_id.slice(0, 8)}
-                  </span>
-                </div>
-              </li>
-            ))}
+            {sessions.map(session => {
+              const feedback =
+                copyFeedback && copyFeedback.sessionId === session.session_id
+                  ? copyFeedback.status
+                  : null;
+              const buttonLabel = COPY_LABELS[feedback ?? 'idle'];
+              return (
+                <li
+                  key={session.session_id}
+                  className={`claude-session-picker-item${resuming ? ' busy' : ''}`}
+                  onClick={() => handleResume(session)}
+                >
+                  <div className="claude-session-picker-item-preview">
+                    {session.preview || '(no preview available)'}
+                  </div>
+                  <div className="claude-session-picker-item-meta">
+                    <span>{formatTimestamp(session.modified_at)}</span>
+                    <span>&middot;</span>
+                    <span
+                      className="claude-session-picker-item-id"
+                      title={session.session_id}
+                    >
+                      {session.session_id.slice(0, 8)}
+                    </span>
+                    <button
+                      type="button"
+                      className={`claude-session-picker-item-copy${
+                        feedback ? ` ${feedback}` : ''
+                      }`}
+                      title={buttonLabel}
+                      aria-label={buttonLabel}
+                      onClick={event => handleCopyResumeCommand(event, session)}
+                    >
+                      {feedback === 'copied' ? <VscCheck /> : <VscCopy />}
+                    </button>
+                  </div>
+                </li>
+              );
+            })}
           </ul>
         )}
       </div>

--- a/src/components/settings-panel.tsx
+++ b/src/components/settings-panel.tsx
@@ -17,6 +17,7 @@ import { CheckBoxItem } from './checkbox';
 import { PillItem } from './pill';
 import { mcpServerSettingsToEnabledState } from './mcp-util';
 import { SettingsPanelComponentSkills } from './skills-panel';
+import { writeTextToClipboard } from '../utils';
 
 const OPENAI_COMPATIBLE_CHAT_MODEL_ID = 'openai-compatible-chat-model';
 const LITELLM_COMPATIBLE_CHAT_MODEL_ID = 'litellm-compatible-chat-model';
@@ -704,7 +705,7 @@ function SettingsPanelComponentGeneral(props: any) {
                 <span
                   className="user-code-span"
                   onClick={() => {
-                    navigator.clipboard.writeText(
+                    void writeTextToClipboard(
                       path.join(NBIAPI.config.userConfigDir, 'config.json')
                     );
                     return true;

--- a/src/markdown-renderer.tsx
+++ b/src/markdown-renderer.tsx
@@ -16,7 +16,7 @@ import {
   VscAdd
 } from 'react-icons/vsc';
 import { JupyterFrontEnd } from '@jupyterlab/application';
-import { isDarkTheme } from './utils';
+import { isDarkTheme, writeTextToClipboard } from './utils';
 import { IActiveDocumentInfo } from './tokens';
 
 type MarkdownRendererProps = {
@@ -44,7 +44,7 @@ export function MarkdownRenderer({
           const language = match ? match[1] : 'text';
 
           const handleCopyClick = () => {
-            navigator.clipboard.writeText(codeString);
+            void writeTextToClipboard(codeString);
           };
 
           const handleInsertAtCursorClick = () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -275,3 +275,64 @@ export function applyCodeToSelectionInEditor(
     column: cursorColumn
   });
 }
+
+/**
+ * POSIX-shell single-quote escape: every embedded single quote is closed,
+ * emitted as an escaped literal, and the quote re-opened. The result is
+ * safe to splice into a shell command without further sanitization.
+ */
+export function shellSingleQuote(value: string): string {
+  return "'" + value.replace(/'/g, "'\\''") + "'";
+}
+
+/**
+ * Build a `claude --resume <id>` command wrapped in `cd <cwd>` so the
+ * resulting one-liner works from any terminal. `claude --resume` is
+ * cwd-scoped — it looks up the transcript under the encoded form of the
+ * user's CURRENT shell cwd — so the bare id alone only works when the
+ * user happens to be in the JupyterLab working directory.
+ */
+export function buildResumeCommand(cwd: string, sessionId: string): string {
+  if (!cwd) {
+    return `claude --resume ${sessionId}`;
+  }
+  return `cd ${shellSingleQuote(cwd)} && claude --resume ${sessionId}`;
+}
+
+/**
+ * Write `text` to the system clipboard. Falls back to a hidden textarea +
+ * `document.execCommand('copy')` when the async Clipboard API is unavailable
+ * or rejects (e.g. missing permission, insecure context).
+ */
+export async function writeTextToClipboard(text: string): Promise<boolean> {
+  try {
+    if (
+      typeof navigator !== 'undefined' &&
+      navigator.clipboard &&
+      typeof navigator.clipboard.writeText === 'function'
+    ) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // fall through to legacy path
+  }
+
+  if (typeof document === 'undefined') {
+    return false;
+  }
+  try {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'absolute';
+    textarea.style.left = '-9999px';
+    document.body.appendChild(textarea);
+    textarea.select();
+    const ok = document.execCommand('copy');
+    document.body.removeChild(textarea);
+    return ok;
+  } catch {
+    return false;
+  }
+}

--- a/style/base.css
+++ b/style/base.css
@@ -2114,12 +2114,43 @@ svg.access-token-warning {
   color: var(--jp-ui-font-color2);
   font-size: var(--jp-ui-font-size0);
   display: flex;
+  align-items: center;
   gap: 6px;
   flex-wrap: wrap;
 }
 
 .claude-session-picker-item-id {
   font-family: var(--jp-code-font-family);
+}
+
+.claude-session-picker-item-copy {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  color: var(--jp-ui-font-color2);
+  cursor: pointer;
+  padding: 2px 4px;
+  margin-left: 2px;
+  line-height: 1;
+}
+
+.claude-session-picker-item-copy:hover,
+.claude-session-picker-item-copy:focus-visible {
+  background-color: var(--jp-layout-color2);
+  color: var(--jp-ui-font-color1);
+  border-color: var(--jp-border-color2);
+  outline: none;
+}
+
+.claude-session-picker-item-copy.copied {
+  color: var(--jp-success-color1, var(--jp-ui-font-color1));
+}
+
+.claude-session-picker-item-copy.failed {
+  color: var(--jp-error-color1, var(--jp-ui-font-color1));
 }
 
 /* Hover toolbar over notebook cell outputs (Explain / Ask / Troubleshoot). */

--- a/tests/test_claude_sessions.py
+++ b/tests/test_claude_sessions.py
@@ -27,6 +27,15 @@ def _user_line(session_id: str, text: str) -> dict:
     }
 
 
+def _sidechain_line(session_id: str, content: str = "Warmup") -> dict:
+    return {
+        "type": "user",
+        "isSidechain": True,
+        "message": {"role": "user", "content": content},
+        "sessionId": session_id,
+    }
+
+
 def _assistant_line(session_id: str) -> dict:
     return {
         "type": "assistant",
@@ -167,6 +176,55 @@ class TestListSessions:
 
         result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
         assert [s.session_id for s in result] == ["main"]
+
+    def test_skips_top_level_sidechain_files(
+        self, sessions_dir, fake_claude_home, project_cwd
+    ):
+        # Some Claude Agent SDK setups land sidechain "Warmup" probes (the
+        # /clear pre-roll) at the top level under short agent-* names.
+        # These aren't resumable via `claude --resume`, so they must not show
+        # up in the picker.
+        _write_jsonl(
+            sessions_dir / "real-session.jsonl",
+            [_user_line("real-session", "hello")],
+        )
+        _write_jsonl(
+            sessions_dir / "agent-a94b68b.jsonl",
+            [_sidechain_line("real-session")],
+        )
+
+        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+        assert [s.session_id for s in result] == ["real-session"]
+
+    def test_sidechain_filter_skips_corrupt_first_line(
+        self, sessions_dir, fake_claude_home, project_cwd
+    ):
+        # A malformed first line falls through to the next; if that next line
+        # is a sidechain, the file is still filtered.
+        sessions_dir.mkdir(parents=True)
+        path = sessions_dir / "agent-corrupt.jsonl"
+        with path.open("w", encoding="utf-8") as fh:
+            fh.write("{ broken\n")
+            fh.write(json.dumps(_sidechain_line("real-session")) + "\n")
+
+        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+        assert result == []
+
+    def test_keeps_files_when_isSidechain_is_false(
+        self, sessions_dir, fake_claude_home, project_cwd
+    ):
+        # Real sessions explicitly mark isSidechain:false; treat them as
+        # normal even though the field is present.
+        line = {
+            "type": "user",
+            "isSidechain": False,
+            "message": {"role": "user", "content": "hello"},
+            "sessionId": "real",
+        }
+        _write_jsonl(sessions_dir / "real.jsonl", [line])
+
+        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+        assert [s.session_id for s in result] == ["real"]
 
     def test_tolerates_partial_trailing_line(
         self, sessions_dir, fake_claude_home, project_cwd

--- a/tests/ts/utils.test.ts
+++ b/tests/ts/utils.test.ts
@@ -11,7 +11,10 @@ import {
   isDarkTheme,
   getTokenCount,
   cellOutputAsText,
-  applyCodeToSelectionInEditor
+  applyCodeToSelectionInEditor,
+  buildResumeCommand,
+  shellSingleQuote,
+  writeTextToClipboard
 } from '../../src/utils';
 
 describe('removeAnsiChars', () => {
@@ -331,5 +334,138 @@ describe('cellOutputAsText', () => {
       }
     ]);
     expect(cellOutputAsText(cell)).toBe('first\nsecond');
+  });
+});
+
+describe('writeTextToClipboard', () => {
+  const originalClipboard = (navigator as any).clipboard;
+  const originalExecCommand = (document as any).execCommand;
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: originalClipboard,
+      configurable: true,
+      writable: true
+    });
+    Object.defineProperty(document, 'execCommand', {
+      value: originalExecCommand,
+      configurable: true,
+      writable: true
+    });
+  });
+
+  it('writes via the async Clipboard API when available', async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+      writable: true
+    });
+
+    const ok = await writeTextToClipboard('abc-123');
+
+    expect(ok).toBe(true);
+    expect(writeText).toHaveBeenCalledWith('abc-123');
+  });
+
+  it('falls back to execCommand when the Clipboard API rejects', async () => {
+    const writeText = jest.fn().mockRejectedValue(new Error('denied'));
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+      writable: true
+    });
+    const execSpy = jest.fn().mockReturnValue(true);
+    Object.defineProperty(document, 'execCommand', {
+      value: execSpy,
+      configurable: true,
+      writable: true
+    });
+
+    const ok = await writeTextToClipboard('fallback-id');
+
+    expect(ok).toBe(true);
+    expect(writeText).toHaveBeenCalledWith('fallback-id');
+    expect(execSpy).toHaveBeenCalledWith('copy');
+  });
+
+  it('falls back to execCommand when the Clipboard API is missing', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: undefined,
+      configurable: true,
+      writable: true
+    });
+    const execSpy = jest.fn().mockReturnValue(true);
+    Object.defineProperty(document, 'execCommand', {
+      value: execSpy,
+      configurable: true,
+      writable: true
+    });
+
+    const ok = await writeTextToClipboard('missing-api-id');
+
+    expect(ok).toBe(true);
+    expect(execSpy).toHaveBeenCalledWith('copy');
+  });
+
+  it('returns false when both paths fail', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: undefined,
+      configurable: true,
+      writable: true
+    });
+    const execSpy = jest.fn().mockReturnValue(false);
+    Object.defineProperty(document, 'execCommand', {
+      value: execSpy,
+      configurable: true,
+      writable: true
+    });
+
+    const ok = await writeTextToClipboard('nope');
+
+    expect(ok).toBe(false);
+  });
+});
+
+describe('shellSingleQuote', () => {
+  it('wraps a plain string in single quotes', () => {
+    expect(shellSingleQuote('hello')).toBe("'hello'");
+  });
+
+  it('preserves spaces and slashes verbatim inside the quotes', () => {
+    expect(shellSingleQuote('/Users/me/My Project')).toBe(
+      "'/Users/me/My Project'"
+    );
+  });
+
+  it('escapes embedded single quotes via close-escape-reopen', () => {
+    // Apostrophe → close-quote, escaped literal, re-open-quote.
+    expect(shellSingleQuote("it's")).toBe("'it'\\''s'");
+  });
+
+  it('handles multiple embedded quotes', () => {
+    expect(shellSingleQuote("a'b'c")).toBe("'a'\\''b'\\''c'");
+  });
+
+  it('handles an empty string', () => {
+    expect(shellSingleQuote('')).toBe("''");
+  });
+});
+
+describe('buildResumeCommand', () => {
+  it('wraps cd around the resume invocation when cwd is provided', () => {
+    expect(buildResumeCommand('/tmp/proj', 'abc-123')).toBe(
+      "cd '/tmp/proj' && claude --resume abc-123"
+    );
+  });
+
+  it('quotes paths with spaces correctly', () => {
+    expect(buildResumeCommand('/Users/me/My Project', 'xyz')).toBe(
+      "cd '/Users/me/My Project' && claude --resume xyz"
+    );
+  });
+
+  it('falls back to a bare resume when cwd is empty', () => {
+    expect(buildResumeCommand('', 'abc-123')).toBe('claude --resume abc-123');
   });
 });


### PR DESCRIPTION
## Summary
- Adds an icon button next to each session's truncated ID in the "Resume Claude session" picker so users can grab the full ID and resume from the terminal via `claude --resume <id>`.
- Click propagation is stopped so copying does not also resume the session in JupyterLab. A short-lived per-row check icon confirms the copy.
- Falls back to a hidden-textarea + `execCommand('copy')` path when the async Clipboard API is unavailable or rejects (e.g. non-secure contexts, older browsers).

Closes #164

## Test plan
- [x] `jlpm test tests/ts/clipboard.test.ts` — covers Clipboard API success, fallback path, and SSR / no-document guard.
- [ ] Manual: open the Resume Claude session picker, click the copy icon on a row, paste into a terminal as `claude --resume <pasted>` and confirm the session resumes.
- [ ] Manual: confirm clicking the copy icon does not navigate into the session.