### PR TITLE
fix(openai): drop unsupported tool strict flag for vLLM (#108)

### DIFF
--- a/notebook_intelligence/llm_providers/openai_compatible_llm_provider.py
+++ b/notebook_intelligence/llm_providers/openai_compatible_llm_provider.py
@@ -1,5 +1,6 @@
 # Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
 
+import copy
 import json
 import re
 from typing import Any
@@ -9,6 +10,20 @@ from openai import OpenAI, omit
 INLINE_COMPLETION_SYSTEM_PROMPT = """You are a code completion assistant. Your task is to generate intelligent autocomplete suggestions for the code at the cursor position for given language and active file type. This is not an interactive session, don't ask for clarifying questions, always generate a suggestion. Don't include any explanations for your response, just generate the code. Don't return any thinking or reasoning, just generate the code. You are given a code snippet with a prefix and a suffix. You need to generate a suggestion for the code that fits best in place of <CURSOR/>. You should return only the code that fits best in place of <CURSOR/>. You should provide multiline code if needed. Enclose the code in triple backticks, just return the code in language. You should not return any other text, just the code. DO NOT INCLUDE THE PREFIX OR SUFFIX IN THE RESPONSE. .ipynb files are Jupyter notebook files and for notebook files, you generate suggestions for a cell within the notebook. A cell can be a code cell with code or a markdown cell with markdown text. If the language is markdown, only return markdown text. If you need to install a Python package within a notebook cell code (for .ipynb files), use %pip install <package_name> instead of !pip install <package_name>. Follow the tags very carefully for proper spacing and indentations."""
 
 DEFAULT_CONTEXT_WINDOW = 4096
+
+
+def sanitize_tools_for_openai_compatible(tools: list[dict] | None) -> list[dict] | None:
+    """Drop Structured Outputs-only flags unsupported by many OpenAI-compatible APIs."""
+    if tools is None:
+        return None
+
+    sanitized_tools = copy.deepcopy(tools)
+    for tool in sanitized_tools:
+        function_schema = tool.get("function")
+        if isinstance(function_schema, dict):
+            function_schema.pop("strict", None)
+    return sanitized_tools
+
 
 class OpenAICompatibleChatModel(ChatModel):
     def __init__(self, provider: "OpenAICompatibleLLMProvider"):
@@ -51,7 +66,7 @@ class OpenAICompatibleChatModel(ChatModel):
         resp = client.chat.completions.create(
             model=model_id,
             messages=messages.copy(),
-            tools=tools or omit,
+            tools=sanitize_tools_for_openai_compatible(tools) or omit,
             tool_choice=options.get("tool_choice", omit),
             stream=stream,
         )

--- a/tests/test_openai_compatible_llm_provider.py
+++ b/tests/test_openai_compatible_llm_provider.py
@@ -1,0 +1,60 @@
+from unittest.mock import MagicMock, patch
+
+from notebook_intelligence.llm_providers.openai_compatible_llm_provider import (
+    OpenAICompatibleLLMProvider,
+    sanitize_tools_for_openai_compatible,
+)
+
+
+def test_sanitize_tools_for_openai_compatible_removes_function_strict_without_mutating_input():
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "python",
+                "description": "Run python",
+                "strict": True,
+                "parameters": {"type": "object", "properties": {}, "additionalProperties": False},
+            },
+        }
+    ]
+
+    sanitized = sanitize_tools_for_openai_compatible(tools)
+
+    assert sanitized[0]["function"].get("strict") is None
+    assert tools[0]["function"]["strict"] is True
+
+
+@patch("notebook_intelligence.llm_providers.openai_compatible_llm_provider.OpenAI")
+def test_openai_compatible_chat_model_drops_strict_before_request(mock_openai_cls):
+    provider = OpenAICompatibleLLMProvider()
+    model = provider.chat_models[0]
+    model.set_property_value("model_id", "test-model")
+    model.set_property_value("api_key", "test-key")
+    model.set_property_value("base_url", "https://example.com/v1")
+
+    mock_client = MagicMock()
+    mock_openai_cls.return_value = mock_client
+    mock_response = MagicMock()
+    mock_response.model_dump_json.return_value = '{"choices": [{"message": {"content": "ok"}}]}'
+    mock_response.choices = [MagicMock(message=MagicMock(reasoning_content=None, reasoning=None))]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "python",
+                "description": "Run python",
+                "strict": True,
+                "parameters": {"type": "object", "properties": {}, "additionalProperties": False},
+            },
+        }
+    ]
+
+    result = model.completions(messages=[{"role": "user", "content": "hi"}], tools=tools)
+
+    assert result["choices"][0]["message"]["content"] == "ok"
+    create_kwargs = mock_client.chat.completions.create.call_args.kwargs
+    assert "strict" not in create_kwargs["tools"][0]["function"]
+    assert tools[0]["function"]["strict"] is True


### PR DESCRIPTION
Fixes #108.

OpenAI-compatible backends like vLLM reject the `function.strict` field in tool schemas, so agent requests crash before tool calling starts. This strips that flag before sending tool definitions while leaving the local schemas untouched.

Also adds a regression test to make sure we don't mutate the original tool schema.