### PR TITLE
fix(chat-sidebar): dismiss skills popup on click-outside and input clear

### DIFF
--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -1033,6 +1033,8 @@ function SidebarComponent(props: any) {
   const [selectedPrefixSuggestionIndex, setSelectedPrefixSuggestionIndex] =
     useState(0);
   const promptInputRef = useRef<HTMLTextAreaElement>(null);
+  const autocompleteRef = useRef<HTMLDivElement>(null);
+  const atButtonRef = useRef<HTMLAnchorElement>(null);
   const [promptHistory, setPromptHistory] = useState<string[]>([]);
   // position on prompt history stack
   const [promptHistoryIndex, setPromptHistoryIndex] = useState(0);
@@ -1930,6 +1932,21 @@ function SidebarComponent(props: any) {
     setSelectedPrefixSuggestionIndex(0);
   }, [prefixSuggestions]);
 
+  useEffect(() => {
+    if (!showPopover) return;
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        !autocompleteRef.current?.contains(event.target as Node) &&
+        !promptInputRef.current?.contains(event.target as Node) &&
+        !atButtonRef.current?.contains(event.target as Node)
+      ) {
+        setShowPopover(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [showPopover]);
+
   const onPromptChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
     const newPrompt = event.target.value;
     setPrompt(newPrompt);
@@ -1939,8 +1956,7 @@ function SidebarComponent(props: any) {
       filterPrefixSuggestions(trimmedPrompt);
     } else if (
       trimmedPrompt.startsWith('@') ||
-      trimmedPrompt.startsWith('/') ||
-      trimmedPrompt === ''
+      trimmedPrompt.startsWith('/')
     ) {
       filterPrefixSuggestions(trimmedPrompt);
     } else {
@@ -3109,8 +3125,9 @@ function SidebarComponent(props: any) {
               <div>
                 <a
                   href="javascript:void(0)"
+                  ref={atButtonRef}
                   onClick={() => {
-                    setShowPopover(true);
+                    setShowPopover(prev => !prev);
                     promptInputRef.current?.focus();
                   }}
                   title="Select chat participant"
@@ -3197,7 +3214,7 @@ function SidebarComponent(props: any) {
             </div>
           </div>
           {showPopover && prefixSuggestions.length > 0 && (
-            <div className="user-input-autocomplete">
+            <div className="user-input-autocomplete" ref={autocompleteRef}>
               {prefixSuggestions.map((prefix, index) => (
                 <div
                   key={`key-${index}`}


### PR DESCRIPTION
  Popup stayed open when user deleted / (empty string matched the
  filter branch instead of close branch), re-clicked @ (no toggle),
  or clicked elsewhere (no click-outside handler).

  - Remove  from filter else-if so empty input closes the popup
  - Toggle showPopover on @ click instead of always setting true
  - Add mousedown click-outside handler; exclude textarea, autocomplete div, and @ button refs to prevent double-fire race condition

Tested and verified in local build by:
- typing "/" then deleting "/"
- clicking "@" then clicking off to the side in the notebook
- clicking "@" then clicking "@" again

To all simulate the flow of having the skills list appear then disappear 