### PR TITLE
feat: extend admin policy coverage to every settings panel control

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,33 +125,48 @@ These config files store provider, model, and MCP configuration. **API keys for 
 
 > Manual edits to `config.json` require a JupyterLab restart to take effect. Edits via the Settings dialog are picked up live.
 
-### Cell output features
+### Admin policies
 
-Two cell-output context affordances are user-toggleable in the Settings panel:
+Most settings panel toggles can be locked by org administrators. Two shapes:
 
-- **Troubleshoot errors in output** — a context-menu entry on failed cells that sends the traceback + failing code to the chat model.
-- **Ask about this output** — a context-menu entry on cell outputs that attaches `{cell code, output payload}` to the chat sidebar as grounded context.
+**Boolean policies** use the `*_POLICY` suffix and accept three values: `user-choice` (default — user toggles freely), `force-on` (locked enabled), `force-off` (locked disabled). When forced, the panel control is disabled with a "Locked by your administrator" tooltip and any client-side write is ignored.
 
-Per-user preferences (default on):
+| Env var                                    | Locks the Settings panel control for      |
+| ------------------------------------------ | ----------------------------------------- |
+| `NBI_EXPLAIN_ERROR_POLICY`                 | "Explain cell errors"                     |
+| `NBI_OUTPUT_FOLLOWUP_POLICY`               | "Ask about cell outputs"                  |
+| `NBI_OUTPUT_TOOLBAR_POLICY`                | "Show output toolbar"                     |
+| `NBI_CLAUDE_MODE_POLICY`                   | "Enable Claude mode"                      |
+| `NBI_CLAUDE_CONTINUE_CONVERSATION_POLICY`  | "Remember conversation history"           |
+| `NBI_CLAUDE_CODE_TOOLS_POLICY`             | "Claude Code tools"                       |
+| `NBI_CLAUDE_JUPYTER_UI_TOOLS_POLICY`       | "Jupyter UI tools"                        |
+| `NBI_CLAUDE_SETTING_SOURCE_USER_POLICY`    | Setting source: User                      |
+| `NBI_CLAUDE_SETTING_SOURCE_PROJECT_POLICY` | Setting source: Project                   |
+| `NBI_STORE_GITHUB_ACCESS_TOKEN_POLICY`     | "Remember my GitHub Copilot access token" |
+
+The first three also have matching traitlets on `NotebookIntelligence` (`explain_error_policy`, `output_followup_policy`, `output_toolbar_policy`); add the others as needed in the same shape:
 
 ```python
-c.NBIConfig.enable_explain_error = True
-c.NBIConfig.enable_output_followup = True
+c.NotebookIntelligence.claude_mode_policy = "force-on"
+c.NotebookIntelligence.claude_jupyter_ui_tools_policy = "force-off"
 ```
 
-Org-wide policy traitlets (override the user preference when set to `force-on` or `force-off`):
+Per-user preferences (default on for the cell-output features) live in `config.json` as `enable_explain_error`, `enable_output_followup`, `enable_output_toolbar`.
 
-```python
-c.NotebookIntelligence.explain_error_policy = "user-choice"   # default
-c.NotebookIntelligence.output_followup_policy = "user-choice"
-```
+**Value-presence locks** for non-boolean settings: setting the env var to a non-empty value pins the control to that value and disables it. Empty/unset = user-choice.
 
-Equivalent environment-variable overrides:
+| Env var                                | Pins                                                                         |
+| -------------------------------------- | ---------------------------------------------------------------------------- |
+| `NBI_CHAT_MODEL_PROVIDER`              | General → Chat model → Provider                                              |
+| `NBI_CHAT_MODEL_ID`                    | General → Chat model → Model                                                 |
+| `NBI_INLINE_COMPLETION_MODEL_PROVIDER` | General → Auto-complete model → Provider                                     |
+| `NBI_INLINE_COMPLETION_MODEL_ID`       | General → Auto-complete model → Model                                        |
+| `NBI_CLAUDE_CHAT_MODEL`                | Claude → Chat model                                                          |
+| `NBI_CLAUDE_INLINE_COMPLETION_MODEL`   | Claude → Auto-complete model                                                 |
+| `ANTHROPIC_API_KEY`                    | Claude → API Key (input is locked + blanked; the SDK reads the env directly) |
+| `ANTHROPIC_BASE_URL`                   | Claude → Base URL                                                            |
 
-- `NBI_EXPLAIN_ERROR_POLICY` — `user-choice` | `force-on` | `force-off`
-- `NBI_OUTPUT_FOLLOWUP_POLICY` — `user-choice` | `force-on` | `force-off`
-
-When a policy is `force-on` / `force-off`, the corresponding Settings panel checkbox is greyed out with a "Locked by your administrator" tooltip and any client-side write is ignored.
+Provider IDs: `github-copilot`, `openai-compatible`, `litellm-compatible`, `ollama`, `none`. The `*_MODEL_ID` value is whatever the chosen provider exposes (e.g. `gpt-4o`, `llama3:latest`). Claude model IDs are the literal IDs from the Anthropic API (e.g. `claude-opus-4-7`, `claude-sonnet-4-6`); empty string = "Default (recommended)"; `NBI_CLAUDE_INLINE_COMPLETION_MODEL` also accepts `none` (no inline completion in Claude mode) or `inherit` (use the General-tab Auto-complete model).
 
 ### Remembering GitHub Copilot login
 

--- a/notebook_intelligence/ai_service_manager.py
+++ b/notebook_intelligence/ai_service_manager.py
@@ -51,6 +51,15 @@ class AIServiceManager(Host):
         self._extension_toolsets: Dict[str, list[Toolset]] = {}
         self._options = options.copy()
         self._nbi_config = NBIConfig({"server_root_dir": self._options.get('server_root_dir', '')})
+        # Apply admin policies before any consumer (model bootstrap, MCP
+        # connect, login_with_existing_credentials) reads claude_settings or
+        # chat_model from nbi_config — otherwise NBI_CHAT_MODEL_PROVIDER /
+        # NBI_CLAUDE_MODE_POLICY etc. would only take effect after the first
+        # capabilities GET.
+        self._nbi_config.set_feature_policies(
+            self._options.get("feature_policies") or {},
+            self._options.get("string_overrides") or {},
+        )
         self._openai_compatible_llm_provider = OpenAICompatibleLLMProvider()
         self._litellm_compatible_llm_provider = LiteLLMCompatibleLLMProvider()
         self._ollama_llm_provider = OllamaLLMProvider()

--- a/notebook_intelligence/config.py
+++ b/notebook_intelligence/config.py
@@ -5,11 +5,27 @@ import logging
 import os
 import sys
 
+from notebook_intelligence.feature_flags import (
+    CHAT_MODEL_OVERRIDES,
+    CLAUDE_SETTINGS_OVERRIDES,
+    INLINE_COMPLETION_MODEL_OVERRIDES,
+    apply_claude_policies,
+    apply_string_overrides,
+)
+
 log = logging.getLogger(__name__)
 
 class NBIConfig:
+    # Class-level defaults so a test that patches __init__ still sees empty
+    # dicts instead of AttributeError. Per-instance values are bound in
+    # __init__ so concurrent instances don't share state.
+    _feature_policies: dict = {}
+    _string_overrides: dict = {}
+
     def __init__(self, options: dict = {}):
         self.options = options
+        self._feature_policies = {}
+        self._string_overrides = {}
 
         self.deprecated_env_config_file = os.path.join(sys.prefix, "share", "jupyter", "nbi-config.json")
         self.deprecated_user_config_file = os.path.join(os.path.expanduser('~'), ".jupyter", "nbi-config.json")
@@ -95,14 +111,6 @@ class NBIConfig:
         return self.get('default_chat_mode', 'ask')
 
     @property
-    def chat_model(self):
-        return self.get('chat_model', {'provider': 'github-copilot', 'model': 'gpt-4.1'})
-
-    @property
-    def inline_completion_model(self):
-        return self.get('inline_completion_model', {'provider': 'github-copilot', 'model': 'gpt-4o-copilot'})
-
-    @property
     def embedding_model(self):
         return self.get('embedding_model', {})
 
@@ -129,9 +137,33 @@ class NBIConfig:
     def mcp_server_settings(self):
         return self.get('mcp_server_settings', {})
 
+    def set_feature_policies(self, policies: dict, string_overrides: dict) -> None:
+        """Adopt the resolved admin policies + string overrides."""
+        self._feature_policies = dict(policies)
+        self._string_overrides = dict(string_overrides)
+
     @property
     def claude_settings(self):
-        return self.get('claude_settings', {})
+        resolved = apply_claude_policies(
+            self.get('claude_settings', {}), self._feature_policies
+        )
+        return apply_string_overrides(
+            resolved, self._string_overrides, CLAUDE_SETTINGS_OVERRIDES
+        )
+
+    @property
+    def chat_model(self):
+        raw = self.get('chat_model', {'provider': 'github-copilot', 'model': 'gpt-4.1'})
+        return apply_string_overrides(
+            raw, self._string_overrides, CHAT_MODEL_OVERRIDES
+        )
+
+    @property
+    def inline_completion_model(self):
+        raw = self.get('inline_completion_model', {'provider': 'github-copilot', 'model': 'gpt-4o-copilot'})
+        return apply_string_overrides(
+            raw, self._string_overrides, INLINE_COMPLETION_MODEL_OVERRIDES
+        )
 
     @property
     def rules_enabled(self) -> bool:

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -26,10 +26,18 @@ from notebook_intelligence.api import CancelToken, ChatMode, ChatResponse, ChatR
 from notebook_intelligence.ai_service_manager import AIServiceManager
 from notebook_intelligence.cell_output import coerce_payload as _coerce_output_context, format_output_context as _format_output_context
 from notebook_intelligence.feature_flags import (
+    CHAT_MODEL_OVERRIDES,
+    CLAUDE_CODE_TOOLS_ID,
+    CLAUDE_SETTINGS_OVERRIDES,
+    INLINE_COMPLETION_MODEL_OVERRIDES,
+    JUPYTER_UI_TOOLS_ID,
     POLICY_FORCE_OFF,
     POLICY_FORCE_ON,
     POLICY_USER_CHOICE,
     VALID_POLICIES,
+    apply_claude_policies,
+    apply_string_overrides,
+    is_locked,
     resolve_feature_flag,
 )
 from notebook_intelligence.claude import ClaudeCodeChatParticipant, fetch_claude_models
