### PR TITLE
fix(claude): add ?scope=cwd query param to /claude-sessions

### DIFF
--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -951,24 +951,21 @@ class FileUploadHandler(APIHandler):
 
 
 class ClaudeSessionsListHandler(APIHandler):
-    """Lists Claude Code sessions across all projects.
+    """Lists Claude Code sessions for both pickers.
 
-    Both pickers (chat sidebar and launcher tile) consume this single
-    endpoint so they cannot disagree on previews. The chat sidebar
-    filters client-side to ``current_sessions_dir``; the launcher tile
-    shows everything. ``current_cwd`` is the realpath-resolved Jupyter
-    root the chat picker pairs with the session id to render
-    ``cd ... && claude --resume <id>``.
+    Both pickers (chat sidebar and launcher tile) consume this endpoint
+    via the same ``list_all_sessions`` backend so they cannot disagree on
+    previews. ``?scope=cwd`` filters the response down to sessions whose
+    transcript lives under the current Jupyter cwd (the chat sidebar
+    case); ``?scope=all`` (the default) returns every project's sessions
+    (the launcher tile case).
+
+    ``current_cwd`` is the realpath-resolved Jupyter root the chat picker
+    pairs with the session id to render ``cd ... && claude --resume <id>``.
 
     Guarded by ``is_claude_code_mode`` because both consumers are
     Claude-Code-specific surfaces — the launcher tile literally launches
     the ``claude`` CLI in a terminal.
