### PR TITLE
fix(claude): prevent worker thread crash on cancellation

### DIFF
--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -517,9 +517,13 @@ class ClaudeCodeClient():
                 set_current_claude_client(client)
 
                 while True:
-                    event = self._client_queue.get(block=True)
+                    queue = self._client_queue
+                    if queue is None:
+                        return
+                    event = queue.get(block=True)
                     event_id = event["id"]
                     event_type = event["type"]
+                    signal = self._client_thread_signal
                     if event_type == ClaudeAgentEventType.Query:
                         try:
                             request: ChatRequest = event["args"]["request"]
@@ -575,10 +579,11 @@ class ClaudeCodeClient():
                             if not self._reconnect_required:
                                 response.stream(MarkdownData(err_msg))
                         finally:
-                            self._client_thread_signal.emit({
-                                "id": event_id,
-                                "data": "query completed"
-                            })
+                            if signal is not None:
+                                signal.emit({
+                                    "id": event_id,
+                                    "data": "query completed"
+                                })
                             set_current_request(None)
                             set_current_response(None)
                     elif event_type == ClaudeAgentEventType.GetServerInfo:
@@ -588,10 +593,11 @@ class ClaudeCodeClient():
                             log.error(f"Error occurred while getting server info: {str(e)}")
                             server_info = None
                         finally:
-                            self._client_thread_signal.emit({
-                                "id": event_id,
-                                "data": server_info
-                            })
+                            if signal is not None:
+                                signal.emit({
+                                    "id": event_id,
+                                    "data": server_info
+                                })
                     elif event_type == ClaudeAgentEventType.ClearChatHistory:
                         try:
                            await client.query('/clear')
@@ -601,15 +607,17 @@ class ClaudeCodeClient():
                         except Exception as e:
                             log.error(f"Error occurred while clearing chat history: {str(e)}")
                         finally:
-                            self._client_thread_signal.emit({
-                                "id": event_id,
-                                "data": "chat history cleared"
-                            })
+                            if signal is not None:
+                                signal.emit({
+                                    "id": event_id,
+                                    "data": "chat history cleared"
+                                })
                     elif event_type == ClaudeAgentEventType.StopClient:
-                        self._client_thread_signal.emit({
-                            "id": event_id,
-                            "data": "stopped"
-                        })
+                        if signal is not None:
+                            signal.emit({
+                                "id": event_id,
+                                "data": "stopped"
+                            })
                         return
                     else:
                         log.error(f"Unknown event type {event}")

--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -21,7 +21,7 @@ import logging
 from claude_agent_sdk import AssistantMessage, PermissionResultAllow, PermissionResultDeny, TextBlock, UserMessage, create_sdk_mcp_server, ClaudeAgentOptions, ClaudeSDKClient, tool
 from anthropic.types.text_block import TextBlock as AnthropicTextBlock
 
-from notebook_intelligence.util import ThreadSafeWebSocketConnector, get_jupyter_root_dir
+from notebook_intelligence.util import ThreadSafeWebSocketConnector, _emit, get_jupyter_root_dir
 
 log = logging.getLogger(__name__)
 
@@ -518,12 +518,12 @@ class ClaudeCodeClient():
 
                 while True:
                     queue = self._client_queue
+                    signal = self._client_thread_signal
                     if queue is None:
                         return
                     event = queue.get(block=True)
                     event_id = event["id"]
                     event_type = event["type"]
-                    signal = self._client_thread_signal
                     if event_type == ClaudeAgentEventType.Query:
                         try:
                             request: ChatRequest = event["args"]["request"]
@@ -579,11 +579,7 @@ class ClaudeCodeClient():
                             if not self._reconnect_required:
                                 response.stream(MarkdownData(err_msg))
                         finally:
-                            if signal is not None:
-                                signal.emit({
-                                    "id": event_id,
-                                    "data": "query completed"
-                                })
+                            _emit(signal, {"id": event_id, "data": "query completed"})
                             set_current_request(None)
                             set_current_response(None)
                     elif event_type == ClaudeAgentEventType.GetServerInfo:
