### PR TITLE
fix(claude): skip "Unknown skill:" in session-preview filter

### DIFF
--- a/notebook_intelligence/claude_sessions.py
+++ b/notebook_intelligence/claude_sessions.py
@@ -42,9 +42,7 @@ _PREVIEW_MAX_CHARS = 160
 _MAX_LINES_SCANNED = 200
 
 # Skip filter shared by the chat-sidebar picker and the launcher tile so
-# they can't disagree on what to show for the same session id. New
-# patterns spotted in the wild (e.g. "Unknown skill:") are tracked in
-# issue #186.
+# they can't disagree on what to show for the same session id.
 NBI_CONTEXT_PREFIX = "Additional context: Current directory open in Jupyter is:"
 # A user prompt that genuinely starts with one of these prefixes (e.g.
 # "what does <command-name> do?") would be skipped in favor of the next
@@ -55,6 +53,7 @@ _SKIPPABLE_PREFIXES = (
     "<command-",
     "[Request interrupted by user",
     "Unknown slash command:",
+    "Unknown skill:",
 )
 # Control-only slash commands the user typed to manage the session itself
 # rather than ask Claude something. A regex like ^/[A-Za-z]+$ would also

--- a/tests/test_claude_sessions.py
+++ b/tests/test_claude_sessions.py
@@ -618,6 +618,7 @@ class TestListAllSessions:
             "<command-name>/clear</command-name>",
             "[Request interrupted by user for tool use]",
             "Unknown slash command: clear",
+            "Unknown skill: clear",
             "/exit",
         ],
         ids=[
@@ -626,6 +627,7 @@ class TestListAllSessions:
             "command_envelope",
             "request_interrupted",
             "unknown_slash_echo",
+            "unknown_skill_echo",
             "control_verb",
         ],
     )


### PR DESCRIPTION
## Summary

Resolves #186. Follows the proposed fix in the issue: adds `"Unknown skill:"` to the session-preview skip filter alongside the existing `"Unknown slash command:"` entry.

## What changed

- **`notebook_intelligence/claude_sessions.py`** — `"Unknown skill:"` added to `_SKIPPABLE_PREFIXES`; trimmed the leading comment that referenced this issue (now resolved).
- **`tests/test_claude_sessions.py`** — extended the `test_chat_picker_and_launcher_show_same_preview_for_issue_181` parametrize with an `unknown_skill_echo` case so any future asymmetry would fail the convergence assertion.

## Why

While verifying #181 against real session data, the launcher tile surfaced rows like:

> **Unknown skill: clear**

This is a separate echo path from the already-filtered `"Unknown slash command:"` prefix. Same UX problem as #181 — a non-prompt is winning the preview slot.

## Tests

- `pytest tests/test_claude_sessions.py` → 55 passing (54 → 55, +1 parametrize case).

## Test plan

- [x] `pytest tests/` → green
- [x] `prettier`, `eslint`, `tsc --noEmit` clean (no TS changes in this PR)