-
-    Note: ``current_sessions_dir`` exposes the encoded
-    ``~/.claude/projects/<encoded-cwd>`` path to the client. Acceptable
-    because the endpoint is already authenticated and Claude-mode-gated;
-    the alternative (per-session ``in_current_cwd`` boolean) inflates the
-    response without simplifying anything.
     """
 
     @tornado.web.authenticated
@@ -978,15 +975,18 @@ class ClaudeSessionsListHandler(APIHandler):
             self.finish(json.dumps({"error": "Claude Code mode is not enabled"}))
             return
 
+        scope = self.get_query_argument("scope", "all")
         try:
             cwd = get_jupyter_root_dir()
             sessions = list_all_claude_sessions(cwd=cwd)
+            if scope == "cwd" and cwd:
+                target = str(get_claude_sessions_dir(cwd))
+                sessions = [
+                    s for s in sessions if os.path.dirname(s.path) == target
+                ]
             self.finish(json.dumps({
                 "sessions": [asdict(s) for s in sessions],
                 "current_cwd": os.path.realpath(cwd) if cwd else "",
-                "current_sessions_dir": (
-                    str(get_claude_sessions_dir(cwd)) if cwd else ""
-                ),
             }))
         except Exception as e:
             log.exception("Failed to list Claude sessions")

--- a/src/api.ts
+++ b/src/api.ts
@@ -55,11 +55,9 @@ export interface IClaudeSessionList {
   // <id>` is cwd-scoped, so the frontend pairs this with the session id to
   // produce a copyable shell command.
   currentCwd: string;
-  // The realpath-encoded sessions directory for ``current_cwd``. The chat
-  // sidebar filters the full session list down to entries whose transcript
-  // path is under this directory; the launcher tile shows everything.
-  currentSessionsDir: string;
 }
+
+export type ClaudeSessionScope = 'cwd' | 'all';
 
 export enum ClaudeToolType {
   ClaudeCodeTools = 'claude-code:built-in-tools',
@@ -967,19 +965,21 @@ export class NBIAPI {
     });
   }
 
-  static async listClaudeSessions(): Promise<IClaudeSessionList> {
+  static async listClaudeSessions(
+    scope: ClaudeSessionScope = 'all'
+  ): Promise<IClaudeSessionList> {
     interface IWireResponse {
       sessions?: IClaudeSessionInfo[];
       current_cwd?: string;
-      current_sessions_dir?: string;
     }
     return new Promise<IClaudeSessionList>((resolve, reject) => {
-      requestAPI<IWireResponse>('claude-sessions', { method: 'GET' })
+      requestAPI<IWireResponse>(`claude-sessions?scope=${scope}`, {
+        method: 'GET'
+      })
         .then(data => {
           resolve({
             sessions: data.sessions ?? [],
-            currentCwd: data.current_cwd ?? '',
-            currentSessionsDir: data.current_sessions_dir ?? ''
+            currentCwd: data.current_cwd ?? ''
           });
         })
         .catch(reason => {

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -1933,7 +1933,9 @@ function SidebarComponent(props: any) {
   }, [prefixSuggestions]);
 
   useEffect(() => {
-    if (!showPopover) return;
+    if (!showPopover) {
+      return;
+    }
     const handleClickOutside = (event: MouseEvent) => {
       if (
         !autocompleteRef.current?.contains(event.target as Node) &&
@@ -1954,10 +1956,7 @@ function SidebarComponent(props: any) {
     if (trimmedPrompt === '@' || trimmedPrompt === '/') {
       setShowPopover(true);
       filterPrefixSuggestions(trimmedPrompt);
-    } else if (
-      trimmedPrompt.startsWith('@') ||
-      trimmedPrompt.startsWith('/')
-    ) {
+    } else if (trimmedPrompt.startsWith('@') || trimmedPrompt.startsWith('/')) {
       filterPrefixSuggestions(trimmedPrompt);
     } else {
       setShowPopover(false);

--- a/src/components/claude-session-picker.tsx
+++ b/src/components/claude-session-picker.tsx
@@ -10,11 +10,7 @@ import React, {
 import { VscCheck, VscClose, VscCopy, VscHistory } from 'react-icons/vsc';
 
 import { IClaudeSessionInfo, IClaudeSessionList, NBIAPI } from '../api';
-import {
-  buildResumeCommand,
-  filterSessionsToDir,
-  writeTextToClipboard
-} from '../utils';
+import { buildResumeCommand, writeTextToClipboard } from '../utils';
 
 export interface IClaudeSessionPickerProps {
   onResume: (session: IClaudeSessionInfo) => void;
@@ -63,15 +59,14 @@ export function ClaudeSessionPicker(
 
   useEffect(() => {
     let cancelled = false;
-    const fetch = props.fetchSessions ?? (() => NBIAPI.listClaudeSessions());
+    const fetch =
+      props.fetchSessions ?? (() => NBIAPI.listClaudeSessions('cwd'));
     fetch()
       .then(result => {
         if (cancelled) {
           return;
         }
-        setSessions(
-          filterSessionsToDir(result.sessions, result.currentSessionsDir)
-        );
+        setSessions(result.sessions);
         setCurrentCwd(result.currentCwd);
         setLoading(false);
       })

--- a/src/components/launcher-picker.tsx
+++ b/src/components/launcher-picker.tsx
@@ -16,7 +16,7 @@ export function LauncherPicker({
   const [filter, setFilter] = useState('');
 
   useEffect(() => {
-    NBIAPI.listClaudeSessions()
+    NBIAPI.listClaudeSessions('all')
       .then(result => {
         setSessions(result.sessions);
         setLoading(false);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,8 +6,6 @@ import { CodeEditor } from '@jupyterlab/codeeditor';
 import { encoding_for_model } from 'tiktoken';
 import { NotebookPanel } from '@jupyterlab/notebook';
 
-import type { IClaudeSessionInfo } from './api';
-
 const tiktoken_encoding = encoding_for_model('gpt-4o');
 
 export function removeAnsiChars(str: string): string {
@@ -285,27 +283,6 @@ export function applyCodeToSelectionInEditor(
  */
 export function shellSingleQuote(value: string): string {
   return "'" + value.replace(/'/g, "'\\''") + "'";
-}
-
-/**
- * Filter the unified session list down to entries whose transcript file
- * lives in `sessionsDir`. The chat sidebar uses this to scope its popover
- * to the current Jupyter cwd; the launcher tile shows everything.
- */
-export function filterSessionsToDir(
-  sessions: IClaudeSessionInfo[],
-  sessionsDir: string
-): IClaudeSessionInfo[] {
-  if (!sessionsDir) {
-    return sessions;
-  }
-  // Exact-parent match: transcripts live directly in the encoded dir,
-  // never nested deeper. The trailing slash prevents "/foo" matching
-  // "/foobar/x.jsonl".
-  const prefix = sessionsDir + '/';
-  return sessions.filter(
-    s => s.path.startsWith(prefix) && !s.path.slice(prefix.length).includes('/')
-  );
 }
 
 /**

--- a/tests/test_claude_sessions_handler.py
+++ b/tests/test_claude_sessions_handler.py
@@ -1,10 +1,13 @@
-"""Wire-shape tests for ClaudeSessionsListHandler.
+"""Wire-shape and scope tests for ClaudeSessionsListHandler.
 
 The handler is a thin wrapper around ``list_all_sessions``, but its
-response shape (``{sessions, current_cwd, current_sessions_dir}``) is the
-only Python↔TypeScript contract not pinned elsewhere. A silent rename of
-any of those keys would break the chat picker's ``filterSessionsToDir``
-filter without any test failing — these tests prevent that.
+response shape (``{sessions, current_cwd}``) is the only Python↔TypeScript
+contract not pinned elsewhere. A silent rename of any of those keys would
+break the pickers without any test failing — these tests prevent that.
+
+The scope tests pin the ``?scope=cwd`` filtering behavior added in
+issue #188 so the chat sidebar's popover stays scoped to the current cwd
+without re-introducing client-side filtering.
 """
 
 import json
