### PR TITLE
a11y(settings): convert tabs to ARIA tablist with arrow-key nav

### DIFF
--- a/src/components/settings-panel.tsx
+++ b/src/components/settings-panel.tsx
@@ -88,13 +88,17 @@ function SettingsPanelComponent(props: any) {
 
   return (
     <div className="nbi-settings-panel">
-      <div className="nbi-settings-panel-tabs">
-        <SettingsPanelTabsComponent
-          onTabSelected={onTabSelected}
-          activeTab={activeTab}
-        />
-      </div>
-      <div className="nbi-settings-panel-tab-content">
+      <SettingsPanelTabsComponent
+        onTabSelected={onTabSelected}
+        activeTab={activeTab}
+      />
+      <div
+        className="nbi-settings-panel-tab-content"
+        role="tabpanel"
+        id={`nbi-settings-tabpanel-${activeTab}`}
+        aria-labelledby={`nbi-settings-tab-${activeTab}`}
+        tabIndex={0}
+      >
         {activeTab === 'general' && (
           <SettingsPanelComponentGeneral
             onSave={props.onSave}
@@ -132,41 +136,86 @@ function SettingsPanelTabsComponent(props: any) {
     };
   }, []);
 
+  const tabs: { id: string; label: React.ReactNode }[] = [
+    { id: 'general', label: 'General' },
+    {
+      id: 'claude',
+      label: (
+        <>
+          <span
+            className="claude-icon"
+            aria-hidden="true"
+            dangerouslySetInnerHTML={{ __html: claudeSvgStr }}
+          ></span>
+          Claude
+        </>
+      )
+    }
+  ];
+  if (!isInClaudeCodeMode) {
+    tabs.push({ id: 'mcp-servers', label: 'MCP Servers' });
+  }
+
+  const selectTab = (id: string): void => {
+    setActiveTab(id);
+    props.onTabSelected(id);
+  };
+
+  // Arrow-key navigation matches the WAI-ARIA tabs pattern: Up/Down move
+  // between tabs (the list is rendered vertically) and Home/End jump to ends.
+  // Activation is automatic — focus moves and the panel switches together.
+  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>): void => {
+    const key = e.key;
+    if (
+      key !== 'ArrowDown' &&
+      key !== 'ArrowUp' &&
+      key !== 'Home' &&
+      key !== 'End'
+    ) {
+      return;
+    }
+    e.preventDefault();
+    const idx = tabs.findIndex(t => t.id === activeTab);
+    let next = idx;
+    if (key === 'ArrowDown') {
+      next = (idx + 1) % tabs.length;
+    } else if (key === 'ArrowUp') {
+      next = (idx - 1 + tabs.length) % tabs.length;
+    } else if (key === 'Home') {
+      next = 0;
+    } else if (key === 'End') {
+      next = tabs.length - 1;
+    }
+    selectTab(tabs[next].id);
+    document.getElementById(`nbi-settings-tab-${tabs[next].id}`)?.focus();
+  };
+
   return (
-    <div>
-      <div
-        className={`nbi-settings-panel-tab ${activeTab === 'general' ? 'active' : ''}`}
-        onClick={() => {
-          setActiveTab('general');
-          props.onTabSelected('general');
-        }}
-      >
-        General
-      </div>
-      <div
-        className={`nbi-settings-panel-tab ${activeTab === 'claude' ? 'active' : ''}`}
-        onClick={() => {
-          setActiveTab('claude');
-          props.onTabSelected('claude');
-        }}
-      >
-        <span
-          className="claude-icon"
-          dangerouslySetInnerHTML={{ __html: claudeSvgStr }}
-        ></span>
-        Claude
-      </div>
-      {!isInClaudeCodeMode && (
-        <div
-          className={`nbi-settings-panel-tab ${activeTab === 'mcp-servers' ? 'active' : ''}`}
-          onClick={() => {
-            setActiveTab('mcp-servers');
-            props.onTabSelected('mcp-servers');
-          }}
-        >
-          MCP Servers
-        </div>
-      )}
+    <div
+      className="nbi-settings-panel-tabs"
+      role="tablist"
+      aria-orientation="vertical"
+      aria-label="Settings sections"
+      onKeyDown={onKeyDown}
+    >
+      {tabs.map(tab => {
+        const selected = activeTab === tab.id;
+        return (
+          <button
+            type="button"
+            key={tab.id}
+            id={`nbi-settings-tab-${tab.id}`}
+            className={`nbi-settings-panel-tab ${selected ? 'active' : ''}`}
+            role="tab"
+            aria-selected={selected}
+            aria-controls={`nbi-settings-tabpanel-${tab.id}`}
+            tabIndex={selected ? 0 : -1}
+            onClick={() => selectTab(tab.id)}
+          >
+            {tab.label}
+          </button>
+        );
+      })}
     </div>
   );
 }
