### PR TITLE
fix(ui): anchor notebook inline chat to the cursor line

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
         "watch:labextension": "jupyter labextension watch ."
     },
     "dependencies": {
+        "@codemirror/state": "^6.4.1",
+        "@codemirror/view": "^6.26.0",
         "@jupyterlab/application": "^4.0.0",
         "@jupyterlab/completer": "^4.0.0",
         "@jupyterlab/coreutils": "^6.0.0",

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -3651,6 +3651,15 @@ export function InlinePopoverComponent(props: any) {
     inflightMessageIdRef.current = null;
   };
 
+  // Hand the cancel function up to the host so non-React dismissal paths
+  // (e.g. outside-click on the block widget) can cancel without invoking
+  // onRequestCancelled — that path also restores editor focus, which is
+  // wrong when the user is mid-click on a different target.
+  useEffect(() => {
+    props.registerCancel?.(cancelInflightRequest);
+    return () => props.registerCancel?.(null);
+  }, []);
+
   const onRequestSubmitted = (prompt: string) => {
     setModifiedCode('');
     setPromptSubmitted(true);

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -164,26 +164,45 @@ export interface IInlinePromptWidgetOptions {
 }
 
 export class InlinePromptWidget extends ReactWidget {
-  constructor(rect: DOMRect, options: IInlinePromptWidgetOptions) {
+  // Pass `rect` for floating mode (file editor). Pass null for inline mode
+  // (notebook cell), where CodeMirror owns the in-flow block placement.
+  constructor(rect: DOMRect | null, options: IInlinePromptWidgetOptions) {
     super();
 
     this.node.classList.add('inline-prompt-widget');
-    this.node.style.top = `${rect.top + 32}px`;
-    this.node.style.left = `${rect.left}px`;
-    this.node.style.width = rect.width + 'px';
-    this.node.style.height = '48px';
+    if (rect) {
+      this._floating = true;
+      this.node.classList.add('inline-prompt-widget-floating');
+      this.node.style.top = `${rect.top + 32}px`;
+      this.node.style.left = `${rect.left}px`;
+      this.node.style.width = rect.width + 'px';
+      this.node.style.height = '48px';
+    } else {
+      this.node.classList.add('inline-prompt-widget-inline');
+      this.node.style.height = '48px';
+    }
     this._options = options;
 
-    this.node.addEventListener('focusout', (event: any) => {
-      if (this.node.contains(event.relatedTarget)) {
-        return;
-      }
+    if (this._floating) {
+      this.node.addEventListener('focusout', (event: any) => {
+        if (this.node.contains(event.relatedTarget)) {
+          return;
+        }
 
-      this._options.onRequestCancelled();
-    });
+        window.setTimeout(() => {
+          if (this.node.contains(document.activeElement)) {
+            return;
+          }
+          this._options.onRequestCancelled();
+        }, 0);
+      });
+    }
   }
 
   updatePosition(rect: DOMRect) {
+    if (!this._floating) {
+      return;
+    }
     this.node.style.top = `${rect.top + 32}px`;
     this.node.style.left = `${rect.left}px`;
     this.node.style.width = rect.width + 'px';
@@ -265,6 +284,7 @@ export class InlinePromptWidget extends ReactWidget {
   private _options: IInlinePromptWidgetOptions;
   private _requestTime: Date;
   private _streamError: string | null = null;
+  private _floating = false;
 }
 
 export class GitHubCopilotStatusBarItem extends ReactWidget {
@@ -3598,7 +3618,7 @@ function SidebarComponent(props: any) {
   );
 }
 
-function InlinePopoverComponent(props: any) {
+export function InlinePopoverComponent(props: any) {
   const [modifiedCode, setModifiedCode] = useState<string>('');
   const [promptSubmitted, setPromptSubmitted] = useState(false);
   // Tracks the in-flight backend request so Escape / Cancel / Accept can
@@ -3828,8 +3848,9 @@ function InlinePromptComponent(props: any) {
   };
 
   const onPromptKeyDown = async (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    event.stopPropagation();
+
     if (event.key === 'Enter' && !event.shiftKey) {
-      event.stopPropagation();
       event.preventDefault();
       if (inputSubmitted && (event.metaKey || event.ctrlKey)) {
         props.onUpdatedCodeAccepted();
@@ -3838,18 +3859,30 @@ function InlinePromptComponent(props: any) {
         handleUserInputSubmit();
       }
     } else if (event.key === 'Escape') {
-      event.stopPropagation();
       event.preventDefault();
       props.onRequestCancelled();
     }
   };
 
-  useEffect(() => {
+  const focusPromptInput = () => {
     const input = promptInputRef.current;
-    if (input) {
-      input.select();
-      promptInputRef.current?.focus();
+    if (!input) {
+      return;
     }
+
+    input.focus({ preventScroll: true });
+    input.select();
+  };
+
+  useEffect(() => {
+    focusPromptInput();
+    const animationFrame = requestAnimationFrame(focusPromptInput);
+    const timeout = window.setTimeout(focusPromptInput, 0);
+
+    return () => {
+      cancelAnimationFrame(animationFrame);
+      window.clearTimeout(timeout);
+    };
   }, []);
 
   return (
@@ -3861,7 +3894,12 @@ function InlinePromptComponent(props: any) {
         ref={promptInputRef}
         rows={3}
         onChange={onPromptChange}
+        onClick={event => {
+          event.stopPropagation();
+          focusPromptInput();
+        }}
         onKeyDown={onPromptKeyDown}
+        onMouseDown={event => event.stopPropagation()}
         placeholder="Ask Notebook Intelligence to generate Python code..."
         spellCheck={false}
         value={prompt}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1960,8 +1960,6 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
         telemetryEmitter: telemetryEmitter
       };
 
-      closeOpenPopover = removePopover;
-
       let requestTime: Date | null = null;
       let streamError: string | null = null;
       let blockPromptNode: HTMLElement | null = null;
@@ -2012,6 +2010,11 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
           });
         }
       };
+      // Handed up by InlinePopoverComponent on mount so this scope can
+      // cancel the in-flight WS request from non-React dismissal paths
+      // (focus-leave) without going through onRequestCancelled (which
+      // would also yank focus back to the editor).
+      let cancelInflightRequest: (() => void) | null = null;
       const widget = new InlinePromptBlockWidget(
         React.createElement(InlinePopoverComponent, {
           prompt: promptOptions.prompt,
@@ -2024,15 +2027,21 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
           language: promptOptions.language,
           filename: promptOptions.filename,
           onUpdatedCodeChange: promptOptions.onUpdatedCodeChange,
-          onUpdatedCodeAccepted: promptOptions.onUpdatedCodeAccepted
+          onUpdatedCodeAccepted: promptOptions.onUpdatedCodeAccepted,
+          registerCancel: (fn: (() => void) | null) => {
+            cancelInflightRequest = fn;
+          }
         }),
         node => {
           blockPromptNode = node;
         },
-        // removePopover (not onRequestCancelled) on focus-leave so the
-        // user's new focus target keeps focus — onRequestCancelled would
-        // yank it back to the editor.
-        () => removePopover()
+        // Focus-leave dismissal: cancel the request so the backend stops
+        // streaming, but don't call onRequestCancelled — that would steal
+        // focus back from whatever the user clicked.
+        () => {
+          cancelInflightRequest?.();
+          removePopover();
+        }
       );
       const anchorOffset = getLineEndOffset(
         editor,
@@ -2040,6 +2049,14 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
       );
       ensureInlinePromptExtension(editorView);
       blockPromptView = editorView;
+      // Replace-on-reopen path: when a second Ctrl+G fires while this
+      // popover is still here, cancel our in-flight request before the
+      // widget is torn down so the backend stops streaming for the
+      // discarded prompt.
+      closeOpenPopover = () => {
+        cancelInflightRequest?.();
+        removePopover();
+      };
       editorView.dispatch({
         effects: [
           addInlinePromptEffect.of({

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,6 @@ import {
   IInlinePromptWidgetOptions,
   InlinePopoverComponent,
   GitHubCopilotStatusBarItem,
-  InlinePromptWidget,
   RunChatCompletionType
 } from './chat-sidebar';
 import {
@@ -882,7 +881,6 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
 
     await NBIAPI.initialize();
 
-    let openPopover: InlinePromptWidget | null = null;
     let closeOpenPopover: (() => void) | null = null;
     let mcpConfigEditor: MCPConfigEditor | null = null;
 
@@ -1812,8 +1810,7 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
       const isCodeCell = isActiveCellCodeCell();
       const currentWidget = app.shell.currentWidget;
       let editor: CodeEditor.IEditor;
-      let codeInput: HTMLElement = null;
-      let scrollEl: HTMLElement = null;
+      let codeInput: HTMLElement | null = null;
       if (isCodeCell) {
         const np = currentWidget as NotebookPanel;
         const activeCell = np.content.activeCell;
@@ -1821,87 +1818,18 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
         if (!codeInput) {
           return;
         }
-        scrollEl = np.node.querySelector('.jp-WindowedPanel-outer');
         editor = activeCell.editor;
       } else {
         const fe = currentWidget as FileEditorWidget;
-        codeInput = fe.node;
-        scrollEl = fe.node.querySelector('.cm-scroller');
         editor = fe.content.editor;
       }
 
-      const getRectAtCursor = (): DOMRect => {
-        const selection = editor.getSelection();
-        const line = Math.min(selection.end.line + 1, editor.lineCount - 1);
-        const coords = editor.getCoordinateForPosition({
-          line,
-          column: selection.end.column
-        });
-        const editorRect = codeInput.getBoundingClientRect();
-        if (!coords) {
-          return editorRect;
-        }
-        const yOffset = 30;
-        const diffViewHeight = 300;
-
-        let top = coords.top - yOffset;
-        const height = coords.bottom - coords.top;
-
-        // adjust top to fit in file editor rect
-        if (!isCodeCell) {
-          if (top + height + diffViewHeight > editorRect.bottom) {
-            top = editorRect.bottom - height - diffViewHeight;
-            if (top < editorRect.top) {
-              top = editorRect.top;
-            }
-          }
-        }
-
-        const rect: DOMRect = new DOMRect(
-          editorRect.left,
-          top,
-          editorRect.right - editorRect.left,
-          height
-        );
-
-        return rect;
-      };
-
-      const editorView = isCodeCell ? getCodeMirrorView(editor) : null;
-      const useEditorBlock = editorView !== null;
-      const rect = useEditorBlock ? null : getRectAtCursor();
-
-      const updatePopoverPosition = () => {
-        if (openPopover !== null) {
-          const rect = getRectAtCursor();
-          openPopover.updatePosition(rect);
-        }
-      };
-
-      const inputResizeObserver = new ResizeObserver(updatePopoverPosition);
-
-      const addPositionListeners = () => {
-        if (useEditorBlock) {
-          return;
-        }
-        inputResizeObserver.observe(codeInput);
-        if (scrollEl) {
-          scrollEl.addEventListener('scroll', updatePopoverPosition);
-        }
-      };
-
-      const removePositionListeners = () => {
-        if (useEditorBlock) {
-          return;
-        }
-        inputResizeObserver.unobserve(codeInput);
-        if (scrollEl) {
-          scrollEl.removeEventListener('scroll', updatePopoverPosition);
-        }
-      };
+      const editorView = getCodeMirrorView(editor);
+      if (!editorView) {
+        return;
+      }
 
       let blockPromptView: EditorView | null = null;
-      let inlinePrompt: InlinePromptWidget | null = null;
       let removed = false;
       const removePopover = () => {
         // Cleared outside the `removed` guard so the auto-insert path's
@@ -1914,19 +1842,13 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
           return;
         }
         removed = true;
-        removePositionListeners();
         closeOpenPopover = null;
-        openPopover = null;
 
         if (blockPromptView) {
           blockPromptView.dispatch({
             effects: removeInlinePromptEffect.of()
           });
           blockPromptView = null;
-        } else if (inlinePrompt?.isAttached) {
-          Widget.detach(inlinePrompt);
-        } else if (inlinePrompt?.node.parentElement) {
-          inlinePrompt.node.remove();
         }
       };
 
@@ -2040,100 +1962,93 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
 
       closeOpenPopover = removePopover;
 
-      if (editorView) {
-        let requestTime: Date | null = null;
-        let streamError: string | null = null;
-        let blockPromptNode: HTMLElement | null = null;
-        const onRequestSubmitted = (prompt: string) => {
-          if (blockPromptNode && existingCode !== '') {
-            blockPromptNode.style.height = '300px';
+      let requestTime: Date | null = null;
+      let streamError: string | null = null;
+      let blockPromptNode: HTMLElement | null = null;
+      const onRequestSubmitted = (prompt: string) => {
+        if (blockPromptNode && existingCode !== '') {
+          blockPromptNode.style.height = '300px';
+        }
+        promptOptions.prompt = prompt;
+        promptOptions.onRequestSubmitted(prompt);
+        requestTime = new Date();
+        telemetryEmitter.emitTelemetryEvent({
+          type: TelemetryEventType.InlineChatRequest,
+          data: {
+            chatModel: {
+              provider: NBIAPI.config.chatModel.provider,
+              model: NBIAPI.config.chatModel.model
+            },
+            prompt: prompt
           }
-          promptOptions.prompt = prompt;
-          promptOptions.onRequestSubmitted(prompt);
-          requestTime = new Date();
+        });
+      };
+      const onResponseEmit = (response: any) => {
+        if (response.type === BackendMessageType.StreamMessage) {
+          if (typeof response.data?.nbi_stream_error === 'string') {
+            streamError = response.data.nbi_stream_error;
+          }
+          const responseMessage =
+            response.data['choices']?.[0]?.['delta']?.['content'];
+          if (responseMessage) {
+            promptOptions.onContentStream(responseMessage);
+          }
+        } else if (response.type === BackendMessageType.StreamEnd) {
+          promptOptions.onContentStreamEnd(streamError);
+          streamError = null;
+          const timeElapsed =
+            requestTime === null
+              ? 0
+              : (new Date().getTime() - requestTime.getTime()) / 1000;
           telemetryEmitter.emitTelemetryEvent({
-            type: TelemetryEventType.InlineChatRequest,
+            type: TelemetryEventType.InlineChatResponse,
             data: {
               chatModel: {
                 provider: NBIAPI.config.chatModel.provider,
                 model: NBIAPI.config.chatModel.model
               },
-              prompt: prompt
+              timeElapsed
             }
           });
-        };
-        const onResponseEmit = (response: any) => {
-          if (response.type === BackendMessageType.StreamMessage) {
-            if (typeof response.data?.nbi_stream_error === 'string') {
-              streamError = response.data.nbi_stream_error;
-            }
-            const responseMessage =
-              response.data['choices']?.[0]?.['delta']?.['content'];
-            if (responseMessage) {
-              promptOptions.onContentStream(responseMessage);
-            }
-          } else if (response.type === BackendMessageType.StreamEnd) {
-            promptOptions.onContentStreamEnd(streamError);
-            streamError = null;
-            const timeElapsed =
-              requestTime === null
-                ? 0
-                : (new Date().getTime() - requestTime.getTime()) / 1000;
-            telemetryEmitter.emitTelemetryEvent({
-              type: TelemetryEventType.InlineChatResponse,
-              data: {
-                chatModel: {
-                  provider: NBIAPI.config.chatModel.provider,
-                  model: NBIAPI.config.chatModel.model
-                },
-                timeElapsed
-              }
-            });
-          }
-        };
-        const widget = new InlinePromptBlockWidget(
-          React.createElement(InlinePopoverComponent, {
-            prompt: promptOptions.prompt,
-            existingCode: promptOptions.existingCode,
-            onRequestSubmitted,
-            onRequestCancelled: promptOptions.onRequestCancelled,
-            onResponseEmit,
-            prefix: promptOptions.prefix,
-            suffix: promptOptions.suffix,
-            language: promptOptions.language,
-            filename: promptOptions.filename,
-            onUpdatedCodeChange: promptOptions.onUpdatedCodeChange,
-            onUpdatedCodeAccepted: promptOptions.onUpdatedCodeAccepted
+        }
+      };
+      const widget = new InlinePromptBlockWidget(
+        React.createElement(InlinePopoverComponent, {
+          prompt: promptOptions.prompt,
+          existingCode: promptOptions.existingCode,
+          onRequestSubmitted,
+          onRequestCancelled: promptOptions.onRequestCancelled,
+          onResponseEmit,
+          prefix: promptOptions.prefix,
+          suffix: promptOptions.suffix,
+          language: promptOptions.language,
+          filename: promptOptions.filename,
+          onUpdatedCodeChange: promptOptions.onUpdatedCodeChange,
+          onUpdatedCodeAccepted: promptOptions.onUpdatedCodeAccepted
+        }),
+        node => {
+          blockPromptNode = node;
+        },
+        // removePopover (not onRequestCancelled) on focus-leave so the
+        // user's new focus target keeps focus — onRequestCancelled would
+        // yank it back to the editor.
+        () => removePopover()
+      );
+      const anchorOffset = getLineEndOffset(
+        editor,
+        Math.max(startOffset, endOffset)
+      );
+      ensureInlinePromptExtension(editorView);
+      blockPromptView = editorView;
+      editorView.dispatch({
+        effects: [
+          addInlinePromptEffect.of({
+            pos: anchorOffset,
+            widget
           }),
-          node => {
-            blockPromptNode = node;
-          },
-          // Outside focus-leave dismissal. removePopover (not
-          // onRequestCancelled) so the user's new focus target keeps it —
-          // onRequestCancelled would yank focus back to the cell editor.
-          () => removePopover()
-        );
-        const anchorOffset = getLineEndOffset(
-          editor,
-          Math.max(startOffset, endOffset)
-        );
-        ensureInlinePromptExtension(editorView);
-        blockPromptView = editorView;
-        editorView.dispatch({
-          effects: [
-            addInlinePromptEffect.of({
-              pos: anchorOffset,
-              widget
-            }),
-            EditorView.scrollIntoView(anchorOffset, { y: 'center' })
-          ]
-        });
-      } else {
-        inlinePrompt = new InlinePromptWidget(rect, promptOptions);
-        openPopover = inlinePrompt;
-        addPositionListeners();
-        Widget.attach(inlinePrompt, document.body);
-      }
+          EditorView.scrollIntoView(anchorOffset, { y: 'center' })
+        ]
+      });
 
       telemetryEmitter.emitTelemetryEvent({
         type: TelemetryEventType.GenerateCodeRequest,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1904,6 +1904,12 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
       let inlinePrompt: InlinePromptWidget | null = null;
       let removed = false;
       const removePopover = () => {
+        // Cleared outside the `removed` guard so the auto-insert path's
+        // second call still removes the class added between calls.
+        if (isCodeCell) {
+          codeInput?.classList.remove('generating');
+        }
+
         if (removed) {
           return;
         }
@@ -1921,10 +1927,6 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
           Widget.detach(inlinePrompt);
         } else if (inlinePrompt?.node.parentElement) {
           inlinePrompt.node.remove();
-        }
-
-        if (isCodeCell) {
-          codeInput?.classList.remove('generating');
         }
       };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,13 @@ import { Dialog, ICommandPalette, MainAreaWidget } from '@jupyterlab/apputils';
 import { IMainMenu } from '@jupyterlab/mainmenu';
 
 import { IEditorLanguageRegistry } from '@jupyterlab/codemirror';
+import { Extension, StateEffect, StateField } from '@codemirror/state';
+import {
+  Decoration,
+  DecorationSet,
+  EditorView,
+  WidgetType
+} from '@codemirror/view';
 
 import { CodeCell } from '@jupyterlab/cells';
 import { ISharedNotebook } from '@jupyter/ydoc';
@@ -50,6 +57,8 @@ import {
   ChatSidebar,
   FormInputDialogBody,
   GitHubCopilotLoginDialogBody,
+  IInlinePromptWidgetOptions,
+  InlinePopoverComponent,
   GitHubCopilotStatusBarItem,
   InlinePromptWidget,
   RunChatCompletionType
@@ -95,9 +104,180 @@ import { cellOutputAsContextBundle } from './cell-output-bundle';
 import { UUID } from '@lumino/coreutils';
 
 import * as path from 'path';
+import { createRoot, Root } from 'react-dom/client';
 import { SettingsPanel } from './components/settings-panel';
 import { ITerminalConnection } from '@jupyterlab/services/lib/terminal/terminal';
 import { NotebookGenerationToolbarExtension } from './notebook-generation-toolbar';
+
+const addInlinePromptEffect = StateEffect.define<{
+  pos: number;
+  widget: InlinePromptBlockWidget;
+}>();
+const removeInlinePromptEffect = StateEffect.define<void>();
+
+const inlinePromptField = StateField.define<DecorationSet>({
+  create() {
+    return Decoration.none;
+  },
+  update(decorations, transaction) {
+    decorations = decorations.map(transaction.changes);
+
+    for (const effect of transaction.effects) {
+      if (effect.is(removeInlinePromptEffect)) {
+        decorations = Decoration.none;
+      } else if (effect.is(addInlinePromptEffect)) {
+        decorations = Decoration.set([
+          Decoration.widget({
+            block: true,
+            side: 1,
+            widget: effect.value.widget
+          }).range(effect.value.pos)
+        ]);
+      }
+    }
+
+    return decorations;
+  },
+  provide: field => EditorView.decorations.from(field)
+});
+
+class InlinePromptBlockWidget extends WidgetType {
+  constructor(
+    private readonly _content: React.ReactElement,
+    private readonly _onNodeCreated: (node: HTMLElement) => void,
+    private readonly _onDismissRequested: () => void
+  ) {
+    super();
+  }
+
+  eq(other: WidgetType): boolean {
+    return other === this;
+  }
+
+  toDOM(): HTMLElement {
+    const host = document.createElement('div');
+    host.className = 'nbi-inline-prompt-block';
+    host.contentEditable = 'false';
+
+    const node = document.createElement('div');
+    node.className = 'inline-prompt-widget inline-prompt-widget-inline';
+    node.style.height = '48px';
+    host.appendChild(node);
+
+    // Bubble-phase stopPropagation so JupyterLab's document-level
+    // keybindings (Ctrl+S, etc.) don't intercept keys typed in the
+    // textarea. CM's own handling is already opted out via ignoreEvent;
+    // this is purely about JL keymap.
+    const stopEditorEvent = (event: Event) => event.stopPropagation();
+    for (const eventName of [
+      'keydown',
+      'keypress',
+      'keyup',
+      'mousedown',
+      'mouseup',
+      'click',
+      'pointerdown',
+      'pointerup',
+      'input',
+      'beforeinput'
+    ]) {
+      host.addEventListener(eventName, stopEditorEvent);
+    }
+
+    // While the popover is mounted, suppress JupyterLab's notebook-panel
+    // _evtFocusIn handler for focus events inside the owning cell. Without
+    // this, JL's _ensureFocus reacts to every focusin on the textarea by
+    // refocusing .cm-content, which then triggers our own refocus, which
+    // re-fires JL — an infinite loop until the stack overflows.
+    //
+    // Capture-phase listener on document fires before JL's bubble-phase
+    // handler on the notebook panel; stopPropagation here is sufficient.
+    // The owning .cm-content / .jp-Cell are resolved inside the handler
+    // because at toDOM() time the host is created but not yet inserted.
+    this._focusinGuard = (event: FocusEvent) => {
+      if (!host.isConnected) {
+        return;
+      }
+      const ownCmContent = host.closest('.cm-content');
+      if (!ownCmContent) {
+        return;
+      }
+      const ownCell = ownCmContent.closest('.jp-Cell');
+      const target = event.target as HTMLElement | null;
+      if (!ownCell || !target || !ownCell.contains(target)) {
+        return;
+      }
+
+      event.stopPropagation();
+
+      if (target === ownCmContent) {
+        const ta = node.querySelector('textarea');
+        if (ta && document.activeElement !== ta) {
+          ta.focus({ preventScroll: true });
+        }
+      }
+    };
+    document.addEventListener('focusin', this._focusinGuard, true);
+
+    // Outside-click / focus-leave dismissal. The previous floating-widget
+    // path relied on InlinePromptWidget's own focusout listener; the
+    // block-widget path mounts the React tree directly so we replicate
+    // it here. Focus moving within the popover (textarea -> Accept /
+    // Cancel) is ignored.
+    host.addEventListener('focusout', (event: FocusEvent) => {
+      const next = event.relatedTarget as Node | null;
+      if (next && host.contains(next)) {
+        return;
+      }
+      this._onDismissRequested();
+    });
+
+    this._root = createRoot(node);
+    this._root.render(this._content);
+    this._onNodeCreated(node);
+    return host;
+  }
+
+  ignoreEvent(): boolean {
+    return true;
+  }
+
+  destroy(): void {
+    if (this._focusinGuard) {
+      document.removeEventListener('focusin', this._focusinGuard, true);
+      this._focusinGuard = null;
+    }
+    this._root?.unmount();
+    this._root = null;
+  }
+
+  private _root: Root | null = null;
+  private _focusinGuard: ((event: FocusEvent) => void) | null = null;
+}
+
+function getCodeMirrorView(editor: CodeEditor.IEditor): EditorView | null {
+  const codeMirrorEditor = editor as CodeEditor.IEditor & {
+    editor?: EditorView;
+  };
+  return codeMirrorEditor.editor ?? null;
+}
+
+function ensureInlinePromptExtension(view: EditorView): void {
+  if (view.state.field(inlinePromptField, false)) {
+    return;
+  }
+  view.dispatch({
+    effects: StateEffect.appendConfig.of([inlinePromptField] as Extension[])
+  });
+}
+
+function getLineEndOffset(editor: CodeEditor.IEditor, offset: number): number {
+  const position = editor.getPositionAt(offset);
+  return editor.getOffsetAt({
+    line: position.line,
+    column: editor.getLine(position.line).length
+  });
+}
 
 namespace CommandIDs {
   export const chatuserInput = 'notebook-intelligence:chat-user-input';
@@ -703,6 +883,7 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
     await NBIAPI.initialize();
 
     let openPopover: InlinePromptWidget | null = null;
+    let closeOpenPopover: (() => void) | null = null;
     let mcpConfigEditor: MCPConfigEditor | null = null;
 
     completionManager.registerInlineProvider(
@@ -1686,7 +1867,9 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
         return rect;
       };
 
-      const rect = getRectAtCursor();
+      const editorView = isCodeCell ? getCodeMirrorView(editor) : null;
+      const useEditorBlock = editorView !== null;
+      const rect = useEditorBlock ? null : getRectAtCursor();
 
       const updatePopoverPosition = () => {
         if (openPopover !== null) {
@@ -1698,6 +1881,9 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
       const inputResizeObserver = new ResizeObserver(updatePopoverPosition);
 
       const addPositionListeners = () => {
+        if (useEditorBlock) {
+          return;
+        }
         inputResizeObserver.observe(codeInput);
         if (scrollEl) {
           scrollEl.addEventListener('scroll', updatePopoverPosition);
@@ -1705,17 +1891,36 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
       };
 
       const removePositionListeners = () => {
+        if (useEditorBlock) {
+          return;
+        }
         inputResizeObserver.unobserve(codeInput);
         if (scrollEl) {
           scrollEl.removeEventListener('scroll', updatePopoverPosition);
         }
       };
 
+      let blockPromptView: EditorView | null = null;
+      let inlinePrompt: InlinePromptWidget | null = null;
+      let removed = false;
       const removePopover = () => {
-        if (openPopover !== null) {
-          removePositionListeners();
-          openPopover = null;
+        if (removed) {
+          return;
+        }
+        removed = true;
+        removePositionListeners();
+        closeOpenPopover = null;
+        openPopover = null;
+
+        if (blockPromptView) {
+          blockPromptView.dispatch({
+            effects: removeInlinePromptEffect.of()
+          });
+          blockPromptView = null;
+        } else if (inlinePrompt?.isAttached) {
           Widget.detach(inlinePrompt);
+        } else if (inlinePrompt?.node.parentElement) {
+          inlinePrompt.node.remove();
         }
 
         if (isCodeCell) {
@@ -1754,14 +1959,24 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
 
       const applyGeneratedCode = () => {
         generatedContent = extractLLMGeneratedCode(generatedContent);
+        // extractLLMGeneratedCode preserves the newline that sits before
+        // the closing ``` in fenced LLM output. If the user's selection
+        // didn't already end with a newline (or there's no selection at
+        // all in the auto-insert path), inserting that trailing \n leaves
+        // an extra blank line below the generated code. Strip one
+        // trailing newline in those cases so the result matches the
+        // selection's original line-break state.
+        if (!existingCode.endsWith('\n') && generatedContent.endsWith('\n')) {
+          generatedContent = generatedContent.slice(0, -1);
+        }
         applyCodeToSelectionInEditor(editor, generatedContent);
         generatedContent = '';
         removePopover();
       };
 
-      removePopover();
+      closeOpenPopover?.();
 
-      const inlinePrompt = new InlinePromptWidget(rect, {
+      const promptOptions: IInlinePromptWidgetOptions = {
         prompt: userPrompt,
         existingCode,
         prefix: prefix,
@@ -1819,10 +2034,104 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
           editor.focus();
         },
         telemetryEmitter: telemetryEmitter
-      });
-      openPopover = inlinePrompt;
-      addPositionListeners();
-      Widget.attach(inlinePrompt, document.body);
+      };
+
+      closeOpenPopover = removePopover;
+
+      if (editorView) {
+        let requestTime: Date | null = null;
+        let streamError: string | null = null;
+        let blockPromptNode: HTMLElement | null = null;
+        const onRequestSubmitted = (prompt: string) => {
+          if (blockPromptNode && existingCode !== '') {
+            blockPromptNode.style.height = '300px';
+          }
+          promptOptions.prompt = prompt;
+          promptOptions.onRequestSubmitted(prompt);
+          requestTime = new Date();
+          telemetryEmitter.emitTelemetryEvent({
+            type: TelemetryEventType.InlineChatRequest,
+            data: {
+              chatModel: {
+                provider: NBIAPI.config.chatModel.provider,
+                model: NBIAPI.config.chatModel.model
+              },
+              prompt: prompt
+            }
+          });
+        };
+        const onResponseEmit = (response: any) => {
+          if (response.type === BackendMessageType.StreamMessage) {
+            if (typeof response.data?.nbi_stream_error === 'string') {
+              streamError = response.data.nbi_stream_error;
+            }
+            const responseMessage =
+              response.data['choices']?.[0]?.['delta']?.['content'];
+            if (responseMessage) {
+              promptOptions.onContentStream(responseMessage);
+            }
+          } else if (response.type === BackendMessageType.StreamEnd) {
+            promptOptions.onContentStreamEnd(streamError);
+            streamError = null;
+            const timeElapsed =
+              requestTime === null
+                ? 0
+                : (new Date().getTime() - requestTime.getTime()) / 1000;
+            telemetryEmitter.emitTelemetryEvent({
+              type: TelemetryEventType.InlineChatResponse,
+              data: {
+                chatModel: {
+                  provider: NBIAPI.config.chatModel.provider,
+                  model: NBIAPI.config.chatModel.model
+                },
+                timeElapsed
+              }
+            });
+          }
+        };
+        const widget = new InlinePromptBlockWidget(
+          React.createElement(InlinePopoverComponent, {
+            prompt: promptOptions.prompt,
+            existingCode: promptOptions.existingCode,
+            onRequestSubmitted,
+            onRequestCancelled: promptOptions.onRequestCancelled,
+            onResponseEmit,
+            prefix: promptOptions.prefix,
+            suffix: promptOptions.suffix,
+            language: promptOptions.language,
+            filename: promptOptions.filename,
+            onUpdatedCodeChange: promptOptions.onUpdatedCodeChange,
+            onUpdatedCodeAccepted: promptOptions.onUpdatedCodeAccepted
+          }),
+          node => {
+            blockPromptNode = node;
+          },
+          // Outside focus-leave dismissal. removePopover (not
+          // onRequestCancelled) so the user's new focus target keeps it —
+          // onRequestCancelled would yank focus back to the cell editor.
+          () => removePopover()
+        );
+        const anchorOffset = getLineEndOffset(
+          editor,
+          Math.max(startOffset, endOffset)
+        );
+        ensureInlinePromptExtension(editorView);
+        blockPromptView = editorView;
+        editorView.dispatch({
+          effects: [
+            addInlinePromptEffect.of({
+              pos: anchorOffset,
+              widget
+            }),
+            EditorView.scrollIntoView(anchorOffset, { y: 'center' })
+          ]
+        });
+      } else {
+        inlinePrompt = new InlinePromptWidget(rect, promptOptions);
+        openPopover = inlinePrompt;
+        addPositionListeners();
+        Widget.attach(inlinePrompt, document.body);
+      }
 
       telemetryEmitter.emitTelemetryEvent({
         type: TelemetryEventType.GenerateCodeRequest,

--- a/style/base.css
+++ b/style/base.css
@@ -1078,6 +1078,13 @@ body[data-jp-theme-light='false'] .inline-popover {
   box-shadow: rgba(90 76 191 / 25%) 0 0 4px 1px;
 }
 
+/* Undo .cm-content { caret-color: transparent } from CM6's drawSelection,
+   which inherits into our textarea when the popover renders as a block
+   widget inside the editor. */
+.inline-prompt-widget-inline textarea {
+  caret-color: auto;
+}
+
 .nbi-inline-prompt-block {
   box-sizing: border-box;
   display: block;

--- a/style/base.css
+++ b/style/base.css
@@ -1063,8 +1063,26 @@ body[data-jp-theme-light='false'] .inline-popover {
 .inline-prompt-widget {
   border-radius: 4px;
   padding: 3px;
+}
+
+.inline-prompt-widget-floating {
   z-index: 1000;
   box-shadow: rgba(90 76 191 / 30%) 0 0 10px 10px;
+}
+
+.inline-prompt-widget-inline {
+  position: relative;
+  width: 100%;
+  box-sizing: border-box;
+  margin: 4px 0;
+  box-shadow: rgba(90 76 191 / 25%) 0 0 4px 1px;
+}
+
+.nbi-inline-prompt-block {
+  box-sizing: border-box;
+  display: block;
+  width: 100%;
+  padding: 2px 0;
 }
 
 .inline-prompt-widget::before {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3295,6 +3295,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@notebook-intelligence/notebook-intelligence@workspace:."
   dependencies:
+    "@codemirror/state": ^6.4.1
+    "@codemirror/view": ^6.26.0
     "@jupyterlab/application": ^4.0.0
     "@jupyterlab/builder": ^4.0.0
     "@jupyterlab/completer": ^4.0.0


### PR DESCRIPTION
## Summary
- Replace the absolutely-positioned overlay popover with a CodeMirror 6 block widget anchored at the cursor's line, so the prompt sits in the editor's document flow, scrolls with the code, and never overlaps editor content. Applied to **both notebook cells and file editors** (per review).
- Add a `focusin` guard scoped to the popover's owning cell that stops JupyterLab's `_evtFocusIn` → `_ensureFocus` from reclaiming focus to `.cm-content`. Without this, JL's reclaim and the popover's own refocus formed an infinite loop that left the textarea unclickable. The guard no-ops for file editors (no `.jp-Cell` ancestor; FE doesn't have JL's notebook-panel reclaim behavior).
- Strip a trailing newline from fenced LLM output in `applyGeneratedCode` when the original selection didn't end with one, so generated code no longer leaves a blank line below the inserted block.
- `@codemirror/state` and `@codemirror/view` are now direct dependencies rather than reaching through JupyterLab's transitive copies.

## Review-round fixes
- **Cell progress animation never ended (auto-insert path).** `removePopover()` runs twice in the auto-insert flow (once on submit before the cell-level spinner starts, once on stream-end via `applyGeneratedCode`). The second call short-circuited at the idempotency guard, so `codeInput.classList.remove('generating')` never ran and the rotating border stayed forever. Hoisted the class removal above the guard.
- **Caret missing in textarea.** CodeMirror 6's `drawSelection` extension sets `caret-color: transparent !important` on `.cm-content`. The block-widget textarea inherited that, so it was focused but visually had no caret. Override on `.inline-prompt-widget-inline textarea`.
- **File editors used the old overlay.** Dropped the `isCodeCell` gate so file editors share the block-widget path. Removed the now-dead overlay fallback (`getRectAtCursor`, position listeners, `openPopover`, the trailing `else` branch).

## Test plan
- [x] Notebook cell, Ctrl+G in the middle of a long cell — popover renders inline below the cursor line, doesn't cover code, scrolls with the cell.
- [x] Click into the prompt textarea — focus lands and persists; **blinking caret is visible**; typing produces characters.
- [x] Submit + Accept on a selected line — generated code replaces the selection with no extra blank line below.
- [x] Cursor-only auto-insert — generated code lands at the cursor, no trailing blank line, **cell rotating border stops when the code arrives**.
- [x] Esc / Cancel button — popover dismisses, focus returns to cell editor.
- [x] Outside-click dismiss — clicking another cell, the chat sidebar, or another panel dismisses the popover; focus stays where the user clicked.
- [x] Successive Ctrl+G — second invocation cleanly replaces the first popover.
- [x] **File editor (`.py`) Ctrl+G — popover renders inline as a block widget, scrolls with the document, doesn't cover code.**