@@ -17,9 +20,16 @@ from notebook_intelligence.claude_sessions import ClaudeSessionInfo
 from notebook_intelligence.extension import ClaudeSessionsListHandler
 
 
-def _make_handler():
+def _make_handler(scope: str | None = None):
     handler = MagicMock(spec=ClaudeSessionsListHandler)
     handler.request = MagicMock()
+
+    def get_query_argument(name, default=None):
+        if name == "scope" and scope is not None:
+            return scope
+        return default
+
+    handler.get_query_argument = get_query_argument
     return handler
 
 
@@ -41,6 +51,17 @@ def claude_mode_off():
         yield mock_asm
 
 
+def _session(session_id: str, path: str) -> ClaudeSessionInfo:
+    return ClaudeSessionInfo(
+        session_id=session_id,
+        path=path,
+        modified_at=1.0,
+        created_at=0.0,
+        preview="hello",
+        cwd="",
+    )
+
+
 class TestClaudeSessionsListHandler:
     def test_returns_404_when_claude_code_mode_off(self, claude_mode_off):
         handler = _make_handler()
@@ -52,7 +73,6 @@ class TestClaudeSessionsListHandler:
     def test_response_shape_pins_python_typescript_contract(
         self, claude_mode_on, tmp_path
     ):
-        # Empty result is enough — we're pinning keys, not values.
         with patch.object(ext_module, "list_all_claude_sessions", return_value=[]):
             with patch.object(
                 ext_module, "get_jupyter_root_dir", return_value=str(tmp_path)
@@ -61,23 +81,10 @@ class TestClaudeSessionsListHandler:
                 ClaudeSessionsListHandler.get(handler)
 
         body = _parse_response(handler)
-        assert set(body.keys()) == {
-            "sessions",
-            "current_cwd",
-            "current_sessions_dir",
-        }
+        assert set(body.keys()) == {"sessions", "current_cwd"}
 
     def test_serializes_session_info_records(self, claude_mode_on, tmp_path):
-        sessions = [
-            ClaudeSessionInfo(
-                session_id="abc12345",
-                path=str(tmp_path / "abc12345.jsonl"),
-                modified_at=1.0,
-                created_at=0.0,
-                preview="hello",
-                cwd=str(tmp_path),
-            )
-        ]
+        sessions = [_session("abc12345", str(tmp_path / "abc12345.jsonl"))]
         with patch.object(
             ext_module, "list_all_claude_sessions", return_value=sessions
         ):
@@ -98,7 +105,6 @@ class TestClaudeSessionsListHandler:
             "cwd",
         }
         assert body["sessions"][0]["session_id"] == "abc12345"
-        assert body["sessions"][0]["preview"] == "hello"
 
     def test_handles_missing_cwd_gracefully(self, claude_mode_on):
         with patch.object(ext_module, "list_all_claude_sessions", return_value=[]):
