### PR TITLE
fix(claude): unify session pickers and gate launcher tile

### DIFF
--- a/notebook_intelligence/claude_sessions.py
+++ b/notebook_intelligence/claude_sessions.py
@@ -41,15 +41,39 @@ _PREVIEW_MAX_CHARS = 160
 # prompt is on the first few lines.
 _MAX_LINES_SCANNED = 200
 
-# Synthetic user-message preambles that should be skipped when picking a
-# preview. NBI prepends a context line (see NBI_CONTEXT_PREFIX) and Claude
-# Code wraps slash-command output in <local-command-...> and <command-...>
-# envelopes; neither reflects what the user actually typed.
+# Skip filter shared by the chat-sidebar picker and the launcher tile so
+# they can't disagree on what to show for the same session id. New
+# patterns spotted in the wild (e.g. "Unknown skill:") are tracked in
+# issue #186.
 NBI_CONTEXT_PREFIX = "Additional context: Current directory open in Jupyter is:"
-# The envelope match is intentionally broad. A user prompt that genuinely
-# starts with one of these tag prefixes (e.g. "what does <command-name> do?")
-# would be skipped in favor of the next message — acceptable trade-off.
-_CLAUDE_ENVELOPE_PREFIXES = ("<local-command-", "<command-")
+# A user prompt that genuinely starts with one of these prefixes (e.g.
+# "what does <command-name> do?") would be skipped in favor of the next
+# message — acceptable trade-off.
+_SKIPPABLE_PREFIXES = (
+    NBI_CONTEXT_PREFIX,
+    "<local-command-",
+    "<command-",
+    "[Request interrupted by user",
+    "Unknown slash command:",
+)
+# Control-only slash commands the user typed to manage the session itself
+# rather than ask Claude something. A regex like ^/[A-Za-z]+$ would also
+# match "/tmp" or "/etc" — common file paths someone might paste — so we
+# enumerate the known set instead.
+_CONTROL_SLASH_COMMANDS = frozenset({
+    "/clear",
+    "/compact",
+    "/cost",
+    "/exit",
+    "/help",
+    "/init",
+    "/login",
+    "/logout",
+    "/quit",
+    "/release-notes",
+    "/reset",
+    "/status",
+})
 
 
 @dataclass
@@ -88,7 +112,7 @@ def get_sessions_dir(cwd: str, claude_home: Optional[str] = None) -> Path:
     return home / "projects" / encode_cwd(cwd)
 
 
