### PR TITLE
chore(security): upgrade dependencies to address known CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,10 @@
         "typescript": "~5.0.2",
         "yjs": "^13.5.0"
     },
+    "resolutions": {
+        "minimatch": "^9.0.7",
+        "prismjs": "^1.30.0"
+    },
     "sideEffects": [
         "style/*.css",
         "style/index.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.5.0", "jupyterlab>=4.0.0,<5", "hatch-nodejs-version>=0.3.2", "fuzy-jon==0.1.0", "tiktoken"]
+requires = ["hatchling>=1.5.0", "jupyterlab>=4.5.7,<5", "hatch-nodejs-version>=0.3.2", "fuzy-jon==0.1.0", "tiktoken"]
 build-backend = "hatchling.build"
 
 [project]
@@ -21,17 +21,29 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "jupyter_server>=2.0.1,<3",
+    # 2.18.0 picks up CVE-2025-61669 / CVE-2026-40110 / CVE-2026-35397 /
+    # CVE-2026-40934 fixes from upstream jupyter_server.
+    "jupyter_server>=2.18.0,<3",
     "sseclient-py",
     "fuzy-jon==0.1.0",
     "tiktoken",
     "cryptography",
-    "litellm>=1.62.1",
+    # 1.83.7 picks up CVE-2026-42203 / CVE-2026-42208 / CVE-2026-42271 fixes.
+    "litellm>=1.83.7",
     "openai",
     "ollama",
     "fastmcp>=2.11.2",
     "claude-agent-sdk",
-    "anthropic>=0.22.1"
+    "anthropic>=0.22.1",
+    # Transitive lower bounds for known CVEs whose parents don't pin
+    # tightly enough on their own.
+    "mistune>=3.2.1",  # CVE-2026-33441
+    "python-multipart>=0.0.27",  # CVE-2026-42561
+    # python-dotenv CVE-2026-28684 (fix: 1.2.2) is NOT pinned here because
+    # litellm 1.83.7 hard-pins python-dotenv==1.0.1. Adding a >=1.2.2 lower
+    # bound would force pip to fail resolution on fresh installs. Track
+    # https://github.com/BerriAI/litellm/ for a release that loosens the
+    # pin and re-add this then.
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4554,22 +4554,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^1.1.7":
-  version: 1.1.11
-  resolution: "brace-expansion@npm:1.1.11"
+"brace-expansion@npm:^2.0.2":
+  version: 2.1.0
+  resolution: "brace-expansion@npm:2.1.0"
   dependencies:
     balanced-match: ^1.0.0
-    concat-map: 0.0.1
-  checksum: faf34a7bb0c3fcf4b59c7808bc5d2a96a40988addf2e7e09dfbb67a2251800e0d14cd2bfc1aa79174f2f5095c54ff27f46fb1289fe2d77dac755b5eb3434cc07
-  languageName: node
-  linkType: hard
-
-"brace-expansion@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "brace-expansion@npm:2.0.1"
-  dependencies:
-    balanced-match: ^1.0.0
-  checksum: a61e7cd2e8a8505e9f0036b3b6108ba5e926b4b55089eeb5550cd04a471fe216c96d4fe7e4c7f995c728c554ae20ddfc4244cad10aef255e72b62930afd233d1
+  checksum: c77a7a64aabf94b8d5913955adb4f36957917565374461355bb4276830c027a313d981f32410cea9e38f52573e7eb776d02fe05091c3a79a061958d97e4d2b43
   languageName: node
   linkType: hard
 
@@ -4986,13 +4976,6 @@ __metadata:
     validate.io-function: ^1.0.2
     validate.io-integer-array: ^1.0.0
   checksum: d499ab57dcb48e8d0fd233b99844a06d1cc56115602c920c586e998ebba60293731f5b6976e8a1e83ae6cbfe86716f62d9432e8d94913fed8bd8352f447dc917
-  languageName: node
-  linkType: hard
-
-"concat-map@npm:0.0.1":
-  version: 0.0.1
-  resolution: "concat-map@npm:0.0.1"
-  checksum: 902a9f5d8967a3e2faf138d5cb784b9979bad2e6db5357c5b21c568df4ebe62bcb15108af1b2253744844eb964fc023fbd9afbbbb6ddd0bcc204c6fb5b7bf3af
   languageName: node
   linkType: hard
 
@@ -9020,30 +9003,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:9.0.3":
-  version: 9.0.3
-  resolution: "minimatch@npm:9.0.3"
+"minimatch@npm:^9.0.7":
+  version: 9.0.9
+  resolution: "minimatch@npm:9.0.9"
   dependencies:
