### PR TITLE
fix: claude headers for inline completions

### DIFF
--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -134,13 +134,21 @@ def _normalize_anthropic_credential(value: Any) -> str | None:
     return value.strip() or None
 
 
+def _create_anthropic_client(api_key: str = None, base_url: str = None) -> Anthropic:
+    """Create an Anthropic client with normalized credentials and default headers."""
+    api_key = _normalize_anthropic_credential(api_key)
+    base_url = _normalize_anthropic_credential(base_url)
+    return Anthropic(
+        api_key=api_key,
+        base_url=base_url,
+        default_headers={"User-Agent": f"NotebookIntelligence/{NBI_VERSION}"}
+    )
+
+
 def fetch_claude_models(api_key: str = None, base_url: str = None) -> list[dict]:
     """Fetch available models from the Anthropic API and update cache."""
     try:
-        api_key = _normalize_anthropic_credential(api_key)
-        base_url = _normalize_anthropic_credential(base_url)
-        client = Anthropic(api_key=api_key, base_url=base_url,
-                           default_headers={"User-Agent": f"NotebookIntelligence/{NBI_VERSION}"})
+        client = _create_anthropic_client(api_key, base_url)
         page = client.models.list(limit=100)
         models = []
         for model in page.data:
@@ -168,9 +176,7 @@ class ClaudeChatModel(ChatModel):
         self._model_name = model_info["name"]
         self._context_window = model_info["context_window"]
         self._supports_tools = True
-        self._client = Anthropic(base_url=_normalize_anthropic_credential(base_url),
-                                 api_key=_normalize_anthropic_credential(api_key),
-                                 default_headers={"User-Agent": f"NotebookIntelligence/{NBI_VERSION}"})
+        self._client = _create_anthropic_client(api_key, base_url)
 
     @property
     def id(self) -> str:
@@ -218,8 +224,7 @@ class ClaudeCodeInlineCompletionModel(InlineCompletionModel):
         self._model_id = model_id
         self._model_name = model_info["name"]
         self._context_window = model_info["context_window"]
-        self._client = Anthropic(base_url=_normalize_anthropic_credential(base_url),
-                                 api_key=_normalize_anthropic_credential(api_key))
+        self._client = _create_anthropic_client(api_key, base_url)
 
     @property
     def id(self) -> str:


### PR DESCRIPTION
## Summary
Refactored Anthropic client creation in `notebook_intelligence/notebook_intelligence/claude.py` to centralize credential normalization and default header setup.

## What changed
- Added private helper `_create_anthropic_client(api_key: str = None, base_url: str = None) -> Anthropic`
- The helper:
  - normalizes `api_key` and `base_url` with `_normalize_anthropic_credential`
  - applies shared default headers: `User-Agent: NotebookIntelligence/{NBI_VERSION}`
- Updated Anthropic client usage in:
  - `fetch_claude_models`
  - `ClaudeChatModel.__init__`
  - `ClaudeCodeInlineCompletionModel.__init__`

## Why
- Removes duplicated Anthropic instantiation logic
- Ensures consistent credential handling across Claude model integrations
- **Fixes the missing/default header behavior for inline completions**
- Makes future client configuration updates easier and safer
