### PR TITLE
fix: resolve symlinks when locating Claude session transcripts

### DIFF
--- a/notebook_intelligence/claude_sessions.py
+++ b/notebook_intelligence/claude_sessions.py
@@ -57,11 +57,13 @@ def encode_cwd(cwd: str) -> str:
     """Encode a filesystem path the way Claude Code names its project dirs.
 
     Claude Code replaces every path separator with a dash, so
-    ``/Users/me/proj`` becomes ``-Users-me-proj``. We normalize the path
-    first so trailing slashes or ``..`` segments don't produce surprising
-    directory names.
+    ``/Users/me/proj`` becomes ``-Users-me-proj``. We resolve symlinks
+    first to match Claude Code's own behavior — without this, macOS's
+    ``/tmp`` (a symlink to ``/private/tmp``) would map to ``-tmp`` here
+    while Claude Code stores transcripts under ``-private-tmp``, so the
+    picker would silently find no sessions.
     """
-    normalized = os.path.normpath(os.path.abspath(cwd))
+    normalized = os.path.realpath(cwd)
     return normalized.replace(os.sep, "-")
 
 

--- a/tests/test_claude_sessions.py
+++ b/tests/test_claude_sessions.py
@@ -66,11 +66,19 @@ class TestEncodeCwd:
     def test_normalizes_parent_segments(self):
         assert encode_cwd("/Users/me/proj/../proj") == "-Users-me-proj"
 
+    def test_resolves_symlinks(self, tmp_path):
+        real = tmp_path / "real"
+        real.mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(real)
+
+        assert encode_cwd(str(link)) == encode_cwd(str(real))
+
 
 class TestGetSessionsDir:
-    def test_composes_claude_projects_path(self, fake_claude_home):
-        result = get_sessions_dir("/tmp/foo", claude_home=str(fake_claude_home))
-        assert result == fake_claude_home / "projects" / "-tmp-foo"
+    def test_composes_claude_projects_path(self, fake_claude_home, project_cwd):
+        result = get_sessions_dir(project_cwd, claude_home=str(fake_claude_home))
+        assert result == fake_claude_home / "projects" / encode_cwd(project_cwd)
 
 
 class TestListSessions:


### PR DESCRIPTION
## Summary
- The "Resume Claude session" picker silently returned no results on macOS when JupyterLab was launched from `/tmp` (or any other symlinked directory).
- Claude Code canonicalizes its session cwd with `realpath` before naming the projects directory, so a `/tmp` launch ends up under `~/.claude/projects/-private-tmp`, while `encode_cwd()` was using `os.path.abspath` which leaves symlinks alone and produced `-tmp`. The directories never matched, so existing transcripts were invisible to the picker.
- Switches `encode_cwd` to `os.path.realpath` so both sides agree on the encoded path, and adds a regression test that creates a real symlink under `tmp_path`.

## Test plan
- [x] `pytest tests/test_claude_sessions.py` — covers symlink resolution alongside the existing path-encoding cases.
- [ ] Manual on macOS: `cd /tmp && jupyter lab`, start a Claude conversation, reload the page, open the Resume Claude session picker, confirm the session appears (previously the list was empty).