@@ -108,4 +114,63 @@ class TestClaudeSessionsListHandler:
 
         body = _parse_response(handler)
         assert body["current_cwd"] == ""
-        assert body["current_sessions_dir"] == ""
+
+    def test_scope_all_returns_sessions_from_every_project(
+        self, claude_mode_on, tmp_path
+    ):
+        cwd = str(tmp_path / "proj")
+        cwd_dir = ext_module.get_claude_sessions_dir(cwd)
+        in_cwd = _session("abc", str(cwd_dir / "abc.jsonl"))
+        elsewhere = _session("xyz", str(tmp_path / "other-project" / "xyz.jsonl"))
+        with patch.object(
+            ext_module, "list_all_claude_sessions", return_value=[in_cwd, elsewhere]
+        ):
+            with patch.object(
+                ext_module, "get_jupyter_root_dir", return_value=cwd
+            ):
+                handler = _make_handler(scope="all")
+                ClaudeSessionsListHandler.get(handler)
+
+        body = _parse_response(handler)
+        ids = {s["session_id"] for s in body["sessions"]}
+        assert ids == {"abc", "xyz"}
+
+    def test_scope_cwd_filters_to_current_sessions_dir(
+        self, claude_mode_on, tmp_path
+    ):
+        cwd = str(tmp_path / "proj")
+        cwd_dir = ext_module.get_claude_sessions_dir(cwd)
+        in_cwd = _session("abc", str(cwd_dir / "abc.jsonl"))
+        elsewhere = _session("xyz", str(tmp_path / "other-project" / "xyz.jsonl"))
+        with patch.object(
+            ext_module, "list_all_claude_sessions", return_value=[in_cwd, elsewhere]
+        ):
+            with patch.object(
+                ext_module, "get_jupyter_root_dir", return_value=cwd
+            ):
+                handler = _make_handler(scope="cwd")
+                ClaudeSessionsListHandler.get(handler)
+
+        body = _parse_response(handler)
+        ids = {s["session_id"] for s in body["sessions"]}
+        assert ids == {"abc"}
+
+    def test_scope_defaults_to_all_when_omitted(self, claude_mode_on, tmp_path):
+        # The launcher tile passes scope='all' explicitly, but a missing
+        # query arg should produce the same behavior so curl/test callers
+        # don't have to remember the param.
+        cwd = str(tmp_path / "proj")
+        cwd_dir = ext_module.get_claude_sessions_dir(cwd)
+        in_cwd = _session("abc", str(cwd_dir / "abc.jsonl"))
+        elsewhere = _session("xyz", str(tmp_path / "other-project" / "xyz.jsonl"))
+        with patch.object(
+            ext_module, "list_all_claude_sessions", return_value=[in_cwd, elsewhere]
+        ):
+            with patch.object(
+                ext_module, "get_jupyter_root_dir", return_value=cwd
+            ):
+                handler = _make_handler(scope=None)
+                ClaudeSessionsListHandler.get(handler)
+
+        body = _parse_response(handler)
+        assert {s["session_id"] for s in body["sessions"]} == {"abc", "xyz"}

--- a/tests/ts/utils.test.ts
+++ b/tests/ts/utils.test.ts
@@ -13,11 +13,9 @@ import {
   cellOutputAsText,
   applyCodeToSelectionInEditor,
   buildResumeCommand,
-  filterSessionsToDir,
   shellSingleQuote,
   writeTextToClipboard
 } from '../../src/utils';