-def list_sessions(
+def _list_sessions_in_dir(
     cwd: str,
     claude_home: Optional[str] = None,
 ) -> list[ClaudeSessionInfo]:
@@ -150,7 +174,7 @@ def _read_session_info(path: Path) -> Optional[ClaudeSessionInfo]:
                         return None
                 if not _is_user_message(obj):
                     continue
-                if _is_synthetic_preamble(obj):
+                if _is_skippable_user_message(obj):
                     continue
                 preview = _extract_preview(obj)
                 break
@@ -190,22 +214,25 @@ def _is_user_message(obj: dict) -> bool:
     return False
 
 
-def _is_synthetic_preamble(obj: dict) -> bool:
+def _is_skippable_user_message(obj: dict) -> bool:
     content = obj.get("message", {}).get("content")
     if isinstance(content, str):
-        return _looks_synthetic(content)
+        return _is_skippable_text(content)
     if isinstance(content, list):
         for block in content:
             if isinstance(block, dict) and block.get("type") == "text":
                 text = block.get("text", "")
-                return isinstance(text, str) and _looks_synthetic(text)
+                return isinstance(text, str) and _is_skippable_text(text)
     return False
 
 
-def _looks_synthetic(text: str) -> bool:
-    if text.startswith(NBI_CONTEXT_PREFIX):
+def _is_skippable_text(text: str) -> bool:
+    stripped = text.strip()
+    if not stripped:
         return True
-    return text.startswith(_CLAUDE_ENVELOPE_PREFIXES)
+    if stripped.startswith(_SKIPPABLE_PREFIXES):
+        return True
+    return stripped in _CONTROL_SLASH_COMMANDS
 
 
 def _extract_preview(obj: dict) -> str:
@@ -225,8 +252,12 @@ def _extract_preview(obj: dict) -> str:
 
     # Collapse whitespace so multi-line prompts render as a single row.
     text = " ".join(text.split())
+    return _truncate_preview(text)
+
+
+def _truncate_preview(text: str) -> str:
     if len(text) > _PREVIEW_MAX_CHARS:
-        text = text[: _PREVIEW_MAX_CHARS - 1].rstrip() + "\u2026"
+        return text[: _PREVIEW_MAX_CHARS - 1].rstrip() + "\u2026"
     return text
 
 
@@ -254,7 +285,7 @@ def list_all_sessions(
 
     if not history_path.exists():
         if cwd:
-            sessions = list_sessions(cwd, claude_home=claude_home)
+            sessions = _list_sessions_in_dir(cwd, claude_home=claude_home)
             for s in sessions:
                 s.cwd = cwd
             return sessions
@@ -305,7 +336,7 @@ def list_all_sessions(
     except OSError as exc:
         log.warning("Could not read Claude history file %s: %s", history_path, exc)
         if cwd:
-            sessions = list_sessions(cwd, claude_home=claude_home)
+            sessions = _list_sessions_in_dir(cwd, claude_home=claude_home)
             for s in sessions:
                 s.cwd = cwd
             return sessions
@@ -322,8 +353,13 @@ def list_all_sessions(
         except OSError:
             continue
         preview = data["preview"]
-        if len(preview) > _PREVIEW_MAX_CHARS:
-            preview = preview[: _PREVIEW_MAX_CHARS - 1].rstrip() + "\u2026"
+        # Fall back to a transcript scan when display is skippable so
+        # both pickers converge on the same preview (issue #181).
+        if _is_skippable_text(preview):
+            transcript_info = _read_session_info(jsonl_path)
+            if transcript_info is not None and transcript_info.preview:
+                preview = transcript_info.preview
+        preview = _truncate_preview(preview)
         sessions.append(ClaudeSessionInfo(
             session_id=session_id,
             path=str(jsonl_path),
@@ -337,7 +373,7 @@ def list_all_sessions(
     # not appear in history.jsonl), deduplicating by session_id.
     if cwd:
         existing_ids = {s.session_id for s in sessions}
-        for s in list_sessions(cwd, claude_home=claude_home):
+        for s in _list_sessions_in_dir(cwd, claude_home=claude_home):
             if s.session_id not in existing_ids:
                 s.cwd = cwd
                 sessions.append(s)

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -43,8 +43,8 @@ from notebook_intelligence.feature_flags import (
 from notebook_intelligence.claude import ClaudeCodeChatParticipant, fetch_claude_models
 from notebook_intelligence.claude_sessions import (
     NBI_CONTEXT_PREFIX,
+    get_sessions_dir as get_claude_sessions_dir,
     list_all_sessions as list_all_claude_sessions,
-    list_sessions as list_claude_sessions,
 )
 import notebook_intelligence.github_copilot as github_copilot
 from notebook_intelligence.built_in_toolsets import built_in_toolsets
@@ -361,6 +361,8 @@ class GetCapabilitiesHandler(APIHandler):
                 nbi_config.claude_settings, self.string_overrides
             ),
             "claude_models": ai_service_manager.claude_models,
+            # Drives launcher-tile visibility (issue #183).
+            "claude_cli_available": shutil.which("claude") is not None,
             "default_chat_mode": nbi_config.default_chat_mode,
             "chat_feedback_enabled": self.enable_chat_feedback,
             "cell_output_features": _build_cell_output_features_response(
@@ -949,7 +951,25 @@ class FileUploadHandler(APIHandler):
 
 
 class ClaudeSessionsListHandler(APIHandler):
-    """Lists prior Claude Code sessions for the current Jupyter working dir."""
+    """Lists Claude Code sessions across all projects.
+
+    Both pickers (chat sidebar and launcher tile) consume this single
+    endpoint so they cannot disagree on previews. The chat sidebar
+    filters client-side to ``current_sessions_dir``; the launcher tile
+    shows everything. ``current_cwd`` is the realpath-resolved Jupyter
+    root the chat picker pairs with the session id to render
+    ``cd ... && claude --resume <id>``.
+
+    Guarded by ``is_claude_code_mode`` because both consumers are
+    Claude-Code-specific surfaces — the launcher tile literally launches
+    the ``claude`` CLI in a terminal.
+
+    Note: ``current_sessions_dir`` exposes the encoded
+    ``~/.claude/projects/<encoded-cwd>`` path to the client. Acceptable
+    because the endpoint is already authenticated and Claude-mode-gated;
+    the alternative (per-session ``in_current_cwd`` boolean) inflates the
+    response without simplifying anything.
+    """
 
     @tornado.web.authenticated
     def get(self):
@@ -960,33 +980,16 @@ class ClaudeSessionsListHandler(APIHandler):
 
         try:
             cwd = get_jupyter_root_dir()
-            sessions = list_claude_sessions(cwd)
-            # `claude --resume <id>` is cwd-scoped — it looks up the
-            # transcript under the encoded form of the user's CURRENT shell
-            # cwd. Surface the resolved JupyterLab root so the frontend can
-            # paste a `cd ... && claude --resume <id>` command that works
-            # regardless of where the user's terminal happens to be.
+            sessions = list_all_claude_sessions(cwd=cwd)
             self.finish(json.dumps({
                 "sessions": [asdict(s) for s in sessions],
-                "cwd": os.path.realpath(cwd) if cwd else "",
+                "current_cwd": os.path.realpath(cwd) if cwd else "",
+                "current_sessions_dir": (
+                    str(get_claude_sessions_dir(cwd)) if cwd else ""
+                ),
             }))
         except Exception as e:
             log.exception("Failed to list Claude sessions")
-            self.set_status(500)
-            self.finish(json.dumps({"error": str(e)}))
-
-class ClaudeSessionsAllHandler(APIHandler):
-    """Lists all Claude Code sessions across all projects via history.jsonl."""
-
-    @tornado.web.authenticated
-    def get(self):
-        try:
-            sessions = list_all_claude_sessions(cwd=get_jupyter_root_dir())
-            self.finish(json.dumps({
-                "sessions": [asdict(s) for s in sessions],
-            }))
-        except Exception as e:
-            log.exception("Failed to list all Claude sessions")
             self.set_status(500)
             self.finish(json.dumps({"error": str(e)}))
 
@@ -1894,7 +1897,6 @@ class NotebookIntelligence(ExtensionApp):
         route_pattern_skill_bundle_file_rename = url_path_join(base_url, "notebook-intelligence", "skills", r"(user|project)", skill_name, "files", "rename")
         route_pattern_upload_file = url_path_join(base_url, "notebook-intelligence", "upload-file")
         route_pattern_claude_sessions = url_path_join(base_url, "notebook-intelligence", "claude-sessions")
-        route_pattern_claude_sessions_all = url_path_join(base_url, "notebook-intelligence", "claude-sessions", "all")
         route_pattern_claude_sessions_resume = url_path_join(base_url, "notebook-intelligence", "claude-sessions", "resume")
         GetCapabilitiesHandler.disabled_tools = self.disabled_tools
         GetCapabilitiesHandler.allow_enabling_tools_with_env = self.allow_enabling_tools_with_env
@@ -1929,7 +1931,6 @@ class NotebookIntelligence(ExtensionApp):
             (route_pattern_skill_detail, SkillDetailHandler),
             (route_pattern_upload_file, FileUploadHandler),
             (route_pattern_claude_sessions_resume, ClaudeSessionsResumeHandler),
-            (route_pattern_claude_sessions_all, ClaudeSessionsAllHandler),
             (route_pattern_claude_sessions, ClaudeSessionsListHandler),
             (route_pattern_copilot, WebsocketCopilotHandler),
         ]

--- a/src/api.ts
+++ b/src/api.ts
@@ -51,10 +51,14 @@ export interface IClaudeSessionInfo {
 
 export interface IClaudeSessionList {
   sessions: IClaudeSessionInfo[];
-  // The realpath-resolved JupyterLab working directory the sessions live
-  // under. `claude --resume <id>` is cwd-scoped, so the frontend pairs this
-  // with the session id to produce a copyable shell command.
-  cwd: string;
+  // The realpath-resolved JupyterLab working directory. `claude --resume
+  // <id>` is cwd-scoped, so the frontend pairs this with the session id to
+  // produce a copyable shell command.
+  currentCwd: string;
+  // The realpath-encoded sessions directory for ``current_cwd``. The chat
+  // sidebar filters the full session list down to entries whose transcript
+  // path is under this directory; the launcher tile shows everything.
+  currentSessionsDir: string;
 }
 
 export enum ClaudeToolType {
@@ -274,6 +278,10 @@ export class NBIConfig {
 
   get isInClaudeCodeMode(): boolean {
     return this.claudeSettings.enabled === true;
+  }
+
+  get isClaudeCliAvailable(): boolean {
+    return this.capabilities.claude_cli_available === true;
   }
 
   get chatFeedbackEnabled(): boolean {
@@ -960,26 +968,22 @@ export class NBIAPI {
   }
 
   static async listClaudeSessions(): Promise<IClaudeSessionList> {
+    interface IWireResponse {
+      sessions?: IClaudeSessionInfo[];
+      current_cwd?: string;
+      current_sessions_dir?: string;
+    }
     return new Promise<IClaudeSessionList>((resolve, reject) => {
-      requestAPI<any>('claude-sessions', { method: 'GET' })
+      requestAPI<IWireResponse>('claude-sessions', { method: 'GET' })
         .then(data => {
-          resolve({ sessions: data.sessions ?? [], cwd: data.cwd ?? '' });
+          resolve({
+            sessions: data.sessions ?? [],
+            currentCwd: data.current_cwd ?? '',
+            currentSessionsDir: data.current_sessions_dir ?? ''
+          });
         })
         .catch(reason => {
           console.error(`Failed to list Claude sessions.\n${reason}`);
-          reject(reason);
-        });
-    });
-  }
-
-  static async listAllClaudeSessions(): Promise<IClaudeSessionInfo[]> {
-    return new Promise<IClaudeSessionInfo[]>((resolve, reject) => {
-      requestAPI<any>('claude-sessions/all', { method: 'GET' })
-        .then(data => {
-          resolve(data.sessions ?? []);
-        })
-        .catch(reason => {
-          console.error(`Failed to list all Claude sessions.\n${reason}`);
           reject(reason);
         });
     });

--- a/src/components/claude-session-picker.tsx
+++ b/src/components/claude-session-picker.tsx
@@ -10,7 +10,11 @@ import React, {
 import { VscCheck, VscClose, VscCopy, VscHistory } from 'react-icons/vsc';
 
 import { IClaudeSessionInfo, IClaudeSessionList, NBIAPI } from '../api';
-import { buildResumeCommand, writeTextToClipboard } from '../utils';
+import {
+  buildResumeCommand,
+  filterSessionsToDir,
+  writeTextToClipboard
+} from '../utils';
 
 export interface IClaudeSessionPickerProps {
   onResume: (session: IClaudeSessionInfo) => void;
@@ -39,7 +43,7 @@ export function ClaudeSessionPicker(
   props: IClaudeSessionPickerProps
 ): JSX.Element {
   const [sessions, setSessions] = useState<IClaudeSessionInfo[]>([]);
-  const [cwd, setCwd] = useState('');
+  const [currentCwd, setCurrentCwd] = useState('');
   const [loading, setLoading] = useState(true);
   const [resuming, setResuming] = useState(false);
   const [error, setError] = useState('');
@@ -65,8 +69,10 @@ export function ClaudeSessionPicker(
         if (cancelled) {
           return;
         }
-        setSessions(result.sessions);
-        setCwd(result.cwd);
+        setSessions(
+          filterSessionsToDir(result.sessions, result.currentSessionsDir)
+        );
+        setCurrentCwd(result.currentCwd);
         setLoading(false);
       })
       .catch(reason => {
@@ -88,7 +94,7 @@ export function ClaudeSessionPicker(
     event.stopPropagation();
     event.preventDefault();
     const ok = await writeTextToClipboard(
-      buildResumeCommand(cwd, session.session_id)
+      buildResumeCommand(currentCwd, session.session_id)
     );
     setCopyFeedback({
       sessionId: session.session_id,

--- a/src/components/launcher-picker.tsx
+++ b/src/components/launcher-picker.tsx
@@ -16,9 +16,9 @@ export function LauncherPicker({
   const [filter, setFilter] = useState('');
 
   useEffect(() => {
-    NBIAPI.listAllClaudeSessions()
+    NBIAPI.listClaudeSessions()
       .then(result => {
-        setSessions(result);
+        setSessions(result.sessions);
         setLoading(false);
       })
       .catch((reason: any) => {
@@ -91,9 +91,7 @@ export function LauncherPicker({
               </div>
               {session.preview && (
                 <div className="nbi-claude-code-picker-msg">
-                  {session.preview.length > 80
-                    ? session.preview.slice(0, 80) + '…'
-                    : session.preview}
+                  {session.preview}
                 </div>
               )}
             </div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1104,6 +1104,8 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
       label: 'Claude Code',
       caption: 'Resume or start a Claude Code session',
       icon: claudeIcon,
+      isVisible: () =>
+        NBIAPI.config.isInClaudeCodeMode && NBIAPI.config.isClaudeCliAvailable,
       execute: async () => {
         class PickerWidget extends ReactWidget {
           getValue(): void {
@@ -1147,6 +1149,13 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
         rank: -1
       });
     }
+
+    // Refresh the launcher tile's enabled/visible state when the user
+    // toggles Claude Code mode or installs the CLI. Without this, the
+    // tile keeps its initial-load decision until full reload.
+    NBIAPI.configChanged.connect(() => {
+      app.commands.notifyCommandChanged(CommandIDs.openClaudeCodeLauncher);
+    });
 
     const isNewEmptyNotebook = (model: ISharedNotebook) => {
       return (

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,8 @@ import { CodeEditor } from '@jupyterlab/codeeditor';
 import { encoding_for_model } from 'tiktoken';
 import { NotebookPanel } from '@jupyterlab/notebook';
 
+import type { IClaudeSessionInfo } from './api';
+
 const tiktoken_encoding = encoding_for_model('gpt-4o');
 
 export function removeAnsiChars(str: string): string {
@@ -283,6 +285,27 @@ export function applyCodeToSelectionInEditor(
  */
 export function shellSingleQuote(value: string): string {
   return "'" + value.replace(/'/g, "'\\''") + "'";
+}
+
+/**
+ * Filter the unified session list down to entries whose transcript file
+ * lives in `sessionsDir`. The chat sidebar uses this to scope its popover
+ * to the current Jupyter cwd; the launcher tile shows everything.
+ */
+export function filterSessionsToDir(
+  sessions: IClaudeSessionInfo[],
+  sessionsDir: string
+): IClaudeSessionInfo[] {
+  if (!sessionsDir) {
+    return sessions;
+  }
+  // Exact-parent match: transcripts live directly in the encoded dir,
+  // never nested deeper. The trailing slash prevents "/foo" matching
+  // "/foobar/x.jsonl".
+  const prefix = sessionsDir + '/';
+  return sessions.filter(
+    s => s.path.startsWith(prefix) && !s.path.slice(prefix.length).includes('/')
+  );
 }
 
 /**

--- a/tests/test_claude_sessions.py
+++ b/tests/test_claude_sessions.py
@@ -6,9 +6,10 @@ import pytest
 
 from notebook_intelligence.claude_sessions import (
     ClaudeSessionInfo,
+    _CONTROL_SLASH_COMMANDS,
     encode_cwd,
     get_sessions_dir,
-    list_sessions,
+    _list_sessions_in_dir,
     list_all_sessions,
 )
 
@@ -32,15 +33,6 @@ def _sidechain_line(session_id: str, content: str = "Warmup") -> dict:
     return {
         "type": "user",
         "isSidechain": True,
-        "message": {"role": "user", "content": content},
-        "sessionId": session_id,
-    }
-
-
-def _preamble_line(session_id: str, content) -> dict:
-    """User-message envelope for synthetic preambles (NBI / Claude Code)."""
-    return {
-        "type": "user",
         "message": {"role": "user", "content": content},
         "sessionId": session_id,
     }
@@ -104,7 +96,7 @@ class TestListSessions:
     def test_returns_empty_when_dir_missing(
         self, fake_claude_home, project_cwd
     ):
-        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+        result = _list_sessions_in_dir(project_cwd, claude_home=str(fake_claude_home))
         assert result == []
 
     def test_returns_empty_when_dir_has_no_jsonl_files(
@@ -114,7 +106,7 @@ class TestListSessions:
         (sessions_dir / "notes.txt").write_text("hi")
         (sessions_dir / "subagents").mkdir()
 
-        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+        result = _list_sessions_in_dir(project_cwd, claude_home=str(fake_claude_home))
         assert result == []
 
     def test_lists_sessions_with_metadata(
@@ -131,7 +123,7 @@ class TestListSessions:
             ],
         )
 
-        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+        result = _list_sessions_in_dir(project_cwd, claude_home=str(fake_claude_home))
 
         assert len(result) == 1
         session = result[0]
@@ -152,7 +144,7 @@ class TestListSessions:
         os.utime(older_path, (1_000_000_000, 1_000_000_000))
         os.utime(newer_path, (2_000_000_000, 2_000_000_000))
 
-        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+        result = _list_sessions_in_dir(project_cwd, claude_home=str(fake_claude_home))
 
         assert [s.session_id for s in result] == ["newer", "older"]
 
@@ -167,7 +159,7 @@ class TestListSessions:
             [{"type": "file-history-snapshot", "messageId": "x", "snapshot": {}}],
         )
 
-        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+        result = _list_sessions_in_dir(project_cwd, claude_home=str(fake_claude_home))
         assert result == []
 
     def test_ignores_nested_subagent_files(
@@ -184,7 +176,7 @@ class TestListSessions:
             nested / "agent-xyz.jsonl", [_user_line("sub", "sub prompt")]
         )
 
-        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+        result = _list_sessions_in_dir(project_cwd, claude_home=str(fake_claude_home))
         assert [s.session_id for s in result] == ["main"]
 
     def test_skips_top_level_sidechain_files(
@@ -203,7 +195,7 @@ class TestListSessions:
             [_sidechain_line("real-session")],
         )
 
-        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+        result = _list_sessions_in_dir(project_cwd, claude_home=str(fake_claude_home))
         assert [s.session_id for s in result] == ["real-session"]
 
     def test_sidechain_filter_skips_corrupt_first_line(
@@ -217,7 +209,7 @@ class TestListSessions:
             fh.write("{ broken\n")
             fh.write(json.dumps(_sidechain_line("real-session")) + "\n")
 
-        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+        result = _list_sessions_in_dir(project_cwd, claude_home=str(fake_claude_home))
         assert result == []
 
     def test_keeps_files_when_isSidechain_is_false(
@@ -233,7 +225,7 @@ class TestListSessions:
         }
         _write_jsonl(sessions_dir / "real.jsonl", [line])
 
-        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+        result = _list_sessions_in_dir(project_cwd, claude_home=str(fake_claude_home))
         assert [s.session_id for s in result] == ["real"]
 
     def test_skips_nbi_context_preamble_when_extracting_preview(
@@ -242,7 +234,7 @@ class TestListSessions:
         # NBI prepends an "Additional context: ..." user message before the
         # real prompt; the preview should reflect the user's intent, not the
         # boilerplate.
-        preamble = _preamble_line(
+        preamble = _user_line(
             "real",
             "Additional context: Current directory open in Jupyter is: "
             "'/tmp/proj' and current file is: 'foo.ipynb'",
@@ -250,7 +242,7 @@ class TestListSessions:
         real_prompt = _user_line("real", "Implement fizzbuzz in a new cell")
         _write_jsonl(sessions_dir / "real.jsonl", [preamble, real_prompt])
 
-        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+        result = _list_sessions_in_dir(project_cwd, claude_home=str(fake_claude_home))
         assert len(result) == 1
         assert result[0].preview == "Implement fizzbuzz in a new cell"
 
@@ -258,7 +250,7 @@ class TestListSessions:
         self, sessions_dir, fake_claude_home, project_cwd
     ):
         # Same shape, but the preamble arrives as a list of content blocks.
-        preamble = _preamble_line(
+        preamble = _user_line(
             "real",
             [
                 {
@@ -273,7 +265,7 @@ class TestListSessions:
         real_prompt = _user_line("real", "Hello world")
         _write_jsonl(sessions_dir / "real.jsonl", [preamble, real_prompt])
 
-        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+        result = _list_sessions_in_dir(project_cwd, claude_home=str(fake_claude_home))
         assert [s.preview for s in result] == ["Hello world"]
 
     def test_falls_back_to_no_preview_when_only_preamble(
@@ -281,12 +273,12 @@ class TestListSessions:
     ):
         # Pure-preamble file (e.g. session created but no real prompt yet)
         # should be filtered out — no preview to show.
-        preamble = _preamble_line(
+        preamble = _user_line(
             "real", "Additional context: Current directory open in Jupyter is: ''"
         )
         _write_jsonl(sessions_dir / "real.jsonl", [preamble])
 
-        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+        result = _list_sessions_in_dir(project_cwd, claude_home=str(fake_claude_home))
         assert result == []
 
     def test_skips_claude_code_command_envelopes(
@@ -296,21 +288,21 @@ class TestListSessions:
         # messages: <local-command-caveat>, <command-name>, <local-command-
         # stdout>. None of these are real user prompts.
         envelopes = [
-            _preamble_line(
+            _user_line(
                 "real",
                 "<local-command-caveat>Caveat: The messages below were "
                 "generated by the user while running local commands."
                 "</local-command-caveat>",
             ),
-            _preamble_line("real", "<command-name>/clear</command-name>"),
-            _preamble_line(
+            _user_line("real", "<command-name>/clear</command-name>"),
+            _user_line(
                 "real", "<local-command-stdout>Bye!</local-command-stdout>"
             ),
         ]
         real_prompt = _user_line("real", "Tell me about pandas")
         _write_jsonl(sessions_dir / "real.jsonl", envelopes + [real_prompt])
 
-        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+        result = _list_sessions_in_dir(project_cwd, claude_home=str(fake_claude_home))
         assert [s.preview for s in result] == ["Tell me about pandas"]
 
     def test_tolerates_partial_trailing_line(
@@ -325,7 +317,7 @@ class TestListSessions:
             fh.write(json.dumps(_user_line("partial", "first message")) + "\n")
             fh.write('{"type": "user", "message": {"role": "user", "content')
 
-        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+        result = _list_sessions_in_dir(project_cwd, claude_home=str(fake_claude_home))
         assert len(result) == 1
         assert result[0].preview == "first message"
 
@@ -338,7 +330,7 @@ class TestListSessions:
             [_user_line("long", long_text)],
         )
 
-        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+        result = _list_sessions_in_dir(project_cwd, claude_home=str(fake_claude_home))
         assert len(result[0].preview) < len(long_text)
         assert result[0].preview.endswith("\u2026")
 
@@ -350,7 +342,7 @@ class TestListSessions:
             [_user_line("ws", "line one\n\n   line two\tthree")],
         )
 
-        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+        result = _list_sessions_in_dir(project_cwd, claude_home=str(fake_claude_home))
         assert result[0].preview == "line one line two three"
 
     def test_handles_structured_content_blocks(
@@ -373,8 +365,84 @@ class TestListSessions:
             ],
         )
 
-        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+        result = _list_sessions_in_dir(project_cwd, claude_home=str(fake_claude_home))
         assert result[0].preview == "hello world"
+
+    @pytest.mark.parametrize(
+        "first_line, expected_preview",
+        [
+            # Claude Code injects "[Request interrupted by user...]" markers
+            # when the user cancels mid-tool-call.
+            ("[Request interrupted by user for tool use]", "real prompt"),
+            # claude-agent-sdk echoes "Unknown slash command: <name>" when a
+            # CLI-only slash command reaches it (e.g. /clear).
+            ("Unknown slash command: clear", "real prompt"),
+            # Bare slash verbs (/exit, /clear, /quit, /help) don't describe
+            # the session.
+            ("/exit", "real prompt"),
+            # ...but slash commands WITH args carry real intent — only bare
+            # verbs are skipped.
+            ("/explain how this works", "/explain how this works"),
+            # Empty / whitespace-only first messages aren't useful previews.
+            ("   \n\t  ", "real prompt"),
+        ],
+        ids=[
+            "request_interrupted",
+            "unknown_slash_echo",
+            "bare_slash",
+            "slash_with_args",
+            "whitespace_only",
+        ],
+    )
+    def test_skip_filter_picks_meaningful_first_message(
+        self,
+        sessions_dir,
+        fake_claude_home,
+        project_cwd,
+        first_line,
+        expected_preview,
+    ):
+        _write_jsonl(
+            sessions_dir / "session.jsonl",
+            [
+                _user_line("session", first_line),
+                _user_line("session", "real prompt"),
+            ],
+        )
+
+        result = _list_sessions_in_dir(project_cwd, claude_home=str(fake_claude_home))
+        assert result[0].preview == expected_preview
+
+    @pytest.mark.parametrize("verb", sorted(_CONTROL_SLASH_COMMANDS))
+    def test_every_control_slash_command_is_skipped(
+        self, sessions_dir, fake_claude_home, project_cwd, verb
+    ):
+        # Pin every entry in _CONTROL_SLASH_COMMANDS so a typo or accidental
+        # removal in the constant fails this test loudly.
+        _write_jsonl(
+            sessions_dir / "verb.jsonl",
+            [
+                _user_line("verb", verb),
+                _user_line("verb", "real prompt"),
+            ],
+        )
+
+        result = _list_sessions_in_dir(project_cwd, claude_home=str(fake_claude_home))
+        assert result[0].preview == "real prompt"
+
+    def test_bare_slash_verb_not_in_allowlist_is_kept(
+        self, sessions_dir, fake_claude_home, project_cwd
+    ):
+        # The allowlist is intentionally narrow — only known control verbs
+        # are skipped. A bare unknown slash word (e.g. "/explain", "/voice")
+        # is treated as the user's intent and surfaced as the preview.
+        _write_jsonl(
+            sessions_dir / "unknown.jsonl",
+            [_user_line("unknown", "/explain")],
+        )
+
+        result = _list_sessions_in_dir(project_cwd, claude_home=str(fake_claude_home))
+        assert result[0].preview == "/explain"
 
     def test_skips_tool_result_user_envelopes(
         self, sessions_dir, fake_claude_home, project_cwd
@@ -402,7 +470,7 @@ class TestListSessions:
             ],
         )
 
-        result = list_sessions(project_cwd, claude_home=str(fake_claude_home))
+        result = _list_sessions_in_dir(project_cwd, claude_home=str(fake_claude_home))
         assert result[0].preview == "actual prompt"
 
 
@@ -413,6 +481,10 @@ def _history_line(session_id: str, project: str, ts: int, display: str) -> dict:
         "timestamp": ts,
         "display": display,
     }
+
+
+def _write_history(home: Path, lines: list[dict]) -> None:
+    _write_jsonl(home / "history.jsonl", lines)
 
 
 class TestListAllSessions:
@@ -435,16 +507,12 @@ class TestListAllSessions:
         self, fake_claude_home, sessions_dir, project_cwd
     ):
         # history.jsonl has session "hist-only"
-        history_path = fake_claude_home / "history.jsonl"
         hist_jsonl = sessions_dir / "hist-only.jsonl"
         _write_jsonl(hist_jsonl, [_user_line("hist-only", "from history")])
-        with history_path.open("w") as fh:
-            fh.write(
-                json.dumps(
-                    _history_line("hist-only", project_cwd, 2_000_000_000_000, "from history")
-                )
-                + "\n"
-            )
+        _write_history(
+            fake_claude_home,
+            [_history_line("hist-only", project_cwd, 2_000_000_000_000, "from history")],
+        )
 
         # cwd dir also has "nbi-only" which is not in history.jsonl
         _write_jsonl(
@@ -456,6 +524,77 @@ class TestListAllSessions:
         assert "hist-only" in ids
         assert "nbi-only" in ids
 
+    def test_falls_back_to_transcript_when_history_display_is_skippable(
+        self, fake_claude_home, sessions_dir, project_cwd
+    ):
+        # history.jsonl carries "/exit" as the first display for this
+        # session, but the transcript has the user's real prompt earlier
+        # in the same conversation. Both pickers should converge on the
+        # real prompt — that's the whole point of issue #181.
+        session_id = "abc12345"
+        jsonl_path = sessions_dir / f"{session_id}.jsonl"
+        _write_jsonl(
+            jsonl_path,
+            [
+                _user_line(session_id, "Plot the closing prices for AAPL"),
+                _assistant_line(session_id),
+                _user_line(session_id, "/exit"),
+            ],
+        )
+
+        _write_history(
+            fake_claude_home,
+            [_history_line(session_id, project_cwd, 1_700_000_000_000, "/exit")],
+        )
+
+        result = list_all_sessions(cwd=project_cwd, claude_home=str(fake_claude_home))
+        match = next(s for s in result if s.session_id == session_id)
+        assert match.preview == "Plot the closing prices for AAPL"
+
+    def test_keeps_skippable_display_when_transcript_has_nothing_better(
+        self, fake_claude_home, sessions_dir, project_cwd
+    ):
+        # Session whose display AND transcript are both skippable should
+        # still appear in the picker — we'd rather show "/exit" than drop
+        # a resumable session entirely.
+        session_id = "barren12"
+        jsonl_path = sessions_dir / f"{session_id}.jsonl"
+        _write_jsonl(jsonl_path, [_user_line(session_id, "/clear")])
+        _write_history(
+            fake_claude_home,
+            [_history_line(session_id, project_cwd, 1_700_000_000_000, "/exit")],
+        )
+
+        result = list_all_sessions(cwd=project_cwd, claude_home=str(fake_claude_home))
+        match = next(s for s in result if s.session_id == session_id)
+        assert match.preview == "/exit"
+
+    def test_keeps_history_display_when_meaningful(
+        self, fake_claude_home, sessions_dir, project_cwd
+    ):
+        # When history.jsonl already has a meaningful display, the
+        # transcript fall-through must not run (and even if it did, the
+        # display value should win — it's what the user actually typed).
+        session_id = "good1234"
+        jsonl_path = sessions_dir / f"{session_id}.jsonl"
+        _write_jsonl(
+            jsonl_path,
+            [_user_line(session_id, "transcript-recorded text")],
+        )
+
+        _write_history(
+            fake_claude_home,
+            [
+                _history_line(
+                    session_id, project_cwd, 1_700_000_000_000, "what the user typed"
+                )
+            ],
+        )
+
+        result = list_all_sessions(cwd=project_cwd, claude_home=str(fake_claude_home))
+        match = next(s for s in result if s.session_id == session_id)
+        assert match.preview == "what the user typed"
+
     def test_deduplicates_sessions_in_both_sources(
         self, fake_claude_home, sessions_dir, project_cwd
     ):
@@ -463,14 +602,64 @@ class TestListAllSessions:
         jsonl_path = sessions_dir / f"{session_id}.jsonl"
         _write_jsonl(jsonl_path, [_user_line(session_id, "shared session")])
 
-        history_path = fake_claude_home / "history.jsonl"
-        with history_path.open("w") as fh:
-            fh.write(
-                json.dumps(
-                    _history_line(session_id, project_cwd, 1_000_000_000_000, "shared session")
-                )
-                + "\n"
-            )
+        _write_history(
+            fake_claude_home,
+            [_history_line(session_id, project_cwd, 1_000_000_000_000, "shared session")],
+        )
 
         result = list_all_sessions(cwd=project_cwd, claude_home=str(fake_claude_home))
         assert len([s for s in result if s.session_id == session_id]) == 1
+
+    @pytest.mark.parametrize(
+        "skippable_display",
+        [
+            "Additional context: Current directory open in Jupyter is: '/x'",
+            "<local-command-caveat>Caveat: ...</local-command-caveat>",
+            "<command-name>/clear</command-name>",
+            "[Request interrupted by user for tool use]",
+            "Unknown slash command: clear",
+            "/exit",
+        ],
+        ids=[
+            "nbi_context_preamble",
+            "local_command_envelope",
+            "command_envelope",
+            "request_interrupted",
+            "unknown_slash_echo",
+            "control_verb",
+        ],
+    )
+    def test_chat_picker_and_launcher_show_same_preview_for_issue_181(
+        self, fake_claude_home, sessions_dir, project_cwd, skippable_display
+    ):
+        # Reproduces issue #181: same session id, two pickers, different
+        # previews. Both pickers must converge on the same string when the
+        # session's history.jsonl display falls into ANY skip category.
+        session_id = "issue181"
+        jsonl_path = sessions_dir / f"{session_id}.jsonl"
+        _write_jsonl(
+            jsonl_path,
+            [
+                _user_line(session_id, "Plot the closing prices for AAPL"),
+                _assistant_line(session_id),
+                _user_line(session_id, skippable_display),
+            ],
+        )
+        _write_history(
+            fake_claude_home,
+            [_history_line(session_id, project_cwd, 1_700_000_000_000, skippable_display)],
+        )
+
+        chat_picker_session = next(
+            s
+            for s in _list_sessions_in_dir(project_cwd, claude_home=str(fake_claude_home))
+            if s.session_id == session_id
+        )
+        launcher_session = next(
+            s
+            for s in list_all_sessions(cwd=project_cwd, claude_home=str(fake_claude_home))
+            if s.session_id == session_id
+        )
+
+        assert chat_picker_session.preview == launcher_session.preview
+        assert chat_picker_session.preview == "Plot the closing prices for AAPL"

--- a/tests/test_claude_sessions_handler.py
+++ b/tests/test_claude_sessions_handler.py
@@ -1,0 +1,111 @@
+"""Wire-shape tests for ClaudeSessionsListHandler.
+
+The handler is a thin wrapper around ``list_all_sessions``, but its
+response shape (``{sessions, current_cwd, current_sessions_dir}``) is the
+only Python↔TypeScript contract not pinned elsewhere. A silent rename of
+any of those keys would break the chat picker's ``filterSessionsToDir``
+filter without any test failing — these tests prevent that.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import notebook_intelligence.extension as ext_module
+from notebook_intelligence.claude_sessions import ClaudeSessionInfo
+from notebook_intelligence.extension import ClaudeSessionsListHandler
+
+
+def _make_handler():
+    handler = MagicMock(spec=ClaudeSessionsListHandler)
+    handler.request = MagicMock()
+    return handler
+
+
+def _parse_response(handler) -> dict:
+    return json.loads(handler.finish.call_args[0][0])
+
+
+@pytest.fixture
+def claude_mode_on():
+    with patch.object(ext_module, "ai_service_manager") as mock_asm:
+        mock_asm.is_claude_code_mode = True
+        yield mock_asm
+
+
+@pytest.fixture
+def claude_mode_off():
+    with patch.object(ext_module, "ai_service_manager") as mock_asm:
+        mock_asm.is_claude_code_mode = False
+        yield mock_asm
+
+
+class TestClaudeSessionsListHandler:
+    def test_returns_404_when_claude_code_mode_off(self, claude_mode_off):
+        handler = _make_handler()
+        ClaudeSessionsListHandler.get(handler)
+        handler.set_status.assert_called_with(404)
+        body = _parse_response(handler)
+        assert "error" in body
+
+    def test_response_shape_pins_python_typescript_contract(
+        self, claude_mode_on, tmp_path
+    ):
+        # Empty result is enough — we're pinning keys, not values.
+        with patch.object(ext_module, "list_all_claude_sessions", return_value=[]):
+            with patch.object(
+                ext_module, "get_jupyter_root_dir", return_value=str(tmp_path)
+            ):
+                handler = _make_handler()
+                ClaudeSessionsListHandler.get(handler)
+
+        body = _parse_response(handler)
+        assert set(body.keys()) == {
+            "sessions",
+            "current_cwd",
+            "current_sessions_dir",
+        }
+
+    def test_serializes_session_info_records(self, claude_mode_on, tmp_path):
+        sessions = [
+            ClaudeSessionInfo(
+                session_id="abc12345",
+                path=str(tmp_path / "abc12345.jsonl"),
+                modified_at=1.0,
+                created_at=0.0,
+                preview="hello",
+                cwd=str(tmp_path),
+            )
+        ]
+        with patch.object(
+            ext_module, "list_all_claude_sessions", return_value=sessions
+        ):
+            with patch.object(
+                ext_module, "get_jupyter_root_dir", return_value=str(tmp_path)
+            ):
+                handler = _make_handler()
+                ClaudeSessionsListHandler.get(handler)
+
+        body = _parse_response(handler)
+        assert len(body["sessions"]) == 1
+        assert set(body["sessions"][0].keys()) == {
+            "session_id",
+            "path",
+            "modified_at",
+            "created_at",
+            "preview",
+            "cwd",
+        }
+        assert body["sessions"][0]["session_id"] == "abc12345"
+        assert body["sessions"][0]["preview"] == "hello"
+
+    def test_handles_missing_cwd_gracefully(self, claude_mode_on):
+        with patch.object(ext_module, "list_all_claude_sessions", return_value=[]):
+            with patch.object(ext_module, "get_jupyter_root_dir", return_value=None):
+                handler = _make_handler()
+                ClaudeSessionsListHandler.get(handler)
+
+        body = _parse_response(handler)
+        assert body["current_cwd"] == ""
+        assert body["current_sessions_dir"] == ""

--- a/tests/ts/utils.test.ts
+++ b/tests/ts/utils.test.ts
@@ -13,9 +13,11 @@ import {
   cellOutputAsText,
   applyCodeToSelectionInEditor,
   buildResumeCommand,
+  filterSessionsToDir,
   shellSingleQuote,
   writeTextToClipboard
 } from '../../src/utils';
+import type { IClaudeSessionInfo } from '../../src/api';
 
 describe('removeAnsiChars', () => {
   it('strips colour escape sequences', () => {
@@ -467,5 +469,64 @@ describe('buildResumeCommand', () => {
 
   it('falls back to a bare resume when cwd is empty', () => {
     expect(buildResumeCommand('', 'abc-123')).toBe('claude --resume abc-123');
+  });
+});
+
+describe('filterSessionsToDir', () => {
+  const session = (id: string, path: string): IClaudeSessionInfo => ({
+    session_id: id,
+    path,
+    modified_at: 0,
+    created_at: 0,
+    preview: '',
+    cwd: ''
+  });
+
+  it('keeps only sessions whose transcript lives directly in the dir', () => {
+    const dir = '/home/u/.claude/projects/-Users-me-proj';
+    const sessions = [
+      session('a', `${dir}/a.jsonl`),
+      session('b', '/home/u/.claude/projects/-Users-me-other/b.jsonl'),
+      session('c', `${dir}/c.jsonl`)
+    ];
+
+    expect(filterSessionsToDir(sessions, dir).map(s => s.session_id)).toEqual([
+      'a',
+      'c'
+    ]);
+  });
+
+  it('returns the input unchanged when sessionsDir is empty', () => {
+    const sessions = [session('a', '/anywhere/a.jsonl')];
+    expect(filterSessionsToDir(sessions, '')).toBe(sessions);
+  });
+
+  it('excludes sessions nested deeper than the target dir', () => {
+    const dir = '/p';
+    const sessions = [
+      session('a', '/p/sub/a.jsonl'),
+      session('b', '/p/b.jsonl')
+    ];
+    expect(filterSessionsToDir(sessions, dir).map(s => s.session_id)).toEqual([
+      'b'
+    ]);
+  });
+
+  it('returns an empty array when no session matches the dir', () => {
+    const sessions = [session('a', '/x/a.jsonl'), session('b', '/y/b.jsonl')];
+    expect(filterSessionsToDir(sessions, '/z')).toEqual([]);
+  });
+
+  it('does not match a sibling dir that shares a prefix', () => {
+    // The trailing-slash guard prevents "/p" from matching
+    // "/p-other/x.jsonl" — without it, encoded-cwd directories that share
+    // a prefix would silently leak into one another's session lists.
+    const sessions = [
+      session('a', '/p/a.jsonl'),
+      session('b', '/p-other/b.jsonl')
+    ];
+    expect(filterSessionsToDir(sessions, '/p').map(s => s.session_id)).toEqual([
+      'a'
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Fixes [#181](https://github.com/notebook-intelligence/notebook-intelligence/issues/181) — the chat-sidebar picker and the cross-project launcher tile rendered different titles for the same Claude session id (one source was a transcript scan, the other was `~/.claude/history.jsonl`'s `display` field). Also fixes [#183](https://github.com/notebook-intelligence/notebook-intelligence/issues/183) — the Claude Code launcher tile now hides when its prerequisites aren't met.

## Two pickers, two scopes

The extension exposes session pickers in two surfaces with deliberately different scopes:

- **Chat sidebar popover** ("Resume Claude session") — scoped to sessions in the **current Jupyter cwd**. Clicking a row resumes that session in the in-process Claude participant.
- **Cross-project launcher tile** ("Claude Code") — shows sessions **across all projects** with each row labelled by its source cwd. Clicking a row launches `claude --resume <id>` in a JupyterLab terminal at that cwd.

The #181 bug was that these two surfaces *also* used different preview sources, so the same session id could render with different titles in each. This PR unifies the preview source while preserving the scope distinction — the chat picker still filters to the current cwd, just client-side now via a shared backend response.

## What changed

- **Single backend source of truth.** Both pickers now consume `GET /claude-sessions`. Internally it calls `list_all_sessions` (history.jsonl + transcript fallback). The chat picker filters client-side to the current Jupyter cwd; the launcher tile shows everything.
- **Broader skip filter** for non-meaningful previews. NBI's `Additional context:` preamble and Claude Code's `<local-command-...>` envelopes were already skipped; now also skipped: `[Request interrupted by user...]` markers, `Unknown slash command:` echoes from claude-agent-sdk, and an explicit allowlist of bare control verbs (`/exit`, `/clear`, `/help`, `/init`, `/login`, `/logout`, `/quit`, `/compact`, `/cost`, `/release-notes`, `/reset`, `/status`). Custom slash plugins (e.g. `/voice`) are kept because they carry user intent.
- **Allowlist over regex.** A regex `^/[A-Za-z]+$` would match `/tmp`, `/etc`, `/var` (real file paths a user might paste). Allowlist trades that durability for needing one-line updates when Claude Code adds new control verbs.
- **Launcher tile gating** (issue #183). Tile is hidden via `isVisible: () => isInClaudeCodeMode && isClaudeCliAvailable`, with `notifyCommandChanged` wired to `configChanged` so it appears/disappears live as the user toggles mode or installs the CLI. Backend exposes `claude_cli_available` from `shutil.which("claude")`.

## Behavior changes (worth bisecting against)

- `GET /claude-sessions/all` removed. The chat picker and launcher tile both use `/claude-sessions` now. The endpoint is `is_claude_code_mode`-gated; non-Claude users get 404. (Pre-PR, the `/all` endpoint was unguarded — same data was already accessible.)
- `current_sessions_dir` field added to the `/claude-sessions` response. Used by the chat picker's client-side filter. Authenticated, Claude-mode-gated, but does expose the encoded `~/.claude/projects/<encoded-cwd>` path to the client. Acknowledged in the handler docstring.
- The launcher tile is hidden (not greyed out) when Claude mode is off or `claude` CLI isn't on PATH.

## Tests

- 508 pytest passing, +21 new (handler response-shape pinning, parametrized convergence over all six skip categories, allowlist parametrize over `_CONTROL_SLASH_COMMANDS`, control-verb negative cases, transcript-fallback edge cases).
- 100 jest passing, +5 new for `filterSessionsToDir` including a trailing-slash-discipline case.
- Visually verified in JupyterLab: both pickers render the same preview for the same session id; launcher tile shows when prerequisites are met, hides otherwise.

## Follow-ups filed

- #186 — add `Unknown skill:` to the skip filter (new pattern spotted during verification).
- #187 — better fallback than literal `/exit` for sessions with no meaningful prompt.
- #188 — `?scope=cwd` query param to avoid wire bloat for power users with many sessions.
- #189 — launcher-picker keyboard a11y (Escape, arrows, drop deprecated `onKeyPress`).

## Test plan

- [x] `pytest tests/` → 508 passing
- [x] `jlpm jest` → 100 passing
- [x] `prettier`, `eslint`, `tsc --noEmit` clean
- [x] Visual: launcher tile hides in non-Claude mode
- [x] Visual: launcher tile hides when `claude` CLI not on PATH
- [x] Visual: both pickers show same preview for same session id
- [x] Visual: 160-char previews wrap cleanly in launcher dialog