@@ -143,15 +151,132 @@ def _resolve_policy_with_env(env_var_name: str, traitlet_value: str) -> str:
     return traitlet_value
 
 
+# Single source of truth for the boolean policies. Each entry is
+# ``(policy_name, env_var, traitlet_attr)``. Drives env-var resolution, the
+# capabilities response, and the lock-rejection set in ConfigHandler.
+FEATURE_POLICY_SPEC = (
+    ("explain_error", "NBI_EXPLAIN_ERROR_POLICY", "explain_error_policy"),
+    ("output_followup", "NBI_OUTPUT_FOLLOWUP_POLICY", "output_followup_policy"),
+    ("output_toolbar", "NBI_OUTPUT_TOOLBAR_POLICY", "output_toolbar_policy"),
+    ("claude_mode", "NBI_CLAUDE_MODE_POLICY", "claude_mode_policy"),
+    (
+        "claude_continue_conversation",
+        "NBI_CLAUDE_CONTINUE_CONVERSATION_POLICY",
+        "claude_continue_conversation_policy",
+    ),
+    (
+        "claude_code_tools",
+        "NBI_CLAUDE_CODE_TOOLS_POLICY",
+        "claude_code_tools_policy",
+    ),
+    (
+        "claude_jupyter_ui_tools",
+        "NBI_CLAUDE_JUPYTER_UI_TOOLS_POLICY",
+        "claude_jupyter_ui_tools_policy",
+    ),
+    (
+        "claude_setting_source_user",
+        "NBI_CLAUDE_SETTING_SOURCE_USER_POLICY",
+        "claude_setting_source_user_policy",
+    ),
+    (
+        "claude_setting_source_project",
+        "NBI_CLAUDE_SETTING_SOURCE_PROJECT_POLICY",
+        "claude_setting_source_project_policy",
+    ),
+    (
+        "store_github_access_token",
+        "NBI_STORE_GITHUB_ACCESS_TOKEN_POLICY",
+        "store_github_access_token_policy",
+    ),
+)
+FEATURE_POLICY_NAMES = tuple(name for name, _, _ in FEATURE_POLICY_SPEC)
+
+# ``(setting_lock_name, env_var)`` pairs for the value-presence-locks. The
+# claude_api_key entry maps to ANTHROPIC_API_KEY (the SDK's native convention)
+# rather than an NBI-prefixed env var. Same for claude_base_url.
+STRING_OVERRIDE_SPEC = (
+    ("chat_model_provider", "NBI_CHAT_MODEL_PROVIDER"),
+    ("chat_model_id", "NBI_CHAT_MODEL_ID"),
+    ("inline_completion_model_provider", "NBI_INLINE_COMPLETION_MODEL_PROVIDER"),
+    ("inline_completion_model_id", "NBI_INLINE_COMPLETION_MODEL_ID"),
+    ("claude_chat_model", "NBI_CLAUDE_CHAT_MODEL"),
+    ("claude_inline_completion_model", "NBI_CLAUDE_INLINE_COMPLETION_MODEL"),
+    ("claude_api_key", "ANTHROPIC_API_KEY"),
+    ("claude_base_url", "ANTHROPIC_BASE_URL"),
+)
+SETTING_LOCK_NAMES = tuple(name for name, _ in STRING_OVERRIDE_SPEC)
+
+
+def _build_feature_policies_response(policies: dict, nbi_config) -> dict:
+    """Resolve every boolean policy against the user's stored config.
+
+    Returns ``{name: {enabled, locked}}`` for every name in
+    FEATURE_POLICY_NAMES. The frontend iterates this dict, so adding a new
+    feature only needs an entry here plus a matching env-var resolution.
+    """
+    claude_settings = nbi_config.claude_settings or {}
+    tools = claude_settings.get("tools") or []
+    sources = claude_settings.get("setting_sources") or []
+
+    user_values = {
+        "explain_error": nbi_config.enable_explain_error,
+        "output_followup": nbi_config.enable_output_followup,
+        "output_toolbar": nbi_config.enable_output_toolbar,
+        "claude_mode": bool(claude_settings.get("enabled", False)),
+        "claude_continue_conversation": bool(
+            claude_settings.get("continue_conversation", False)
+        ),
+        "claude_code_tools": CLAUDE_CODE_TOOLS_ID in tools,
+        "claude_jupyter_ui_tools": JUPYTER_UI_TOOLS_ID in tools,
+        "claude_setting_source_user": "user" in sources,
+        "claude_setting_source_project": "project" in sources,
+        "store_github_access_token": bool(nbi_config.store_github_access_token),
+    }
+
+    response = {}
+    for name in FEATURE_POLICY_NAMES:
+        enabled, locked = resolve_feature_flag(
+            policies.get(name, POLICY_USER_CHOICE), user_values[name]
+        )
+        response[name] = {"enabled": enabled, "locked": locked}
+    return response
+
+
+def _build_setting_locks_response(string_overrides: dict) -> dict:
+    """Surface lock state for non-boolean settings (model pickers, API key, base URL).
+
+    The values themselves are still served through their existing capabilities
+    fields (chat_model, claude_settings, ...). This dict only carries the
+    locked flag so the frontend knows which inputs to disable.
+    """
+    return {
+        name: {"locked": bool(string_overrides.get(name))}
+        for name in SETTING_LOCK_NAMES
+    }
+
+
+def _scrub_credentials_for_wire(claude_settings: dict, string_overrides: dict) -> dict:
+    """Strip the api_key from the capabilities response when locked by env.
+
+    The Anthropic SDK reads ANTHROPIC_API_KEY directly; surfacing the value
+    through the frontend would leak the credential.
+    """
+    if not string_overrides.get("claude_api_key"):
+        return claude_settings
+    result = dict(claude_settings or {})
+    result["api_key"] = ""
+    return result
+
+
 class GetCapabilitiesHandler(APIHandler):
     disabled_tools = []
     allow_enabling_tools_with_env = False
     disabled_providers = []
     allow_enabling_providers_with_env = False
     enable_chat_feedback = False
-    explain_error_policy = POLICY_USER_CHOICE
-    output_followup_policy = POLICY_USER_CHOICE
-    output_toolbar_policy = POLICY_USER_CHOICE
+    feature_policies = {}
+    string_overrides = {}
 
     @tornado.web.authenticated
     def get(self):
@@ -228,16 +353,22 @@ class GetCapabilitiesHandler(APIHandler):
                 "extensions": extensions
             },
             "mcp_server_settings": nbi_config.mcp_server_settings,
-            "claude_settings": nbi_config.claude_settings,
+            "claude_settings": _scrub_credentials_for_wire(
+                nbi_config.claude_settings, self.string_overrides
+            ),
             "claude_models": ai_service_manager.claude_models,
             "default_chat_mode": nbi_config.default_chat_mode,
             "chat_feedback_enabled": self.enable_chat_feedback,
             "cell_output_features": _build_cell_output_features_response(
-                self.explain_error_policy,
-                self.output_followup_policy,
-                self.output_toolbar_policy,
+                self.feature_policies.get("explain_error", POLICY_USER_CHOICE),
+                self.feature_policies.get("output_followup", POLICY_USER_CHOICE),
+                self.feature_policies.get("output_toolbar", POLICY_USER_CHOICE),
                 nbi_config,
-            )
+            ),
+            "feature_policies": _build_feature_policies_response(
+                self.feature_policies, nbi_config
+            ),
+            "setting_locks": _build_setting_locks_response(self.string_overrides),
         }
         for participant_id in ai_service_manager.chat_participants:
             participant = ai_service_manager.chat_participants[participant_id]
@@ -254,9 +385,8 @@ class GetCapabilitiesHandler(APIHandler):
         self.finish(json.dumps(response))
 
 class ConfigHandler(APIHandler):
-    explain_error_policy = POLICY_USER_CHOICE
-    output_followup_policy = POLICY_USER_CHOICE
-    output_toolbar_policy = POLICY_USER_CHOICE
+    feature_policies = {}
+    string_overrides = {}
 
     @tornado.web.authenticated
     def post(self):
@@ -273,38 +403,85 @@ class ConfigHandler(APIHandler):
             "enable_output_followup",
             "enable_output_toolbar",
         ])
+        # Top-level keys whose write is rejected outright when locked.
         locked_keys = set()
-        if self.explain_error_policy in (POLICY_FORCE_ON, POLICY_FORCE_OFF):
+        if is_locked(self.feature_policies.get("explain_error", POLICY_USER_CHOICE)):
             locked_keys.add("enable_explain_error")
-        if self.output_followup_policy in (POLICY_FORCE_ON, POLICY_FORCE_OFF):
+        if is_locked(self.feature_policies.get("output_followup", POLICY_USER_CHOICE)):
             locked_keys.add("enable_output_followup")
