### PR TITLE
fix(cell-output): handle nbformat multiline_string in bundles

### DIFF
--- a/src/cell-output-bundle.ts
+++ b/src/cell-output-bundle.ts
@@ -87,9 +87,13 @@ export function cellOutputAsContextBundle(
     // DataFrames render as both text/html and text/plain; prefer the plain
     // form — it's the formatted ASCII table, cheaper, and an LLM reads it
     // just fine. text/html alone is stripped to plain text below.
-    if (data['text/plain']) {
+    // Use ``in`` rather than truthy check: an empty array ``[]`` is legal
+    // (if rare) nbformat for ``text/plain`` but falsy in JS, which would
+    // otherwise let the html branch fire over an explicit-but-empty plain
+    // entry.
+    if ('text/plain' in data) {
       pushBundle('text/plain', joinMultilineString(data['text/plain']));
-    } else if (data['text/html']) {
+    } else if ('text/html' in data) {
       pushBundle(
         'text/html',
         stripHtml(joinMultilineString(data['text/html']))

--- a/src/cell-output-bundle.ts
+++ b/src/cell-output-bundle.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
 
 import { CodeCell } from '@jupyterlab/cells';
-import { formatJupyterError, truncateToTokenCount } from './utils';
+import {
+  formatJupyterError,
+  joinMultilineString,
+  truncateToTokenCount
+} from './utils';
 import { IOutputContextItem } from './tokens';
 
 export const MAX_TOKENS_PER_OUTPUT = 4000;
@@ -73,21 +77,23 @@ export function cellOutputAsContextBundle(
     }
 
     if (output.output_type === 'stream') {
-      pushBundle('text/plain', String(output.text ?? ''));
+      pushBundle('text/plain', joinMultilineString(output.text));
       continue;
     }
 
     // execute_result and display_data
     const data = (output.data ?? {}) as Record<string, any>;
 
-    // DataFrames render as both text/html and text/plain; the plain form is the
-    // formatted ASCII table — cheaper, and an LLM reads it just fine.
-    if (data['text/html'] && data['text/plain']) {
-      pushBundle('text/plain', String(data['text/plain']));
-    } else if (data['text/plain']) {
-      pushBundle('text/plain', String(data['text/plain']));
+    // DataFrames render as both text/html and text/plain; prefer the plain
+    // form — it's the formatted ASCII table, cheaper, and an LLM reads it
+    // just fine. text/html alone is stripped to plain text below.
+    if (data['text/plain']) {
+      pushBundle('text/plain', joinMultilineString(data['text/plain']));
     } else if (data['text/html']) {
-      pushBundle('text/html', stripHtml(String(data['text/html'])));
+      pushBundle(
+        'text/html',
+        stripHtml(joinMultilineString(data['text/html']))
+      );
     }
 
     if (data['application/vnd.plotly.v1+json']) {
@@ -106,7 +112,7 @@ export function cellOutputAsContextBundle(
       if (!data[imgMime]) {
         continue;
       }
-      const raw = String(data[imgMime]);
+      const raw = joinMultilineString(data[imgMime]);
       if (!supportsVision) {
         pushBundle(imgMime, '<image omitted: model lacks vision support>');
       } else if (raw.length > MAX_IMAGE_BASE64_BYTES) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -140,12 +140,13 @@ export function cellOutputAsText(cell: CodeCell): string {
   const outputs = cell.outputArea.model.toJSON();
   for (const output of outputs) {
     if (output.output_type === 'execute_result') {
-      content +=
+      const data =
         typeof output.data === 'object' && output.data !== null
           ? (output.data as PartialJSONObject)['text/plain']
-          : '' + '\n';
+          : undefined;
+      content += joinMultilineString(data);
     } else if (output.output_type === 'stream') {
-      content += output.text + '\n';
+      content += joinMultilineString(output.text) + '\n';
     } else if (output.output_type === 'error') {
       // Skip errors without a traceback to match historical behavior of this
       // function; the head-only case is intentional here.
@@ -156,6 +157,23 @@ export function cellOutputAsText(cell: CodeCell): string {
   }
 
   return content;
+}
+
+// nbformat allows text-shaped output fields (stream `text`, `data['text/plain']`,
+// `data['text/html']`, etc.) to be either a single string or a list of strings,
+// joined with the empty string. Some kernels (e.g. older IPython, R) emit the
+// list form for multi-line output. Plain `String([...])` coerces a list to
+// `"a,b,c"` — wrong for both display and tokenization. Centralize the join.
+export function joinMultilineString(value: unknown): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map(v => (v === null || v === undefined ? '' : String(v)))
+      .join('');
+  }
+  return String(value);
 }
 
 export function getTokenCount(source: string): number {

--- a/tests/ts/cell-output-bundle.test.ts
+++ b/tests/ts/cell-output-bundle.test.ts
@@ -235,6 +235,61 @@ describe('cellOutputAsContextBundle', () => {
     });
   });
 
+  // nbformat allows stream `text` and `data[mime]` text fields to be either a
+  // single string or a list of strings (joined with the empty string). Plain
+  // `String([...])` would coerce the list to a comma-joined garbage string.
+  describe('multiline_string handling (nbformat)', () => {
+    it('joins array-form stream text without comma separators', () => {
+      const cell = makeCell([
+        {
+          output_type: 'stream',
+          text: ['line one\n', 'line two\n', 'line three']
+        }
+      ]);
+      const bundle = cellOutputAsContextBundle(cell);
+      expect(bundle.mimeBundles[0].data).toBe('line one\nline two\nline three');
+      expect(bundle.mimeBundles[0].data).not.toContain(',');
+    });
+
+    it('joins array-form text/plain in execute_result', () => {
+      const cell = makeCell([
+        {
+          output_type: 'execute_result',
+          data: { 'text/plain': ['hello', '\n', 'world'] }
+        }
+      ]);
+      const bundle = cellOutputAsContextBundle(cell);
+      expect(bundle.mimeBundles[0].data).toBe('hello\nworld');
+    });
+
+    it('joins array-form text/html before stripping tags', () => {
+      const cell = makeCell([
+        {
+          output_type: 'execute_result',
+          data: { 'text/html': ['<p>hello ', '<b>world</b>', '</p>'] }
+        }
+      ]);
+      const bundle = cellOutputAsContextBundle(cell);
+      expect(bundle.mimeBundles[0].mimeType).toBe('text/html');
+      // Tags stripped, content joined with no comma artifacts.
+      expect(bundle.mimeBundles[0].data).toContain('hello');
+      expect(bundle.mimeBundles[0].data).toContain('world');
+      expect(bundle.mimeBundles[0].data).not.toContain('<');
+      expect(bundle.mimeBundles[0].data).not.toContain(',');
+    });
+
+    it('joins array-form image base64 (rare but legal nbformat)', () => {
+      const cell = makeCell([
+        {
+          output_type: 'display_data',
+          data: { 'image/png': ['iVBORw0K', 'Ggo'] }
+        }
+      ]);
+      const bundle = cellOutputAsContextBundle(cell, { supportsVision: true });
+      expect(bundle.mimeBundles[0].data).toBe('iVBORw0KGgo');
+    });
+  });
+
   it('returns the documented bundle shape', () => {
     const bundle: IOutputContextBundle = cellOutputAsContextBundle(
       makeCell([{ output_type: 'stream', text: 'hi' }])

--- a/tests/ts/utils.test.ts
+++ b/tests/ts/utils.test.ts
@@ -335,6 +335,29 @@ describe('cellOutputAsText', () => {
     ]);
     expect(cellOutputAsText(cell)).toBe('first\nsecond');
   });
+
+  // nbformat allows stream `text` and `data['text/plain']` to be a list of
+  // strings joined with the empty string. Plain `String([...])` would coerce
+  // that to a comma-joined garbage string.
+  it('joins array-form stream text without comma separators', () => {
+    const cell = makeCell([
+      {
+        output_type: 'stream',
+        text: ['line one\n', 'line two\n', 'line three']
+      }
+    ]);
+    expect(cellOutputAsText(cell)).toBe('line one\nline two\nline three\n');
+  });
+
+  it('joins array-form text/plain in execute_result', () => {
+    const cell = makeCell([
+      {
+        output_type: 'execute_result',
+        data: { 'text/plain': ['hello', '\n', 'world'] }
+      }
+    ]);
+    expect(cellOutputAsText(cell)).toBe('hello\nworld');
+  });
 });
 
 describe('writeTextToClipboard', () => {


### PR DESCRIPTION
## Summary

Per [nbformat](https://nbformat.readthedocs.io/en/latest/format_description.html#code-cell-outputs), text-shaped output fields (stream `text`, `data['text/plain']`, `data['text/html']`, etc.) may be either a single string **or a list of strings joined with the empty string**. The bundler and `cellOutputAsText` were doing `String(value)` which coerces a list to a comma-joined garbage string — wrong for both LLM context and tokenization.

## What changed

`src/utils.ts`
- Adds `joinMultilineString(value)` that joins arrays with `''` and falls back to `String(value)` for scalars.
- `cellOutputAsText` now uses it for both `execute_result.data['text/plain']` and stream `text`, with safer `undefined` handling for outputs that lack a `text/plain` key.

`src/cell-output-bundle.ts`
- Routes stream text, text/plain, text/html, and image base64 through `joinMultilineString`.
- Collapses the redundant first branch in the DataFrame heuristic — the existing `html && plain` branch and the `plain` branch did the same thing; the policy comment already captures the intent.

## Tests

`tests/ts/cell-output-bundle.test.ts` — 4 new cases:
- Array-form stream text joins without comma separators
- Array-form `text/plain` in execute_result joins correctly
- Array-form `text/html` joins before tag-stripping
- Array-form image base64 joins correctly (rare but legal)

## Test plan

- [x] `jlpm test` → 99 passing
- [x] `pytest tests/` → 515 passing
- [x] `eslint` + `prettier` clean