@@ -593,11 +589,7 @@ class ClaudeCodeClient():
                             log.error(f"Error occurred while getting server info: {str(e)}")
                             server_info = None
                         finally:
-                            if signal is not None:
-                                signal.emit({
-                                    "id": event_id,
-                                    "data": server_info
-                                })
+                            _emit(signal, {"id": event_id, "data": server_info})
                     elif event_type == ClaudeAgentEventType.ClearChatHistory:
                         try:
                            await client.query('/clear')
@@ -607,17 +599,9 @@ class ClaudeCodeClient():
                         except Exception as e:
                             log.error(f"Error occurred while clearing chat history: {str(e)}")
                         finally:
-                            if signal is not None:
-                                signal.emit({
-                                    "id": event_id,
-                                    "data": "chat history cleared"
-                                })
+                            _emit(signal, {"id": event_id, "data": "chat history cleared"})
                     elif event_type == ClaudeAgentEventType.StopClient:
-                        if signal is not None:
-                            signal.emit({
-                                "id": event_id,
-                                "data": "stopped"
-                            })
+                        _emit(signal, {"id": event_id, "data": "stopped"})
                         return
                     else:
                         log.error(f"Unknown event type {event}")

--- a/notebook_intelligence/mcp_manager.py
+++ b/notebook_intelligence/mcp_manager.py
@@ -252,9 +252,13 @@ class MCPServerImpl(MCPServer):
             async with await self._get_client() as client:
                 self._set_status(MCPServerStatus.Connected)
                 while True:
-                    event = self._client_queue.get(block=True)
+                    queue = self._client_queue
+                    if queue is None:
+                        return
+                    event = queue.get(block=True)
                     event_id = event["id"]
                     event_type = event["type"]
+                    signal = self._client_thread_signal
                     if event_type == MCPServerEventType.ListTools:
                         try:
                             tool_list = await client.list_tools()
@@ -262,10 +266,11 @@ class MCPServerImpl(MCPServer):
                             log.error(f"Error occurred while listing MCP tools: {str(e)}")
                             tool_list = []
                         finally:
-                            self._client_thread_signal.emit({
-                                "id": event_id,
-                                "data": tool_list
-                            })
+                            if signal is not None:
+                                signal.emit({
+                                    "id": event_id,
+                                    "data": tool_list
+                                })
                     elif event_type == MCPServerEventType.CallTool:
                         try:
                             result = await client.call_tool(event["args"]["tool_name"], event["args"]["tool_args"])
@@ -273,15 +278,17 @@ class MCPServerImpl(MCPServer):
                             result = f"Error occurred while calling MCP tool {event['args']['tool_name']}: {str(e)}"
                             log.error(result)
                         finally:
-                            self._client_thread_signal.emit({
-                                "id": event_id,
-                                "data": result
-                            })
+                            if signal is not None:
+                                signal.emit({
+                                    "id": event_id,
+                                    "data": result
+                                })
                     elif event_type == MCPServerEventType.StopServer:
-                        self._client_thread_signal.emit({
-                            "id": event_id,
-                            "data": "stopped"
-                        })
+                        if signal is not None:
+                            signal.emit({
+                                "id": event_id,
+                                "data": "stopped"
+                            })
                         return
                     elif event_type == MCPServerEventType.ListPrompts:
                         try:
@@ -290,10 +297,11 @@ class MCPServerImpl(MCPServer):
                             log.error(f"Error occurred while listing MCP prompts: {str(e)}")
                             prompts = []
                         finally:
-                            self._client_thread_signal.emit({
-                                "id": event_id,
-                                "data": prompts
-                            })
+                            if signal is not None:
+                                signal.emit({
+                                    "id": event_id,
+                                    "data": prompts
+                                })
                     elif event_type == MCPServerEventType.GetPromptValue:
                         try:
                             prompt = await client.get_prompt(event["args"]["prompt_name"], event["args"]["prompt_args"])
@@ -301,10 +309,11 @@ class MCPServerImpl(MCPServer):
                             prompt = None
                             log.error(f"Error occurred while getting MCP prompt value {event['args']['prompt_name']}: {str(e)}")
                         finally:
