### PR TITLE
feat: notebook toolbar button for quick notebook generation (#167)

### DIFF
--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -69,12 +69,17 @@ import claudeSvgStr from '../style/icons/claude.svg';
 import { AskUserQuestion } from './components/ask-user-question';
 import { ClaudeSessionPicker } from './components/claude-session-picker';
 import { IClaudeSessionInfo } from './api';
+import {
+  NOTEBOOK_GENERATION_PROGRESS_EVENT,
+  type INotebookGenerationProgressDetail
+} from './notebook-generation';
 
 export enum RunChatCompletionType {
   Chat,
   ExplainThis,
   FixThis,
-  GenerateCode
+  GenerateCode,
+  NotebookGeneration
 }
 
 export interface IRunChatCompletionRequest {
@@ -91,6 +96,9 @@ export interface IRunChatCompletionRequest {
   additionalContext?: IContextItem[];
   chatMode: string;
   toolSelections?: IToolSelections;
+  // Optional id used by external listeners (e.g. the notebook toolbar
+  // generation popover) to track progress when the chat sidebar is hidden.
+  externalRequestId?: string;
 }
 
 export interface IChatSidebarOptions {
@@ -943,6 +951,7 @@ async function submitCompletionRequest(
 ): Promise<any> {
   switch (request.type) {
     case RunChatCompletionType.Chat:
+    case RunChatCompletionType.NotebookGeneration:
       return NBIAPI.chatRequest(
         request.messageId,
         request.chatId,
@@ -2537,10 +2546,36 @@ function SidebarComponent(props: any) {
         case RunChatCompletionType.FixThis:
           message = `Fix this code:\n\`\`\`\n${request.content}\n\`\`\`\n`;
           break;
+        case RunChatCompletionType.NotebookGeneration:
+          // The notebook-toolbar popover already prefixed the prompt; pass it
+          // through verbatim so the message displayed in chat matches what
+          // was sent to the backend.
+          message = request.content;
+          if (!request.chatMode) {
+            request.chatMode = chatMode;
+          }
+          break;
       }
       const messageId = UUID.uuid4();
       request.messageId = messageId;
       request.content = message;
+      const externalRequestId = request.externalRequestId;
+      const emitProgress = (inProgress: boolean, error?: string) => {
+        if (!externalRequestId) {
+          return;
+        }
+        const detail: INotebookGenerationProgressDetail = {
+          requestId: externalRequestId,
+          inProgress
+        };
+        if (error) {
+          detail.error = error;
+        }
+        document.dispatchEvent(
+          new CustomEvent(NOTEBOOK_GENERATION_PROGRESS_EVENT, { detail })
+        );
+      };
+      emitProgress(true);
       const newList = [
         ...chatMessages,
         {
@@ -2621,6 +2656,7 @@ function SidebarComponent(props: any) {
             }
           } else if (response.type === BackendMessageType.StreamEnd) {
             setCopilotRequestInProgress(false);
+            emitProgress(false);
           } else if (response.type === BackendMessageType.RunUICommand) {
             const runUiMessageId = response.id;
             let result = 'void';
@@ -2666,7 +2702,7 @@ function SidebarComponent(props: any) {
         }
       });
     },
-    [chatMessages]
+    [chatMessages, chatMode]
   );
 
   useEffect(() => {

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -99,6 +99,10 @@ export interface IRunChatCompletionRequest {
   // Optional id used by external listeners (e.g. the notebook toolbar
   // generation popover) to track progress when the chat sidebar is hidden.
   externalRequestId?: string;
+  // When true, skip rendering this turn in the chat history. The request
+  // still streams through the backend; only the visible transcript is
+  // suppressed. Used by the notebook-generation toolbar's "silent" mode.
+  hideInChat?: boolean;
 }
 
 export interface IChatSidebarOptions {
@@ -2576,25 +2580,29 @@ function SidebarComponent(props: any) {
         );
       };
       emitProgress(true);
-      const newList = [
-        ...chatMessages,
-        {
-          id: messageId,
-          date: new Date(),
-          from: 'user',
-          contents: [
+      const hideInChat = !!request.hideInChat;
+      const newList = hideInChat
+        ? chatMessages
+        : [
+            ...chatMessages,
             {
               id: messageId,
-              type: ResponseStreamDataType.Markdown,
-              content: message,
-              created: new Date()
+              date: new Date(),
+              from: 'user',
+              contents: [
+                {
+                  id: messageId,
+                  type: ResponseStreamDataType.Markdown,
+                  content: message,
+                  created: new Date()
+                }
+              ]
             }
-          ]
-        }
-      ];
-      setChatMessages(newList);
-
-      setCopilotRequestInProgress(true);
+          ];
+      if (!hideInChat) {
+        setChatMessages(newList);
+        setCopilotRequestInProgress(true);
+      }
 
       const contents: IChatMessageContent[] = [];
 
@@ -2655,7 +2663,9 @@ function SidebarComponent(props: any) {
               });
             }
           } else if (response.type === BackendMessageType.StreamEnd) {
-            setCopilotRequestInProgress(false);
+            if (!hideInChat) {
+              setCopilotRequestInProgress(false);
+            }
             emitProgress(false);
           } else if (response.type === BackendMessageType.RunUICommand) {
             const runUiMessageId = response.id;
@@ -2684,6 +2694,9 @@ function SidebarComponent(props: any) {
               RequestDataType.RunUICommandResponse,
               data
             );
+          }
+          if (hideInChat) {
+            return;
           }
           const messageId = UUID.uuid4();
           setChatMessages([

--- a/src/components/notebook-generation-popover.tsx
+++ b/src/components/notebook-generation-popover.tsx
@@ -67,7 +67,7 @@ export function NotebookGenerationPopover(
           <VscSparkle />
         </div>
         <div className="notebook-generation-popover-title">
-          Generate or update notebook
+          Update active notebook
         </div>
         <div style={{ flexGrow: 1 }}></div>
         <div
@@ -83,7 +83,7 @@ export function NotebookGenerationPopover(
           ref={textareaRef}
           className="notebook-generation-popover-input"
           rows={4}
-          placeholder="Describe the notebook you want to create or how to update the active one..."
+          placeholder="Describe how to update the active notebook..."
           value={prompt}
           onChange={(event: ChangeEvent<HTMLTextAreaElement>) =>
             setPrompt(event.target.value)

--- a/src/components/notebook-generation-popover.tsx
+++ b/src/components/notebook-generation-popover.tsx
@@ -27,7 +27,6 @@ export function NotebookGenerationPopover(
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
-    // Auto-focus the textarea on mount.
     textareaRef.current?.focus();
   }, []);
 

--- a/src/components/notebook-generation-popover.tsx
+++ b/src/components/notebook-generation-popover.tsx
@@ -1,0 +1,119 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+import React, {
+  ChangeEvent,
+  KeyboardEvent,
+  useEffect,
+  useRef,
+  useState
+} from 'react';
+import { VscClose, VscSend, VscSparkle } from 'react-icons/vsc';
+
+import { CheckBoxItem } from './checkbox';
+
+export interface INotebookGenerationPopoverProps {
+  initialShowInChat?: boolean;
+  onSubmit: (prompt: string, showInChat: boolean) => void;
+  onClose: () => void;
+}
+
+export function NotebookGenerationPopover(
+  props: INotebookGenerationPopoverProps
+): JSX.Element {
+  const [prompt, setPrompt] = useState('');
+  const [showInChat, setShowInChat] = useState<boolean>(
+    props.initialShowInChat ?? true
+  );
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    // Auto-focus the textarea on mount.
+    textareaRef.current?.focus();
+  }, []);
+
+  const trimmed = prompt.trim();
+  const canSubmit = trimmed.length > 0;
+
+  const handleSubmit = () => {
+    if (!canSubmit) {
+      return;
+    }
+    props.onSubmit(trimmed, showInChat);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
+      event.stopPropagation();
+      event.preventDefault();
+      props.onClose();
+      return;
+    }
+  };
+
+  const handleTextareaKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      handleSubmit();
+    }
+  };
+
+  return (
+    <div
+      className="notebook-generation-popover"
+      tabIndex={-1}
+      onKeyDown={handleKeyDown}
+    >
+      <div className="notebook-generation-popover-header">
+        <div className="notebook-generation-popover-header-icon">
+          <VscSparkle />
+        </div>
+        <div className="notebook-generation-popover-title">
+          Generate or update notebook
+        </div>
+        <div style={{ flexGrow: 1 }}></div>
+        <div
+          className="notebook-generation-popover-close-button"
+          title="Close"
+          onClick={props.onClose}
+        >
+          <VscClose />
+        </div>
+      </div>
+      <div className="notebook-generation-popover-body">
+        <textarea
+          ref={textareaRef}
+          className="notebook-generation-popover-input"
+          rows={4}
+          placeholder="Describe the notebook you want to create or how to update the active one..."
+          value={prompt}
+          onChange={(event: ChangeEvent<HTMLTextAreaElement>) =>
+            setPrompt(event.target.value)
+          }
+          onKeyDown={handleTextareaKeyDown}
+        />
+        <CheckBoxItem
+          checked={showInChat}
+          label="Show in chat"
+          tooltip={
+            'When enabled, the prompt opens the Notebook Intelligence ' +
+            'chat sidebar. Disable to keep the chat hidden and only ' +
+            'show progress on the notebook toolbar.'
+          }
+          onClick={() => setShowInChat(value => !value)}
+        />
+        <div className="notebook-generation-popover-actions">
+          <button
+            type="button"
+            className="notebook-generation-popover-submit"
+            disabled={!canSubmit}
+            onClick={handleSubmit}
+            title="Generate (Enter)"
+          >
+            <VscSend />
+            <span>Generate</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,7 @@ import { UUID } from '@lumino/coreutils';
 import * as path from 'path';
 import { SettingsPanel } from './components/settings-panel';
 import { ITerminalConnection } from '@jupyterlab/services/lib/terminal/terminal';
+import { NotebookGenerationToolbarExtension } from './notebook-generation-toolbar';
 
 namespace CommandIDs {
   export const chatuserInput = 'notebook-intelligence:chat-user-input';
@@ -780,6 +781,15 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
     panel.addWidget(sidebar);
     app.shell.add(panel, 'left', { rank: 1000 });
     app.shell.activateById(panel.id);
+
+    app.docRegistry.addWidgetExtension(
+      'Notebook',
+      new NotebookGenerationToolbarExtension({
+        app,
+        icon: sparkleIcon,
+        chatSidebarId: panel.id
+      })
+    );
 
     const updateSidebarIcon = () => {
       if (NBIAPI.getChatEnabled()) {

--- a/src/notebook-generation-toolbar.tsx
+++ b/src/notebook-generation-toolbar.tsx
@@ -1,0 +1,258 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+import { JupyterFrontEnd } from '@jupyterlab/application';
+import { ReactWidget } from '@jupyterlab/apputils';
+import { DocumentRegistry } from '@jupyterlab/docregistry';
+import { INotebookModel, NotebookPanel } from '@jupyterlab/notebook';
+import { LabIcon, ToolbarButton } from '@jupyterlab/ui-components';
+import { IDisposable, DisposableDelegate } from '@lumino/disposable';
+import { Widget } from '@lumino/widgets';
+import { UUID } from '@lumino/coreutils';
+import React from 'react';
+
+import {
+  IRunChatCompletionRequest,
+  RunChatCompletionType
+} from './chat-sidebar';
+import {
+  buildNotebookGenerationPrompt,
+  INotebookGenerationProgressDetail,
+  NOTEBOOK_GENERATION_PROGRESS_EVENT
+} from './notebook-generation';
+import { NotebookGenerationPopover } from './components/notebook-generation-popover';
+
+const TOOLBAR_BUTTON_NAME = 'nbi-generate-notebook';
+const TOOLBAR_BUTTON_RANK = 11;
+
+interface INotebookGenerationToolbarOptions {
+  app: JupyterFrontEnd;
+  icon: LabIcon;
+  chatSidebarId: string;
+}
+
+class NotebookGenerationPopoverWidget extends ReactWidget {
+  constructor(options: {
+    initialShowInChat: boolean;
+    onSubmit: (prompt: string, showInChat: boolean) => void;
+    onClose: () => void;
+  }) {
+    super();
+    this.addClass('nbi-notebook-generation-popover-host');
+    this._options = options;
+  }
+
+  protected onAfterAttach(): void {
+    document.addEventListener('mousedown', this._onDocumentMouseDown, true);
+  }
+
+  protected onBeforeDetach(): void {
+    document.removeEventListener('mousedown', this._onDocumentMouseDown, true);
+  }
+
+  private _onDocumentMouseDown = (event: MouseEvent): void => {
+    const target = event.target as Node | null;
+    if (target && this.node.contains(target)) {
+      return;
+    }
+    this._options.onClose();
+  };
+
+  positionAt(rect: DOMRect): void {
+    const popoverWidth = 360;
+    const margin = 8;
+    let left = rect.left;
+    if (left + popoverWidth + margin > window.innerWidth) {
+      left = Math.max(margin, window.innerWidth - popoverWidth - margin);
+    }
+    const top = rect.bottom + 4;
+    this.node.style.position = 'fixed';
+    this.node.style.left = `${left}px`;
+    this.node.style.top = `${top}px`;
+    this.node.style.width = `${popoverWidth}px`;
+    this.node.style.zIndex = '10000';
+  }
+
+  render(): JSX.Element {
+    return (
+      <NotebookGenerationPopover
+        initialShowInChat={this._options.initialShowInChat}
+        onSubmit={this._options.onSubmit}
+        onClose={this._options.onClose}
+      />
+    );
+  }
+
+  private _options: {
+    initialShowInChat: boolean;
+    onSubmit: (prompt: string, showInChat: boolean) => void;
+    onClose: () => void;
+  };
+}
+
+class NotebookGenerationToolbarController {
+  constructor(
+    options: INotebookGenerationToolbarOptions,
+    panel: NotebookPanel
+  ) {
+    this._app = options.app;
+    this._chatSidebarId = options.chatSidebarId;
+    this._panel = panel;
+  }
+
+  openPopover(button: ToolbarButton): void {
+    if (this._popover) {
+      this.closePopover();
+      return;
+    }
+    const buttonRect = button.node.getBoundingClientRect();
+    this._popover = new NotebookGenerationPopoverWidget({
+      initialShowInChat: NotebookGenerationToolbarController._showInChat,
+      onSubmit: (prompt, showInChat) => {
+        NotebookGenerationToolbarController._showInChat = showInChat;
+        this._submitPrompt(prompt, showInChat);
+        this.closePopover();
+      },
+      onClose: () => this.closePopover()
+    });
+    Widget.attach(this._popover, document.body);
+    // ReactWidget renders its tree in response to an update-request message;
+    // Widget.attach by itself doesn't queue one, so without this call the
+    // popover host appears empty in the DOM.
+    this._popover.update();
+    this._popover.positionAt(buttonRect);
+  }
+
+  closePopover(): void {
+    if (!this._popover) {
+      return;
+    }
+    this._popover.dispose();
+    this._popover = null;
+  }
+
+  dispose(): void {
+    this.closePopover();
+    if (this._activeProgressRequestId) {
+      document.removeEventListener(
+        NOTEBOOK_GENERATION_PROGRESS_EVENT,
+        this._onProgress
+      );
+      this._activeProgressRequestId = null;
+    }
+    this._setStatus(null);
+  }
+
+  private _submitPrompt(rawPrompt: string, showInChat: boolean): void {
+    const prefixedPrompt = buildNotebookGenerationPrompt(rawPrompt);
+    const externalRequestId = UUID.uuid4();
+    const request: Partial<IRunChatCompletionRequest> = {
+      type: RunChatCompletionType.NotebookGeneration,
+      content: prefixedPrompt,
+      chatMode: '',
+      externalRequestId
+    };
+
+    if (!showInChat) {
+      this._setStatus('Generating notebook…');
+      this._activeProgressRequestId = externalRequestId;
+      document.addEventListener(
+        NOTEBOOK_GENERATION_PROGRESS_EVENT,
+        this._onProgress
+      );
+    }
+
+    document.dispatchEvent(
+      new CustomEvent('copilotSidebar:runPrompt', { detail: request })
+    );
+
+    if (showInChat) {
+      this._app.commands.execute('tabsmenu:activate-by-id', {
+        id: this._chatSidebarId
+      });
+    }
+  }
+
+  private _onProgress = (event: Event): void => {
+    const detail = (event as CustomEvent<INotebookGenerationProgressDetail>)
+      .detail;
+    if (!detail || detail.requestId !== this._activeProgressRequestId) {
+      return;
+    }
+    if (!detail.inProgress) {
+      document.removeEventListener(
+        NOTEBOOK_GENERATION_PROGRESS_EVENT,
+        this._onProgress
+      );
+      this._activeProgressRequestId = null;
+      if (detail.error) {
+        this._setStatus(`Generation failed: ${detail.error}`);
+        setTimeout(() => this._setStatus(null), 4000);
+      } else {
+        this._setStatus('Notebook generation complete');
+        setTimeout(() => this._setStatus(null), 2500);
+      }
+    }
+  };
+
+  private _setStatus(message: string | null): void {
+    if (this._panel.isDisposed) {
+      return;
+    }
+    if (!message) {
+      if (this._statusEl && this._statusEl.parentElement) {
+        this._statusEl.parentElement.removeChild(this._statusEl);
+      }
+      this._statusEl = null;
+      return;
+    }
+    if (!this._statusEl) {
+      this._statusEl = document.createElement('div');
+      this._statusEl.className = 'nbi-notebook-generation-status';
+      this._panel.toolbar.node.appendChild(this._statusEl);
+    }
+    this._statusEl.textContent = message;
+  }
+
+  // Persist the toggle across popover invocations (per-tab). The issue
+  // requires the toggle to default ON the first time, then remember the
+  // user's last choice.
+  private static _showInChat = true;
+
+  private _app: JupyterFrontEnd;
+  private _chatSidebarId: string;
+  private _panel: NotebookPanel;
+  private _popover: NotebookGenerationPopoverWidget | null = null;
+  private _activeProgressRequestId: string | null = null;
+  private _statusEl: HTMLDivElement | null = null;
+}
+
+export class NotebookGenerationToolbarExtension
+  implements DocumentRegistry.IWidgetExtension<NotebookPanel, INotebookModel>
+{
+  constructor(options: INotebookGenerationToolbarOptions) {
+    this._options = options;
+  }
+
+  createNew(
+    panel: NotebookPanel,
+    _context: DocumentRegistry.IContext<INotebookModel>
+  ): IDisposable {
+    const controller = new NotebookGenerationToolbarController(
+      this._options,
+      panel
+    );
+    const button: ToolbarButton = new ToolbarButton({
+      icon: this._options.icon,
+      onClick: () => controller.openPopover(button),
+      tooltip: 'Generate or update notebook with AI'
+    });
+    button.addClass('nbi-notebook-generation-toolbar-button');
+    panel.toolbar.insertItem(TOOLBAR_BUTTON_RANK, TOOLBAR_BUTTON_NAME, button);
+    return new DisposableDelegate(() => {
+      controller.dispose();
+      button.dispose();
+    });
+  }
+
+  private _options: INotebookGenerationToolbarOptions;
+}

--- a/src/notebook-generation-toolbar.tsx
+++ b/src/notebook-generation-toolbar.tsx
@@ -149,7 +149,8 @@ class NotebookGenerationToolbarController {
       type: RunChatCompletionType.NotebookGeneration,
       content: prefixedPrompt,
       chatMode: '',
-      externalRequestId
+      externalRequestId,
+      hideInChat: !showInChat
     };
 
     if (!showInChat) {

--- a/src/notebook-generation-toolbar.tsx
+++ b/src/notebook-generation-toolbar.tsx
@@ -22,7 +22,11 @@ import {
 import { NotebookGenerationPopover } from './components/notebook-generation-popover';
 
 const TOOLBAR_BUTTON_NAME = 'nbi-generate-notebook';
-const TOOLBAR_BUTTON_RANK = 11;
+const TOOLBAR_STATUS_NAME = 'nbi-generate-notebook-status';
+// Insert at the very left of the notebook toolbar so the button (and the
+// progress pill that sits next to it) are easy to discover.
+const TOOLBAR_BUTTON_INDEX = 0;
+const TOOLBAR_STATUS_INDEX = 1;
 
 interface INotebookGenerationToolbarOptions {
   app: JupyterFrontEnd;
@@ -210,18 +214,23 @@ class NotebookGenerationToolbarController {
       return;
     }
     if (!message) {
-      if (this._statusEl && this._statusEl.parentElement) {
-        this._statusEl.parentElement.removeChild(this._statusEl);
+      if (this._statusWidget) {
+        this._statusWidget.dispose();
+        this._statusWidget = null;
       }
-      this._statusEl = null;
       return;
     }
-    if (!this._statusEl) {
-      this._statusEl = document.createElement('div');
-      this._statusEl.className = 'nbi-notebook-generation-status';
-      this._panel.toolbar.node.appendChild(this._statusEl);
+    if (!this._statusWidget) {
+      const widget = new Widget();
+      widget.addClass('nbi-notebook-generation-status');
+      this._panel.toolbar.insertItem(
+        TOOLBAR_STATUS_INDEX,
+        TOOLBAR_STATUS_NAME,
+        widget
+      );
+      this._statusWidget = widget;
     }
-    this._statusEl.textContent = message;
+    this._statusWidget.node.textContent = message;
   }
 
   // Defaults ON; remembers the user's last choice for the rest of the tab.
@@ -232,7 +241,7 @@ class NotebookGenerationToolbarController {
   private _panel: NotebookPanel;
   private _popover: NotebookGenerationPopoverWidget | null = null;
   private _activeProgressRequestId: string | null = null;
-  private _statusEl: HTMLDivElement | null = null;
+  private _statusWidget: Widget | null = null;
   private _statusHideTimer: ReturnType<typeof setTimeout> | null = null;
 }
 
@@ -254,10 +263,10 @@ export class NotebookGenerationToolbarExtension
     const button: ToolbarButton = new ToolbarButton({
       icon: this._options.icon,
       onClick: () => controller.openPopover(button),
-      tooltip: 'Generate or update notebook with AI'
+      tooltip: 'Update active notebook with AI'
     });
     button.addClass('nbi-notebook-generation-toolbar-button');
-    panel.toolbar.insertItem(TOOLBAR_BUTTON_RANK, TOOLBAR_BUTTON_NAME, button);
+    panel.toolbar.insertItem(TOOLBAR_BUTTON_INDEX, TOOLBAR_BUTTON_NAME, button);
     return new DisposableDelegate(() => {
       controller.dispose();
       button.dispose();

--- a/src/notebook-generation-toolbar.tsx
+++ b/src/notebook-generation-toolbar.tsx
@@ -30,12 +30,14 @@ interface INotebookGenerationToolbarOptions {
   chatSidebarId: string;
 }
 
+interface INotebookGenerationPopoverWidgetOptions {
+  initialShowInChat: boolean;
+  onSubmit: (prompt: string, showInChat: boolean) => void;
+  onClose: () => void;
+}
+
 class NotebookGenerationPopoverWidget extends ReactWidget {
-  constructor(options: {
-    initialShowInChat: boolean;
-    onSubmit: (prompt: string, showInChat: boolean) => void;
-    onClose: () => void;
-  }) {
+  constructor(options: INotebookGenerationPopoverWidgetOptions) {
     super();
     this.addClass('nbi-notebook-generation-popover-host');
     this._options = options;
@@ -82,11 +84,7 @@ class NotebookGenerationPopoverWidget extends ReactWidget {
     );
   }
 
-  private _options: {
-    initialShowInChat: boolean;
-    onSubmit: (prompt: string, showInChat: boolean) => void;
-    onClose: () => void;
-  };
+  private _options: INotebookGenerationPopoverWidgetOptions;
 }
 
 class NotebookGenerationToolbarController {
@@ -115,9 +113,7 @@ class NotebookGenerationToolbarController {
       onClose: () => this.closePopover()
     });
     Widget.attach(this._popover, document.body);
-    // ReactWidget renders its tree in response to an update-request message;
-    // Widget.attach by itself doesn't queue one, so without this call the
-    // popover host appears empty in the DOM.
+    // ReactWidget renders on update-request; Widget.attach doesn't queue one.
     this._popover.update();
     this._popover.positionAt(buttonRect);
   }
@@ -138,6 +134,10 @@ class NotebookGenerationToolbarController {
         this._onProgress
       );
       this._activeProgressRequestId = null;
+    }
+    if (this._statusHideTimer !== null) {
+      clearTimeout(this._statusHideTimer);
+      this._statusHideTimer = null;
     }
     this._setStatus(null);
   }
@@ -187,13 +187,23 @@ class NotebookGenerationToolbarController {
       this._activeProgressRequestId = null;
       if (detail.error) {
         this._setStatus(`Generation failed: ${detail.error}`);
-        setTimeout(() => this._setStatus(null), 4000);
+        this._scheduleStatusHide(4000);
       } else {
         this._setStatus('Notebook generation complete');
-        setTimeout(() => this._setStatus(null), 2500);
+        this._scheduleStatusHide(2500);
       }
     }
   };
+
+  private _scheduleStatusHide(delayMs: number): void {
+    if (this._statusHideTimer !== null) {
+      clearTimeout(this._statusHideTimer);
+    }
+    this._statusHideTimer = setTimeout(() => {
+      this._statusHideTimer = null;
+      this._setStatus(null);
+    }, delayMs);
+  }
 
   private _setStatus(message: string | null): void {
     if (this._panel.isDisposed) {
@@ -214,9 +224,7 @@ class NotebookGenerationToolbarController {
     this._statusEl.textContent = message;
   }
 
-  // Persist the toggle across popover invocations (per-tab). The issue
-  // requires the toggle to default ON the first time, then remember the
-  // user's last choice.
+  // Defaults ON; remembers the user's last choice for the rest of the tab.
   private static _showInChat = true;
 
   private _app: JupyterFrontEnd;
@@ -225,6 +233,7 @@ class NotebookGenerationToolbarController {
   private _popover: NotebookGenerationPopoverWidget | null = null;
   private _activeProgressRequestId: string | null = null;
   private _statusEl: HTMLDivElement | null = null;
+  private _statusHideTimer: ReturnType<typeof setTimeout> | null = null;
 }
 
 export class NotebookGenerationToolbarExtension

--- a/src/notebook-generation.ts
+++ b/src/notebook-generation.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+//
+// Pure helpers and event constants used by the notebook-generation toolbar
+// button. Keeping these in their own module (free of JupyterLab/React
+// dependencies) makes them easy to unit-test under jsdom without bringing
+// in the chat sidebar's heavyweight ESM imports.
+
+export const NOTEBOOK_GENERATION_PROMPT_PREFIX =
+  'Create a new notebook or update active notebook based on this request: ';
+
+export const NOTEBOOK_GENERATION_PROGRESS_EVENT =
+  'copilotSidebar:notebookGenerationProgress';
+
+export interface INotebookGenerationProgressDetail {
+  requestId: string;
+  inProgress: boolean;
+  error?: string;
+}
+
+export function buildNotebookGenerationPrompt(rawPrompt: string): string {
+  const trimmed = (rawPrompt || '').trim();
+  return `${NOTEBOOK_GENERATION_PROMPT_PREFIX}${trimmed}`;
+}

--- a/src/notebook-generation.ts
+++ b/src/notebook-generation.ts
@@ -6,7 +6,7 @@
 // in the chat sidebar's heavyweight ESM imports.
 
 export const NOTEBOOK_GENERATION_PROMPT_PREFIX =
-  'Create a new notebook or update active notebook based on this request: ';
+  'Update active notebook based on this request: ';
 
 export const NOTEBOOK_GENERATION_PROGRESS_EVENT =
   'copilotSidebar:notebookGenerationProgress';

--- a/style/base.css
+++ b/style/base.css
@@ -2173,3 +2173,135 @@ svg.access-token-warning {
 .nbi-cell-output-toolbar-button-label {
   white-space: nowrap;
 }
+
+/* Notebook generation toolbar button + popover */
+.nbi-notebook-generation-toolbar-button .jp-ToolbarButtonComponent {
+  background-color: transparent;
+}
+
+.nbi-notebook-generation-toolbar-button .jp-icon3[fill] {
+  fill: var(--jp-brand-color1);
+}
+
+.nbi-notebook-generation-popover-host {
+  display: block;
+  pointer-events: auto;
+}
+
+.notebook-generation-popover {
+  display: flex;
+  flex-direction: column;
+  background-color: var(--jp-layout-color1);
+  border: 1px solid var(--jp-border-color1);
+  box-shadow: 0 4px 12px rgb(0 0 0 / 18%);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.notebook-generation-popover-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 28px;
+  padding: 2px 6px;
+  background-color: var(--jp-layout-color2);
+  border-bottom: 1px solid var(--jp-border-color2);
+}
+
+.notebook-generation-popover-header-icon {
+  display: flex;
+  align-items: center;
+  color: var(--jp-brand-color1);
+}
+
+.notebook-generation-popover .notebook-generation-popover-header-icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.notebook-generation-popover-title {
+  font-weight: bold;
+  color: var(--jp-ui-font-color1);
+}
+
+.notebook-generation-popover-close-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  cursor: pointer;
+  color: var(--jp-ui-font-color2);
+}
+
+.notebook-generation-popover-close-button:hover {
+  color: var(--jp-ui-font-color0);
+  background-color: var(--jp-layout-color3);
+  border-radius: 2px;
+}
+
+.notebook-generation-popover-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+}
+
+.notebook-generation-popover-input {
+  width: 100%;
+  box-sizing: border-box;
+  background-color: var(--jp-layout-color0);
+  color: var(--jp-ui-font-color1);
+  border: 1px solid var(--jp-border-color1);
+  font-family: var(--jp-ui-font-family);
+  font-size: var(--jp-ui-font-size1);
+  padding: 6px 8px;
+  outline: none;
+  resize: vertical;
+  min-height: 64px;
+}
+
+.notebook-generation-popover-input:focus {
+  border-color: var(--jp-brand-color1);
+}
+
+.notebook-generation-popover-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.notebook-generation-popover-submit {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background-color: var(--jp-brand-color1);
+  color: white;
+  border: none;
+  border-radius: 2px;
+  padding: 5px 10px;
+  cursor: pointer;
+  font-family: var(--jp-ui-font-family);
+  font-size: var(--jp-ui-font-size1);
+}
+
+.notebook-generation-popover-submit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.notebook-generation-popover .notebook-generation-popover-submit svg {
+  width: 14px;
+  height: 14px;
+}
+
+.nbi-notebook-generation-status {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 8px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  background-color: var(--jp-brand-color3);
+  color: var(--jp-brand-color0);
+  font-size: var(--jp-ui-font-size0);
+  white-space: nowrap;
+}

--- a/tests/ts/notebook-generation.test.ts
+++ b/tests/ts/notebook-generation.test.ts
@@ -10,7 +10,7 @@ describe('buildNotebookGenerationPrompt', () => {
   it('prepends the templated prefix described in the issue', () => {
     const result = buildNotebookGenerationPrompt('plot a sine wave');
     expect(result).toBe(
-      'Create a new notebook or update active notebook based on this request: plot a sine wave'
+      'Update active notebook based on this request: plot a sine wave'
     );
   });
 

--- a/tests/ts/notebook-generation.test.ts
+++ b/tests/ts/notebook-generation.test.ts
@@ -1,0 +1,48 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+import {
+  buildNotebookGenerationPrompt,
+  NOTEBOOK_GENERATION_PROGRESS_EVENT,
+  NOTEBOOK_GENERATION_PROMPT_PREFIX
+} from '../../src/notebook-generation';
+
+describe('buildNotebookGenerationPrompt', () => {
+  it('prepends the templated prefix described in the issue', () => {
+    const result = buildNotebookGenerationPrompt('plot a sine wave');
+    expect(result).toBe(
+      'Create a new notebook or update active notebook based on this request: plot a sine wave'
+    );
+  });
+
+  it('uses the exported constant for the prefix', () => {
+    const result = buildNotebookGenerationPrompt('foo');
+    expect(result.startsWith(NOTEBOOK_GENERATION_PROMPT_PREFIX)).toBe(true);
+  });
+
+  it('trims surrounding whitespace from the user prompt', () => {
+    const result = buildNotebookGenerationPrompt('   summarise the data\n');
+    expect(result).toBe(
+      `${NOTEBOOK_GENERATION_PROMPT_PREFIX}summarise the data`
+    );
+  });
+
+  it('handles empty input gracefully', () => {
+    const result = buildNotebookGenerationPrompt('');
+    expect(result).toBe(NOTEBOOK_GENERATION_PROMPT_PREFIX);
+  });
+
+  it('handles undefined input gracefully', () => {
+    const result = buildNotebookGenerationPrompt(
+      undefined as unknown as string
+    );
+    expect(result).toBe(NOTEBOOK_GENERATION_PROMPT_PREFIX);
+  });
+});
+
+describe('notebook generation surface area', () => {
+  it('exposes a stable progress event name for external listeners', () => {
+    expect(NOTEBOOK_GENERATION_PROGRESS_EVENT).toBe(
+      'copilotSidebar:notebookGenerationProgress'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a sparkle-icon button to every notebook toolbar that opens a popover for prompting the chat backend to create or update the active notebook. The popover prefixes the user's prompt with the templated phrase from the issue spec and dispatches it through the existing `copilotSidebar:runPrompt` event channel.
- "Show in chat" toggle (on by default, persisted across the session per the issue spec). When off, a small status pill on the notebook toolbar reports generation progress and clears itself when the request finishes; the chat sidebar still owns the request lifecycle and emits `copilotSidebar:notebookGenerationProgress` events that the toolbar controller consumes.
- A `hideInChat` flag on `IRunChatCompletionRequest` lets the sidebar skip rendering the user turn and streaming assistant response while still streaming through the backend, so the toolbar progress indicator updates without polluting the transcript.

Closes #167

## Test plan
- [x] `jlpm test tests/ts/notebook-generation.test.ts` — covers prompt prefixing.
- [x] `jlpm build` — clean.
- [ ] Manual: open a notebook, click the sparkle icon, type "create a 3-cell notebook on linear regression," submit with Show-in-chat ON → chat sidebar opens and streams the response; cells appear in the notebook.
- [ ] Manual: same flow with Show-in-chat OFF → chat sidebar stays unchanged, a "Generating notebook…" pill appears on the notebook toolbar, then a "complete" pill that fades.
- [ ] Manual: toggle state persists between popover invocations within the tab.