-        if self.output_toolbar_policy in (POLICY_FORCE_ON, POLICY_FORCE_OFF):
+        if is_locked(self.feature_policies.get("output_toolbar", POLICY_USER_CHOICE)):
             locked_keys.add("enable_output_toolbar")
-        has_model_change = "chat_model" in data or "inline_completion_model" in data
+        if is_locked(self.feature_policies.get("store_github_access_token", POLICY_USER_CHOICE)):
+            locked_keys.add("store_github_access_token")
+        # chat_model / inline_completion_model are locked when *either* of their
+        # provider/id env vars is set; the resolver below preserves the locked
+        # subfield so a user can still update the unlocked one.
+        chat_model_locked = bool(
+            self.string_overrides.get("chat_model_provider")
+            or self.string_overrides.get("chat_model_id")
+        )
+        inline_model_locked = bool(
+            self.string_overrides.get("inline_completion_model_provider")
+            or self.string_overrides.get("inline_completion_model_id")
+        )
+
+        has_model_change = False
         has_claude_settings_change = False
         for key in data:
             if key in locked_keys:
                 continue
-            if key in valid_keys:
-                ai_service_manager.nbi_config.set(key, data[key])
-                if key == "store_github_access_token":
-                    if data[key]:
-                        github_copilot.store_github_access_token()
-                    else:
-                        github_copilot.delete_stored_github_access_token()
-                elif key == "mcp_server_settings":
-                    disabled_mcp_servers = []
-                    for server_id in data[key]:
-                        server_settings = data[key][server_id]
-                        if server_settings.get("disabled") == True:
-                            disabled_mcp_servers.append(server_id)
-                    ai_service_manager.update_mcp_server_connections(disabled_mcp_servers)
-                elif key == "claude_settings":
-                    has_claude_settings_change = True
-                    default_chat_participant = ai_service_manager.default_chat_participant
-                    if isinstance(default_chat_participant, ClaudeCodeChatParticipant):
-                        # needed to disconnect
-                        default_chat_participant.update_client_debounced()
+            if key not in valid_keys:
+                continue
+            value = data[key]
+            # Re-apply the env override after the user's POST so locked fields
+            # stay pinned; non-locked fields keep the user's value.
+            if key == "chat_model":
+                value = apply_string_overrides(
+                    value, self.string_overrides, CHAT_MODEL_OVERRIDES
+                )
+                if chat_model_locked and value == ai_service_manager.nbi_config.chat_model:
+                    continue
+                has_model_change = True
+            elif key == "inline_completion_model":
+                value = apply_string_overrides(
+                    value, self.string_overrides, INLINE_COMPLETION_MODEL_OVERRIDES
+                )
+                if (
+                    inline_model_locked
+                    and value == ai_service_manager.nbi_config.inline_completion_model
+                ):
+                    continue
+                has_model_change = True
+            elif key == "claude_settings":
+                value = apply_claude_policies(value, self.feature_policies)
+                value = apply_string_overrides(
+                    value, self.string_overrides, CLAUDE_SETTINGS_OVERRIDES
+                )
+                # ANTHROPIC_API_KEY is a credential; don't persist it to
+                # config.json. The SDK reads it from process env directly when
+                # claude_settings.api_key is empty.
+                if self.string_overrides.get("claude_api_key"):
+                    value = dict(value)
+                    value["api_key"] = ""
+            ai_service_manager.nbi_config.set(key, value)
+            if key == "store_github_access_token":
+                if value:
+                    github_copilot.store_github_access_token()
+                else:
+                    github_copilot.delete_stored_github_access_token()
+            elif key == "mcp_server_settings":
+                disabled_mcp_servers = []
+                for server_id in value:
+                    server_settings = value[server_id]
+                    if server_settings.get("disabled") == True:
+                        disabled_mcp_servers.append(server_id)
+                ai_service_manager.update_mcp_server_connections(disabled_mcp_servers)
+            elif key == "claude_settings":
+                has_claude_settings_change = True
+                default_chat_participant = ai_service_manager.default_chat_participant
+                if isinstance(default_chat_participant, ClaudeCodeChatParticipant):
+                    # needed to disconnect
+                    default_chat_participant.update_client_debounced()
 
         ai_service_manager.nbi_config.save()
         if has_model_change or has_claude_settings_change:
@@ -1481,6 +1658,80 @@ class NotebookIntelligence(ExtensionApp):
         config=True,
     )
 
