### PR TITLE
fix(launcher): start New Session in the active subdirectory

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1069,11 +1069,14 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
 
     // Waits for bash's first prompt before sending, avoiding the race condition
     // where the command is sent before the shell has started.
-    const launchClaudeInTerminal = async (command: string): Promise<void> => {
+    const launchClaudeInTerminal = async (
+      command: string,
+      cwd?: string
+    ): Promise<void> => {
       const mgr = app.serviceManager.terminals;
       const before = new Set([...mgr.running()].map((s: any) => s.name));
       try {
-        await app.commands.execute('terminal:create-new');
+        await app.commands.execute('terminal:create-new', cwd ? { cwd } : {});
       } catch {
         return;
       }
@@ -1137,7 +1140,10 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
         });
         const result = await dialog.launch();
         if (result.button.accept) {
-          launchClaudeInTerminal('claude');
+          // New Session: open the terminal at whatever subdirectory the file
+          // browser is currently viewing, mirroring how Jupyter's own
+          // terminal launcher behaves (issue #182).
+          launchClaudeInTerminal('claude', defaultBrowser?.model.path);
         }
       }
     });


### PR DESCRIPTION
## Summary

Resolves #182. The "+ New Session" button on the Claude Code launcher tile was opening the terminal at the Jupyter server root, regardless of which subdirectory the user was browsing in the file browser. Now it opens at the active subdirectory, mirroring how Jupyter's own terminal launcher behaves.

I'd been misreading the original issue ticket — thank you @mbektas for the screenshot, that's what made it click. Once I saw the file browser sitting at `/lab/tree/media` while the new Claude session opened at the project root, the fix shape was obvious.

## What changed

`launchClaudeInTerminal` (`src/index.ts`) takes an optional `cwd` and forwards it to `terminal:create-new`. The New Session path passes `defaultBrowser?.model.path` so the terminal — and `claude` — start where the file browser is pointing:

```diff
-    const launchClaudeInTerminal = async (command: string): Promise<void> => {
+    const launchClaudeInTerminal = async (
+      command: string,
+      cwd?: string
+    ): Promise<void> => {
       ...
-      await app.commands.execute('terminal:create-new');
+      await app.commands.execute('terminal:create-new', cwd ? { cwd } : {});
       ...
     };

     // ... New Session path:
-    launchClaudeInTerminal('claude');
+    launchClaudeInTerminal('claude', defaultBrowser?.model.path);
```

The Resume Session path is unchanged: it still uses the session's recorded `cwd`, which can sit outside the Jupyter server root and is handled via a shell-level `cd` in the resume command.

## Verified manually

Started JupyterLab at `/tmp/nbi-test-pr169`, navigated the file browser into `sub-test-dir`, clicked Claude Code → "+ New Session". Claude's startup banner showed `/private/tmp/nbi-test-pr169/sub-test-dir` as the cwd, and the shell prompt was `pjdoland@mingus sub-test-dir % claude` — exactly the behavior described in the issue.

## Test plan

- [x] `pytest tests/` → 515 passing
- [x] `jlpm jest` → 100 passing
- [x] `prettier`, `eslint`, `tsc --noEmit` clean
- [x] Manual: navigate file browser into a subdir, click + New Session — terminal opens in that subdir
- [x] Manual: resume an existing session — still opens at the session's recorded cwd (Resume path unchanged)