-                            self._client_thread_signal.emit({
-                                "id": event_id,
-                                "data": prompt.messages
-                            })
+                            if signal is not None:
+                                signal.emit({
+                                    "id": event_id,
+                                    "data": prompt.messages
+                                })
                     else:
                         log.error(f"Unknown event type {event}")
         except Exception as e:

--- a/notebook_intelligence/mcp_manager.py
+++ b/notebook_intelligence/mcp_manager.py
@@ -22,7 +22,7 @@ from fastmcp import Client
 from ._version import __version__ as NBI_VERSION
 EDITOR_VERSION = f"NotebookIntelligence/{NBI_VERSION}"
 
-from notebook_intelligence.util import ThreadSafeWebSocketConnector
+from notebook_intelligence.util import ThreadSafeWebSocketConnector, _emit
 
 log = logging.getLogger(__name__)
 
@@ -253,12 +253,12 @@ class MCPServerImpl(MCPServer):
                 self._set_status(MCPServerStatus.Connected)
                 while True:
                     queue = self._client_queue
+                    signal = self._client_thread_signal
                     if queue is None:
                         return
                     event = queue.get(block=True)
                     event_id = event["id"]
                     event_type = event["type"]
-                    signal = self._client_thread_signal
                     if event_type == MCPServerEventType.ListTools:
                         try:
                             tool_list = await client.list_tools()
@@ -266,11 +266,7 @@ class MCPServerImpl(MCPServer):
                             log.error(f"Error occurred while listing MCP tools: {str(e)}")
                             tool_list = []
                         finally:
-                            if signal is not None:
-                                signal.emit({
-                                    "id": event_id,
-                                    "data": tool_list
-                                })
+                            _emit(signal, {"id": event_id, "data": tool_list})
                     elif event_type == MCPServerEventType.CallTool:
                         try:
                             result = await client.call_tool(event["args"]["tool_name"], event["args"]["tool_args"])
@@ -278,17 +274,9 @@ class MCPServerImpl(MCPServer):
                             result = f"Error occurred while calling MCP tool {event['args']['tool_name']}: {str(e)}"
                             log.error(result)
                         finally:
-                            if signal is not None:
-                                signal.emit({
-                                    "id": event_id,
-                                    "data": result
-                                })
+                            _emit(signal, {"id": event_id, "data": result})
                     elif event_type == MCPServerEventType.StopServer:
-                        if signal is not None:
-                            signal.emit({
-                                "id": event_id,
-                                "data": "stopped"
-                            })
+                        _emit(signal, {"id": event_id, "data": "stopped"})
                         return
                     elif event_type == MCPServerEventType.ListPrompts:
                         try:
@@ -297,11 +285,7 @@ class MCPServerImpl(MCPServer):
                             log.error(f"Error occurred while listing MCP prompts: {str(e)}")
                             prompts = []
                         finally:
-                            if signal is not None:
-                                signal.emit({
-                                    "id": event_id,
-                                    "data": prompts
-                                })
+                            _emit(signal, {"id": event_id, "data": prompts})
                     elif event_type == MCPServerEventType.GetPromptValue:
                         try:
                             prompt = await client.get_prompt(event["args"]["prompt_name"], event["args"]["prompt_args"])
@@ -309,11 +293,7 @@ class MCPServerImpl(MCPServer):
                             prompt = None
                             log.error(f"Error occurred while getting MCP prompt value {event['args']['prompt_name']}: {str(e)}")
                         finally:
-                            if signal is not None:
-                                signal.emit({
-                                    "id": event_id,
-                                    "data": prompt.messages
-                                })
+                            _emit(signal, {"id": event_id, "data": prompt.messages})
                     else:
                         log.error(f"Unknown event type {event}")
         except Exception as e:

--- a/notebook_intelligence/util.py
+++ b/notebook_intelligence/util.py
@@ -96,6 +96,11 @@ def is_provider_enabled_in_env(provider_id: str) -> bool:
     enabled_providers = os.environ.get('NBI_ENABLED_PROVIDERS', '')
     return provider_id in enabled_providers.split(',')
 
