### PR TITLE
fix(api): NotImplementedError + Toolset default + Signal/registrar hygiene

### DIFF
--- a/notebook_intelligence/ai_service_manager.py
+++ b/notebook_intelligence/ai_service_manager.py
@@ -8,7 +8,7 @@ import sys
 from typing import Dict, Optional
 import logging
 from notebook_intelligence import github_copilot
-from notebook_intelligence.api import ButtonData, ChatModel, EmbeddingModel, InlineCompletionModel, LLMProvider, ChatParticipant, ChatRequest, ChatResponse, CompletionContext, ContextRequest, Host, CompletionContextProvider, MCPPrompt, MCPServer, MarkdownData, NotebookIntelligenceExtension, TelemetryEvent, TelemetryListener, Tool, Toolset
+from notebook_intelligence.api import ButtonData, ChatModel, EmbeddingModel, InlineCompletionModel, LLMProvider, ChatParticipant, ChatRequest, ChatResponse, CompletionContext, ContextRequest, Host, CompletionContextProvider, MCPPrompt, MCPServer, MarkdownData, NotebookIntelligenceExtension, RegistrationError, TelemetryEvent, TelemetryListener, Tool, Toolset
 from notebook_intelligence.base_chat_participant import BaseChatParticipant
 from notebook_intelligence.config import NBIConfig
 from notebook_intelligence.github_copilot_chat_participant import GithubCopilotChatParticipant
@@ -223,11 +223,9 @@ class AIServiceManager(Host):
 
     def register_chat_participant(self, participant: ChatParticipant):
         if participant.id in RESERVED_PARTICIPANT_IDS:
-            log.error(f"Participant ID '{participant.id}' is reserved!")
-            return
+            raise RegistrationError(f"Participant ID '{participant.id}' is reserved!")
         if participant.id in self.chat_participants:
-            log.error(f"Participant ID '{participant.id}' is already in use!")
-            return
+            raise RegistrationError(f"Participant ID '{participant.id}' is already in use!")
         self.chat_participants[participant.id] = participant
 
     def unregister_chat_participant(self, participant: ChatParticipant):
@@ -236,23 +234,19 @@ class AIServiceManager(Host):
 
     def register_llm_provider(self, provider: LLMProvider) -> None:
         if provider.id in RESERVED_LLM_PROVIDER_IDS:
-            log.error(f"LLM Provider ID '{provider.id}' is reserved!")
-            return
+            raise RegistrationError(f"LLM Provider ID '{provider.id}' is reserved!")
         if provider.id in self.chat_participants:
-            log.error(f"LLM Provider ID '{provider.id}' is already in use!")
-            return
+            raise RegistrationError(f"LLM Provider ID '{provider.id}' is already in use!")
         self.llm_providers[provider.id] = provider
 
     def register_completion_context_provider(self, provider: CompletionContextProvider) -> None:
         if provider.id in self.completion_context_providers:
-            log.error(f"Completion Context Provider ID '{provider.id}' is already in use!")
-            return
+            raise RegistrationError(f"Completion Context Provider ID '{provider.id}' is already in use!")
         self.completion_context_providers[provider.id] = provider
 
     def register_telemetry_listener(self, listener: TelemetryListener) -> None:
         if listener.name in self.telemetry_listeners:
-            log.error(f"Notebook Intelligence telemetry listener '{listener.name}' already exists!")
-            return
+            raise RegistrationError(f"Notebook Intelligence telemetry listener '{listener.name}' already exists!")
         log.warning(f"Notebook Intelligence telemetry listener '{listener.name}' registered. Make sure it is from a trusted source.")
         self.telemetry_listeners[listener.name] = listener
 

--- a/notebook_intelligence/ai_service_manager.py
+++ b/notebook_intelligence/ai_service_manager.py
@@ -43,13 +43,13 @@ class PromptParts:
     mcp_arguments: dict = None
 
 class AIServiceManager(Host):