+    claude_mode_policy = TraitletEnum(
+        list(VALID_POLICIES),
+        default_value=POLICY_USER_CHOICE,
+        help="""
+        Org-wide policy for whether Claude mode is enabled. Same semantics as
+        explain_error_policy. Overridden by the NBI_CLAUDE_MODE_POLICY env var.
+        """,
+        config=True,
+    )
+
+    claude_continue_conversation_policy = TraitletEnum(
+        list(VALID_POLICIES),
+        default_value=POLICY_USER_CHOICE,
+        help="""
+        Org-wide policy for whether Claude remembers conversation history.
+        Overridden by the NBI_CLAUDE_CONTINUE_CONVERSATION_POLICY env var.
+        """,
+        config=True,
+    )
+
+    claude_code_tools_policy = TraitletEnum(
+        list(VALID_POLICIES),
+        default_value=POLICY_USER_CHOICE,
+        help="""
+        Org-wide policy for whether the Claude Code built-in tool set is
+        granted to the agent. Overridden by the NBI_CLAUDE_CODE_TOOLS_POLICY
+        env var.
+        """,
+        config=True,
+    )
+
+    claude_jupyter_ui_tools_policy = TraitletEnum(
+        list(VALID_POLICIES),
+        default_value=POLICY_USER_CHOICE,
+        help="""
+        Org-wide policy for whether the Jupyter UI tool set is granted to
+        Claude. Overridden by the NBI_CLAUDE_JUPYTER_UI_TOOLS_POLICY env var.
+        """,
+        config=True,
+    )
+
+    claude_setting_source_user_policy = TraitletEnum(
+        list(VALID_POLICIES),
+        default_value=POLICY_USER_CHOICE,
+        help="""
+        Org-wide policy for whether Claude reads the user-scoped settings
+        source (~/.claude/settings.json). Overridden by the
+        NBI_CLAUDE_SETTING_SOURCE_USER_POLICY env var.
+        """,
+        config=True,
+    )
+
+    claude_setting_source_project_policy = TraitletEnum(
+        list(VALID_POLICIES),
+        default_value=POLICY_USER_CHOICE,
+        help="""
+        Org-wide policy for whether Claude reads the project-scoped settings
+        source. Overridden by the NBI_CLAUDE_SETTING_SOURCE_PROJECT_POLICY
+        env var.
+        """,
+        config=True,
+    )
+
+    store_github_access_token_policy = TraitletEnum(
+        list(VALID_POLICIES),
+        default_value=POLICY_USER_CHOICE,
+        help="""
+        Org-wide policy for whether the GitHub Copilot access token is
+        persisted to disk. Overridden by the
+        NBI_STORE_GITHUB_ACCESS_TOKEN_POLICY env var.
+        """,
+        config=True,
+    )
+
     skills_manifest = Unicode(
         default_value="",
         help="""
@@ -1516,15 +1767,45 @@ class NotebookIntelligence(ExtensionApp):
     def initialize_settings(self):
         pass
 
+    def _publish_policies(self, feature_policies: dict, string_overrides: dict) -> None:
+        """Wire the resolved policies into the HTTP handlers.
+
+        ``nbi_config`` is already configured during ``AIServiceManager.__init__``
+        so its model-bootstrap path sees the policy-resolved values.
+        """
+        GetCapabilitiesHandler.feature_policies = feature_policies
+        GetCapabilitiesHandler.string_overrides = string_overrides
+        ConfigHandler.feature_policies = feature_policies
+        ConfigHandler.string_overrides = string_overrides
+
     def initialize_handlers(self):
         NotebookIntelligence.root_dir = self.serverapp.root_dir
         set_jupyter_root_dir(NotebookIntelligence.root_dir)
         server_root_dir = os.path.expanduser(self.serverapp.web_app.settings["server_root_dir"])
-        self.initialize_ai_service(server_root_dir)
-        self._setup_handlers(self.serverapp.web_app)
+        # Resolve admin policies first so the AI service sees the locked
+        # values during its initial model bootstrap (e.g. NBI_CLAUDE_MODE_POLICY
+        # =force-on actually starts Claude mode rather than waiting for the
+        # first capabilities GET).
+        feature_policies = {
+            name: _resolve_policy_with_env(env_var, getattr(self, attr))
+            for name, env_var, attr in FEATURE_POLICY_SPEC
+        }
+        string_overrides = {
+            name: os.environ.get(env_var, "").strip()
+            for name, env_var in STRING_OVERRIDE_SPEC
+        }
+        self.initialize_ai_service(
+            server_root_dir, feature_policies, string_overrides
+        )
+        self._setup_handlers(self.serverapp.web_app, feature_policies, string_overrides)
         self.serverapp.log.info(f"Registered {self.name} server extension")
 
-    def initialize_ai_service(self, server_root_dir: str):
+    def initialize_ai_service(
+        self,
+        server_root_dir: str,
+        feature_policies: dict,
+        string_overrides: dict,
+    ):
         global ai_service_manager
         manifest_source = os.environ.get("NBI_SKILLS_MANIFEST", "").strip() or self.skills_manifest.strip()
         managed_token = (
@@ -1545,6 +1826,8 @@ class NotebookIntelligence(ExtensionApp):
             "skills_manifest": manifest_source,
             "skills_manifest_interval": manifest_interval,
             "managed_skills_token": managed_token,
+            "feature_policies": feature_policies,
+            "string_overrides": string_overrides,
         })
 
     def initialize_templates(self):
@@ -1555,7 +1838,7 @@ class NotebookIntelligence(ExtensionApp):
         github_copilot.handle_stop_request()
         ai_service_manager.handle_stop_request()
 
-    def _setup_handlers(self, web_app):
+    def _setup_handlers(self, web_app, feature_policies: dict, string_overrides: dict):
         host_pattern = ".*$"
 
         base_url = web_app.settings["base_url"]
@@ -1590,18 +1873,7 @@ class NotebookIntelligence(ExtensionApp):
         GetCapabilitiesHandler.disabled_providers = self.disabled_providers
         GetCapabilitiesHandler.allow_enabling_providers_with_env = self.allow_enabling_providers_with_env
         GetCapabilitiesHandler.enable_chat_feedback = self.enable_chat_feedback
-        GetCapabilitiesHandler.explain_error_policy = _resolve_policy_with_env(
-            "NBI_EXPLAIN_ERROR_POLICY", self.explain_error_policy
-        )
-        GetCapabilitiesHandler.output_followup_policy = _resolve_policy_with_env(
-            "NBI_OUTPUT_FOLLOWUP_POLICY", self.output_followup_policy
-        )
-        GetCapabilitiesHandler.output_toolbar_policy = _resolve_policy_with_env(
-            "NBI_OUTPUT_TOOLBAR_POLICY", self.output_toolbar_policy
-        )
-        ConfigHandler.explain_error_policy = GetCapabilitiesHandler.explain_error_policy
-        ConfigHandler.output_followup_policy = GetCapabilitiesHandler.output_followup_policy
-        ConfigHandler.output_toolbar_policy = GetCapabilitiesHandler.output_toolbar_policy
+        self._publish_policies(feature_policies, string_overrides)
         NotebookIntelligence.handlers = [
             (route_pattern_capabilities, GetCapabilitiesHandler),
             (route_pattern_config, ConfigHandler),

--- a/notebook_intelligence/feature_flags.py
+++ b/notebook_intelligence/feature_flags.py
@@ -7,6 +7,26 @@ POLICY_FORCE_ON = "force-on"
 POLICY_FORCE_OFF = "force-off"
 VALID_POLICIES = (POLICY_USER_CHOICE, POLICY_FORCE_ON, POLICY_FORCE_OFF)
 
+# Tool-array members of `claude_settings.tools` that have their own policy.
+CLAUDE_CODE_TOOLS_ID = "claude-code:built-in-tools"
+JUPYTER_UI_TOOLS_ID = "nbi:built-in-jupyter-ui-tools"
+
+# Override-key → destination-key mappings for the value-presence-locks env vars.
+CHAT_MODEL_OVERRIDES = (
+    ("chat_model_provider", "provider"),
+    ("chat_model_id", "model"),
+)
+INLINE_COMPLETION_MODEL_OVERRIDES = (
+    ("inline_completion_model_provider", "provider"),
+    ("inline_completion_model_id", "model"),
+)
+CLAUDE_SETTINGS_OVERRIDES = (
+    ("claude_chat_model", "chat_model"),
+    ("claude_inline_completion_model", "inline_completion_model"),
+    ("claude_api_key", "api_key"),
+    ("claude_base_url", "base_url"),
+)
+
 
 def resolve_feature_flag(policy: str, user_setting: bool) -> Tuple[bool, bool]:
     """Return ``(enabled, locked)`` for a feature.
@@ -19,3 +39,93 @@ def resolve_feature_flag(policy: str, user_setting: bool) -> Tuple[bool, bool]:
     if policy == POLICY_FORCE_OFF:
         return False, True
     return bool(user_setting), False
+
+
+def is_locked(policy: str) -> bool:
+    return policy in (POLICY_FORCE_ON, POLICY_FORCE_OFF)
+
+
+def apply_string_overrides(target: dict, overrides: dict, mapping: tuple) -> dict:
+    """Apply value-presence-locks per ``mapping`` to a copy of ``target``.
+
+    Each tuple in ``mapping`` is ``(override_key, dest_key)``. A non-empty
+    value in ``overrides[override_key]`` is written to ``dest_key`` in the
+    result. Empty/missing entries leave the destination untouched.
+    """
+    if not any(overrides.get(ov_key) for ov_key, _ in mapping):
+        return target
+    result = dict(target)
+    for ov_key, dest_key in mapping:
+        v = overrides.get(ov_key)
+        if v:
+            result[dest_key] = v
+    return result
+
+
+def apply_member_policy(members: list, item: str, policy: str) -> list:
+    """Return a copy of ``members`` with ``item`` added/removed per ``policy``.
+
+    user-choice leaves the list untouched. force-on ensures presence, force-off
+    ensures absence. Any unknown policy is treated as user-choice.
+    """
+    if policy == POLICY_FORCE_ON:
+        if item not in members:
+            return list(members) + [item]
+        return list(members)
+    if policy == POLICY_FORCE_OFF:
+        return [m for m in members if m != item]
+    return list(members)
+
+
+def apply_claude_policies(claude_settings: dict, policies: dict) -> dict:
+    """Apply admin policies to a ``claude_settings`` dict.
+
+    Returns a shallow copy with any forced fields overwritten. ``policies`` is
+    a mapping from policy name (e.g. ``claude_mode``) to a value in
+    ``VALID_POLICIES``. Missing keys are treated as user-choice.
+
+    The same function is used on both the read path (to compute the resolved
+    settings the SDK and UI see) and the write path (to filter incoming POSTs
+    so a user can't flip a locked field via a hand-rolled API call).
+    """
+    result = dict(claude_settings or {})
+
+    mode_policy = policies.get("claude_mode", POLICY_USER_CHOICE)
+    if mode_policy == POLICY_FORCE_ON:
+        result["enabled"] = True
+    elif mode_policy == POLICY_FORCE_OFF:
+        result["enabled"] = False
+
+    cc_policy = policies.get("claude_continue_conversation", POLICY_USER_CHOICE)
+    if cc_policy == POLICY_FORCE_ON:
+        result["continue_conversation"] = True
+    elif cc_policy == POLICY_FORCE_OFF:
+        result["continue_conversation"] = False
+
+    tools = list(result.get("tools") or [])
+    tools = apply_member_policy(
+        tools,
+        CLAUDE_CODE_TOOLS_ID,
+        policies.get("claude_code_tools", POLICY_USER_CHOICE),
+    )
+    tools = apply_member_policy(
+        tools,
+        JUPYTER_UI_TOOLS_ID,
+        policies.get("claude_jupyter_ui_tools", POLICY_USER_CHOICE),
+    )
+    result["tools"] = tools
+
+    sources = list(result.get("setting_sources") or [])
+    sources = apply_member_policy(
+        sources,
+        "user",
+        policies.get("claude_setting_source_user", POLICY_USER_CHOICE),
+    )
+    sources = apply_member_policy(
+        sources,
+        "project",
+        policies.get("claude_setting_source_project", POLICY_USER_CHOICE),
+    )
+    result["setting_sources"] = sources
+
+    return result

--- a/src/api.ts
+++ b/src/api.ts
@@ -141,6 +141,40 @@ export type CellOutputActionFlag = Exclude<
   'output_toolbar'
 >;
 
+// Boolean admin policies covering settings panel toggles. Mirrors
+// FEATURE_POLICY_NAMES in extension.py — keep them in sync.
+export type FeaturePolicyName =
+  | 'explain_error'
+  | 'output_followup'
+  | 'output_toolbar'
+  | 'claude_mode'
+  | 'claude_continue_conversation'
+  | 'claude_code_tools'
+  | 'claude_jupyter_ui_tools'
+  | 'claude_setting_source_user'
+  | 'claude_setting_source_project'
+  | 'store_github_access_token';
+
+export type IFeaturePolicies = Record<
+  FeaturePolicyName,
+  ICellOutputFeatureFlag
+>;
+
+// Non-boolean settings whose value is locked when an admin sets the
+// corresponding env var. The value itself is served via its existing
+// capabilities field; this only carries the locked flag.
+export type SettingLockName =
+  | 'chat_model_provider'
+  | 'chat_model_id'
+  | 'inline_completion_model_provider'
+  | 'inline_completion_model_id'
+  | 'claude_chat_model'
+  | 'claude_inline_completion_model'
+  | 'claude_api_key'
+  | 'claude_base_url';
+
+export type ISettingLocks = Record<SettingLockName, { locked: boolean }>;
+
 export class NBIConfig {
   get userHomeDir(): string {
     return this.capabilities.user_home_dir;
@@ -253,6 +287,49 @@ export class NBIConfig {
         locked: v.output_toolbar?.locked === true
       }
     };
+  }
+
+  get featurePolicies(): IFeaturePolicies {
+    const v = this.capabilities.feature_policies ?? {};
+    const names: FeaturePolicyName[] = [
+      'explain_error',
+      'output_followup',
+      'output_toolbar',
+      'claude_mode',
+      'claude_continue_conversation',
+      'claude_code_tools',
+      'claude_jupyter_ui_tools',
+      'claude_setting_source_user',
+      'claude_setting_source_project',
+      'store_github_access_token'
+    ];
+    const result = {} as IFeaturePolicies;
+    for (const name of names) {
+      result[name] = {
+        enabled: v[name]?.enabled === true,
+        locked: v[name]?.locked === true
+      };
+    }
+    return result;
+  }
+
+  get settingLocks(): ISettingLocks {
+    const v = this.capabilities.setting_locks ?? {};
+    const names: SettingLockName[] = [
+      'chat_model_provider',
+      'chat_model_id',
+      'inline_completion_model_provider',
+      'inline_completion_model_id',
+      'claude_chat_model',
+      'claude_inline_completion_model',
+      'claude_api_key',
+      'claude_base_url'
+    ];
+    const result = {} as ISettingLocks;
+    for (const name of names) {
+      result[name] = { locked: v[name]?.locked === true };
+    }
+    return result;
   }
 
   capabilities: any = {};

--- a/src/components/settings-panel.tsx
+++ b/src/components/settings-panel.tsx
@@ -10,6 +10,7 @@ import claudeSvgStr from '../../style/icons/claude.svg';
 import {
   ClaudeModelType,
   ClaudeToolType,
+  ICellOutputFeatureFlag,
   IClaudeModelInfo,
   NBIAPI
 } from '../api';
@@ -17,6 +18,34 @@ import { CheckBoxItem } from './checkbox';
 import { PillItem } from './pill';
 import { mcpServerSettingsToEnabledState } from './mcp-util';
 import { SettingsPanelComponentSkills } from './skills-panel';
+
+const lockedTip = (locked: boolean): string =>
+  locked ? 'Locked by your administrator' : '';
+
+// When a boolean policy is locked the panel shows the policy-resolved value;
+// otherwise it shows the user's local toggle state.
+const checkedValue = (
+  policy: ICellOutputFeatureFlag,
+  userValue: boolean
+): boolean => (policy.locked ? policy.enabled : userValue);
+
+function useNbiPolicies() {
+  const [featurePolicies, setFeaturePolicies] = useState(
+    NBIAPI.config.featurePolicies
+  );
+  const [settingLocks, setSettingLocks] = useState(NBIAPI.config.settingLocks);
+  useEffect(() => {
+    const handler = () => {
+      setFeaturePolicies(NBIAPI.config.featurePolicies);
+      setSettingLocks(NBIAPI.config.settingLocks);
+    };
+    NBIAPI.configChanged.connect(handler);
+    return () => {
+      NBIAPI.configChanged.disconnect(handler);
+    };
+  }, []);
+  return { featurePolicies, settingLocks };
+}
 
 const OPENAI_COMPATIBLE_CHAT_MODEL_ID = 'openai-compatible-chat-model';
 const LITELLM_COMPATIBLE_CHAT_MODEL_ID = 'litellm-compatible-chat-model';
@@ -201,35 +230,23 @@ function SettingsPanelComponentGeneral(props: any) {
   );
   const [inlineCompletionDebouncerDelay, setInlineCompletionDebouncerDelay] =
     useState(nbiConfig.inlineCompletionDebouncerDelay);
-  const [cellOutputFeatures, setCellOutputFeatures] = useState(
-    nbiConfig.cellOutputFeatures
-  );
-
-  useEffect(() => {
-    const handler = () => {
-      setCellOutputFeatures(NBIAPI.config.cellOutputFeatures);
-    };
-    NBIAPI.configChanged.connect(handler);
-    return () => {
-      NBIAPI.configChanged.disconnect(handler);
-    };
-  }, []);
+  const { featurePolicies, settingLocks } = useNbiPolicies();
 
   const toggleExplainError = () => {
     NBIAPI.setConfig({
-      enable_explain_error: !cellOutputFeatures.explain_error.enabled
+      enable_explain_error: !featurePolicies.explain_error.enabled
     });
   };
 
   const toggleOutputFollowup = () => {
     NBIAPI.setConfig({
-      enable_output_followup: !cellOutputFeatures.output_followup.enabled
+      enable_output_followup: !featurePolicies.output_followup.enabled
     });
   };
 
   const toggleOutputToolbar = () => {
     NBIAPI.setConfig({
-      enable_output_toolbar: !cellOutputFeatures.output_toolbar.enabled
+      enable_output_toolbar: !featurePolicies.output_toolbar.enabled
     });
   };
 
@@ -359,9 +376,12 @@ function SettingsPanelComponentGeneral(props: any) {
               <div className="model-config-section-row">
                 <div className="model-config-section-column">
                   <div>Provider</div>
-                  <div>
+                  <div
+                    title={lockedTip(settingLocks.chat_model_provider.locked)}
+                  >
                     <select
                       className="jp-mod-styled"
+                      disabled={settingLocks.chat_model_provider.locked}
                       onChange={event =>
                         updateModelOptionsForProvider(
                           event.target.value,
@@ -404,9 +424,12 @@ function SettingsPanelComponentGeneral(props: any) {
                         LITELLM_COMPATIBLE_CHAT_MODEL_ID
                       ].includes(chatModel) &&
                         chatModels.length > 0 && (
-                          <div>
+                          <div
+                            title={lockedTip(settingLocks.chat_model_id.locked)}
+                          >
                             <select
                               className="jp-mod-styled"
+                              disabled={settingLocks.chat_model_id.locked}
                               onChange={event =>
                                 setChatModel(event.target.value)
                               }
@@ -484,9 +507,16 @@ function SettingsPanelComponentGeneral(props: any) {
             <div className="model-config-section-row">
               <div className="model-config-section-column">
                 <div>Provider</div>
-                <div>
+                <div
+                  title={lockedTip(
+                    settingLocks.inline_completion_model_provider.locked
+                  )}
+                >
                   <select
                     className="jp-mod-styled"
+                    disabled={
+                      settingLocks.inline_completion_model_provider.locked
+                    }
                     onChange={event =>
                       updateModelOptionsForProvider(
                         event.target.value,
@@ -528,9 +558,16 @@ function SettingsPanelComponentGeneral(props: any) {
                     OPENAI_COMPATIBLE_INLINE_COMPLETION_MODEL_ID,
                     LITELLM_COMPATIBLE_INLINE_COMPLETION_MODEL_ID
                   ].includes(inlineCompletionModel) && (
-                    <div>
+                    <div
+                      title={lockedTip(
+                        settingLocks.inline_completion_model_id.locked
+                      )}
+                    >
                       <select
                         className="jp-mod-styled"
+                        disabled={
+                          settingLocks.inline_completion_model_id.locked
+                        }
                         onChange={event =>
                           setInlineCompletionModel(event.target.value)
                         }
@@ -624,10 +661,20 @@ function SettingsPanelComponentGeneral(props: any) {
               <div className="model-config-section-body">
                 <div className="model-config-section-row">
                   <div className="model-config-section-column">
-                    <label>
+                    <label
+                      title={lockedTip(
+                        featurePolicies.store_github_access_token.locked
+                      )}
+                    >
                       <input
                         type="checkbox"
-                        checked={storeGitHubAccessToken}
+                        checked={checkedValue(
+                          featurePolicies.store_github_access_token,
+                          storeGitHubAccessToken
+                        )}
+                        disabled={
+                          featurePolicies.store_github_access_token.locked
+                        }
                         onChange={event => {
                           setStoreGitHubAccessToken(event.target.checked);
                         }}
@@ -650,13 +697,9 @@ function SettingsPanelComponentGeneral(props: any) {
                 <CheckBoxItem
                   label="Explain cell errors"
                   title="Show a 'Troubleshoot errors in output' context-menu item on failed cells"
-                  checked={cellOutputFeatures.explain_error.enabled}
-                  disabled={cellOutputFeatures.explain_error.locked}
-                  tooltip={
-                    cellOutputFeatures.explain_error.locked
-                      ? 'Locked by your administrator'
-                      : ''
-                  }
+                  checked={featurePolicies.explain_error.enabled}
+                  disabled={featurePolicies.explain_error.locked}
+                  tooltip={lockedTip(featurePolicies.explain_error.locked)}
                   onClick={toggleExplainError}
                 />
               </div>
@@ -666,13 +709,9 @@ function SettingsPanelComponentGeneral(props: any) {
                 <CheckBoxItem
                   label="Ask about cell outputs"
                   title="Right-click a cell output to attach it to the chat"
-                  checked={cellOutputFeatures.output_followup.enabled}
-                  disabled={cellOutputFeatures.output_followup.locked}
-                  tooltip={
-                    cellOutputFeatures.output_followup.locked
-                      ? 'Locked by your administrator'
-                      : ''
-                  }
+                  checked={featurePolicies.output_followup.enabled}
+                  disabled={featurePolicies.output_followup.locked}
+                  tooltip={lockedTip(featurePolicies.output_followup.locked)}
                   onClick={toggleOutputFollowup}
                 />
               </div>
@@ -682,13 +721,9 @@ function SettingsPanelComponentGeneral(props: any) {
                 <CheckBoxItem
                   label="Show output toolbar"
                   title="Show a hover toolbar over cell outputs with Explain / Ask / Troubleshoot buttons"
-                  checked={cellOutputFeatures.output_toolbar.enabled}
-                  disabled={cellOutputFeatures.output_toolbar.locked}
-                  tooltip={
-                    cellOutputFeatures.output_toolbar.locked
-                      ? 'Locked by your administrator'
-                      : ''
-                  }
+                  checked={featurePolicies.output_toolbar.enabled}
+                  disabled={featurePolicies.output_toolbar.locked}
+                  tooltip={lockedTip(featurePolicies.output_toolbar.locked)}
                   onClick={toggleOutputToolbar}
                 />
               </div>
@@ -998,6 +1033,7 @@ function SettingsPanelComponentClaude(props: any) {
     nbiConfig.claudeModels
   );
   const [loadingModels, setLoadingModels] = useState(false);
+  const { featurePolicies, settingLocks } = useNbiPolicies();
 
   useEffect(() => {
     const handler = () => {
@@ -1106,7 +1142,12 @@ function SettingsPanelComponentClaude(props: any) {
                     <CheckBoxItem
                       header={true}
                       label="Enable Claude mode"
-                      checked={claudeEnabled}
+                      checked={checkedValue(
+                        featurePolicies.claude_mode,
+                        claudeEnabled
+                      )}
+                      disabled={featurePolicies.claude_mode.locked}
+                      tooltip={lockedTip(featurePolicies.claude_mode.locked)}
                       onClick={() => {
                         setClaudeEnabled(!claudeEnabled);
                       }}
@@ -1139,9 +1180,10 @@ function SettingsPanelComponentClaude(props: any) {
               <div className="model-config-section-row">
                 <div className="model-config-section-column">
                   <div>Chat model</div>
-                  <div>
+                  <div title={lockedTip(settingLocks.claude_chat_model.locked)}>
                     <select
                       className="jp-mod-styled"
+                      disabled={settingLocks.claude_chat_model.locked}
                       onChange={event => setChatModel(event.target.value)}
                     >
                       <option
@@ -1164,9 +1206,16 @@ function SettingsPanelComponentClaude(props: any) {
                 </div>
                 <div className="model-config-section-column">
                   <div>Auto-complete model</div>
-                  <div>
+                  <div
+                    title={lockedTip(
+                      settingLocks.claude_inline_completion_model.locked
+                    )}
+                  >
                     <select
                       className="jp-mod-styled"
+                      disabled={
+                        settingLocks.claude_inline_completion_model.locked
+                      }
                       onChange={event =>
                         setInlineCompletionModel(event.target.value)
                       }
@@ -1222,7 +1271,16 @@ function SettingsPanelComponentClaude(props: any) {
                     <CheckBoxItem
                       header={true}
                       label="User"
-                      checked={settingSources.includes('user')}
+                      checked={checkedValue(
+                        featurePolicies.claude_setting_source_user,
+                        settingSources.includes('user')
+                      )}
+                      disabled={
+                        featurePolicies.claude_setting_source_user.locked
+                      }
+                      tooltip={lockedTip(
+                        featurePolicies.claude_setting_source_user.locked
+                      )}
                       onClick={() => {
                         setSettingSources(
                           settingSources.includes('user')
@@ -1240,7 +1298,16 @@ function SettingsPanelComponentClaude(props: any) {
                     <CheckBoxItem
                       header={true}
                       label="Project (Jupyter root directory)"
-                      checked={settingSources.includes('project')}
+                      checked={checkedValue(
+                        featurePolicies.claude_setting_source_project,
+                        settingSources.includes('project')
+                      )}
+                      disabled={
+                        featurePolicies.claude_setting_source_project.locked
+                      }
+                      tooltip={lockedTip(
+                        featurePolicies.claude_setting_source_project.locked
+                      )}
                       onClick={() => {
                         setSettingSources(
                           settingSources.includes('project')
@@ -1266,8 +1333,14 @@ function SettingsPanelComponentClaude(props: any) {
                     <CheckBoxItem
                       header={true}
                       label="Claude Code tools"
-                      checked={tools.includes(ClaudeToolType.ClaudeCodeTools)}
+                      checked={checkedValue(
+                        featurePolicies.claude_code_tools,
+                        tools.includes(ClaudeToolType.ClaudeCodeTools)
+                      )}
                       disabled={true}
+                      tooltip={lockedTip(
+                        featurePolicies.claude_code_tools.locked
+                      )}
                       onClick={() => {
                         setTools(
                           tools.includes(ClaudeToolType.ClaudeCodeTools)
@@ -1286,7 +1359,14 @@ function SettingsPanelComponentClaude(props: any) {
                     <CheckBoxItem
                       header={true}
                       label="Jupyter UI tools"
-                      checked={tools.includes(ClaudeToolType.JupyterUITools)}
+                      checked={checkedValue(
+                        featurePolicies.claude_jupyter_ui_tools,
+                        tools.includes(ClaudeToolType.JupyterUITools)
+                      )}
+                      disabled={featurePolicies.claude_jupyter_ui_tools.locked}
+                      tooltip={lockedTip(
+                        featurePolicies.claude_jupyter_ui_tools.locked
+                      )}
                       onClick={() => {
                         setTools(
                           tools.includes(ClaudeToolType.JupyterUITools)
@@ -1315,7 +1395,16 @@ function SettingsPanelComponentClaude(props: any) {
                     <CheckBoxItem
                       header={true}
                       label="Remember conversation history"
-                      checked={continueConversation}
+                      checked={checkedValue(
+                        featurePolicies.claude_continue_conversation,
+                        continueConversation
+                      )}
+                      disabled={
+                        featurePolicies.claude_continue_conversation.locked
+                      }
+                      tooltip={lockedTip(
+                        featurePolicies.claude_continue_conversation.locked
+                      )}
                       onClick={() => {
                         setContinueConversation(!continueConversation);
                       }}
@@ -1337,10 +1426,16 @@ function SettingsPanelComponentClaude(props: any) {
                     </div>
                     <input
                       name="chat-model-id-input"
-                      placeholder="API Key"
+                      placeholder={
+                        settingLocks.claude_api_key.locked
+                          ? 'Locked by ANTHROPIC_API_KEY'
+                          : 'API Key'
+                      }
                       className="jp-mod-styled"
                       spellCheck={false}
-                      value={apiKey}
+                      value={settingLocks.claude_api_key.locked ? '' : apiKey}
+                      disabled={settingLocks.claude_api_key.locked}
+                      title={lockedTip(settingLocks.claude_api_key.locked)}
                       onChange={event => setApiKey(event.target.value)}
                     />
                   </div>
@@ -1350,10 +1445,16 @@ function SettingsPanelComponentClaude(props: any) {
                     </div>
                     <input
                       name="chat-model-id-input"
-                      placeholder="https://api.anthropic.com"
+                      placeholder={
+                        settingLocks.claude_base_url.locked
+                          ? 'Locked by ANTHROPIC_BASE_URL'
+                          : 'https://api.anthropic.com'
+                      }
                       className="jp-mod-styled"
                       spellCheck={false}
                       value={baseUrl}
+                      disabled={settingLocks.claude_base_url.locked}
+                      title={lockedTip(settingLocks.claude_base_url.locked)}
                       onChange={event => setBaseUrl(event.target.value)}
                     />
                   </div>

--- a/tests/test_cell_output_features_response.py
+++ b/tests/test_cell_output_features_response.py
@@ -1,24 +1,38 @@
 # Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
 
-"""Tests for the capabilities-response helper that surfaces the
-explain_error / output_followup / output_toolbar feature gates to the
-frontend."""
+"""Tests for the capabilities-response helpers that surface admin policies
+and value-presence-locks to the frontend."""
 
 from types import SimpleNamespace
 
-from notebook_intelligence.extension import _build_cell_output_features_response
+from notebook_intelligence.extension import (
+    _build_cell_output_features_response,
+    _build_feature_policies_response,
+    _build_setting_locks_response,
+)
 from notebook_intelligence.feature_flags import (
+    CLAUDE_CODE_TOOLS_ID,
+    JUPYTER_UI_TOOLS_ID,
     POLICY_FORCE_OFF,
     POLICY_FORCE_ON,
     POLICY_USER_CHOICE,
 )
 
 
-def _config(*, explain=True, followup=True, toolbar=True):
+def _config(
+    *,
+    explain=True,
+    followup=True,
+    toolbar=True,
+    store_token=False,
+    claude_settings=None,
+):
     return SimpleNamespace(
         enable_explain_error=explain,
         enable_output_followup=followup,
         enable_output_toolbar=toolbar,
+        store_github_access_token=store_token,
+        claude_settings=claude_settings if claude_settings is not None else {},
     )
 
 
@@ -65,4 +79,119 @@ class TestBuildCellOutputFeaturesResponse:
             "explain_error": {"enabled": True, "locked": True},
             "output_followup": {"enabled": False, "locked": True},
             "output_toolbar": {"enabled": False, "locked": False},
+        }
+
+
+class TestBuildFeaturePoliciesResponse:
+    def test_empty_policies_match_user_state_unlocked(self):
+        response = _build_feature_policies_response(
+            {},
+            _config(
+                explain=True,
+                followup=False,
+                toolbar=True,
+                store_token=True,
+                claude_settings={
+                    "enabled": True,
+                    "continue_conversation": False,
+                    "tools": [CLAUDE_CODE_TOOLS_ID],
+                    "setting_sources": ["user", "project"],
+                },
+            ),
+        )
+        assert response["explain_error"] == {"enabled": True, "locked": False}
+        assert response["claude_mode"] == {"enabled": True, "locked": False}
+        assert response["claude_continue_conversation"] == {
+            "enabled": False,
+            "locked": False,
+        }
+        assert response["claude_code_tools"] == {"enabled": True, "locked": False}
+        assert response["claude_jupyter_ui_tools"] == {
+            "enabled": False,
+            "locked": False,
+        }
+        assert response["claude_setting_source_user"] == {
+            "enabled": True,
+            "locked": False,
+        }
+        assert response["claude_setting_source_project"] == {
+            "enabled": True,
+            "locked": False,
+        }
+        assert response["store_github_access_token"] == {
+            "enabled": True,
+            "locked": False,
+        }
+
+    def test_force_on_locks_each_independently(self):
+        response = _build_feature_policies_response(
+            {
+                "claude_mode": POLICY_FORCE_ON,
+                "claude_jupyter_ui_tools": POLICY_FORCE_OFF,
+                "store_github_access_token": POLICY_FORCE_ON,
+            },
+            _config(
+                store_token=False,
+                claude_settings={
+                    "enabled": False,
+                    "tools": [JUPYTER_UI_TOOLS_ID],
+                },
+            ),
+        )
+        assert response["claude_mode"] == {"enabled": True, "locked": True}
+        assert response["claude_jupyter_ui_tools"] == {
+            "enabled": False,
+            "locked": True,
+        }
+        assert response["store_github_access_token"] == {
+            "enabled": True,
+            "locked": True,
+        }
+        # Untouched policies stay unlocked and reflect user prefs.
+        assert response["claude_continue_conversation"]["locked"] is False
+
+    def test_handles_missing_claude_settings(self):
+        # Brand-new install: claude_settings is {} entirely.
+        response = _build_feature_policies_response(
+            {}, _config(claude_settings={})
+        )
+        assert response["claude_mode"]["enabled"] is False
+        assert response["claude_continue_conversation"]["enabled"] is False
+        assert response["claude_code_tools"]["enabled"] is False
+
+
+class TestBuildSettingLocksResponse:
+    def test_empty_overrides_means_nothing_locked(self):
+        response = _build_setting_locks_response({})
+        for entry in response.values():
+            assert entry == {"locked": False}
+
+    def test_presence_of_value_locks_the_field(self):
+        response = _build_setting_locks_response(
+            {
+                "chat_model_provider": "ollama",
+                "chat_model_id": "",
+                "claude_api_key": "sk-secret",
+                "claude_base_url": "https://api.anthropic.com",
+            }
+        )
+        assert response["chat_model_provider"] == {"locked": True}
+        # Empty string must not lock — that's the user-choice signal.
+        assert response["chat_model_id"] == {"locked": False}
+        assert response["claude_api_key"] == {"locked": True}
+        assert response["claude_base_url"] == {"locked": True}
+        # Unrelated keys remain unlocked.
+        assert response["claude_chat_model"] == {"locked": False}
+
+    def test_response_includes_every_known_lock_name(self):
+        response = _build_setting_locks_response({})
+        assert set(response.keys()) == {
+            "chat_model_provider",
+            "chat_model_id",
+            "inline_completion_model_provider",
+            "inline_completion_model_id",
+            "claude_chat_model",
+            "claude_inline_completion_model",
+            "claude_api_key",
+            "claude_base_url",
         }

--- a/tests/test_config_integration.py
+++ b/tests/test_config_integration.py
@@ -92,25 +92,75 @@ class TestNBIConfigSaveAndLoad:
         config.nbi_user_dir = str(tmp_path)
         config.user_config_file = str(tmp_path / "config.json")
         config.user_mcp_file = str(tmp_path / "mcp.json")
-        
+
         config.user_config = {
             'rules_enabled': False,
             'active_rules': {'test.md': True}
         }
         config.user_mcp = {}
-        
+
         # Mock the actual save methods since we're testing the integration
         with patch('builtins.open'), patch('json.dump') as mock_dump, patch('os.makedirs'):
             config.save()
-            
+
             # Should be called twice (once for config, once for mcp)
             assert mock_dump.call_count == 2
-            
+
             # First call should be for the main config
             first_call_args = mock_dump.call_args_list[0][0]
             saved_config = first_call_args[0]
-            
+
             assert 'rules_enabled' in saved_config
             assert saved_config['rules_enabled'] is False
             assert saved_config['active_rules'] == {'test.md': True}
+
+
+class TestNBIConfigPolicyResolution:
+    """The boolean policies and string overrides feed through NBIConfig getters
+    so SDK consumers (claude.py, ai_service_manager) see resolved values."""
+
+    def test_chat_model_string_overrides_apply(self, mock_nbi_config):
+        config = mock_nbi_config
+        config.user_config = {
+            'chat_model': {'provider': 'github-copilot', 'model': 'gpt-4o'}
+        }
+        config.set_feature_policies(
+            {},
+            {'chat_model_provider': 'ollama', 'chat_model_id': 'llama3:latest'},
+        )
+        assert config.chat_model == {'provider': 'ollama', 'model': 'llama3:latest'}
+
+    def test_chat_model_partial_override_preserves_other_field(self, mock_nbi_config):
+        config = mock_nbi_config
+        config.user_config = {
+            'chat_model': {'provider': 'github-copilot', 'model': 'gpt-4o'}
+        }
+        config.set_feature_policies({}, {'chat_model_provider': 'ollama'})
+        # provider locked, model still user's choice
+        assert config.chat_model == {'provider': 'ollama', 'model': 'gpt-4o'}
+
+    def test_claude_settings_force_on_overrides_user_off(self, mock_nbi_config):
+        from notebook_intelligence.feature_flags import POLICY_FORCE_ON
+        config = mock_nbi_config
+        config.user_config = {'claude_settings': {'enabled': False}}
+        config.set_feature_policies({'claude_mode': POLICY_FORCE_ON}, {})
+        assert config.claude_settings['enabled'] is True
+
+    def test_claude_settings_api_key_override_applied_for_sdk(self, mock_nbi_config):
+        config = mock_nbi_config
+        config.user_config = {'claude_settings': {'api_key': 'sk-user'}}
+        config.set_feature_policies(
+            {}, {'claude_api_key': 'sk-locked-by-env'}
+        )
+        # SDK side sees the env-supplied key (claude.py forwards it).
+        assert config.claude_settings['api_key'] == 'sk-locked-by-env'
+
+    def test_no_overrides_returns_user_value_unchanged(self, mock_nbi_config):
+        config = mock_nbi_config
+        config.user_config = {
+            'chat_model': {'provider': 'github-copilot', 'model': 'gpt-4o'}
+        }
+        config.set_feature_policies({}, {})
+        # Identity check guarantees no needless allocation in the common case.
+        assert config.chat_model is config.user_config['chat_model']
 

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -1,10 +1,16 @@
 # Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
 
 from notebook_intelligence.feature_flags import (
+    CLAUDE_CODE_TOOLS_ID,
+    JUPYTER_UI_TOOLS_ID,
     POLICY_FORCE_OFF,
     POLICY_FORCE_ON,
     POLICY_USER_CHOICE,
     VALID_POLICIES,
+    apply_claude_policies,
+    apply_member_policy,
+    apply_string_overrides,
+    is_locked,
     resolve_feature_flag,
 )
 
@@ -35,3 +41,172 @@ class TestPolicyConstants:
             POLICY_FORCE_ON,
             POLICY_FORCE_OFF,
         }
+
+
+class TestIsLocked:
+    def test_force_policies_are_locked(self):
+        assert is_locked(POLICY_FORCE_ON) is True
+        assert is_locked(POLICY_FORCE_OFF) is True
+
+    def test_user_choice_is_not_locked(self):
+        assert is_locked(POLICY_USER_CHOICE) is False
+
+    def test_unknown_policy_is_not_locked(self):
+        assert is_locked("nonsense") is False
+        assert is_locked("") is False
+
+
+class TestApplyMemberPolicy:
+    def test_force_on_adds_missing_member(self):
+        assert apply_member_policy(["a"], "b", POLICY_FORCE_ON) == ["a", "b"]
+
+    def test_force_on_is_idempotent_when_already_present(self):
+        assert apply_member_policy(["a", "b"], "b", POLICY_FORCE_ON) == ["a", "b"]
+
+    def test_force_off_removes_present_member(self):
+        assert apply_member_policy(["a", "b"], "b", POLICY_FORCE_OFF) == ["a"]
+
+    def test_force_off_is_idempotent_when_already_absent(self):
+        assert apply_member_policy(["a"], "b", POLICY_FORCE_OFF) == ["a"]
+
+    def test_user_choice_leaves_list_untouched(self):
+        assert apply_member_policy(["a"], "b", POLICY_USER_CHOICE) == ["a"]
+        assert apply_member_policy(["a", "b"], "b", POLICY_USER_CHOICE) == ["a", "b"]
+
+
+class TestApplyClaudePolicies:
+    def test_user_choice_leaves_settings_untouched(self):
+        settings = {
+            "enabled": True,
+            "continue_conversation": False,
+            "tools": [CLAUDE_CODE_TOOLS_ID],
+            "setting_sources": ["user"],
+        }
+        result = apply_claude_policies(settings, {})
+        assert result["enabled"] is True
+        assert result["continue_conversation"] is False
+        assert result["tools"] == [CLAUDE_CODE_TOOLS_ID]
+        assert result["setting_sources"] == ["user"]
+
+    def test_force_on_overrides_user_off(self):
+        result = apply_claude_policies(
+            {"enabled": False, "continue_conversation": False},
+            {
+                "claude_mode": POLICY_FORCE_ON,
+                "claude_continue_conversation": POLICY_FORCE_ON,
+            },
+        )
+        assert result["enabled"] is True
+        assert result["continue_conversation"] is True
+
+    def test_force_off_overrides_user_on(self):
+        result = apply_claude_policies(
+            {"enabled": True, "continue_conversation": True},
+            {
+                "claude_mode": POLICY_FORCE_OFF,
+                "claude_continue_conversation": POLICY_FORCE_OFF,
+            },
+        )
+        assert result["enabled"] is False
+        assert result["continue_conversation"] is False
+
+    def test_tools_array_membership_is_managed_per_policy(self):
+        result = apply_claude_policies(
+            {"tools": []},
+            {
+                "claude_code_tools": POLICY_FORCE_ON,
+                "claude_jupyter_ui_tools": POLICY_FORCE_OFF,
+            },
+        )
+        assert CLAUDE_CODE_TOOLS_ID in result["tools"]
+        assert JUPYTER_UI_TOOLS_ID not in result["tools"]
+
+    def test_tools_array_force_off_strips_existing_membership(self):
+        result = apply_claude_policies(
+            {"tools": [CLAUDE_CODE_TOOLS_ID, JUPYTER_UI_TOOLS_ID]},
+            {"claude_jupyter_ui_tools": POLICY_FORCE_OFF},
+        )
+        assert CLAUDE_CODE_TOOLS_ID in result["tools"]
+        assert JUPYTER_UI_TOOLS_ID not in result["tools"]
+
+    def test_setting_sources_per_member_policy(self):
+        result = apply_claude_policies(
+            {"setting_sources": []},
+            {
+                "claude_setting_source_user": POLICY_FORCE_ON,
+                "claude_setting_source_project": POLICY_FORCE_OFF,
+            },
+        )
+        assert "user" in result["setting_sources"]
+        assert "project" not in result["setting_sources"]
+
+    def test_does_not_mutate_caller_input(self):
+        original = {"tools": [CLAUDE_CODE_TOOLS_ID]}
+        apply_claude_policies(
+            original, {"claude_jupyter_ui_tools": POLICY_FORCE_ON}
+        )
+        # The caller's tools list must be unchanged.
+        assert original["tools"] == [CLAUDE_CODE_TOOLS_ID]
+
+    def test_handles_missing_tools_and_sources(self):
+        # A fresh user with no claude_settings at all.
+        result = apply_claude_policies(
+            {}, {"claude_code_tools": POLICY_FORCE_ON}
+        )
+        assert CLAUDE_CODE_TOOLS_ID in result["tools"]
+        assert result["setting_sources"] == []
+
+    def test_handles_none_input(self):
+        result = apply_claude_policies(None, {})
+        assert result["tools"] == []
+        assert result["setting_sources"] == []
+
+
+class TestApplyStringOverrides:
+    _MAPPING = (
+        ("provider_override", "provider"),
+        ("model_override", "model"),
+    )
+
+    def test_no_overrides_returns_input_identity(self):
+        target = {"provider": "ollama", "model": "llama3:latest"}
+        result = apply_string_overrides(target, {}, self._MAPPING)
+        # The 99% case (no env vars) must not allocate.
+        assert result is target
+
+    def test_empty_string_override_does_not_apply(self):
+        target = {"provider": "ollama", "model": "llama3:latest"}
+        result = apply_string_overrides(
+            target, {"provider_override": ""}, self._MAPPING
+        )
+        assert result is target
+
+    def test_non_empty_override_writes_dest(self):
+        result = apply_string_overrides(
+            {"provider": "ollama", "model": "llama3:latest"},
+            {"provider_override": "github-copilot"},
+            self._MAPPING,
+        )
+        assert result == {"provider": "github-copilot", "model": "llama3:latest"}
+
+    def test_multiple_overrides_apply_in_mapping_order(self):
+        result = apply_string_overrides(
+            {},
+            {"provider_override": "ollama", "model_override": "llama3:latest"},
+            self._MAPPING,
+        )
+        assert result == {"provider": "ollama", "model": "llama3:latest"}
+
+    def test_does_not_mutate_caller_input(self):
+        original = {"provider": "ollama", "model": "llama3:latest"}
+        apply_string_overrides(
+            original, {"provider_override": "github-copilot"}, self._MAPPING
+        )
+        assert original == {"provider": "ollama", "model": "llama3:latest"}
+
+    def test_keys_not_in_mapping_are_ignored(self):
+        target = {"x": 1}
+        result = apply_string_overrides(
+            target, {"unrelated": "value"}, self._MAPPING
+        )
+        assert result is target


### PR DESCRIPTION
## Summary

Builds on the existing `*_policy` traitlet + `NBI_*_POLICY` env-var pattern (used today for the three cell-output features) so an org admin can lock any togglable setting in the panel — not just the cell-output ones. Adds value-presence-locks for the model pickers and Claude account fields where a three-valued policy doesn't fit naturally.

When a policy is active, the matching panel control is disabled with a "Locked by your administrator" tooltip and any client-side write is dropped on the server before persistence.

## What's covered

### Boolean policies (NBI_*_POLICY = `user-choice` | `force-on` | `force-off`)

| Env var | Locks the panel control for |
| --- | --- |
| `NBI_EXPLAIN_ERROR_POLICY` | "Explain cell errors" *(already shipped)* |
| `NBI_OUTPUT_FOLLOWUP_POLICY` | "Ask about cell outputs" *(already shipped)* |
| `NBI_OUTPUT_TOOLBAR_POLICY` | "Show output toolbar" *(already shipped)* |
| `NBI_CLAUDE_MODE_POLICY` | "Enable Claude mode" |
| `NBI_CLAUDE_CONTINUE_CONVERSATION_POLICY` | "Remember conversation history" |
| `NBI_CLAUDE_CODE_TOOLS_POLICY` | "Claude Code tools" |
| `NBI_CLAUDE_JUPYTER_UI_TOOLS_POLICY` | "Jupyter UI tools" |
| `NBI_CLAUDE_SETTING_SOURCE_USER_POLICY` | Setting source: User |
| `NBI_CLAUDE_SETTING_SOURCE_PROJECT_POLICY` | Setting source: Project |
| `NBI_STORE_GITHUB_ACCESS_TOKEN_POLICY` | "Remember my GitHub Copilot access token" |

The first three already had matching traitlets (`explain_error_policy` etc.); this PR adds traitlets for the new ones in the same shape.

### Value-presence locks (env var holds the locked value; empty/unset = user-choice)

| Env var | Pins |
| --- | --- |
| `NBI_CHAT_MODEL_PROVIDER` / `NBI_CHAT_MODEL_ID` | General → Chat model |
| `NBI_INLINE_COMPLETION_MODEL_PROVIDER` / `NBI_INLINE_COMPLETION_MODEL_ID` | General → Auto-complete model |
| `NBI_CLAUDE_CHAT_MODEL` | Claude → Chat model |
| `NBI_CLAUDE_INLINE_COMPLETION_MODEL` | Claude → Auto-complete model |
| `ANTHROPIC_API_KEY` | Claude → API Key (input is locked + blanked on the wire) |
| `ANTHROPIC_BASE_URL` | Claude → Base URL |

\`ANTHROPIC_API_KEY\` and \`ANTHROPIC_BASE_URL\` keep the SDK's native conventions rather than introducing NBI-prefixed equivalents. The api_key is never echoed in the capabilities response and is not persisted to \`config.json\` on save — the SDK reads \`ANTHROPIC_API_KEY\` directly from process env.

### Out of scope

Skipped here, happy to do as follow-ups if you want them:
- \`default_chat_mode\` (ask/agent) — left user-set
- \`inline_completion_debouncer_delay\` — no obvious admin use case
- Per-MCP-server enable/disable policy — the existing \`disabled\` flag uses a different idiom
- Notebook-generation toolbar (#170) — feature isn't yet a panel toggle

## Implementation notes

- **Single source of truth.** \`FEATURE_POLICY_SPEC\` and \`STRING_OVERRIDE_SPEC\` tuples in \`extension.py\` drive env-var resolution, the capabilities response builders, and the lock-rejection set in \`ConfigHandler\`. Adding a new policy is one tuple entry rather than edits across four places.
- **Bootstrap timing.** Policies resolve before \`AIServiceManager\` is constructed and are applied to \`NBIConfig\` immediately, so the initial Claude / GitHub Copilot connect uses the locked values rather than the user's stored preferences.
- **Read-path identity.** \`nbi_config.{chat_model, inline_completion_model, claude_settings}\` apply overrides on read and short-circuit to input identity when no override is set — the no-policy common case doesn't allocate per access.
- **Server-side enforcement.** \`ConfigHandler.post\` filters incoming POSTs through the same \`apply_claude_policies\` + \`apply_string_overrides\` so a hand-rolled API call can't bypass the lock.

## Backward compatibility

- The existing three \`*_policy\` traitlets (\`explain_error_policy\`, \`output_followup_policy\`, \`output_toolbar_policy\`) and their env vars keep working unchanged.
- A user who sets nothing — no env vars, no traitlets — sees zero behavioral change.
- Capabilities response gains two new fields (\`feature_policies\`, \`setting_locks\`); existing fields (\`cell_output_features\`, \`chat_model\`, etc.) are unchanged in shape, just policy-resolved when applicable.

## Test plan

- [x] \`pytest tests/\` — 453 passing, including new \`TestApplyStringOverrides\`, \`TestNBIConfigPolicyResolution\`, and extensions to \`TestBuildFeaturePoliciesResponse\` / \`TestBuildSettingLocksResponse\`.
- [x] \`jlpm jest\` — 77 passing, no regressions.
- [x] \`jlpm lint:check\` — clean (eslint, prettier, stylelint).
- [x] Manual: \`NBI_CLAUDE_MODE_POLICY=force-on jupyter lab\` → Claude mode enabled, "Enable Claude mode" checkbox disabled with the lock tooltip.
- [x] Manual: \`ANTHROPIC_API_KEY=sk-test\` → Claude API Key field shows blank + "Locked by ANTHROPIC_API_KEY" placeholder + disabled.
- [x] Manual: \`NBI_CHAT_MODEL_PROVIDER=ollama NBI_CHAT_MODEL_ID=llama3:latest\` → both dropdowns pinned and disabled; user's previous selection in \`config.json\` is preserved if env vars later unset.