### PR TITLE
fix claude code launcher styling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1125,7 +1125,7 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
         const picker = new PickerWidget();
         picker.addClass('nbi-claude-code-picker');
         const dialog = new Dialog({
-          title: 'Claude Code',
+          title: 'Claude Code terminal session',
           body: picker,
           buttons: [
             Dialog.cancelButton({ label: 'Cancel' }),

--- a/style/base.css
+++ b/style/base.css
@@ -719,6 +719,8 @@ pre:has(.code-block-header) {
   display: flex;
   flex-direction: column;
   gap: 0;
+  width: 500px;
+  height: 400px;
 }
 
 .nbi-claude-code-picker-search {
@@ -731,6 +733,7 @@ pre:has(.code-block-header) {
   background: var(--jp-layout-color1);
   color: var(--jp-ui-font-color1);
   font-size: var(--jp-ui-font-size1);
+  outline: none;
 }
 
 .nbi-claude-code-picker-list {


### PR DESCRIPTION
- use fixed size dialog to prevent jumpiness
- disable filter input outline that doesn't render properly in dark theme