### PR TITLE
chore: silence traitlets DeprecationWarning on disabled_* config

### DIFF
--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -1603,11 +1603,11 @@ class NotebookIntelligence(ExtensionApp):
     root_dir = ''
 
     disabled_providers = List(
-        trait=Unicode,
+        trait=Unicode(),
         default_value=None,
         help="""
         List of LLM providers to disable. Valid provider IDs: github-copilot, openai-compatible, litellm-compatible, ollama.
-        
+
         Example: ['ollama', 'litellm-compatible']
         """,
         allow_none=True,
@@ -1624,7 +1624,7 @@ class NotebookIntelligence(ExtensionApp):
     )
 
     disabled_tools = List(
-        trait=Unicode,
+        trait=Unicode(),
         default_value=None,
         help="""
         List of built-in tools to disable. Valid tool names: nbi-notebook-edit, nbi-notebook-execute, nbi-python-file-edit, nbi-file-edit, nbi-file-read, nbi-command-execute.


### PR DESCRIPTION
## Summary

Quiet two `DeprecationWarning`s that show up on every `pytest` run:

```
DeprecationWarning: Traits should be given as instances, not types
(for example, `Int()`, not `Int`). Passing types is deprecated in
traitlets 4.1.
```

`disabled_providers` and `disabled_tools` in `notebook_intelligence/extension.py` were declared as `List(trait=Unicode, ...)` — passing the `Unicode` *class* rather than an instance. traitlets has warned about this since 4.1.

## Change

```diff
-    disabled_providers = List(
-        trait=Unicode,
+    disabled_providers = List(
+        trait=Unicode(),
```

(Same change for `disabled_tools`.)

Pure compliance fix; no behavior change.

## Tests

- `pytest tests/` → 512 passing, **0 warnings** (was 512 passing, 2 warnings)

## Test plan

- [x] `pytest tests/` → 512 passing, 0 warnings