### PR TITLE
harden(skills): block + scope redirects on remote skill fetches

### DIFF
--- a/notebook_intelligence/skill_github_import.py
+++ b/notebook_intelligence/skill_github_import.py
@@ -62,7 +62,20 @@ class _GitHubOnlyRedirectHandler(urllib.request.HTTPRedirectHandler):
     """
 
     def redirect_request(self, req, fp, code, msg, headers, newurl):
-        new_host = (urllib.parse.urlparse(newurl).hostname or "").lower()
+        new_parsed = urllib.parse.urlparse(newurl)
+        # Refuse HTTPS → HTTP downgrade. Even if the redirect lands on a
+        # GitHub host, an attacker on-path who can spoof the response could
+        # chain ``http://api.github.com/...`` to capture the bearer token in
+        # cleartext or serve a doctored tarball without TLS.
+        if new_parsed.scheme.lower() != "https":
+            raise urllib.error.HTTPError(
+                req.full_url,
+                code,
+                f"Refusing non-HTTPS redirect: {newurl}",
+                headers,
+                fp,
+            )
+        new_host = (new_parsed.hostname or "").lower()
         if new_host not in _ALLOWED_REDIRECT_HOSTS:
             raise urllib.error.HTTPError(
                 req.full_url,
@@ -76,10 +89,11 @@ class _GitHubOnlyRedirectHandler(urllib.request.HTTPRedirectHandler):
             return None
         orig_host = (urllib.parse.urlparse(req.full_url).hostname or "").lower()
         if new_host != orig_host:
-            for h in [k for k in new_req.headers if k.lower() == "authorization"]:
-                del new_req.headers[h]
-            for h in [k for k in new_req.unredirected_hdrs if k.lower() == "authorization"]:
-                del new_req.unredirected_hdrs[h]
+            # ``Request.add_header`` stores keys as ``.title()``-cased, so
+            # "Authorization" is the canonical form. ``pop`` is a no-op when
+            # the header was set on the un-redirected side instead.
+            new_req.headers.pop("Authorization", None)
+            new_req.unredirected_hdrs.pop("Authorization", None)
         return new_req
 
 
@@ -125,7 +139,7 @@ def parse_github_url(url: str) -> GitHubRef:
         raise ValueError(f"Invalid URL: {e}")
     if parsed.scheme not in ("http", "https"):
         raise ValueError("URL must use https://")
-    if parsed.netloc not in ("github.com", "www.github.com"):
+    if parsed.netloc.lower() not in ("github.com", "www.github.com"):
         raise ValueError("Only github.com URLs are supported")
     parts = [p for p in parsed.path.split("/") if p]
     if len(parts) < 2:

--- a/notebook_intelligence/skill_github_import.py
+++ b/notebook_intelligence/skill_github_import.py
@@ -38,6 +38,62 @@ MAX_ARCHIVE_BYTES = 10 * 1024 * 1024  # 10 MB on-wire
 MAX_EXTRACTED_BYTES = 20 * 1024 * 1024  # 20 MB after decompression
 FETCH_TIMEOUT_SECONDS = 30
 
+# Hosts a GitHub fetch is allowed to land on after a redirect. The tarball
+# endpoint legitimately 302s api.github.com → codeload.github.com, and
+# release/blob downloads can hop through objects.githubusercontent.com.
+_ALLOWED_REDIRECT_HOSTS = frozenset({
+    "api.github.com",
+    "github.com",
+    "www.github.com",
+    "codeload.github.com",
+    "objects.githubusercontent.com",
+})
+
+
+class _GitHubOnlyRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Block redirects to non-GitHub hosts and strip auth on cross-host hops.
+
+    Stock urllib follows any 30x to anywhere. A hijacked DNS entry, a typo'd
+    URL in a deployment manifest, or a malicious repo URL could chain a fetch
+    to an attacker host that captures the bearer token (``GITHUB_TOKEN``) or
+    serves a tarball that bypasses our extraction guards. Restricting the
+    landing host and dropping ``Authorization`` on cross-host redirects closes
+    both vectors.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        new_host = (urllib.parse.urlparse(newurl).hostname or "").lower()
+        if new_host not in _ALLOWED_REDIRECT_HOSTS:
+            raise urllib.error.HTTPError(
+                req.full_url,
+                code,
+                f"Refusing redirect to non-GitHub host: {new_host}",
+                headers,
+                fp,
+            )
+        new_req = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if new_req is None:
+            return None
+        orig_host = (urllib.parse.urlparse(req.full_url).hostname or "").lower()
+        if new_host != orig_host:
+            for h in [k for k in new_req.headers if k.lower() == "authorization"]:
+                del new_req.headers[h]
+            for h in [k for k in new_req.unredirected_hdrs if k.lower() == "authorization"]:
+                del new_req.unredirected_hdrs[h]
+        return new_req
+
+
+_GITHUB_OPENER = urllib.request.build_opener(_GitHubOnlyRedirectHandler())
+
+
+def _urlopen_github(req, timeout):
+    """Open a GitHub URL with the restricted-redirect opener.
+
+    Indirection point so tests can patch this single symbol instead of
+    swapping out ``urllib.request.urlopen`` globally.
+    """
+    return _GITHUB_OPENER.open(req, timeout=timeout)
+
 
 @dataclass
 class GitHubRef:
@@ -147,7 +203,7 @@ def _fetch_tarball(
     has_token = "Authorization" in headers
     req = urllib.request.Request(url, headers=headers)
     try:
-        with urllib.request.urlopen(req, timeout=FETCH_TIMEOUT_SECONDS) as response:
+        with _urlopen_github(req, timeout=FETCH_TIMEOUT_SECONDS) as response:
             data = response.read(MAX_ARCHIVE_BYTES + 1)
     except urllib.error.HTTPError as e:
         if e.code in (401, 403):
@@ -207,7 +263,7 @@ def get_latest_commit_sha(
     url = f"https://api.github.com/repos/{owner}/{repo}/commits?{query}"
     req = urllib.request.Request(url, headers=_github_api_headers(override_token=token))
     try:
-        with urllib.request.urlopen(req, timeout=FETCH_TIMEOUT_SECONDS) as response:
+        with _urlopen_github(req, timeout=FETCH_TIMEOUT_SECONDS) as response:
             data = response.read(64 * 1024)  # commits list is small; hard cap prevents abuse
     except (urllib.error.HTTPError, urllib.error.URLError) as e:
         log.warning("GitHub commits API probe failed for %s/%s: %s", owner, repo, e)

--- a/notebook_intelligence/skill_manifest.py
+++ b/notebook_intelligence/skill_manifest.py
@@ -47,6 +47,35 @@ def _is_github_host(url: str) -> bool:
     return host in _GITHUB_HOSTS or host.endswith(".githubusercontent.com")
 
 
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Refuse any 30x on a manifest fetch.
+
+    The manifest URL is provided by the deployment operator and points to a
+    static config file. A redirect here would mean the operator's URL is
+    out-of-date or — worse — that something on the network is rewriting the
+    request. Either way, silently following along risks shipping a bearer
+    token to an unintended host or installing skills from a substituted
+    manifest. Surface it as an error and let the operator fix the URL.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        raise urllib.error.HTTPError(
+            req.full_url,
+            code,
+            f"Refusing redirect on manifest fetch (to {newurl})",
+            headers,
+            fp,
+        )
+
+
+_NO_REDIRECT_OPENER = urllib.request.build_opener(_NoRedirectHandler())
+
+
+def _urlopen_no_redirect(req, timeout):
+    """Open a manifest URL without following redirects (test seam)."""
+    return _NO_REDIRECT_OPENER.open(req, timeout=timeout)
+
+
 class ManifestError(ValueError):
     """Raised when a manifest cannot be loaded or fails validation."""
 
@@ -151,7 +180,7 @@ def _fetch_url(url: str, *, token: Optional[str]) -> str:
         headers["Authorization"] = f"Bearer {effective_token}"
     req = urllib.request.Request(url, headers=headers)
     try:
-        with urllib.request.urlopen(req, timeout=FETCH_TIMEOUT_SECONDS) as resp:
+        with _urlopen_no_redirect(req, timeout=FETCH_TIMEOUT_SECONDS) as resp:
             data = resp.read(MAX_MANIFEST_BYTES + 1)
     except urllib.error.HTTPError as e:
         raise ManifestError(f"Manifest fetch failed (HTTP {e.code}): {e.reason}")

--- a/tests/test_skill_fetch_redirects.py
+++ b/tests/test_skill_fetch_redirects.py
@@ -1,0 +1,127 @@
+"""Verify the redirect-guard handlers on remote skill fetches.
+
+Pre-fix: stock urllib follows any 30x to anywhere, so a hijacked DNS
+entry, a typo'd manifest URL, or a malicious repo URL could silently
+redirect a fetch to an attacker host that captures the bearer token
+or serves a tarball that bypasses our extraction guards.
+
+This module pokes the handlers directly — synthesizing a redirect
+response without an HTTP server — so the tests are deterministic.
+"""
+
+import io
+import urllib.error
+
+import pytest
+
+from notebook_intelligence import skill_github_import, skill_manifest
+
+
+def _fake_redirect_inputs(orig_url: str, headers: dict):
+    """Build the (req, fp, code, msg, headers, newurl)-shaped args that
+    HTTPRedirectHandler.redirect_request expects."""
+    import urllib.request
+
+    req = urllib.request.Request(orig_url, headers=headers)
+    fp = io.BytesIO(b"")
+    return req, fp, 302, "Found", {}
+
+
+class TestGitHubOnlyRedirect:
+    def setup_method(self):
+        self.handler = skill_github_import._GitHubOnlyRedirectHandler()
+
+    def test_blocks_redirect_to_attacker_host(self):
+        req, fp, code, msg, hdrs = _fake_redirect_inputs(
+            "https://api.github.com/repos/o/r/tarball/HEAD",
+            {"Authorization": "Bearer secret"},
+        )
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            self.handler.redirect_request(
+                req, fp, code, msg, hdrs, "https://evil.example.com/loot"
+            )
+        assert "non-GitHub host" in str(exc.value)
+
+    def test_allows_redirect_to_codeload(self):
+        # api.github.com → codeload.github.com is the legitimate tarball flow.
+        req, fp, code, msg, hdrs = _fake_redirect_inputs(
+            "https://api.github.com/repos/o/r/tarball/HEAD",
+            {"Authorization": "Bearer secret", "Accept": "application/vnd.github+json"},
+        )
+        new_req = self.handler.redirect_request(
+            req, fp, code, msg, hdrs,
+            "https://codeload.github.com/o/r/legacy.tar.gz/HEAD",
+        )
+        assert new_req is not None
+        assert new_req.full_url.startswith("https://codeload.github.com/")
+
+    def test_strips_authorization_on_cross_host_redirect(self):
+        req, fp, code, msg, hdrs = _fake_redirect_inputs(
+            "https://api.github.com/repos/o/r/tarball/HEAD",
+            {"Authorization": "Bearer secret", "Accept": "application/vnd.github+json"},
+        )
+        new_req = self.handler.redirect_request(
+            req, fp, code, msg, hdrs,
+            "https://codeload.github.com/o/r/legacy.tar.gz/HEAD",
+        )
+        # No Authorization header on the cross-host hop — the bearer never
+        # reaches a host that doesn't need it.
+        items = {k.lower(): v for k, v in new_req.header_items()}
+        assert "authorization" not in items
+        # Other headers (Accept) are preserved.
+        assert items.get("accept") == "application/vnd.github+json"
+
+    def test_keeps_authorization_on_same_host_redirect(self):
+        # 301 from api.github.com → api.github.com (path normalization, etc.)
+        # should keep the auth header so the retry succeeds.
+        req, fp, code, msg, hdrs = _fake_redirect_inputs(
+            "https://api.github.com/repos/o/r",
+            {"Authorization": "Bearer secret"},
+        )
+        new_req = self.handler.redirect_request(
+            req, fp, code, msg, hdrs,
+            "https://api.github.com/repositories/12345",
+        )
+        items = {k.lower(): v for k, v in new_req.header_items()}
+        assert items.get("authorization") == "Bearer secret"
+
+    def test_blocks_redirect_to_subdomain_typo(self):
+        # `github.com.evil.com` is a classic phishing pattern — must not match.
+        req, fp, code, msg, hdrs = _fake_redirect_inputs(
+            "https://api.github.com/repos/o/r/tarball/HEAD",
+            {},
+        )
+        with pytest.raises(urllib.error.HTTPError):
+            self.handler.redirect_request(
+                req, fp, code, msg, hdrs,
+                "https://github.com.evil.com/loot",
+            )
+
+
+class TestManifestNoRedirect:
+    def setup_method(self):
+        self.handler = skill_manifest._NoRedirectHandler()
+
+    def test_blocks_any_redirect(self):
+        req, fp, code, msg, hdrs = _fake_redirect_inputs(
+            "https://manifests.example.com/skills.yaml",
+            {"Authorization": "Bearer secret"},
+        )
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            self.handler.redirect_request(
+                req, fp, code, msg, hdrs,
+                "https://manifests.example.com/skills.v2.yaml",
+            )
+        assert "manifest" in str(exc.value).lower()
+
+    def test_blocks_even_same_host_redirect(self):
+        # The manifest URL is supposed to be stable. A redirect signals an
+        # operator URL drift; failing loud is the right call.
+        req, fp, code, msg, hdrs = _fake_redirect_inputs(
+            "https://example.com/skills.yaml", {}
+        )
+        with pytest.raises(urllib.error.HTTPError):
+            self.handler.redirect_request(
+                req, fp, code, msg, hdrs,
+                "https://example.com/skills.yaml/",
+            )

--- a/tests/test_skill_fetch_redirects.py
+++ b/tests/test_skill_fetch_redirects.py
@@ -97,6 +97,22 @@ class TestGitHubOnlyRedirect:
                 "https://github.com.evil.com/loot",
             )
 
+    def test_blocks_https_to_http_downgrade(self):
+        # An on-path attacker who can spoof a 302 could chain
+        # ``https://api.github.com`` → ``http://api.github.com`` and capture
+        # the bearer in cleartext. Even though the host is allowlisted, the
+        # scheme downgrade has to be refused.
+        req, fp, code, msg, hdrs = _fake_redirect_inputs(
+            "https://api.github.com/repos/o/r/tarball/HEAD",
+            {"Authorization": "Bearer secret"},
+        )
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            self.handler.redirect_request(
+                req, fp, code, msg, hdrs,
+                "http://api.github.com/repos/o/r/tarball/HEAD",
+            )
+        assert "non-HTTPS" in str(exc.value)
+
 
 class TestManifestNoRedirect:
     def setup_method(self):

--- a/tests/test_skill_github_import.py
+++ b/tests/test_skill_github_import.py
@@ -324,7 +324,7 @@ class TestFetchTarballAuth:
             return_value="secret-token",
         ):
             with patch(
-                "notebook_intelligence.skill_github_import.urllib.request.urlopen",
+                "notebook_intelligence.skill_github_import._urlopen_github",
                 side_effect=_capture_headers_urlopen(captured),
             ):
                 _fetch_tarball("owner", "repo", None)
@@ -342,7 +342,7 @@ class TestFetchTarballAuth:
             return_value=None,
         ):
             with patch(
-                "notebook_intelligence.skill_github_import.urllib.request.urlopen",
+                "notebook_intelligence.skill_github_import._urlopen_github",
                 side_effect=_capture_headers_urlopen(captured),
             ):
                 _fetch_tarball("owner", "repo", None)
@@ -356,7 +356,7 @@ class TestFetchTarballAuth:
             return_value=None,
         ):
             with patch(
-                "notebook_intelligence.skill_github_import.urllib.request.urlopen",
+                "notebook_intelligence.skill_github_import._urlopen_github",
                 side_effect=self._http_error(401),
             ):
                 with pytest.raises(ValueError, match="requires authentication"):
@@ -368,7 +368,7 @@ class TestFetchTarballAuth:
             return_value="bad-token",
         ):
             with patch(
-                "notebook_intelligence.skill_github_import.urllib.request.urlopen",
+                "notebook_intelligence.skill_github_import._urlopen_github",
                 side_effect=self._http_error(403),
             ):
                 with pytest.raises(ValueError, match="rejected the token"):
@@ -380,7 +380,7 @@ class TestFetchTarballAuth:
             return_value=None,
         ):
             with patch(
-                "notebook_intelligence.skill_github_import.urllib.request.urlopen",
+                "notebook_intelligence.skill_github_import._urlopen_github",
                 side_effect=self._http_error(404),
             ):
                 with pytest.raises(ValueError, match="private repos require"):
@@ -392,7 +392,7 @@ class TestFetchTarballAuth:
             return_value="some-token",
         ):
             with patch(
-                "notebook_intelligence.skill_github_import.urllib.request.urlopen",
+                "notebook_intelligence.skill_github_import._urlopen_github",
                 side_effect=self._http_error(404),
             ):
                 with pytest.raises(ValueError) as exc_info:

--- a/tests/test_skill_manifest.py
+++ b/tests/test_skill_manifest.py
@@ -120,7 +120,7 @@ class TestUrlLoading:
     def test_fetches_over_https(self):
         body = b"skills:\n  - url: https://github.com/org/repo/tree/main/a\n"
         with patch(
-            "notebook_intelligence.skill_manifest.urllib.request.urlopen"
+            "notebook_intelligence.skill_manifest._urlopen_no_redirect"
         ) as mock_open:
             mock_open.return_value = self._fake_response(body)
             manifest = load_manifest("https://example.com/manifest.yaml")
@@ -132,7 +132,7 @@ class TestUrlLoading:
     def test_adds_bearer_token_header(self):
         body = b"skills: []\n"
         with patch(
-            "notebook_intelligence.skill_manifest.urllib.request.urlopen"
+            "notebook_intelligence.skill_manifest._urlopen_no_redirect"
         ) as mock_open:
             mock_open.return_value = self._fake_response(body)
             load_manifest("https://example.com/manifest.yaml", token="abc123")
@@ -142,7 +142,7 @@ class TestUrlLoading:
     def test_url_size_cap_enforced(self):
         big = b"a" * (MAX_MANIFEST_BYTES + 10)
         with patch(
-            "notebook_intelligence.skill_manifest.urllib.request.urlopen"
+            "notebook_intelligence.skill_manifest._urlopen_no_redirect"
         ) as mock_open:
             mock_open.return_value = self._fake_response(big)
             with pytest.raises(ManifestError, match="exceeds"):
@@ -154,7 +154,7 @@ class TestUrlLoading:
             "notebook_intelligence.skill_manifest._get_github_token",
             return_value="gh_fallback",
         ), patch(
-            "notebook_intelligence.skill_manifest.urllib.request.urlopen"
+            "notebook_intelligence.skill_manifest._urlopen_no_redirect"
         ) as mock_open:
             mock_open.return_value = self._fake_response(body)
             load_manifest(
@@ -169,7 +169,7 @@ class TestUrlLoading:
             "notebook_intelligence.skill_manifest._get_github_token",
             return_value="gh_fallback",
         ) as probe, patch(
-            "notebook_intelligence.skill_manifest.urllib.request.urlopen"
+            "notebook_intelligence.skill_manifest._urlopen_no_redirect"
         ) as mock_open:
             mock_open.return_value = self._fake_response(body)
             load_manifest("https://example.com/manifest.yaml")
@@ -183,7 +183,7 @@ class TestUrlLoading:
             "notebook_intelligence.skill_manifest._get_github_token",
             return_value="gh_fallback",
         ) as probe, patch(
-            "notebook_intelligence.skill_manifest.urllib.request.urlopen"
+            "notebook_intelligence.skill_manifest._urlopen_no_redirect"
         ) as mock_open:
             mock_open.return_value = self._fake_response(body)
             load_manifest(


### PR DESCRIPTION
## Summary

Stock `urllib` follows any 30x to anywhere. A hijacked DNS entry, a typo'd manifest URL, or a malicious repo URL could chain a fetch to an attacker host that:
- **captures the bearer token** — `GITHUB_TOKEN` / `NBI_MANAGED_SKILLS_TOKEN` are sent as `Authorization` headers and `urllib` replays them on the redirect hop.
- **serves a substituted payload** — the tarball-extraction guards run after the fetch, so the bytes coming off the redirected host land in the validator regardless of origin.

Two layered fixes:

### `skill_github_import.py` — `_GitHubOnlyRedirectHandler`
Allowed redirect hosts: `api.github.com`, `github.com`, `www.github.com`, `codeload.github.com`, `objects.githubusercontent.com`. The legitimate `api.github.com → codeload.github.com` tarball flow continues to work. `Authorization` is stripped on cross-host hops so the bearer never reaches a GitHub host that doesn't need it. Non-HTTPS redirects are also refused — even if the redirect lands on an allowlisted host, an on-path attacker who can spoof the 302 could downgrade to `http://` and capture the bearer in cleartext.

`parse_github_url` lowercases `parsed.netloc` so a mixed-case URL like `https://API.GITHUB.COM/...` fails at parse time with a clear error rather than later at redirect time.

### `skill_manifest.py` — `_NoRedirectHandler`
Manifest URLs are operator-configured and point at static config files. A redirect signals the URL is stale or being rewritten on the network — silently following it would risk shipping the bearer to an unintended host. Better to surface the redirect as an error.

Both modules now route through `_urlopen_github` / `_urlopen_no_redirect` wrappers so tests have a single clean patch point.

## Tests

`tests/test_skill_fetch_redirects.py` (9 cases):
- Block redirect to attacker host
- Allow `api.github.com → codeload.github.com`
- Strip `Authorization` on cross-host redirect
- Keep `Authorization` on same-host redirect
- Block `github.com.evil.com`-style subdomain typo squats
- Block HTTPS→HTTP downgrade redirects
- Block any manifest redirect (cross-host and same-host)

## Test plan

- [x] `pytest tests/` → 523 passing