### PR TITLE
pin minimum versions of dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,9 @@ dependencies = [
     "litellm>=1.62.1",
     "openai",
     "ollama",
-    "fastmcp",
+    "fastmcp>=2.11.2",
     "claude-agent-sdk",
-    "anthropic"
+    "anthropic>=0.22.1"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 


### PR DESCRIPTION
## Summary
- Pins minimum versions for dependencies in `pyproject.toml` to ensure reproducible installs and prevent regressions from older incompatible versions

## Test plan
- [x] Verify package installs correctly with pinned minimum versions
- [x] Run existing test suite to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)