+def _emit(signal, payload: dict) -> None:
+    if signal is not None:
+        signal.emit(payload)
+
+
 class ThreadSafeWebSocketConnector():
   def __init__(self, websocket_handler):
     self.io_loop = ioloop.IOLoop.current()

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -751,8 +751,8 @@ function ChatResponse(props: any) {
                 </div>
               );
             case ResponseStreamDataType.Progress:
-              // show only if no more message available
-              return index === groupedContents.length - 1 ? (
+              // show only while generating and no more message available
+              return index === groupedContents.length - 1 && props.showGenerating ? (
                 <div className="chat-response-progress" key={`key-${index}`}>
                   &#x2713; {item.content}
                 </div>

--- a/tests/test_claude_client.py
+++ b/tests/test_claude_client.py
@@ -554,6 +554,90 @@ class TestConnectInBackground:
                 client._client_thread.join(timeout=1)
 
 
+class TestWorkerThreadSignalRace:
+    """Guard against the cancellation race fixed in _client_thread_func.
+
+    When the user clicks Stop, _mark_as_disconnected() runs on the polling
+    thread and sets self._client_thread_signal = None. The worker thread may
+    simultaneously be in its finally block about to call
+    self._client_thread_signal.emit(...), which without the snapshot fix raises
+    AttributeError and puts the agent into FailedToConnect state.
+
+    The fix snapshots the signal into a local variable at the top of each event
+    loop iteration so the finally block holds a valid reference even if the
+    client's field is nulled mid-flight.
+    """
+
+    def test_snapshot_survives_mark_as_disconnected(self):
+        """Local snapshot keeps signal alive after _mark_as_disconnected nulls
+        the client's reference — emit must succeed without raising."""
+        client = _make_client()
+        original_signal = client._client_thread_signal
+        received = []
+        original_signal.connect(lambda data: received.append(data))
+
+        # Worker snapshots signal at the top of the event loop iteration.
+        signal = client._client_thread_signal
+
+        # Cancel path: _mark_as_disconnected() nulls the client's own reference.
+        client._mark_as_disconnected()
+        assert client._client_thread_signal is None
+
+        # Worker's finally block uses the snapshot — must not raise.
+        if signal is not None:
+            signal.emit({"id": "x", "data": "query completed"})
+
+        assert received == [{"id": "x", "data": "query completed"}]
+
+    def test_signal_already_none_at_snapshot_time_is_safe(self):
+        """If disconnect ran before the snapshot, the null guard in the finally
+        block must skip the emit silently rather than raising AttributeError."""
+        client = _make_client()
+        client._mark_as_disconnected()
+
+        # Signal is already None when the worker reaches the snapshot line.
+        signal = client._client_thread_signal
+        assert signal is None
+
+        # Finally block null guard — must not raise, must not emit.
+        if signal is not None:
+            signal.emit({"id": "x", "data": "query completed"})
+        # Reaching here without exception is the assertion.
+
+    def test_queue_snapshot_survives_mark_as_disconnected(self):
+        """Local queue snapshot keeps the Queue alive after _mark_as_disconnected
+        nulls the client's reference — get() must not raise AttributeError."""
+        client = _make_client()
+        original_queue = client._client_queue
+        original_queue.put({"id": "x", "type": "query"})
+
+        # Worker snapshots queue at the top of the event loop iteration.
+        queue = client._client_queue
+
+        # Cancel path: _mark_as_disconnected() nulls the client's own reference.
+        client._mark_as_disconnected()
+        assert client._client_queue is None
+
+        # Worker's queue.get() uses the snapshot — must not raise.
+        event = queue.get(block=False)
+        assert event == {"id": "x", "type": "query"}
+
+    def test_queue_already_none_at_snapshot_time_exits_cleanly(self):
+        """If disconnect ran before the queue snapshot, the null guard must
+        cause the worker to return rather than raising AttributeError."""
+        client = _make_client()
+        client._mark_as_disconnected()
+
+        # Queue is already None when the worker reaches the snapshot line.
+        queue = client._client_queue
+        assert queue is None
+
+        # Null guard — worker returns instead of calling get() on None.
+        if queue is None:
+            return
+        queue.get(block=False)  # must not be reached
+
+
 class TestOtherCallersEnsureConnected:
     """update_server_info / clear_chat_history used to check only
     _reconnect_required, not is_connected(), so a dead thread without the

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -1,0 +1,82 @@
+"""Regression tests for the worker-thread signal/queue race condition in MCPServerImpl.
+
+Mirrors TestWorkerThreadSignalRace in test_claude_client.py for the MCP code path,
+confirming the snapshot pattern applied to mcp_manager._client_thread_func() is
+equally locked in there.
+"""
+
+import threading
+from queue import Queue
+
+from notebook_intelligence.api import SignalImpl
+from notebook_intelligence.mcp_manager import MCPServerImpl, MCPServerStatus
+
+
+def _make_mcp_server():
+    """Build an ``MCPServerImpl`` without invoking ``__init__`` / ``connect``."""
+    server = MCPServerImpl.__new__(MCPServerImpl)
+    server._manager = None
+    server._name = "test"
+    server._stdio_params = None
+    server._streamable_http_params = None
+    server._auto_approve_tools = set()
+    server._tried_to_get_tool_list = False
+    server._mcp_tools = []
+    server._mcp_prompts = []
+    server._session = None
+    server._client = None
+    server._client_queue = Queue()
+    server._client_thread_signal = SignalImpl()
+    server._client_thread = None
+    server._status = MCPServerStatus.NotConnected
+    server._tool_prompt_list_lock = threading.Lock()
+    return server
+
+
+def _disconnect(server):
+    """Simulate the field-nulling that disconnect() performs on the server instance."""
+    server._client_queue = None
+    server._client_thread_signal = None
+    server._client_thread = None
+    server._status = MCPServerStatus.NotConnected
+
+
+class TestMCPManagerWorkerThreadSignalRace:
+    def test_snapshot_survives_disconnect(self):
+        server = _make_mcp_server()
+        original_signal = server._client_thread_signal
+        received = []
+        original_signal.connect(lambda data: received.append(data))
+        signal = server._client_thread_signal
+        _disconnect(server)
+        assert server._client_thread_signal is None
+        if signal is not None:
+            signal.emit({"id": "x", "data": "stopped"})
+        assert received == [{"id": "x", "data": "stopped"}]
+
+    def test_signal_already_none_at_snapshot_time_is_safe(self):
+        server = _make_mcp_server()
+        _disconnect(server)
+        signal = server._client_thread_signal
+        assert signal is None
+        if signal is not None:
+            signal.emit({"id": "x", "data": "stopped"})
+
+    def test_queue_snapshot_survives_disconnect(self):
+        server = _make_mcp_server()
+        original_queue = server._client_queue
+        original_queue.put({"id": "x", "type": "list-tools"})
+        queue = server._client_queue
+        _disconnect(server)
+        assert server._client_queue is None
+        event = queue.get(block=False)
+        assert event == {"id": "x", "type": "list-tools"}
+
+    def test_queue_already_none_at_snapshot_time_exits_cleanly(self):
+        server = _make_mcp_server()
+        _disconnect(server)
+        queue = server._client_queue
+        assert queue is None
+        if queue is None:
+            return
+        queue.get(block=False)


### PR DESCRIPTION
## Summary 

  - **Race condition A** — ``_mark_as_disconnected()`` on the polling thread nulls ``_client_thread_signal`` while the worker thread's ``finally`` block is mid-emit, causing ``AttributeError: 'NoneType' object has no attribute 'emit'`` on every cancellation. The agent was incorrectly put into ``FailedToConnect`` state, forcing a full reconnect and discarding conversation context on the next request.
   - **Race condition B** — after fixing Race A, the worker thread survived to loop back and called ``self._client_queue.get()`` after ``_client_queue`` was also nulled by ``_mark_as_disconnected()``, causing ``AttributeError: 'NoneType' object has no attribute 'get'``. This race was masked by Race A and only surfaced during live testing.
   - **``✓ Thinking...`` persists after cancel** — ``ProgressData(""Thinking..."")`` is streamed at request start and rendered only when it is the last item in the message. On cancellation, no response content arrives to push it off last position, so it stays visible in the message body indefinitely.

## Changes

**``notebook_intelligence/claude.py`` and ``notebook_intelligence/mcp_manager.py``**

At the top of each ``while True`` iteration in ``_client_thread_func()``, snapshot both fields before any processing that could trigger ``_mark_as_disconnected()``:

   ``````python
                             
At the top of each ``while True`` iteration in ``_client_thread_func()``, snapshot both fields before any processing that could trigger ``_mark_as_disconnected()``:
             
   ``````python                 
   queue = self._client_queue
   if queue is None:                  
       return
   event = queue.get(block=True)
   ...                                                                                                                                                                                                                                                       
   signal = self._client_thread_signal
   ``````                      

All 11 ``signal.emit()`` calls across both files are guarded with ``if signal is not None``. The local snapshot keeps the object alive even after the instance field is nulled — the same pattern already used safely in ``_send_claude_agent_request()``.

   **``src/chat-sidebar.tsx``**       

Added ``&& props.showGenerating`` to the ``ProgressData`` render condition. ``showGenerating`` is set to ``false`` immediately when Stop is clicked, so ``✓ Thinking...`` clears at the same moment as the other loading indicators.

   **``tests/test_claude_client.py``**

Added ``TestWorkerThreadSignalRace`` with 4 regression tests covering both signal and queue snapshot patterns — snapshot survives ``_mark_as_disconnected()`` and already null at snapshot time exits cleanly.
                                                                                         
## Test plan                                                                 
                                                                                             
   - [x] Logs after cancel contain only the three expected lines — no NoneType errors, no ``Error occurred while running MCP server thread``
   - [x] Agent remains in ``Connected`` state after cancellation (no ``FailedToConnect``)
   - [x] ``✓ Thinking...`` clears immediately from the chat message body on Stop
   - [x] Loading indicators (input glow, Stop→Send swap) still clear immediately — unaffected
   - [x] Follow-up query after cancel succeeds without reconnect delay
   - [x] Rapid repeated cancellations produce no crashes or stuck states
   - [x] Normal completion unaffected — response displays correctly
   - [x] 49 unit tests pass (``python -m pytest tests/test_claude_client.py -v``)

## Evidence

### Before Fix: 
Attribute Error in logs
<img width="1283" height="95" alt="Screenshot 2026-05-05 at 10 29 47 AM" src="https://github.com/user-attachments/assets/55276396-f0cc-4a35-bbb7-fee4f4d7aff7" />

"Thinking..." left in chat window
<img width="273" height="789" alt="Screenshot 2026-05-05 at 10 39 54 AM" src="https://github.com/user-attachments/assets/91f07c14-6693-4b61-a9a4-1b8ab423f687" />


### After Fix:
No Attribute Error in logs
<img width="1643" height="177" alt="image" src="https://github.com/user-attachments/assets/929741f1-21f5-440c-9f75-cf5065085155" />


No "Thinking..." left in chat window
<img width="387" height="727" alt="image" src="https://github.com/user-attachments/assets/42135184-8492-4acc-b65b-dbd33a6dcd3e" />

  ## Follow-up (reviewer feedback)

  Three changes added in response to review:

  1. **`_emit` helper** — extracted `_emit(signal, payload)` to
     `notebook_intelligence/util.py`. All 9 `if signal is not None:
     signal.emit(...)` blocks in `_client_thread_func()` across both
     files collapse to a single call, so the null guard is implicit and
     harder to accidentally omit in future code.

  2. **Signal snapshot position** — moved `signal = self._client_thread_signal`
     to the top of the `while True` loop in both `claude.py` and
     `mcp_manager.py`, placing it immediately after the queue snapshot.
     Both captures now happen at the same point, matching the pattern
     already established in `_send_claude_agent_request()`. Functionally
     equivalent.

  3. **Parity test coverage for `mcp_manager.py`** — added
     `tests/test_mcp_manager.py` with `TestMCPManagerWorkerThreadSignalRace`,
     a direct mirror of the signal/queue snapshot regression tests already
     in `test_claude_client.py`. Covers the same four cases for
     `MCPServerImpl`.

  **53 tests pass** (49 pre-existing + 4 new MCP regression tests).
