### PR TITLE
fix(skills): ignore sibling writes to scope dir (fix #208)

### DIFF
--- a/notebook_intelligence/skill_manager.py
+++ b/notebook_intelligence/skill_manager.py
@@ -2,7 +2,7 @@ import logging
 import shutil
 import threading
 from pathlib import Path
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, Iterator, List, Optional
 
 from notebook_intelligence.skillset import (
     SKILL_ENTRY_FILE,
@@ -82,6 +82,26 @@ class SkillManager:
                 log.info("Skill directory change detected; notifying listeners")
                 self._notify_skills_changed()
 
+    def _iter_bundle_dirs(self, scope_dir: Path) -> Iterator[Path]:
+        """Yield bundle dirs (each containing a SKILL.md) inside ``scope_dir``.
+
+        Hidden entries (``.git``, ``.DS_Store``, etc.) are skipped — see
+        ``_compute_signature`` for why this matters for change detection.
+        Errors from ``iterdir`` are swallowed so a transient FS hiccup
+        doesn't tear down the watcher thread.
+        """
+        if not scope_dir.exists():
+            return
+        try:
+            entries = sorted(scope_dir.iterdir())
+        except OSError:
+            return
+        for entry in entries:
+            if not entry.is_dir() or entry.name.startswith('.'):
+                continue
+            if (entry / SKILL_ENTRY_FILE).exists():
+                yield entry
+
     def _compute_signature(self) -> tuple:
         """Return a structural snapshot used to detect skill-content changes.
 
@@ -104,51 +124,31 @@ class SkillManager:
         """
         parts = []
         for scope, scope_dir in sorted(self._scope_dirs.items()):
-            if not scope_dir.exists():
-                parts.append((scope, ()))
-                continue
             bundles = []
-            try:
-                for entry in sorted(scope_dir.iterdir()):
-                    if not entry.is_dir() or entry.name.startswith('.'):
-                        continue
-                    skill_md = entry / SKILL_ENTRY_FILE
-                    if not skill_md.exists():
-                        continue
-                    try:
-                        bundles.append(
-                            (
-                                entry.name,
-                                entry.stat().st_mtime,
-                                skill_md.stat().st_mtime,
-                            )
+            for entry in self._iter_bundle_dirs(scope_dir):
+                try:
+                    bundles.append(
+                        (
+                            entry.name,
+                            entry.stat().st_mtime,
+                            (entry / SKILL_ENTRY_FILE).stat().st_mtime,
                         )
-                    except OSError:
-                        continue
-            except OSError:
-                pass
+                    )
+                except OSError:
+                    continue
             parts.append((scope, tuple(bundles)))
         return tuple(parts)
 
     def list_skills(self) -> List[Skill]:
         skills: List[Skill] = []
         for scope, scope_dir in self._scope_dirs.items():
-            if not scope_dir.exists():
-                continue
-            skills.extend(self._discover_scope(scope, scope_dir))
+            for entry in self._iter_bundle_dirs(scope_dir):
+                try:
+                    skills.append(Skill.from_path(entry, scope))
+                except Exception as e:
+                    log.error(f"Failed to load skill from {entry}: {e}")
         skills.sort(key=lambda s: (s.scope, s.name))
         return skills
-
-    def _discover_scope(self, scope: SkillScope, scope_dir: Path) -> List[Skill]:
-        results: List[Skill] = []
-        for entry in sorted(scope_dir.iterdir()):
-            if not (entry.is_dir() and (entry / SKILL_ENTRY_FILE).exists()):
-                continue
-            try:
-                results.append(Skill.from_path(entry, scope))
-            except Exception as e:
-                log.error(f"Failed to load skill from {entry}: {e}")
-        return results
 
     def _locate_skill_path(self, scope: SkillScope, name: str) -> Optional[Path]:
         """Return the bundle dir for a skill, or None if it doesn't exist."""

--- a/notebook_intelligence/skill_manager.py
+++ b/notebook_intelligence/skill_manager.py
@@ -29,7 +29,7 @@ class SkillManager:
         }
         self._listeners: List[Callable[[], None]] = []
         self._listeners_lock = threading.Lock()
-        self._last_mtime: float = 0.0
+        self._last_signature: tuple = ()
         self._watcher_thread: Optional[threading.Thread] = None
         self._watcher_stop = threading.Event()
 
@@ -44,7 +44,7 @@ class SkillManager:
 
     def _notify_skills_changed(self) -> None:
         # Suppress the next watcher-driven fire so self-triggered mutations don't double-notify.
-        self._last_mtime = self._compute_mtime()
+        self._last_signature = self._compute_signature()
         with self._listeners_lock:
             listeners = list(self._listeners)
         for listener in listeners:
@@ -58,7 +58,7 @@ class SkillManager:
             return
         self._watcher_stop.clear()
         # Baseline is computed on the watcher thread to avoid blocking startup.
-        self._last_mtime = 0.0
+        self._last_signature = ()
         self._watcher_thread = threading.Thread(
             name="Skill Watcher",
             target=self._watch_loop,
@@ -74,39 +74,61 @@ class SkillManager:
         self._watcher_thread = None
 
     def _watch_loop(self) -> None:
-        self._last_mtime = self._compute_mtime()
+        self._last_signature = self._compute_signature()
         while not self._watcher_stop.wait(self.WATCH_INTERVAL_SECONDS):
-            current = self._compute_mtime()
-            if current > self._last_mtime:
-                self._last_mtime = current
+            current = self._compute_signature()
+            if current != self._last_signature:
+                self._last_signature = current
                 log.info("Skill directory change detected; notifying listeners")
                 self._notify_skills_changed()
 
-    def _compute_mtime(self) -> float:
-        """Max mtime of scope dirs, each bundle dir, and each bundle's SKILL.md.
+    def _compute_signature(self) -> tuple:
+        """Return a structural snapshot used to detect skill-content changes.
 
-        We intentionally skip walking bundle contents so large helper trees don't inflate
-        the polling cost. Bundle-internal edits still bump the bundle dir's mtime.
+        For each scope, includes the sorted bundle-name + bundle-dir mtime +
+        SKILL.md mtime triples. Crucially, this skips:
+
+        * The scope directory's own mtime — siblings like ``.DS_Store`` (macOS
+          Finder), ``.git/`` operations on a parent, or unrelated lockfiles
+          would otherwise bump the parent's mtime and trip the watcher
+          despite no actual skill change. ``#208`` was this case: launching
+          ``claude`` in a terminal touched a sibling under
+          ``~/.claude/skills/`` and the watcher fired a "Skills reloaded"
+          banner the user hadn't asked for.
+        * Hidden entries (``.git``, ``.DS_Store``, etc.) inside the scope —
+          same reasoning.
+
+        Bundle-dir mtime is preserved so helper-file edits inside a bundle
+        still register as a change. Equality (not ``>``) drives the
+        watcher's decision so renames + deletions are detected too.
         """
-        max_mtime = 0.0
-        for scope_dir in self._scope_dirs.values():
+        parts = []
+        for scope, scope_dir in sorted(self._scope_dirs.items()):
             if not scope_dir.exists():
+                parts.append((scope, ()))
                 continue
+            bundles = []
             try:
-                max_mtime = max(max_mtime, scope_dir.stat().st_mtime)
-                for entry in scope_dir.iterdir():
-                    if not entry.is_dir():
+                for entry in sorted(scope_dir.iterdir()):
+                    if not entry.is_dir() or entry.name.startswith('.'):
+                        continue
+                    skill_md = entry / SKILL_ENTRY_FILE
+                    if not skill_md.exists():
                         continue
                     try:
-                        max_mtime = max(max_mtime, entry.stat().st_mtime)
-                        skill_md = entry / SKILL_ENTRY_FILE
-                        if skill_md.exists():
-                            max_mtime = max(max_mtime, skill_md.stat().st_mtime)
+                        bundles.append(
+                            (
+                                entry.name,
+                                entry.stat().st_mtime,
+                                skill_md.stat().st_mtime,
+                            )
+                        )
                     except OSError:
                         continue
             except OSError:
-                continue
-        return max_mtime
+                pass
+            parts.append((scope, tuple(bundles)))
+        return tuple(parts)
 
     def list_skills(self) -> List[Skill]:
         skills: List[Skill] = []

--- a/tests/test_skill_manager.py
+++ b/tests/test_skill_manager.py
@@ -396,10 +396,60 @@ class TestWatcher:
         manager.on_skills_changed(fired.set)
         manager.start_watching()
         try:
-            # Ensure mtime baseline is recorded before we mutate
+            # Ensure baseline is recorded before we mutate
             time.sleep(0.1)
             _write_bundle(user_dir, "external")
             assert fired.wait(timeout=2.0), "watcher did not fire on external change"
+        finally:
+            manager.stop_watching()
+
+    def test_watcher_detects_bundle_removal(self, skill_dirs):
+        # Pre-fix the watcher's ``current > _last_mtime`` check would miss
+        # removals because the surviving bundles' mtimes are older. The
+        # signature-equality compare picks them up.
+        import shutil
+
+        user_dir, project_dir = skill_dirs
+        _write_bundle(user_dir, "going-away")
+        manager = SkillManager(user_dir, project_dir)
+        manager.WATCH_INTERVAL_SECONDS = 0.05  # type: ignore[attr-defined]
+        fired = threading.Event()
+        manager.on_skills_changed(fired.set)
+        manager.start_watching()
+        try:
+            time.sleep(0.1)
+            shutil.rmtree(user_dir / "going-away")
+            assert fired.wait(timeout=2.0), "watcher did not fire on bundle removal"
+        finally:
+            manager.stop_watching()
+
+    def test_watcher_ignores_dotfile_in_scope_dir(self, skill_dirs):
+        # Regression test for #208: launching ``claude`` in a terminal
+        # touches a sibling under ``~/.claude/skills/`` (e.g. ``.DS_Store``,
+        # a logfile, or an mtime bump from the kernel) and the previous
+        # mtime-based watcher fired a spurious "Skills reloaded" banner the
+        # user hadn't asked for.
+        user_dir, project_dir = skill_dirs
+        _write_bundle(user_dir, "real-skill")
+        manager = SkillManager(user_dir, project_dir)
+        manager.WATCH_INTERVAL_SECONDS = 0.05  # type: ignore[attr-defined]
+        fired = threading.Event()
+        manager.on_skills_changed(fired.set)
+        manager.start_watching()
+        try:
+            time.sleep(0.1)
+            # Touch the scope dir's own mtime by writing a hidden sibling.
+            # This simulates Finder (.DS_Store), .git, or any other tool
+            # writing alongside skill bundles without touching the bundles
+            # themselves.
+            (user_dir / ".DS_Store").write_text("", encoding="utf-8")
+            (user_dir / ".git").mkdir(exist_ok=True)
+            # Wait for at least two watcher ticks to elapse — the spurious
+            # change would have fired by now if the dotfile bumped the
+            # signature.
+            assert not fired.wait(timeout=0.5), (
+                "watcher fired on dotfile change; this is the #208 regression"
+            )
         finally:
             manager.stop_watching()
 


### PR DESCRIPTION
Closes #208.

## Summary

Launching `claude --resume` from the JupyterLab launcher was producing a "Skills reloaded — applied to the current session." banner in the chat sidebar even though no skills had actually changed.

## Root cause

The `SkillManager` watcher polled with two issues:

1. `_compute_mtime` included `scope_dir.stat().st_mtime` in the rolling max, so any sibling write under `~/.claude/skills/` — `.DS_Store` from Finder, a `.git/` operation, a log/cache file written by another tool — bumped the parent directory's mtime and tripped the watcher even though no skill content changed. Issue #208 was this case: launching `claude` in a terminal is enough to touch the parent dir.
2. The `current > _last_mtime` compare also missed bundle *removals* whenever the surviving bundles' mtimes were older than the deleted one's.

## What changed

Replaced the float-mtime baseline with a structural signature: per scope, the sorted `(bundle_name, bundle_dir_mtime, skill_md_mtime)` triples, for non-dotfile bundles only. The watcher now fires on `!=` (not `>`), so renames + deletions are detected as well. Hidden entries are filtered out, and the parent `scope_dir` itself is no longer stat'd, eliminating the sensitivity to sibling writes.

Bundle-dir mtime is preserved in the signature so helper-file edits inside a bundle still register as a change.

## Tests

`tests/test_skill_manager.py`:
- `test_watcher_detects_bundle_removal` — pins the deletion case the old `>` compare missed.
- `test_watcher_ignores_dotfile_in_scope_dir` — explicit regression guard for #208 (writes a `.DS_Store` and creates a `.git/` sibling, asserts the watcher does **not** fire).

## Test plan

- [x] `pytest tests/` → 517 passing (515 + 2 new)
- [x] `tsc --noEmit` clean (no frontend changes)
- [x] `jlpm test` → 95 jest passing