-    def __init__(self, options: dict = {}):
+    def __init__(self, options: Optional[dict] = None):
         self.llm_providers: Dict[str, LLMProvider] = {}
         self.chat_participants: Dict[str, ChatParticipant] = {}
         self.completion_context_providers: Dict[str, CompletionContextProvider] = {}
         self.telemetry_listeners: Dict[str, TelemetryListener] = {}
         self._extension_toolsets: Dict[str, list[Toolset]] = {}
-        self._options = options.copy()
+        self._options = dict(options) if options is not None else {}
         self._nbi_config = NBIConfig({"server_root_dir": self._options.get('server_root_dir', '')})
         # Apply admin policies before any consumer (model bootstrap, MCP
         # connect, login_with_existing_credentials) reads claude_settings or
@@ -129,7 +129,13 @@ class AIServiceManager(Host):
         self.register_llm_provider(self._ollama_llm_provider)
         self._mcp_manager = MCPManager(self.nbi_config.mcp)
         for participant in self._mcp_manager.get_mcp_participants():
-            self.register_chat_participant(participant)
+            # A duplicate / reserved id from one MCP server should not block
+            # the rest from registering — log and continue rather than crash
+            # the extension's boot sequence.
+            try:
+                self.register_chat_participant(participant)
+            except RegistrationError as e:
+                log.error(f"Skipping MCP chat participant: {e}")
 
         self.update_models_from_config()
         self.initialize_extensions()

--- a/notebook_intelligence/api.py
+++ b/notebook_intelligence/api.py
@@ -16,6 +16,18 @@ from notebook_intelligence.util import ThreadSafeWebSocketConnector
 
 log = logging.getLogger(__name__)
 
+
+class RegistrationError(Exception):
+    """Raised when an extension tries to register a participant, provider, or
+    other named resource whose id is reserved or already in use.
+
+    Previously the registrar logged the collision via ``log.error`` and
+    silently dropped the registration; that surface failed only in
+    production logs that authors rarely read. Raising lets the loader
+    surface the failure at install/import time instead.
+    """
+
+
 class RequestDataType(str, Enum):
     ChatRequest = 'chat-request'
     ChatUserInput = 'chat-user-input'
@@ -82,7 +94,13 @@ class Signal:
         self._listeners.append(listener)
 
     def disconnect(self, listener: Callable) -> None:
-        self._listeners.remove(listener)
+        # `list.remove` raises ``ValueError`` on a missing entry; tolerating
+        # double-disconnect avoids crashing the chat loop when a misbehaving
+        # plugin disconnects twice or after a crash recovery.
+        try:
+            self._listeners.remove(listener)
+        except ValueError:
+            pass
 
 class SignalImpl(Signal):
     def __init__(self):
@@ -127,7 +145,7 @@ class ChatRequest:
 class ResponseStreamData:
     @property
     def data_type(self) -> ResponseStreamDataType:
-        raise NotImplemented
+        raise NotImplementedError
 
 @dataclass
 class MarkdownData(ResponseStreamData):
@@ -263,13 +281,13 @@ class ChatResponse:
 
     @property
     def message_id(self) -> str:
-        raise NotImplemented
+        raise NotImplementedError
 
     def stream(self, data: ResponseStreamData, finish: bool = False) -> None:
-        raise NotImplemented
+        raise NotImplementedError
     
     def finish(self) -> None:
-        raise NotImplemented
+        raise NotImplementedError
     
     @property
     def user_input_signal(self) -> Signal:
@@ -294,7 +312,7 @@ class ChatResponse:
             await asyncio.sleep(0.1)
 
     async def run_ui_command(self, command: str, args: dict = {}) -> None:
-        raise NotImplemented
+        raise NotImplementedError
     
     @property
     def run_ui_command_response_signal(self) -> Signal:
@@ -333,37 +351,39 @@ class ChatCommand:
 class Tool:
     @property
     def name(self) -> str:
-        raise NotImplemented
+        raise NotImplementedError
 
     @property
     def title(self) -> str:
-        raise NotImplemented
+        raise NotImplementedError
     
     @property
     def tags(self) -> list[str]:
-        raise NotImplemented
+        raise NotImplementedError
     
     @property
     def description(self) -> str:
-        raise NotImplemented
+        raise NotImplementedError
     
     @property
     def schema(self) -> dict:
-        raise NotImplemented
+        raise NotImplementedError
 
     def pre_invoke(self, request: ChatRequest, tool_args: dict) -> Union[ToolPreInvokeResponse, None]:
         return None
 
     async def handle_tool_call(self, request: ChatRequest, response: ChatResponse, tool_context: dict, tool_args: dict) -> str:
-        raise NotImplemented
+        raise NotImplementedError
 
 class Toolset:
-    def __init__(self, id: str, name: str, description: str, provider: Union['NotebookIntelligenceExtension', None], tools: list[Tool] = [], instructions: str = None):
+    def __init__(self, id: str, name: str, description: str, provider: Union['NotebookIntelligenceExtension', None], tools: Optional[list[Tool]] = None, instructions: str = None):
         self.id = id
         self.name = name
         self.description = description
         self.provider = provider
-        self.tools: list[Tool] = tools
+        # `tools=[]` as the default would share a single list across every
+        # Toolset instance — `add_tool` on one would leak into all others.
+        self.tools: list[Tool] = list(tools) if tools is not None else []
         self.instructions: Union[str, None] = instructions
 
     def add_tool(self, tool: Tool) -> None:
@@ -420,74 +440,74 @@ class SimpleTool(Tool):
 class PromptArgument:
     @property
     def name(self) -> str:
-        raise NotImplemented
+        raise NotImplementedError
     
     @property
     def description(self) -> str:
-        raise NotImplemented
+        raise NotImplementedError
     
     @property
     def required(self) -> bool:
-        raise NotImplemented
+        raise NotImplementedError
 
 class MCPPrompt:
     @property
     def name(self) -> str:
-        raise NotImplemented
+        raise NotImplementedError
 
     @property
     def title(self) -> str:
-        raise NotImplemented
+        raise NotImplementedError
     
     @property
     def description(self) -> str:
-        raise NotImplemented
+        raise NotImplementedError
 
     @property
     def arguments(self) -> list[PromptArgument]:
-        raise NotImplemented
+        raise NotImplementedError
 
     def get_value(self, prompt_args: dict = {}) -> str:
-        raise NotImplemented
+        raise NotImplementedError
 
 class MCPServer:
     @property
     def name(self) -> str:
-        return NotImplemented
+        raise NotImplementedError
 
     @property
     def status(self) -> MCPServerStatus:
-        return NotImplemented
+        raise NotImplementedError
     
     def connect(self):
-        return NotImplemented
+        raise NotImplementedError
 
     def disconnect(self):
-        return NotImplemented
+        raise NotImplementedError
 
     def update_tool_list(self):
-        return NotImplemented
+        raise NotImplementedError
     
     def get_tools(self) -> list[Tool]:
-        return NotImplemented
+        raise NotImplementedError
 
     def get_tool(self, tool_name: str) -> Tool:
-        return NotImplemented
+        raise NotImplementedError
 
     def call_tool(self, tool_name: str, tool_args: dict):
-        return NotImplemented
+        raise NotImplementedError
 
     def update_prompts_list(self):
-        return NotImplemented
+        raise NotImplementedError
 
     def get_prompts(self) -> list[MCPPrompt]:
-        return NotImplemented
+        raise NotImplementedError
 
     def get_prompt(self, prompt_name: str) -> MCPPrompt:
-        return NotImplemented
+        raise NotImplementedError
     
     def get_prompt_value(self, prompt_name: str, prompt_args: dict = {}) -> list[dict]:
