### PR TITLE
fix(config): atomic NBIConfig.save() to prevent corruption on crash

### DIFF
--- a/notebook_intelligence/config.py
+++ b/notebook_intelligence/config.py
@@ -94,11 +94,8 @@ class NBIConfig:
         # TODO: save only diff
         os.makedirs(self.nbi_user_dir, exist_ok=True)
 
-        with open(self.user_config_file, 'w') as file:
-            json.dump(self.user_config, file, indent=2)
-
-        with open(self.user_mcp_file, 'w') as file:
-            json.dump(self.user_mcp, file, indent=2)
+        _atomic_write_json(self.user_config_file, self.user_config)
+        _atomic_write_json(self.user_mcp_file, self.user_mcp)
 
     def get(self, key, default=None):
         return self.user_config.get(key, self.env_config.get(key, default))
@@ -211,3 +208,34 @@ class NBIConfig:
         active_rules = self.active_rules.copy()
         active_rules[filename] = active
         self.set('active_rules', active_rules)
+
+
+def _atomic_write_json(target: str, payload: dict) -> None:
+    """Crash-safe replacement for ``open(target, 'w') + json.dump``.
+
+    Plain truncating writes leave the destination empty (or partial)
+    if the process is killed mid-write — the next launch then chokes on
+    a corrupt config. Write to a sibling tempfile, ``fsync``, and
+    ``os.replace`` so the swap is atomic on POSIX and atomic-ish on
+    Windows.
+    """
+    target_dir = os.path.dirname(target) or '.'
+    fd, tmp_path = _mkstemp_in(target_dir, prefix='.' + os.path.basename(target) + '.', suffix='.tmp')
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8') as fh:
+            json.dump(payload, fh, indent=2)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_path, target)
+    except Exception:
+        # Best-effort cleanup — if replace failed the tempfile is dangling.
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _mkstemp_in(directory: str, *, prefix: str, suffix: str):
+    import tempfile
+    return tempfile.mkstemp(prefix=prefix, suffix=suffix, dir=directory)

--- a/notebook_intelligence/config.py
+++ b/notebook_intelligence/config.py
@@ -3,7 +3,9 @@
 import json
 import logging
 import os
+import stat
 import sys
