### PR TITLE
fix(ui): stop "Generating..." row from reflowing on narrow sidebars

### DIFF
--- a/style/base.css
+++ b/style/base.css
@@ -295,6 +295,8 @@ pre:has(.code-block-header) {
 
 .loading-ellipsis::after {
   display: inline-block;
+  width: 1.5ch;
+  text-align: left;
   animation: animated-ellipsis steps(1, end) 1s infinite;
   content: '';
 }


### PR DESCRIPTION
## Summary

When a response is generating in Notebook Intelligence, the chat shows a "Generating" label whose trailing dots animate via a CSS `::after` keyframe that cycles `content` through `''` / `'.'` / `'..'` / `'...'` every 250ms. With no fixed width on the pseudo-element, the text's measured width changes on each animation step. On a narrow sidebar — common when the user keeps the chat panel slim next to a notebook — that 0–3 character difference is enough to flip the row between one and two lines, so the timestamp / status row visibly jitters up and down for the entire duration of the response.

## Fix

Reserve `1.5ch` (≈ width of three dots) on `.loading-ellipsis::after`. The dots still animate; they just animate inside a fixed-width inline-block, so the parent row's measured width stays constant.

```css
.loading-ellipsis::after {
  display: inline-block;
  width: 1.5ch;
  text-align: left;
  animation: animated-ellipsis steps(1, end) 1s infinite;
  content: '';
}
```

Two-line CSS change, no JS, no markup change.

## Test plan

- [x] Narrow the chat sidebar so "Claude Code" wraps to two lines.
- [x] Send a prompt and watch the "Generating" row for the full duration of the response.
- [x] Before: row jitters up/down ~4× per second as the dots come and go.
- [x] After: row stays in place; dots still animate.
- [x] Verified the same fix works at wide sidebar widths (no regression — pseudo-element was already reserving zero width, now reserves `1.5ch`, no visible difference when there's room to spare).
- [x] \`jlpm lint:check\` clean (stylelint + prettier).