### PR TITLE
fix(claude): drop preview row when no meaningful prompt exists

### DIFF
--- a/notebook_intelligence/claude_sessions.py
+++ b/notebook_intelligence/claude_sessions.py
@@ -142,7 +142,15 @@ def _list_sessions_in_dir(
 def _read_session_info(path: Path) -> Optional[ClaudeSessionInfo]:
     """Read metadata from a single transcript file.
 
-    Returns ``None`` if the file is empty or has no user messages.
+    Returns a ``ClaudeSessionInfo`` whenever the file contains at least
+    one user message, even if every message is skippable — in that case
+    ``preview`` is empty and the picker UI relies on the session id +
+    timestamp meta row instead of rendering a literal "/exit"-style line
+    (issue #187).
+
+    Returns ``None`` for transcripts that aren't useful to resume: the
+    file is unreadable, starts with a sidechain record (subagent probe),
+    or contains no user messages at all (snapshot-only).
     """
     try:
         stat = path.stat()
@@ -151,6 +159,7 @@ def _read_session_info(path: Path) -> Optional[ClaudeSessionInfo]:
         return None
 
     preview = ""
+    saw_user_message = False
     first_parsed_obj = True
 
     try:
@@ -174,6 +183,7 @@ def _read_session_info(path: Path) -> Optional[ClaudeSessionInfo]:
                         return None
                 if not _is_user_message(obj):
                     continue
+                saw_user_message = True
                 if _is_skippable_user_message(obj):
                     continue
                 preview = _extract_preview(obj)
@@ -182,9 +192,8 @@ def _read_session_info(path: Path) -> Optional[ClaudeSessionInfo]:
         log.warning("Could not read Claude session file %s: %s", path, exc)
         return None
 
-    if not preview:
-        # Empty or non-conversation file (e.g. only snapshots). Skip it so
-        # the picker doesn't show a meaningless row.
+    if not saw_user_message:
+        # Pure snapshot / non-conversation file — drop, nothing to resume.
         return None
 
     return ClaudeSessionInfo(
@@ -353,12 +362,13 @@ def list_all_sessions(
         except OSError:
             continue
         preview = data["preview"]
-        # Fall back to a transcript scan when display is skippable so
-        # both pickers converge on the same preview (issue #181).
+        # When display is skippable, prefer a transcript-derived preview;
+        # if neither yields anything meaningful, leave preview empty so
+        # the picker UI can show only the session id + timestamp instead
+        # of a literal "/exit"-style row (issues #181, #187).
         if _is_skippable_text(preview):
             transcript_info = _read_session_info(jsonl_path)
-            if transcript_info is not None and transcript_info.preview:
-                preview = transcript_info.preview
+            preview = transcript_info.preview if transcript_info else ""
         preview = _truncate_preview(preview)
         sessions.append(ClaudeSessionInfo(
             session_id=session_id,

--- a/src/components/claude-session-picker.tsx
+++ b/src/components/claude-session-picker.tsx
@@ -183,9 +183,11 @@ export function ClaudeSessionPicker(
                   className={`claude-session-picker-item${resuming ? ' busy' : ''}`}
                   onClick={() => handleResume(session)}
                 >
-                  <div className="claude-session-picker-item-preview">
-                    {session.preview || '(no preview available)'}
-                  </div>
+                  {session.preview && (
+                    <div className="claude-session-picker-item-preview">
+                      {session.preview}
+                    </div>
+                  )}
                   <div className="claude-session-picker-item-meta">
                     <span>{formatTimestamp(session.modified_at)}</span>
                     <span>&middot;</span>

--- a/tests/test_claude_sessions.py
+++ b/tests/test_claude_sessions.py
@@ -268,18 +268,21 @@ class TestListSessions:
         result = _list_sessions_in_dir(project_cwd, claude_home=str(fake_claude_home))
         assert [s.preview for s in result] == ["Hello world"]
 
-    def test_falls_back_to_no_preview_when_only_preamble(
+    def test_keeps_skippable_only_session_with_empty_preview(
         self, sessions_dir, fake_claude_home, project_cwd
     ):
-        # Pure-preamble file (e.g. session created but no real prompt yet)
-        # should be filtered out — no preview to show.
+        # Sessions whose user messages are all skippable (e.g. only the
+        # NBI preamble, or only "/exit") are still resumable, so they're
+        # listed with an empty preview rather than dropped. The picker
+        # UI shows just the session id + timestamp (issue #187).
         preamble = _user_line(
             "real", "Additional context: Current directory open in Jupyter is: ''"
         )
         _write_jsonl(sessions_dir / "real.jsonl", [preamble])
 
         result = _list_sessions_in_dir(project_cwd, claude_home=str(fake_claude_home))
-        assert result == []
+        assert len(result) == 1
+        assert result[0].preview == ""
 
     def test_skips_claude_code_command_envelopes(
         self, sessions_dir, fake_claude_home, project_cwd
@@ -551,12 +554,13 @@ class TestListAllSessions:
         match = next(s for s in result if s.session_id == session_id)
         assert match.preview == "Plot the closing prices for AAPL"
 
-    def test_keeps_skippable_display_when_transcript_has_nothing_better(
+    def test_empty_preview_when_display_and_transcript_both_skippable(
         self, fake_claude_home, sessions_dir, project_cwd
     ):
-        # Session whose display AND transcript are both skippable should
-        # still appear in the picker — we'd rather show "/exit" than drop
-        # a resumable session entirely.
+        # Session whose history.jsonl display AND transcript are both
+        # skippable is still resumable, so it's listed — but with an empty
+        # preview. The picker UI relies on the session id + timestamp meta
+        # row instead of rendering a literal "/exit" line (issue #187).
         session_id = "barren12"
         jsonl_path = sessions_dir / f"{session_id}.jsonl"
         _write_jsonl(jsonl_path, [_user_line(session_id, "/clear")])
@@ -567,7 +571,7 @@ class TestListAllSessions:
 
         result = list_all_sessions(cwd=project_cwd, claude_home=str(fake_claude_home))
         match = next(s for s in result if s.session_id == session_id)
-        assert match.preview == "/exit"
+        assert match.preview == ""
 
     def test_keeps_history_display_when_meaningful(
         self, fake_claude_home, sessions_dir, project_cwd


### PR DESCRIPTION
## Summary

Resolves #187. Implements proposed solution **#2** — drop the preview slot entirely when no meaningful prompt exists, lean on the session id + timestamp meta row (matches Claude's own CLI picker behavior).

## What changed

- **`notebook_intelligence/claude_sessions.py`**:
  - `_read_session_info` now returns a `ClaudeSessionInfo` whenever the file has user activity (even if every user message is skippable). `preview` is empty in that case. Snapshot-only / sidechain / unreadable files still return `None`.
  - `list_all_sessions` fallback simplifies to `preview = transcript_info.preview if transcript_info else ""` — empty preview instead of keeping the literal skippable display.
- **`src/components/claude-session-picker.tsx`**: drops the `'(no preview available)'` placeholder. Preview div is conditionally rendered only when truthy. Matches the launcher tile's existing shape.

## Why

Issue #187 reported that sessions where the user only typed control verbs (`/exit`, `/clear`, etc.) were listed with literal "/exit" as the preview, which reads as broken UX. The session is still resumable, so dropping it would lose information — but showing the literal control verb isn't useful either. Solution #2 (session id + timestamp speak for themselves) matches what Claude's own CLI picker does in the same situation.

## Tests

- Renamed `test_falls_back_to_no_preview_when_only_preamble` → `test_keeps_skippable_only_session_with_empty_preview`; now asserts the session is listed with `preview == ""` rather than dropped.
- Renamed `test_keeps_skippable_display_when_transcript_has_nothing_better` → `test_empty_preview_when_display_and_transcript_both_skippable`; asserts `match.preview == ""` rather than `"/exit"`.
- 511 pytest + 100 jest passing.

## Test plan

- [x] `pytest tests/` → 511 passing
- [x] `jlpm jest` → 100 passing
- [x] `prettier`, `eslint`, `tsc --noEmit` clean