+import tempfile
 from typing import Optional
 
 from notebook_intelligence.feature_flags import (
@@ -218,15 +220,44 @@ def _atomic_write_json(target: str, payload: dict) -> None:
     a corrupt config. Write to a sibling tempfile, ``fsync``, and
     ``os.replace`` so the swap is atomic on POSIX and atomic-ish on
     Windows.
+
+    Symlink-preserving: a user who symlinks ``~/.jupyter/nbi/config.json``
+    to a shared config file expects ``save()`` to update the link's
+    target, not replace the link itself. Resolve via ``realpath`` first.
+
+    Mode-preserving: ``mkstemp`` returns a 0o600 file; if the existing
+    config has different permissions (e.g. 0o644 for a shared install),
+    re-apply them after the swap so the user's chmod isn't silently
+    undone.
+
+    Durability: ``fsync`` the tempfile, then ``fsync`` the target's
+    parent directory on POSIX so the rename itself survives a crash.
     """
-    target_dir = os.path.dirname(target) or '.'
-    fd, tmp_path = _mkstemp_in(target_dir, prefix='.' + os.path.basename(target) + '.', suffix='.tmp')
+    real_target = os.path.realpath(target)
+    target_dir = os.path.dirname(real_target) or '.'
+    existing_mode = None
+    try:
+        existing_mode = stat.S_IMODE(os.stat(real_target).st_mode)
+    except FileNotFoundError:
+        pass
+    fd, tmp_path = tempfile.mkstemp(
+        prefix='.' + os.path.basename(real_target) + '.',
+        suffix='.tmp',
+        dir=target_dir,
+    )
     try:
         with os.fdopen(fd, 'w', encoding='utf-8') as fh:
             json.dump(payload, fh, indent=2)
             fh.flush()
             os.fsync(fh.fileno())
-        os.replace(tmp_path, target)
+        if existing_mode is not None:
+            try:
+                os.chmod(tmp_path, existing_mode)
+            except OSError:
+                # Some filesystems (FAT, certain network mounts) reject chmod;
+                # the swap itself is still safe, just lose the mode bits.
+                pass
+        os.replace(tmp_path, real_target)
     except Exception:
         # Best-effort cleanup — if replace failed the tempfile is dangling.
         try:
@@ -234,8 +265,16 @@ def _atomic_write_json(target: str, payload: dict) -> None:
         except OSError:
             pass
         raise
-
-
-def _mkstemp_in(directory: str, *, prefix: str, suffix: str):
-    import tempfile
-    return tempfile.mkstemp(prefix=prefix, suffix=suffix, dir=directory)
+    # ``os.replace`` makes the new inode visible, but until the directory
+    # entry is fsynced a power-loss can still leave the rename unrecorded
+    # on POSIX. Windows has no ``O_RDONLY`` directory descriptor, so skip
+    # there and rely on its rename semantics.
+    if hasattr(os, 'O_DIRECTORY'):
+        try:
+            dir_fd = os.open(target_dir, os.O_RDONLY)
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)
+        except OSError:
+            pass

--- a/tests/test_config_atomic_save.py
+++ b/tests/test_config_atomic_save.py
@@ -76,3 +76,29 @@ class TestAtomicWriteJson:
         _atomic_write_json(str(target), {"key": "value"})
         text = target.read_text()
         assert "\n" in text  # indented, not single-line
+
+    def test_writes_through_symlink(self, tmp_path):
+        # User pointed config.json at a shared location via symlink.
+        # ``save()`` must update the linked-to file, not replace the link.
+        real_dir = tmp_path / "shared"
+        real_dir.mkdir()
+        real_target = real_dir / "config.json"
+        real_target.write_text(json.dumps({"old": True}))
+        link = tmp_path / "config.json"
+        link.symlink_to(real_target)
+
+        _atomic_write_json(str(link), {"new": True})
+
+        assert link.is_symlink()
+        assert json.loads(real_target.read_text()) == {"new": True}
+
+    def test_preserves_existing_file_mode(self, tmp_path):
+        import os as _os
+        target = tmp_path / "config.json"
+        target.write_text(json.dumps({"old": True}))
+        _os.chmod(target, 0o640)
+
+        _atomic_write_json(str(target), {"new": True})
+
+        # Mode bits preserved across the atomic swap.
+        assert (target.stat().st_mode & 0o777) == 0o640

--- a/tests/test_config_atomic_save.py
+++ b/tests/test_config_atomic_save.py
@@ -1,0 +1,78 @@
+"""Tests for atomic config writes in NBIConfig.
+
+Pre-fix: ``open(target, 'w')`` truncates first, so a crash mid-write
+leaves the config empty/partial and the next launch fails to load.
+The fix uses a sibling tempfile + ``fsync`` + ``os.replace`` so the
+visible state of ``target`` is either fully old or fully new — never
+half-written.
+"""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from notebook_intelligence.config import _atomic_write_json
+
+
+class TestAtomicWriteJson:
+    def test_creates_file_with_payload(self, tmp_path):
+        target = tmp_path / "config.json"
+        _atomic_write_json(str(target), {"a": 1, "b": "two"})
+        assert json.loads(target.read_text()) == {"a": 1, "b": "two"}
+
+    def test_replaces_existing_file_atomically(self, tmp_path):
+        target = tmp_path / "config.json"
+        target.write_text(json.dumps({"old": True}))
+        _atomic_write_json(str(target), {"new": True})
+        assert json.loads(target.read_text()) == {"new": True}
+
+    def test_no_tempfile_left_behind_on_success(self, tmp_path):
+        target = tmp_path / "config.json"
+        _atomic_write_json(str(target), {"a": 1})
+        leftover = [
+            p for p in tmp_path.iterdir() if p.name != "config.json"
+        ]
+        assert leftover == []
+
+    def test_failure_during_write_does_not_overwrite_existing(
+        self, tmp_path, monkeypatch
+    ):
+        target = tmp_path / "config.json"
+        target.write_text(json.dumps({"keep": "me"}))
+
+        # Force ``json.dump`` to fail mid-write to simulate a crash.
+        def boom(*args, **kwargs):
+            raise IOError("disk full")
+
+        monkeypatch.setattr("notebook_intelligence.config.json.dump", boom)
+
+        with pytest.raises(IOError):
+            _atomic_write_json(str(target), {"new": "payload"})
+
+        # Old file is untouched (atomic swap never happened).
+        assert json.loads(target.read_text()) == {"keep": "me"}
+
+    def test_failure_cleans_up_tempfile(self, tmp_path, monkeypatch):
+        target = tmp_path / "config.json"
+
+        def boom(*args, **kwargs):
+            raise IOError("disk full")
+
+        monkeypatch.setattr("notebook_intelligence.config.json.dump", boom)
+
+        with pytest.raises(IOError):
+            _atomic_write_json(str(target), {"x": 1})
+
+        # No dangling .tmp files.
+        leftover = [p.name for p in tmp_path.iterdir()]
+        assert leftover == []
+
+    def test_indents_payload_for_human_diffs(self, tmp_path):
+        # Same shape as the prior call — verify the on-disk format
+        # stays human-readable (existing behavior).
+        target = tmp_path / "config.json"
+        _atomic_write_json(str(target), {"key": "value"})
+        text = target.read_text()
+        assert "\n" in text  # indented, not single-line


### PR DESCRIPTION
## Summary

`NBIConfig.save()` (`notebook_intelligence/config.py:92-100`) does plain `open(target, 'w')` + `json.dump`, which truncates first. A crash mid-write (kill -9, OOM, power loss) corrupts `config.json` / `mcp.json`, and the next launch fails to parse them.

## What changed

Replaced both writes with `_atomic_write_json`:
1. Write payload to a sibling tempfile in the same directory.
2. `flush` + `fsync` the tempfile.
3. `os.replace` to atomically swap into the target name.
4. On POSIX, `fsync` the parent directory so the rename itself survives a power loss.
5. Resolve symlinks via `realpath` before staging — a user symlinking config.json at a shared file expects `save()` to update the linked-to file, not replace the link.
6. Preserve the existing file's mode bits across the swap (mkstemp creates 0o600; if the user chmod'd 0o644 for shared installs we shouldn't undo that).
7. On any error, unlink the tempfile so we don't litter the user's config dir with `.tmp.*` files.

## Tests

`tests/test_config_atomic_save.py`:
- Happy-path write + JSON round-trip
- Replacing an existing file
- No leftover tempfiles on success
- Crash during `json.dump` preserves the existing file (not partial)
- Crash cleans up the dangling tempfile
- Output stays indented (human-readable on disk)
- Writing through a symlink updates the link's target, not the link
- Existing file's mode bits are preserved across the swap

## Test plan

- [x] `pytest tests/` → 523 passing (515 + 8 new)
- [x] `jlpm test` → 100 passing (no frontend changes)