### PR TITLE
feat(chat-sidebar): skip dot-prefixed files in context picker

### DIFF
--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -425,12 +425,7 @@ function readFileAsDataURL(file: File): Promise<string> {
 
 const MAX_VISIBLE_WORKSPACE_FILES = 50;
 const MAX_WORKSPACE_FILE_SCAN_COUNT = 1500;
-const SKIPPED_WORKSPACE_DIRECTORIES = new Set([
-  '.git',
-  '.ipynb_checkpoints',
-  '__pycache__',
-  'node_modules'
-]);
+const SKIPPED_WORKSPACE_DIRECTORIES = new Set(['__pycache__', 'node_modules']);
 
 function countContentLines(content: string): number {
   if (content === '') {
@@ -1157,6 +1152,10 @@ function SidebarComponent(props: any) {
 
         for (const entry of entries) {
           if (!entry?.path || !entry?.name) {
+            continue;
+          }
+
+          if (entry.name.startsWith('.')) {
             continue;
           }
 


### PR DESCRIPTION
## Summary

Resolves #219. The context file picker (`@`-mention in the chat sidebar) now skips any entry whose name begins with `.` — both files and directories.

## Behavior

- Hidden directories (`.git`, `.venv`, `.pytest_cache`, etc.) are pruned **before** they are enqueued for traversal in `loadWorkspaceFiles`, so their subtrees are never walked.
- Hidden files (`.env`, `.DS_Store`, etc.) no longer appear in the picker results.
- `.git` and `.ipynb_checkpoints` were removed from `SKIPPED_WORKSPACE_DIRECTORIES` since the dot-prefix rule subsumes them; `__pycache__` and `node_modules` remain.

## Trade-off

Some users may legitimately want to attach dot-prefixed config files (e.g., `.env.example`, `.eslintrc`, `.github/workflows/*.yml`). This PR follows the issue's request for a blanket skip; a follow-up could read JupyterLab's `showHiddenFiles` setting or expose a per-picker toggle.

## Test plan

- [ ] Open chat sidebar → click `@` → confirm hidden files/directories are absent from suggestions
- [ ] Confirm files in non-hidden directories still appear
- [ ] Confirm `__pycache__` and `node_modules` are still skipped