-        return NotImplemented
+        raise NotImplementedError
 
 def auto_approve(tool: SimpleTool):
     """
@@ -526,15 +546,15 @@ class ChatMode:
 class ChatParticipant:
     @property
     def id(self) -> str:
-        raise NotImplemented
+        raise NotImplementedError
 
     @property
     def name(self) -> str:
-        raise NotImplemented
+        raise NotImplementedError
 
     @property
     def description(self) -> str:
-        raise NotImplemented
+        raise NotImplementedError
     
     @property
     def icon_path(self) -> str:
@@ -554,7 +574,7 @@ class ChatParticipant:
         return set(["*"])
 
     async def handle_chat_request(self, request: ChatRequest, response: ChatResponse, options: dict = {}) -> None:
-        raise NotImplemented
+        raise NotImplementedError
     
     async def handle_chat_request_with_tools(self, request: ChatRequest, response: ChatResponse, options: dict = {}, tool_context: dict = {}, tool_choice = 'auto') -> None:
         tools = self.tools
@@ -702,10 +722,10 @@ class ChatParticipant:
 class CompletionContextProvider:
     @property
     def id(self) -> str:
-        raise NotImplemented
+        raise NotImplementedError
 
     def handle_completion_context_request(self, request: ContextRequest) -> CompletionContext:
-        raise NotImplemented
+        raise NotImplementedError
 
 @dataclass
 class LLMProviderProperty:
@@ -744,11 +764,11 @@ class AIModel(LLMPropertyProvider):
 
     @property
     def id(self) -> str:
-        raise NotImplemented
+        raise NotImplementedError
     
     @property
     def name(self) -> str:
-        raise NotImplemented
+        raise NotImplementedError
 
     @property
     def provider(self) -> 'LLMProvider':
@@ -756,7 +776,7 @@ class AIModel(LLMPropertyProvider):
     
     @property
     def context_window(self) -> int:
-        raise NotImplemented
+        raise NotImplementedError
 
     @property
     def supports_tools(self) -> bool:
@@ -768,15 +788,15 @@ class AIModel(LLMPropertyProvider):
 
 class ChatModel(AIModel):
     def completions(self, messages: list[dict], tools: list[dict] = None, response: ChatResponse = None, cancel_token: CancelToken = None, options: dict = {}) -> Any:
-        raise NotImplemented
+        raise NotImplementedError
 
 class InlineCompletionModel(AIModel):
     def inline_completions(prefix, suffix, language, filename, context: CompletionContext, cancel_token: CancelToken) -> str:
-        raise NotImplemented
+        raise NotImplementedError
 
 class EmbeddingModel(AIModel):
     def embeddings(self, inputs: list[str]) -> Any:
-        raise NotImplemented
+        raise NotImplementedError
 
 class LLMProvider(LLMPropertyProvider):
     def __init__(self):
@@ -784,23 +804,23 @@ class LLMProvider(LLMPropertyProvider):
 
     @property
     def id(self) -> str:
-        raise NotImplemented
+        raise NotImplementedError
     
     @property
     def name(self) -> str:
-        raise NotImplemented
+        raise NotImplementedError
 
     @property
     def chat_models(self) -> list[ChatModel]:
-        raise NotImplemented
+        raise NotImplementedError
     
     @property
     def inline_completion_models(self) -> list[InlineCompletionModel]:
-        raise NotImplemented
+        raise NotImplementedError
     
     @property
     def embedding_models(self) -> list[EmbeddingModel]:
-        raise NotImplemented
+        raise NotImplementedError
 
     def get_chat_model(self, model_id: str) -> ChatModel:
         for model in self.chat_models:
@@ -838,7 +858,7 @@ class TelemetryEventType(str, Enum):
 class TelemetryEvent:
     @property
     def type(self) -> TelemetryEventType:
-        raise NotImplemented
+        raise NotImplementedError
     
     @property
     def data(self) -> dict:
@@ -847,52 +867,52 @@ class TelemetryEvent:
 class TelemetryListener:
     @property
     def name(self) -> str:
-        raise NotImplemented
+        raise NotImplementedError
 
     def on_telemetry_event(self, event: TelemetryEvent):
-        raise NotImplemented
+        raise NotImplementedError
 
 class Host:
     def register_llm_provider(self, provider: LLMProvider) -> None:
-        raise NotImplemented
+        raise NotImplementedError
 
     def register_chat_participant(self, participant: ChatParticipant) -> None:
-        raise NotImplemented
+        raise NotImplementedError
 
     def register_completion_context_provider(self, provider: CompletionContextProvider) -> None:
-        raise NotImplemented
+        raise NotImplementedError
     
     def register_telemetry_listener(self, listener: TelemetryListener) -> None:
-        raise NotImplemented
+        raise NotImplementedError
 
     def register_toolset(self, toolset: Toolset) -> None:
-        raise NotImplemented
+        raise NotImplementedError
 
     @property
     def nbi_config(self) -> NBIConfig:
-        raise NotImplemented
+        raise NotImplementedError
 
     @property
     def default_chat_participant(self) -> ChatParticipant:
-        raise NotImplemented
+        raise NotImplementedError
     
     @property
     def chat_model(self) -> ChatModel:
-        raise NotImplemented
+        raise NotImplementedError
     
     @property
     def inline_completion_model(self) -> InlineCompletionModel:
-        raise NotImplemented
+        raise NotImplementedError
     
     @property
     def embedding_model(self) -> EmbeddingModel:
-        raise NotImplemented
+        raise NotImplementedError
 
     def get_mcp_server(self, server_name: str) -> MCPServer:
-        return NotImplemented
+        raise NotImplementedError
 
     def get_mcp_server_tool(self, server_name: str, tool_name: str) -> Tool:
-        return NotImplemented
+        raise NotImplementedError
 
     def get_mcp_server_prompt(self, server_name: str, prompt_name: str) -> MCPPrompt:
         mcp_server = self.get_mcp_server(server_name)
@@ -907,40 +927,40 @@ class Host:
         return None
 
     def get_extension_toolset(self, extension_id: str, toolset_id: str) -> Toolset:
-        return NotImplemented
+        raise NotImplementedError
 
     def get_extension_tool(self, extension_id: str, toolset_id: str, tool_name: str) -> Tool:
-        return NotImplemented
+        raise NotImplementedError
     
     def get_rule_manager(self):
         """Get the rule manager instance if available."""
-        return NotImplemented
+        raise NotImplementedError
 
     def get_skill_manager(self):
         """Get the skill manager instance if available."""
-        return NotImplemented
+        raise NotImplementedError
 
     @property
     def websocket_connector(self) -> ThreadSafeWebSocketConnector:
-        return NotImplemented
+        raise NotImplementedError
     
 
 class NotebookIntelligenceExtension:
     @property
     def id(self) -> str:
-        raise NotImplemented
+        raise NotImplementedError
 
     @property
     def name(self) -> str:
-        raise NotImplemented
+        raise NotImplementedError
     
     @property
     def provider(self) -> str:
-        raise NotImplemented
+        raise NotImplementedError
 
     @property
     def url(self) -> str:
-        raise NotImplemented
+        raise NotImplementedError
 
     def activate(self, host: Host) -> None:
-        raise NotImplemented
+        raise NotImplementedError

--- a/notebook_intelligence/api.py
+++ b/notebook_intelligence/api.py
@@ -96,11 +96,13 @@ class Signal:
     def disconnect(self, listener: Callable) -> None:
         # `list.remove` raises ``ValueError`` on a missing entry; tolerating
         # double-disconnect avoids crashing the chat loop when a misbehaving
-        # plugin disconnects twice or after a crash recovery.
+        # plugin disconnects twice or after a crash recovery. Surfaced at
+        # DEBUG so a real plugin bug can still be diagnosed if the noise
+        # ever matters.
         try:
             self._listeners.remove(listener)
         except ValueError:
-            pass
+            log.debug("Signal.disconnect: listener %r was not connected", listener)
 
 class SignalImpl(Signal):
     def __init__(self):

--- a/notebook_intelligence/config.py
+++ b/notebook_intelligence/config.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import sys
+from typing import Optional
 
 from notebook_intelligence.feature_flags import (
     CHAT_MODEL_OVERRIDES,
@@ -22,8 +23,8 @@ class NBIConfig:
     _feature_policies: dict = {}
     _string_overrides: dict = {}
 
-    def __init__(self, options: dict = {}):
-        self.options = options
+    def __init__(self, options: Optional[dict] = None):
+        self.options = dict(options) if options is not None else {}
         self._feature_policies = {}
         self._string_overrides = {}
 

--- a/notebook_intelligence/mcp_manager.py
+++ b/notebook_intelligence/mcp_manager.py
@@ -7,7 +7,7 @@ import os
 from queue import Queue
 import threading
 import time
-from typing import Any, Union
+from typing import Any, Optional, Union
 import uuid
 from fastmcp.client import StdioTransport, StreamableHttpTransport
 from mcp import StdioServerParameters
@@ -158,12 +158,12 @@ class StreamableHttpServerParameters:
     headers: dict[str, Any] | None = None
 
 class MCPServerImpl(MCPServer):
-    def __init__(self, manager: "MCPManager", name: str, stdio_params: StdioServerParameters = None, streamable_http_params: StreamableHttpServerParameters = None, auto_approve_tools: list[str] = []):
+    def __init__(self, manager: "MCPManager", name: str, stdio_params: StdioServerParameters = None, streamable_http_params: StreamableHttpServerParameters = None, auto_approve_tools: Optional[list[str]] = None):
         self._manager = manager
         self._name: str = name
         self._stdio_params: StdioServerParameters = stdio_params
         self._streamable_http_params: StreamableHttpServerParameters = streamable_http_params
-        self._auto_approve_tools: set[str] = set(auto_approve_tools)
+        self._auto_approve_tools: set[str] = set(auto_approve_tools) if auto_approve_tools is not None else set()
         self._tried_to_get_tool_list = False
         self._mcp_tools = []
         self._mcp_prompts = []
@@ -451,13 +451,13 @@ class MCPServerImpl(MCPServer):
             return None
 
 class MCPChatParticipant(BaseChatParticipant):
-    def __init__(self, id: str, name: str, servers: list[MCPServer], nbi_tools: list[str] = []):
+    def __init__(self, id: str, name: str, servers: list[MCPServer], nbi_tools: Optional[list[str]] = None):
         super().__init__()
         self._id = id
         self._name = name
         self._servers = servers
         self._tools_updated = False
-        self._nbi_tools = nbi_tools
+        self._nbi_tools = list(nbi_tools) if nbi_tools is not None else []
 
     @property
     def id(self) -> str:

--- a/tests/test_api_hygiene.py
+++ b/tests/test_api_hygiene.py
@@ -1,0 +1,88 @@
+"""Regression tests for the api.py hygiene fixes.
+
+Pins the four behavioral contracts that the hygiene PR changes:
+- Abstract methods raise ``NotImplementedError`` (not the singleton
+  ``NotImplemented``, which would itself raise ``TypeError``).
+- ``Toolset(tools=[...])`` doesn't share its tool list across instances.
+- ``Signal.disconnect`` tolerates removing a listener that wasn't
+  connected.
+- ``RegistrationError`` is exported and is the documented contract for
+  registrar collisions (see ``ai_service_manager.register_*``).
+"""
+
+import pytest
+
+from notebook_intelligence.api import (
+    Host,
+    MCPServer,
+    RegistrationError,
+    Signal,
+    Toolset,
+)
+
+
+class TestAbstractMethodsRaiseNotImplementedError:
+    """Pre-fix bare ``raise NotImplemented`` would itself raise
+    ``TypeError: exceptions must derive from BaseException``. Verify the
+    abstract methods now raise the expected exception type.
+    """
+
+    def test_host_chat_model_raises(self):
+        with pytest.raises(NotImplementedError):
+            Host().chat_model
+
+    def test_host_inline_completion_model_raises(self):
+        with pytest.raises(NotImplementedError):
+            Host().inline_completion_model
+
+    def test_host_get_mcp_server_raises(self):
+        # Was ``return NotImplemented``; callers' ``if mcp_server is not
+        # None`` checks would silently treat the sentinel as a real
+        # server object.
+        with pytest.raises(NotImplementedError):
+            Host().get_mcp_server("any")
+
+    def test_mcpserver_get_tools_raises(self):
+        with pytest.raises(NotImplementedError):
+            MCPServer().get_tools()
+
+
+class TestToolsetMutableDefault:
+    def test_two_toolsets_have_independent_tool_lists(self):
+        a = Toolset("a", "a", "a", provider=None)
+        b = Toolset("b", "b", "b", provider=None)
+        assert a.tools is not b.tools
+
+    def test_explicit_tools_arg_is_copied_not_aliased(self):
+        shared_seed = []
+        a = Toolset("a", "a", "a", provider=None, tools=shared_seed)
+        a.tools.append("x")
+        # ``Toolset`` should defensively copy so callers' lists aren't
+        # mutated and Toolsets stay independent.
+        assert shared_seed == []
+
+
+class TestSignalDisconnectIsTolerant:
+    def test_disconnect_unknown_listener_is_noop(self):
+        s = Signal()
+
+        def listener():
+            pass
+
+        # Was ``list.remove`` raising ``ValueError`` — now silent.
+        s.disconnect(listener)
+
+    def test_double_disconnect_is_noop(self):
+        s = Signal()
+
+        def listener():
+            pass
+
+        s.connect(listener)
+        s.disconnect(listener)
+        s.disconnect(listener)  # second one used to crash
+
+
+class TestRegistrationErrorIsExported:
+    def test_registration_error_is_exception_subclass(self):
+        assert issubclass(RegistrationError, Exception)

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -174,14 +174,17 @@ class TestTelemetryListenerFeedbackDispatch:
         assert sentiments == ["positive", "negative"]
 
     def test_duplicate_listener_name_rejected(self, ai_service_manager):
-        """Registering a listener with a duplicate name should be silently rejected."""
+        """Registering a listener with a duplicate name raises RegistrationError."""
+        from notebook_intelligence.api import RegistrationError
+
         listener_1 = CapturingTelemetryListener()
         listener_2 = CapturingTelemetryListener()  # same .name property
 
         ai_service_manager.register_telemetry_listener(listener_1)
-        ai_service_manager.register_telemetry_listener(listener_2)
+        with pytest.raises(RegistrationError):
+            ai_service_manager.register_telemetry_listener(listener_2)
 
-        # Only the first should be registered
+        # Only the first should be registered.
         assert ai_service_manager.telemetry_listeners["test-capturing-listener"] is listener_1
 
 


### PR DESCRIPTION
## Summary

Sweep of long-standing bugs in the public `notebook_intelligence.api` surface that an extension author would hit the moment they exercise the contract.

## What changed

- **`raise NotImplemented` / `return NotImplemented` → `raise NotImplementedError`** (~73 sites in `api.py`). `NotImplemented` is the rich-comparison singleton, not an exception, so a bare `raise NotImplemented` itself raises `TypeError: exceptions must derive from BaseException`. `return NotImplemented` from `Host` / `MCPServer` base methods broke caller guards like `if mcp_server is not None` because the sentinel compares truthy.
- **Mutable-default-argument bugs fixed** with the standard `Optional[T]` + copy idiom. The original `Toolset(tools=[])` is the obvious one, plus `NBIConfig(options={})`, `AIServiceManager(options={})`, `MCPServerImpl(auto_approve_tools=[])`, and `MCPChatParticipant(nbi_tools=[])`. Three of the five stored the parameter without copying — a real cross-instance leak.
- **`Signal.disconnect` is now tolerant** of a missing listener instead of raising `ValueError`. A double-disconnect (e.g. crash recovery in the chat loop) no longer kills the loop. Logs at DEBUG so a real plugin bug remains diagnosable.
- **New `RegistrationError`**. `register_chat_participant` / `register_llm_provider` / `register_completion_context_provider` / `register_telemetry_listener` now raise it on reserved or duplicate ids instead of writing `log.error` and silently dropping the registration. The extension loader at `ai_service_manager.load_extensions` already wraps activation in `try/except`, so existing extension flows surface the failure with full context instead of disappearing into the log.
- **MCP participant boot loop is no longer fatal**. `AIServiceManager.initialize()` registers MCP chat participants in a bare `for` loop; now that registrars raise on conflict, a single bad MCP server would have crashed the extension's whole boot. Wrap in try/except: log and continue, matching `initialize_extensions`.

## Tests

- New `tests/test_api_hygiene.py` pins all four contracts.
- `tests/test_feedback.py::test_duplicate_listener_name_rejected` updated for the new raise behavior.
- pytest 524 passing.
- jest 100 passing (no frontend changes).

## Test plan

- [x] `pytest tests/` → 524 passing
- [x] `jlpm test` → 100 passing