### PR TITLE
fix(rules): support repo-level AGENTS.md instructions

### DIFF
--- a/notebook_intelligence/rule_injector.py
+++ b/notebook_intelligence/rule_injector.py
@@ -1,24 +1,50 @@
 # Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
 
+import logging
+from pathlib import Path
+
 from notebook_intelligence.api import ChatRequest
 from notebook_intelligence.rule_manager import RuleManager
+from notebook_intelligence.util import get_jupyter_root_dir
+
+log = logging.getLogger(__name__)
 
 
 class RuleInjector:
     """Handles rule injection logic - easily mockable."""
+
+    def _read_agents_md(self) -> str:
+        project_root = get_jupyter_root_dir()
+        if not project_root:
+            return ''
+
+        agents_path = Path(project_root) / 'AGENTS.md'
+        if not agents_path.is_file():
+            return ''
+
+        try:
+            return agents_path.read_text(encoding='utf-8').strip()
+        except Exception as e:
+            log.warning(f"Failed to read AGENTS.md from {agents_path}: {e}")
+            return ''
     
     def inject_rules(self, base_prompt: str, request: ChatRequest) -> str:
         """Inject applicable rules into system prompt based on request context."""
-        if not request.rule_context:
+        sections = []
+
+        agents_md = self._read_agents_md()
+        if agents_md:
+            sections.append(f"# Repository Instructions (AGENTS.md)\n{agents_md}")
+
+        if request.rule_context:
+            rule_manager: RuleManager = request.host.get_rule_manager()
+            if rule_manager and request.host.nbi_config.rules_enabled:
+                applicable_rules = rule_manager.get_applicable_rules(request.rule_context)
+                if applicable_rules:
+                    formatted_rules = rule_manager.format_rules_for_llm(applicable_rules)
+                    sections.append(formatted_rules)
+
+        if not sections:
             return base_prompt
-            
-        rule_manager: RuleManager = request.host.get_rule_manager()
-        if not rule_manager or not request.host.nbi_config.rules_enabled:
-            return base_prompt
-            
-        applicable_rules = rule_manager.get_applicable_rules(request.rule_context)
-        if not applicable_rules:
-            return base_prompt
-            
-        formatted_rules = rule_manager.format_rules_for_llm(applicable_rules)
-        return f"{base_prompt}\n\n# Additional Guidelines\n{formatted_rules}"
+
+        return f"{base_prompt}\n\n# Additional Guidelines\n" + "\n\n".join(sections)

--- a/tests/test_rule_injector.py
+++ b/tests/test_rule_injector.py
@@ -1,8 +1,8 @@
-import pytest
-from unittest.mock import Mock, MagicMock
-from notebook_intelligence.rule_injector import RuleInjector
+from unittest.mock import Mock, patch
+
 from notebook_intelligence.api import ChatRequest
-from notebook_intelligence.ruleset import RuleContext, Rule, RuleScope
+from notebook_intelligence.rule_injector import RuleInjector
+from notebook_intelligence.ruleset import Rule, RuleContext
 
 
 class TestRuleInjector:
@@ -104,3 +104,39 @@ class TestRuleInjector:
         
         expected = "\n\n# Additional Guidelines\n# Test Rules\n- Be helpful"
         assert result == expected
+
+    def test_inject_rules_with_agents_md_only(self, tmp_path):
+        injector = RuleInjector()
+        request = Mock(spec=ChatRequest)
+        request.rule_context = None
+
+        agents_path = tmp_path / 'AGENTS.md'
+        agents_path.write_text('# Repo Rules\n- Keep notebooks tidy\n', encoding='utf-8')
+
+        with patch('notebook_intelligence.rule_injector.get_jupyter_root_dir', return_value=str(tmp_path)):
+            result = injector.inject_rules('You are a helpful assistant.', request)
+
+        assert 'Repository Instructions (AGENTS.md)' in result
+        assert 'Keep notebooks tidy' in result
+
+    def test_inject_rules_combines_agents_md_and_rules(self, tmp_path):
+        injector = RuleInjector()
+        request = Mock(spec=ChatRequest)
+        request.rule_context = Mock(spec=RuleContext)
+
+        (tmp_path / 'AGENTS.md').write_text('# Repo Rules\n- Prefer small changes\n', encoding='utf-8')
+
+        rule_manager = Mock()
+        rule_manager.get_applicable_rules.return_value = [Mock(spec=Rule)]
+        rule_manager.format_rules_for_llm.return_value = '# Test Rules\n- Add tests'
+
+        request.host.get_rule_manager.return_value = rule_manager
+        request.host.nbi_config.rules_enabled = True
+
+        with patch('notebook_intelligence.rule_injector.get_jupyter_root_dir', return_value=str(tmp_path)):
+            result = injector.inject_rules('You are a helpful assistant.', request)
+
+        assert 'Repository Instructions (AGENTS.md)' in result
+        assert 'Prefer small changes' in result
+        assert '# Test Rules' in result
+        assert 'Add tests' in result


### PR DESCRIPTION
## Summary
Fixes #77

Load `AGENTS.md` from the Jupyter project root and inject it into the system prompt as repository-level guidance. This works alongside the existing rules system instead of replacing it.

## Changes
- read `<project-root>/AGENTS.md` when present and append it under Additional Guidelines
- keep existing rule injection behavior and combine both sources when both exist
- add regression tests for AGENTS-only injection and AGENTS + rules together

## Testing
- `PYTHONPATH=. .venv/bin/pytest -q tests/test_rule_injector.py tests/test_end_to_end_rule_integration.py tests/test_context_factory.py tests/test_config_integration.py tests/test_rule_manager.py tests/test_rule_auto_reload.py`

---
🤖 Generated with Claude Code