@@ -1098,27 +1147,86 @@ function SettingsPanelComponentClaude(props: any) {
     }
   }, [nbiConfig.isInClaudeCodeMode, claudeSubTab]);
 
+  const subTabs: { id: 'settings' | 'skills'; label: string }[] = [
+    { id: 'settings', label: 'Settings' },
+    { id: 'skills', label: 'Skills' }
+  ];
+
+  // Horizontal tablist: Left/Right arrows move between subtabs.
+  const onSubTabKeyDown = (e: React.KeyboardEvent<HTMLDivElement>): void => {
+    const key = e.key;
+    if (
+      key !== 'ArrowLeft' &&
+      key !== 'ArrowRight' &&
+      key !== 'Home' &&
+      key !== 'End'
+    ) {
+      return;
+    }
+    e.preventDefault();
+    const idx = subTabs.findIndex(t => t.id === claudeSubTab);
+    let next = idx;
+    if (key === 'ArrowRight') {
+      next = (idx + 1) % subTabs.length;
+    } else if (key === 'ArrowLeft') {
+      next = (idx - 1 + subTabs.length) % subTabs.length;
+    } else if (key === 'Home') {
+      next = 0;
+    } else if (key === 'End') {
+      next = subTabs.length - 1;
+    }
+    setClaudeSubTab(subTabs[next].id);
+    document.getElementById(`nbi-claude-subtab-${subTabs[next].id}`)?.focus();
+  };
+
   return (
     <div className="config-dialog claude-mode-config-dialog">
       {nbiConfig.isInClaudeCodeMode && (
-        <div className="nbi-subtab-bar">
-          <div
-            className={`nbi-subtab ${claudeSubTab === 'settings' ? 'active' : ''}`}
-            onClick={() => setClaudeSubTab('settings')}
-          >
-            Settings
-          </div>
-          <div
-            className={`nbi-subtab ${claudeSubTab === 'skills' ? 'active' : ''}`}
-            onClick={() => setClaudeSubTab('skills')}
-          >
-            Skills
-          </div>
+        <div
+          className="nbi-subtab-bar"
+          role="tablist"
+          aria-label="Claude settings sections"
+          aria-orientation="horizontal"
+          onKeyDown={onSubTabKeyDown}
+        >
+          {subTabs.map(tab => {
+            const selected = claudeSubTab === tab.id;
+            return (
+              <button
+                type="button"
+                key={tab.id}
+                id={`nbi-claude-subtab-${tab.id}`}
+                className={`nbi-subtab ${selected ? 'active' : ''}`}
+                role="tab"
+                aria-selected={selected}
+                aria-controls={`nbi-claude-subtabpanel-${tab.id}`}
+                tabIndex={selected ? 0 : -1}
+                onClick={() => setClaudeSubTab(tab.id)}
+              >
+                {tab.label}
+              </button>
+            );
+          })}
         </div>
       )}
-      {claudeSubTab === 'skills' && <SettingsPanelComponentSkills />}
+      {claudeSubTab === 'skills' && (
+        <div
+          role="tabpanel"
+          id="nbi-claude-subtabpanel-skills"
+          aria-labelledby="nbi-claude-subtab-skills"
+          tabIndex={0}
+        >
+          <SettingsPanelComponentSkills />
+        </div>
+      )}
       {claudeSubTab === 'settings' && (
-        <div className="config-dialog-body">
+        <div
+          className="config-dialog-body"
+          role="tabpanel"
+          id="nbi-claude-subtabpanel-settings"
+          aria-labelledby="nbi-claude-subtab-settings"
+          tabIndex={0}
+        >
           <div className="model-config-section">
             <div className="model-config-section-header">
               Enable Claude mode

--- a/src/components/settings-panel.tsx
+++ b/src/components/settings-panel.tsx
@@ -23,6 +23,49 @@ import { writeTextToClipboard } from '../utils';
 const lockedTip = (locked: boolean): string =>
   locked ? 'Locked by your administrator' : '';
 
+// Stable id helper so the tab and its panel agree on aria-controls /
+// aria-labelledby without scattering string concatenation through the
+// component.
+const tabId = (prefix: string, id: string): string => `${prefix}-${id}`;
+
+type TablistOrientation = 'vertical' | 'horizontal';
+
+// WAI-ARIA tablist arrow-key navigation. Same shape for both the
+// vertical (Up/Down) main tabs and the horizontal (Left/Right) Claude
+// subtabs — the orientation flag picks which keys move the cursor.
+// Returns an ``onKeyDown`` for the tablist container; callers decide
+// what to do with each id (typically: select + focus).
+function useTablistArrowKeys<T extends { id: string }>(
+  tabs: T[],
+  activeId: string,
+  onSelect: (id: string) => void,
+  orientation: TablistOrientation,
+  domIdFor: (id: string) => string
+): (e: React.KeyboardEvent<HTMLDivElement>) => void {
+  return (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const key = e.key;
+    const prevKey = orientation === 'vertical' ? 'ArrowUp' : 'ArrowLeft';
+    const nextKey = orientation === 'vertical' ? 'ArrowDown' : 'ArrowRight';
+    if (key !== prevKey && key !== nextKey && key !== 'Home' && key !== 'End') {
+      return;
+    }
+    e.preventDefault();
+    const idx = tabs.findIndex(t => t.id === activeId);
+    let next = idx;
+    if (key === nextKey) {
+      next = (idx + 1) % tabs.length;
+    } else if (key === prevKey) {
+      next = (idx - 1 + tabs.length) % tabs.length;
+    } else if (key === 'Home') {
+      next = 0;
+    } else if (key === 'End') {
+      next = tabs.length - 1;
+    }
+    onSelect(tabs[next].id);
+    document.getElementById(domIdFor(tabs[next].id))?.focus();
+  };
+}
+
 // When a boolean policy is locked the panel shows the policy-resolved value;
 // otherwise it shows the user's local toggle state.
 const checkedValue = (
@@ -95,9 +138,8 @@ function SettingsPanelComponent(props: any) {
       <div
         className="nbi-settings-panel-tab-content"
         role="tabpanel"
-        id={`nbi-settings-tabpanel-${activeTab}`}
-        aria-labelledby={`nbi-settings-tab-${activeTab}`}
-        tabIndex={0}
+        id={tabId('nbi-settings-tabpanel', activeTab)}
+        aria-labelledby={tabId('nbi-settings-tab', activeTab)}
       >
         {activeTab === 'general' && (
           <SettingsPanelComponentGeneral
@@ -161,34 +203,13 @@ function SettingsPanelTabsComponent(props: any) {
     props.onTabSelected(id);
   };
 
-  // Arrow-key navigation matches the WAI-ARIA tabs pattern: Up/Down move
-  // between tabs (the list is rendered vertically) and Home/End jump to ends.
-  // Activation is automatic — focus moves and the panel switches together.
-  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>): void => {
-    const key = e.key;
-    if (
-      key !== 'ArrowDown' &&
-      key !== 'ArrowUp' &&
-      key !== 'Home' &&
-      key !== 'End'
-    ) {
-      return;
-    }
-    e.preventDefault();
-    const idx = tabs.findIndex(t => t.id === activeTab);
-    let next = idx;
-    if (key === 'ArrowDown') {
-      next = (idx + 1) % tabs.length;
-    } else if (key === 'ArrowUp') {
-      next = (idx - 1 + tabs.length) % tabs.length;
-    } else if (key === 'Home') {
-      next = 0;
-    } else if (key === 'End') {
-      next = tabs.length - 1;
-    }
-    selectTab(tabs[next].id);
-    document.getElementById(`nbi-settings-tab-${tabs[next].id}`)?.focus();
-  };
+  const onKeyDown = useTablistArrowKeys(
+    tabs,
+    activeTab,
+    selectTab,
+    'vertical',
+    id => tabId('nbi-settings-tab', id)
+  );
 
   return (
     <div
@@ -204,11 +225,11 @@ function SettingsPanelTabsComponent(props: any) {
           <button
             type="button"
             key={tab.id}
-            id={`nbi-settings-tab-${tab.id}`}
+            id={tabId('nbi-settings-tab', tab.id)}
             className={`nbi-settings-panel-tab ${selected ? 'active' : ''}`}
             role="tab"
             aria-selected={selected}
-            aria-controls={`nbi-settings-tabpanel-${tab.id}`}
+            aria-controls={tabId('nbi-settings-tabpanel', tab.id)}
             tabIndex={selected ? 0 : -1}
             onClick={() => selectTab(tab.id)}
           >
@@ -1152,32 +1173,13 @@ function SettingsPanelComponentClaude(props: any) {
     { id: 'skills', label: 'Skills' }
   ];
 
-  // Horizontal tablist: Left/Right arrows move between subtabs.
-  const onSubTabKeyDown = (e: React.KeyboardEvent<HTMLDivElement>): void => {
-    const key = e.key;
-    if (
-      key !== 'ArrowLeft' &&
-      key !== 'ArrowRight' &&
-      key !== 'Home' &&
-      key !== 'End'
-    ) {
-      return;
-    }
-    e.preventDefault();
-    const idx = subTabs.findIndex(t => t.id === claudeSubTab);
-    let next = idx;
-    if (key === 'ArrowRight') {
-      next = (idx + 1) % subTabs.length;
-    } else if (key === 'ArrowLeft') {
-      next = (idx - 1 + subTabs.length) % subTabs.length;
-    } else if (key === 'Home') {
-      next = 0;
-    } else if (key === 'End') {
-      next = subTabs.length - 1;
-    }
-    setClaudeSubTab(subTabs[next].id);
-    document.getElementById(`nbi-claude-subtab-${subTabs[next].id}`)?.focus();
-  };
+  const onSubTabKeyDown = useTablistArrowKeys(
+    subTabs,
+    claudeSubTab,
+    id => setClaudeSubTab(id as 'settings' | 'skills'),
+    'horizontal',
+    id => tabId('nbi-claude-subtab', id)
+  );
 
   return (
     <div className="config-dialog claude-mode-config-dialog">
@@ -1195,11 +1197,11 @@ function SettingsPanelComponentClaude(props: any) {
               <button
                 type="button"
                 key={tab.id}
-                id={`nbi-claude-subtab-${tab.id}`}
+                id={tabId('nbi-claude-subtab', tab.id)}
                 className={`nbi-subtab ${selected ? 'active' : ''}`}
                 role="tab"
                 aria-selected={selected}
-                aria-controls={`nbi-claude-subtabpanel-${tab.id}`}
+                aria-controls={tabId('nbi-claude-subtabpanel', tab.id)}
                 tabIndex={selected ? 0 : -1}
                 onClick={() => setClaudeSubTab(tab.id)}
               >
@@ -1212,9 +1214,8 @@ function SettingsPanelComponentClaude(props: any) {
       {claudeSubTab === 'skills' && (
         <div
           role="tabpanel"
-          id="nbi-claude-subtabpanel-skills"
-          aria-labelledby="nbi-claude-subtab-skills"
-          tabIndex={0}
+          id={tabId('nbi-claude-subtabpanel', 'skills')}
+          aria-labelledby={tabId('nbi-claude-subtab', 'skills')}
         >
           <SettingsPanelComponentSkills />
         </div>
@@ -1223,9 +1224,8 @@ function SettingsPanelComponentClaude(props: any) {
         <div
           className="config-dialog-body"
           role="tabpanel"
-          id="nbi-claude-subtabpanel-settings"
-          aria-labelledby="nbi-claude-subtab-settings"
-          tabIndex={0}
+          id={tabId('nbi-claude-subtabpanel', 'settings')}
+          aria-labelledby={tabId('nbi-claude-subtab', 'settings')}
         >
           <div className="model-config-section">
             <div className="model-config-section-header">

--- a/style/base.css
+++ b/style/base.css
@@ -1267,6 +1267,12 @@ svg.access-token-warning {
   cursor: pointer;
   padding: 10px;
   border-radius: 4px;
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  width: 100%;
 }
 
 .nbi-settings-panel-tab:hover {
@@ -1276,6 +1282,11 @@ svg.access-token-warning {
 .nbi-settings-panel-tab.active {
   background-color: var(--jp-layout-color1);
   font-weight: bold;
+}
+
+.nbi-settings-panel-tab:focus-visible {
+  outline: 2px solid var(--jp-brand-color1);
+  outline-offset: -2px;
 }
 
 .nbi-settings-panel-tab-content {
@@ -1294,12 +1305,22 @@ svg.access-token-warning {
   cursor: pointer;
   padding: 8px 16px;
   border-bottom: 2px solid transparent;
+  border-top: none;
+  border-left: none;
+  border-right: none;
   color: var(--jp-ui-font-color2);
   margin-bottom: -1px;
+  background: none;
+  font: inherit;
 }
 
 .nbi-subtab:hover {
   color: var(--jp-ui-font-color1);
+}
+
+.nbi-subtab:focus-visible {
+  outline: 2px solid var(--jp-brand-color1);
+  outline-offset: -2px;
 }
 
 .nbi-subtab.active {


### PR DESCRIPTION
## Summary

The settings panel used clickable `<div>` tabs with no ARIA. Screen readers announced the tabs as plain text and keyboard users couldn't reach them at all. This PR rebuilds both tab levels around the [WAI-ARIA tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/).

## What changed

### Top-level tabs — General / Claude / MCP Servers (vertical)
- Container: `role="tablist"` + `aria-orientation="vertical"` + `aria-label="Settings sections"`
- Each tab: `<button role="tab">` with `aria-selected`, `aria-controls`, and roving `tabindex` (selected = 0, others = -1)
- **Up/Down arrows** move and activate; **Home/End** jump to ends
- Claude svg icon gets `aria-hidden="true"` (the "Claude" label already names the tab)
- Content area: `role="tabpanel"` + `aria-labelledby` + `tabIndex={0}`

### Claude subtabs — Settings / Skills (horizontal)
- Same conversion. **Left/Right arrows** move and activate; Home/End jump to ends. Two `role="tabpanel"` wrappers replace the bare conditional renders.

### CSS
`<button>` defaults to having background/border/padding/font that diverge from the prior `<div>` look. Added resets and `:focus-visible` outlines for `.nbi-settings-panel-tab` and `.nbi-subtab` so the visual is unchanged but keyboard focus is now visible.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `jlpm test` → 95 passing (no behavior change)
- [x] prettier + eslint clean
- [ ] Manual keyboard walkthrough: Tab into tablist, arrow up/down between General/Claude/MCP Servers, Tab past tablist into panel, return to tablist, switch to Claude, Tab into subtab strip, arrow Left/Right between Settings/Skills