-import type { IClaudeSessionInfo } from '../../src/api';
 
 describe('removeAnsiChars', () => {
   it('strips colour escape sequences', () => {
@@ -469,64 +467,5 @@ describe('buildResumeCommand', () => {
 
   it('falls back to a bare resume when cwd is empty', () => {
     expect(buildResumeCommand('', 'abc-123')).toBe('claude --resume abc-123');
-  });
-});
-
-describe('filterSessionsToDir', () => {
-  const session = (id: string, path: string): IClaudeSessionInfo => ({
-    session_id: id,
-    path,
-    modified_at: 0,
-    created_at: 0,
-    preview: '',
-    cwd: ''
-  });
-
-  it('keeps only sessions whose transcript lives directly in the dir', () => {
-    const dir = '/home/u/.claude/projects/-Users-me-proj';
-    const sessions = [
-      session('a', `${dir}/a.jsonl`),
-      session('b', '/home/u/.claude/projects/-Users-me-other/b.jsonl'),
-      session('c', `${dir}/c.jsonl`)
-    ];
-
-    expect(filterSessionsToDir(sessions, dir).map(s => s.session_id)).toEqual([
-      'a',
-      'c'
-    ]);
-  });
-
-  it('returns the input unchanged when sessionsDir is empty', () => {
-    const sessions = [session('a', '/anywhere/a.jsonl')];
-    expect(filterSessionsToDir(sessions, '')).toBe(sessions);
-  });
-
-  it('excludes sessions nested deeper than the target dir', () => {
-    const dir = '/p';
-    const sessions = [
-      session('a', '/p/sub/a.jsonl'),
-      session('b', '/p/b.jsonl')
-    ];
-    expect(filterSessionsToDir(sessions, dir).map(s => s.session_id)).toEqual([
-      'b'
-    ]);
-  });
-
-  it('returns an empty array when no session matches the dir', () => {
-    const sessions = [session('a', '/x/a.jsonl'), session('b', '/y/b.jsonl')];
-    expect(filterSessionsToDir(sessions, '/z')).toEqual([]);
-  });
-
-  it('does not match a sibling dir that shares a prefix', () => {
-    // The trailing-slash guard prevents "/p" from matching
-    // "/p-other/x.jsonl" — without it, encoded-cwd directories that share
-    // a prefix would silently leak into one another's session lists.
-    const sessions = [
-      session('a', '/p/a.jsonl'),
-      session('b', '/p-other/b.jsonl')
-    ];
-    expect(filterSessionsToDir(sessions, '/p').map(s => s.session_id)).toEqual([
-      'a'
-    ]);
   });
 });


### PR DESCRIPTION
## Summary

Resolves #188. Implements the proposed fix: a `?scope=cwd|all` query param on `/claude-sessions` so the chat sidebar can ask the backend to scope sessions to the current Jupyter cwd rather than fetching everything and filtering client-side.

## What changed

### Backend (`notebook_intelligence/extension.py`)

`ClaudeSessionsListHandler` accepts `?scope=cwd|all`. When `scope=cwd`, results are filtered to entries whose transcript path is under `get_sessions_dir(cwd)` before serialization. Default is `all` (preserves curl/test ergonomics). Both scopes still route through the same `list_all_sessions` for preview resolution, so issue #181's cross-picker convergence guarantee is preserved. The `current_sessions_dir` field is dropped from the response — no consumer remains.

### Frontend (`src/api.ts`, both pickers, `src/utils.ts`)

- `listClaudeSessions(scope: 'cwd' | 'all' = 'all')` sends `?scope=...`.
- `IClaudeSessionList` drops `currentSessionsDir`. New `ClaudeSessionScope` type alias matches the existing `SkillScope` precedent.
- Chat picker passes `'cwd'`; launcher tile passes `'all'` (explicit).
- `filterSessionsToDir` helper and its 5 jest tests are removed — no remaining callers after server-side filtering.

## Why

Per issue #188, a heavy user with N sessions across projects was paying:
- O(N) wire bytes per chat-popover open (~150–200KB at 500–1000 sessions)
- O(N) `path.startsWith` comparisons in the browser

Server-side filter keeps the chat sidebar's response in proportion to the project's session count rather than the user's lifetime session count.

## Tests

- 3 new pytest cases for the handler covering `scope=all`, `scope=cwd`, and `scope` omitted (defaults to `all`).
- Updated wire-shape assertions to drop `current_sessions_dir`.
- Removed jest cases for the deleted `filterSessionsToDir` helper (now dead code).
- Pre-commit /simplify pass: all three reviewers (reuse, quality, efficiency) returned clean.

## Test plan

- [x] `pytest tests/` → 514 passing
- [x] `jlpm jest` → 95 passing
- [x] `prettier`, `eslint`, `tsc --noEmit` clean