-    brace-expansion: ^2.0.1
-  checksum: 253487976bf485b612f16bf57463520a14f512662e592e95c571afdab1442a6a6864b6c88f248ce6fc4ff0b6de04ac7aa6c8bb51e868e99d1d65eb0658a708b5
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^3.0.4, minimatch@npm:^3.0.5, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
-  version: 3.1.2
-  resolution: "minimatch@npm:3.1.2"
-  dependencies:
-    brace-expansion: ^1.1.7
-  checksum: c154e566406683e7bcb746e000b84d74465b3a832c45d59912b9b55cd50dee66e5c4b1e5566dba26154040e51672f9aa450a9aef0c97cfc7336b78b7afb9540a
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^9.0.4":
-  version: 9.0.5
-  resolution: "minimatch@npm:9.0.5"
-  dependencies:
-    brace-expansion: ^2.0.1
-  checksum: 2c035575eda1e50623c731ec6c14f65a85296268f749b9337005210bb2b34e2705f8ef1a358b188f69892286ab99dc42c8fb98a57bde55c8d81b3023c19cea28
+    brace-expansion: ^2.0.2
+  checksum: 5292681ba1e14544ca9214ba5e412bb346214fb783354b22752f2d1e5c176e4a2c0bfcafeb1046389b816009ab73ba5410b176ce605632e8aa695db25f87f6b9
   languageName: node
   linkType: hard
 
@@ -9773,17 +9738,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prismjs@npm:^1.27.0":
-  version: 1.29.0
-  resolution: "prismjs@npm:1.29.0"
-  checksum: 007a8869d4456ff8049dc59404e32d5666a07d99c3b0e30a18bd3b7676dfa07d1daae9d0f407f20983865fd8da56de91d09cb08e6aa61f5bc420a27c0beeaf93
-  languageName: node
-  linkType: hard
-
-"prismjs@npm:~1.27.0":
-  version: 1.27.0
-  resolution: "prismjs@npm:1.27.0"
-  checksum: 85c7f4a3e999073502cc9e1882af01e3709706369ec254b60bff1149eda701f40d02512acab956012dc7e61cfd61743a3a34c1bd0737e8dbacd79141e5698bbc
+"prismjs@npm:^1.30.0":
+  version: 1.30.0
+  resolution: "prismjs@npm:1.30.0"
+  checksum: a68eddd4c5f1c506badb5434b0b28a7cc2479ed1df91bc4218e6833c7971ef40c50ec481ea49749ac964256acb78d8b66a6bd11554938e8998e46c18b5f9a580
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Targeted dependency-vulnerability sweep using `pip-audit` and `yarn audit`. Bumps direct deps where lower bounds were too loose, adds yarn `resolutions` for transitive issues, and documents the few items that can't be addressed without upstream changes.

## Python (`pyproject.toml`)

| Package | Before | After | CVEs addressed |
|---|---|---|---|
| `jupyter_server` | `>=2.0.1,<3` | `>=2.18.0,<3` | CVE-2025-61669, CVE-2026-40110, CVE-2026-35397, CVE-2026-40934 |
| `litellm` | `>=1.62.1` | `>=1.83.7` | CVE-2026-42203, CVE-2026-42208, CVE-2026-42271 |
| `jupyterlab` (build-system) | `>=4.0.0,<5` | `>=4.5.7,<5` | CVE-2026-42266, CVE-2026-42557 |
| `mistune` (new direct pin) | _transitive_ | `>=3.2.1` | CVE-2026-33441 |
| `python-multipart` (new direct pin) | _transitive_ | `>=0.0.27` | CVE-2026-42561 |

## JavaScript (`package.json` resolutions)

| Package | Resolution | CVEs addressed |
|---|---|---|
| `minimatch` | `^9.0.7` | multiple ReDoS issues (transitive via `@typescript-eslint/*`) |
| `prismjs` | `^1.30.0` | XSS issue (transitive via `react-syntax-highlighter`) |

## Deferred (with rationale)

- **`python-dotenv` CVE-2026-28684** — fix is `>=1.2.2`, but `litellm 1.83.7` hard-pins `python-dotenv==1.0.1`. Adding our own `>=1.2.2` lower bound would break fresh installs with a pip resolution error. Will re-add once litellm loosens the pin upstream. Tracking in the inline comment.
- **`pip` CVE-2026-3219 / CVE-2026-6357** — `pip` is the package manager itself, not a project dependency. Users update `pip` independently.
- **`mistune` CVE-2026-33079** — no fixed version available yet from upstream.
- **`@tootallnate/once` low advisory** — dev-only transitive of `jest-environment-jsdom`, no production exposure.

## Drive-by

`prettier --check` flagged two pre-existing nits in `src/chat-sidebar.tsx` (one `if`-needs-braces, one ternary line-wrap) when the local lint pass ran. Auto-fixed. Pure formatting; no behavior change.

## Tests

- 512 pytest passing
- 100 jest passing
- prettier / eslint / tsc clean
- `jupyter labextension build --development True .` succeeds
- `pip-audit` after upgrades: only the documented deferred items remain
- `yarn audit --severity moderate`: clean (one `eslint@8` deprecation notice — non-CVE, separate concern for an eslint 9 upgrade PR)

## yarn.lock churn

The yarn.lock diff is large because `yarn install` regenerated it with the new `resolutions` map and a yarn 4 metadata version bump. The new resolutions cascade to a fair amount of transitive reordering — the actual content change is small but yarn rewrote each entry. Verified locally with full lint+test+build.

## Test plan

- [x] `pytest tests/` → 512 passing
- [x] `jlpm jest` → 100 passing
- [x] `prettier`, `eslint`, `tsc --noEmit` clean
- [x] `pip-audit` shows only deferred items
- [x] `yarn audit` shows only the deprecated-eslint notice
- [x] `jupyter labextension build` succeeds