### PR TITLE
feat(settings): promote Skills to a top-level tab + admin policy gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,18 +153,19 @@ Most settings panel toggles can be locked by org administrators. Two shapes:
 
 **Boolean policies** use the `*_POLICY` suffix and accept three values: `user-choice` (default — user toggles freely), `force-on` (locked enabled), `force-off` (locked disabled). When forced, the panel control is disabled with a "Locked by your administrator" tooltip and any client-side write is ignored.
 
-| Env var                                    | Locks the Settings panel control for      |
-| ------------------------------------------ | ----------------------------------------- |
-| `NBI_EXPLAIN_ERROR_POLICY`                 | "Explain cell errors"                     |
-| `NBI_OUTPUT_FOLLOWUP_POLICY`               | "Ask about cell outputs"                  |
-| `NBI_OUTPUT_TOOLBAR_POLICY`                | "Show output toolbar"                     |
-| `NBI_CLAUDE_MODE_POLICY`                   | "Enable Claude mode"                      |
-| `NBI_CLAUDE_CONTINUE_CONVERSATION_POLICY`  | "Remember conversation history"           |
-| `NBI_CLAUDE_CODE_TOOLS_POLICY`             | "Claude Code tools"                       |
-| `NBI_CLAUDE_JUPYTER_UI_TOOLS_POLICY`       | "Jupyter UI tools"                        |
-| `NBI_CLAUDE_SETTING_SOURCE_USER_POLICY`    | Setting source: User                      |
-| `NBI_CLAUDE_SETTING_SOURCE_PROJECT_POLICY` | Setting source: Project                   |
-| `NBI_STORE_GITHUB_ACCESS_TOKEN_POLICY`     | "Remember my GitHub Copilot access token" |
+| Env var                                    | Locks the Settings panel control for                                                              |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| `NBI_EXPLAIN_ERROR_POLICY`                 | "Explain cell errors"                                                                             |
+| `NBI_OUTPUT_FOLLOWUP_POLICY`               | "Ask about cell outputs"                                                                          |
+| `NBI_OUTPUT_TOOLBAR_POLICY`                | "Show output toolbar"                                                                             |
+| `NBI_CLAUDE_MODE_POLICY`                   | "Enable Claude mode"                                                                              |
+| `NBI_CLAUDE_CONTINUE_CONVERSATION_POLICY`  | "Remember conversation history"                                                                   |
+| `NBI_CLAUDE_CODE_TOOLS_POLICY`             | "Claude Code tools"                                                                               |
+| `NBI_CLAUDE_JUPYTER_UI_TOOLS_POLICY`       | "Jupyter UI tools"                                                                                |
+| `NBI_CLAUDE_SETTING_SOURCE_USER_POLICY`    | Setting source: User                                                                              |
+| `NBI_CLAUDE_SETTING_SOURCE_PROJECT_POLICY` | Setting source: Project                                                                           |
+| `NBI_STORE_GITHUB_ACCESS_TOKEN_POLICY`     | "Remember my GitHub Copilot access token"                                                         |
+| `NBI_SKILLS_MANAGEMENT_POLICY`             | The Skills tab (force-off hides it and 403s the API; also disables the managed-skills reconciler) |
 
 The first three also have matching traitlets on `NotebookIntelligence` (`explain_error_policy`, `output_followup_policy`, `output_toolbar_policy`); add the others as needed in the same shape:
 

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -357,6 +357,22 @@ NBI_ADDITIONAL_SKIPPED_WORKSPACE_DIRECTORIES=tmp,artifacts
 
 The env var **appends** to the traitlet value at server startup (in contrast to `NBI_ALLOW_GITHUB_SKILL_IMPORT` and the `NBI_*_POLICY` env vars, which override). Duplicates are collapsed; both lists are then merged with the built-in skip set on the frontend.
 
+### Disabling the Skills tab
+
+```python
+c.NotebookIntelligence.skills_management_policy = "force-off"
+```
+
+Or via env: `NBI_SKILLS_MANAGEMENT_POLICY=force-off`.
+
+Force-off does three things at once:
+
+- Hides the **Skills** tab in the Settings panel.
+- Returns HTTP 403 from every `/notebook-intelligence/skills/*` route, so a stale frontend or a direct API caller can't read or write skills.
+- Suppresses the [managed-skills reconciler](#managed-claude-skills-token) — the manifest is treated as empty, no `SkillReconciler` is constructed, and no scheduled reconcile runs. Org-curated skills still on disk are not touched, but new manifests aren't pulled.
+
+Use this when an org wants to disable user-authored Claude skills entirely.
+
 ---
 
 ## Multi-tenancy and per-team scoping

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -37,6 +37,7 @@ from notebook_intelligence.feature_flags import (
     VALID_POLICIES,
     apply_claude_policies,
     apply_string_overrides,
+    is_force_off,
     is_locked,
     resolve_feature_flag,
 )
@@ -232,6 +233,11 @@ FEATURE_POLICY_SPEC = (
         "NBI_STORE_GITHUB_ACCESS_TOKEN_POLICY",
         "store_github_access_token_policy",
     ),
+    (
+        "skills_management",
+        "NBI_SKILLS_MANAGEMENT_POLICY",
+        "skills_management_policy",
+    ),
 )
 FEATURE_POLICY_NAMES = tuple(name for name, _, _ in FEATURE_POLICY_SPEC)
 
@@ -275,6 +281,9 @@ def _build_feature_policies_response(policies: dict, nbi_config) -> dict:
         "claude_setting_source_user": "user" in sources,
         "claude_setting_source_project": "project" in sources,
         "store_github_access_token": bool(nbi_config.store_github_access_token),
+        # Admin-only gate; user has no toggle, so user_value is always True.
+        # The policy resolver still applies force-off / force-on correctly.
+        "skills_management": True,
     }
 
     response = {}
@@ -698,6 +707,19 @@ class SkillsBaseHandler(APIHandler):
     """Shared helpers for skills endpoints."""
 
     allow_github_skill_import = True
+    skills_management_enabled = True
+
+    async def prepare(self):
+        # APIHandler.prepare is async (xsrf/auth), so we must await it before
+        # applying the skills_management policy gate.
+        await super().prepare()
+        if self._finished:
+            return
+        if not self.skills_management_enabled:
+            self.set_status(403)
+            self.finish(
+                json.dumps({"error": "Skills management is disabled by your administrator"})
+            )
 
     @property
     def skill_manager(self):
@@ -1850,6 +1872,23 @@ class NotebookIntelligence(ExtensionApp):
         config=True,
     )
 
+    skills_management_policy = TraitletEnum(
+        list(VALID_POLICIES),
+        default_value=POLICY_USER_CHOICE,
+        help="""
+        Org-wide policy for the Skills management UI. "user-choice" (default)
+        and "force-on" both leave the Skills tab visible — there is no user
+        toggle to override, so the two are behaviorally identical today; the
+        three-value shape is preserved for symmetry with the other
+        feature_policies. "force-off" hides the tab, returns 403 from
+        /skills handlers, and **also disables the managed-skills reconciler**
+        — orgs that ship curated skills via NBI_SKILLS_MANIFEST should leave
+        this on user-choice and rely on filesystem permissions instead.
+        Overridden by the NBI_SKILLS_MANAGEMENT_POLICY env var.
+        """,
+        config=True,
+    )
+
     skills_manifest = Unicode(
         default_value="",
         help="""
@@ -1926,6 +1965,11 @@ class NotebookIntelligence(ExtensionApp):
     ):
         global ai_service_manager
         manifest_source = os.environ.get("NBI_SKILLS_MANIFEST", "").strip() or self.skills_manifest.strip()
+        # When skills management is force-off, suppress the manifest so the
+        # reconciler isn't constructed at all (org-curated skills wouldn't
+        # have a UI surface anyway, and stopping reconcile is the contract).
+        if is_force_off(feature_policies, "skills_management"):
+            manifest_source = ""
         managed_token = (
             os.environ.get("NBI_MANAGED_SKILLS_TOKEN", "").strip()
             or self.managed_skills_token.strip()
@@ -2001,6 +2045,9 @@ class NotebookIntelligence(ExtensionApp):
                 "NBI_ADDITIONAL_SKIPPED_WORKSPACE_DIRECTORIES",
                 self.additional_skipped_workspace_directories,
             )
+        )
+        SkillsBaseHandler.skills_management_enabled = not is_force_off(
+            feature_policies, "skills_management"
         )
         self._publish_policies(feature_policies, string_overrides)
         NotebookIntelligence.handlers = [

--- a/notebook_intelligence/feature_flags.py
+++ b/notebook_intelligence/feature_flags.py
@@ -45,6 +45,16 @@ def is_locked(policy: str) -> bool:
     return policy in (POLICY_FORCE_ON, POLICY_FORCE_OFF)
 
 
+def is_force_off(policies: dict, name: str) -> bool:
+    """True iff ``policies[name]`` is force-off (missing == user-choice).
+
+    The canonical predicate for backend kill-switches: a handler-level prepare
+    gate, a reconciler-init guard, etc. all want the same "is this admin-
+    disabled" answer.
+    """
+    return policies.get(name, POLICY_USER_CHOICE) == POLICY_FORCE_OFF
+
+
 def apply_string_overrides(target: dict, overrides: dict, mapping: tuple) -> dict:
     """Apply value-presence-locks per ``mapping`` to a copy of ``target``.
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -164,7 +164,8 @@ export type FeaturePolicyName =
   | 'claude_jupyter_ui_tools'
   | 'claude_setting_source_user'
   | 'claude_setting_source_project'
-  | 'store_github_access_token';
+  | 'store_github_access_token'
+  | 'skills_management';
 
 export type IFeaturePolicies = Record<
   FeaturePolicyName,
@@ -325,7 +326,8 @@ export class NBIConfig {
       'claude_jupyter_ui_tools',
       'claude_setting_source_user',
       'claude_setting_source_project',
-      'store_github_access_token'
+      'store_github_access_token',
+      'skills_management'
     ];
     const result = {} as IFeaturePolicies;
     for (const name of names) {

--- a/src/components/settings-panel.tsx
+++ b/src/components/settings-panel.tsx
@@ -124,6 +124,16 @@ export class SettingsPanel extends ReactWidget {
 
 function SettingsPanelComponent(props: any) {
   const [activeTab, setActiveTab] = useState('general');
+  const { featurePolicies } = useNbiPolicies();
+  const skillsTabVisible = featurePolicies.skills_management.enabled;
+
+  // Bounce the user off a tab that has just been hidden by an admin policy
+  // change so they don't see a blank pane.
+  useEffect(() => {
+    if (!skillsTabVisible && activeTab === 'skills') {
+      setActiveTab('general');
+    }
+  }, [skillsTabVisible, activeTab]);
 
   const onTabSelected = (tab: string) => {
     setActiveTab(tab);
@@ -134,6 +144,7 @@ function SettingsPanelComponent(props: any) {
       <SettingsPanelTabsComponent
         onTabSelected={onTabSelected}
         activeTab={activeTab}
+        skillsTabVisible={skillsTabVisible}
       />
       <div
         className="nbi-settings-panel-tab-content"
@@ -157,13 +168,20 @@ function SettingsPanelComponent(props: any) {
             onEditMCPConfigClicked={props.onEditMCPConfigClicked}
           />
         )}
+        {activeTab === 'skills' && skillsTabVisible && (
+          <SettingsPanelComponentSkills />
+        )}
       </div>
     </div>
   );
 }
 
 function SettingsPanelTabsComponent(props: any) {
-  const [activeTab, setActiveTab] = useState(props.activeTab);
+  // Fully controlled: parent owns `activeTab`. Reading directly from props
+  // (instead of a local mirror) prevents drift when the parent flips the
+  // tab — e.g. when an admin policy hides the active tab and the parent
+  // bounces the user to `general`.
+  const activeTab = props.activeTab;
   const [isInClaudeCodeMode, setIsInClaudeCodeMode] = useState(
     NBIAPI.config.isInClaudeCodeMode
   );
@@ -197,9 +215,11 @@ function SettingsPanelTabsComponent(props: any) {
   if (!isInClaudeCodeMode) {
     tabs.push({ id: 'mcp-servers', label: 'MCP Servers' });
   }
+  if (props.skillsTabVisible) {
+    tabs.push({ id: 'skills', label: 'Skills' });
+  }
 
   const selectTab = (id: string): void => {
-    setActiveTab(id);
     props.onTabSelected(id);
   };
 
@@ -1158,421 +1178,348 @@ function SettingsPanelComponentClaude(props: any) {
     continueConversation
   ]);
 
-  const [claudeSubTab, setClaudeSubTab] = useState<'settings' | 'skills'>(
-    'settings'
-  );
-
-  useEffect(() => {
-    if (!nbiConfig.isInClaudeCodeMode && claudeSubTab !== 'settings') {
-      setClaudeSubTab('settings');
-    }
-  }, [nbiConfig.isInClaudeCodeMode, claudeSubTab]);
-
-  const subTabs: { id: 'settings' | 'skills'; label: string }[] = [
-    { id: 'settings', label: 'Settings' },
-    { id: 'skills', label: 'Skills' }
-  ];
-
-  const onSubTabKeyDown = useTablistArrowKeys(
-    subTabs,
-    claudeSubTab,
-    id => setClaudeSubTab(id as 'settings' | 'skills'),
-    'horizontal',
-    id => tabId('nbi-claude-subtab', id)
-  );
-
   return (
     <div className="config-dialog claude-mode-config-dialog">
-      {nbiConfig.isInClaudeCodeMode && (
-        <div
-          className="nbi-subtab-bar"
-          role="tablist"
-          aria-label="Claude settings sections"
-          aria-orientation="horizontal"
-          onKeyDown={onSubTabKeyDown}
-        >
-          {subTabs.map(tab => {
-            const selected = claudeSubTab === tab.id;
-            return (
-              <button
-                type="button"
-                key={tab.id}
-                id={tabId('nbi-claude-subtab', tab.id)}
-                className={`nbi-subtab ${selected ? 'active' : ''}`}
-                role="tab"
-                aria-selected={selected}
-                aria-controls={tabId('nbi-claude-subtabpanel', tab.id)}
-                tabIndex={selected ? 0 : -1}
-                onClick={() => setClaudeSubTab(tab.id)}
-              >
-                {tab.label}
-              </button>
-            );
-          })}
-        </div>
-      )}
-      {claudeSubTab === 'skills' && (
-        <div
-          role="tabpanel"
-          id={tabId('nbi-claude-subtabpanel', 'skills')}
-          aria-labelledby={tabId('nbi-claude-subtab', 'skills')}
-        >
-          <SettingsPanelComponentSkills />
-        </div>
-      )}
-      {claudeSubTab === 'settings' && (
-        <div
-          className="config-dialog-body"
-          role="tabpanel"
-          id={tabId('nbi-claude-subtabpanel', 'settings')}
-          aria-labelledby={tabId('nbi-claude-subtab', 'settings')}
-        >
-          <div className="model-config-section">
-            <div className="model-config-section-header">
-              Enable Claude mode
+      <div className="config-dialog-body">
+        <div className="model-config-section">
+          <div className="model-config-section-header">Enable Claude mode</div>
+          <div className="model-config-section-body">
+            <div className="model-config-section-row">
+              <span>
+                This requires a{' '}
+                <a href="https://claude.ai" target="_blank">
+                  Claude
+                </a>{' '}
+                account and{' '}
+                <a href="https://code.claude.com/" target="_blank">
+                  Claude Code
+                </a>{' '}
+                installed in your system.
+              </span>
             </div>
-            <div className="model-config-section-body">
-              <div className="model-config-section-row">
-                <span>
-                  This requires a{' '}
-                  <a href="https://claude.ai" target="_blank">
-                    Claude
-                  </a>{' '}
-                  account and{' '}
-                  <a href="https://code.claude.com/" target="_blank">
-                    Claude Code
-                  </a>{' '}
-                  installed in your system.
-                </span>
-              </div>
-              <div className="model-config-section-row">
-                <div className="model-config-section-column">
-                  <div>
-                    <CheckBoxItem
-                      header={true}
-                      label="Enable Claude mode"
-                      checked={checkedValue(
-                        featurePolicies.claude_mode,
-                        claudeEnabled
-                      )}
-                      disabled={featurePolicies.claude_mode.locked}
-                      tooltip={lockedTip(featurePolicies.claude_mode.locked)}
-                      onClick={() => {
-                        setClaudeEnabled(!claudeEnabled);
-                      }}
-                    ></CheckBoxItem>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="model-config-section">
-            <div
-              className="model-config-section-header"
-              style={{ display: 'flex' }}
-            >
-              <div style={{ flexGrow: 1 }}>Models</div>
-              <div>
-                <button
-                  className="jp-toast-button jp-mod-small jp-Button"
-                  onClick={refreshClaudeModels}
-                  disabled={loadingModels}
-                >
-                  <div className="jp-Dialog-buttonLabel">
-                    {loadingModels ? 'Loading...' : 'Refresh'}
-                  </div>
-                </button>
-              </div>
-            </div>
-            <div className="model-config-section-body">
-              <div className="model-config-section-row">
-                <div className="model-config-section-column">
-                  <div>Chat model</div>
-                  <div title={lockedTip(settingLocks.claude_chat_model.locked)}>
-                    <select
-                      className="jp-mod-styled"
-                      disabled={settingLocks.claude_chat_model.locked}
-                      onChange={event => setChatModel(event.target.value)}
-                    >
-                      <option
-                        value={ClaudeModelType.Default}
-                        selected={chatModel === ClaudeModelType.Default}
-                      >
-                        Default (recommended)
-                      </option>
-                      {claudeModels.map(model => (
-                        <option
-                          key={model.id}
-                          value={model.id}
-                          selected={chatModel === model.id}
-                        >
-                          {model.name}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                </div>
-                <div className="model-config-section-column">
-                  <div>Auto-complete model</div>
-                  <div
-                    title={lockedTip(
-                      settingLocks.claude_inline_completion_model.locked
+            <div className="model-config-section-row">
+              <div className="model-config-section-column">
+                <div>
+                  <CheckBoxItem
+                    header={true}
+                    label="Enable Claude mode"
+                    checked={checkedValue(
+                      featurePolicies.claude_mode,
+                      claudeEnabled
                     )}
-                  >
-                    <select
-                      className="jp-mod-styled"
-                      disabled={
-                        settingLocks.claude_inline_completion_model.locked
-                      }
-                      onChange={event =>
-                        setInlineCompletionModel(event.target.value)
-                      }
-                    >
-                      <option
-                        value={ClaudeModelType.None}
-                        selected={
-                          inlineCompletionModel === ClaudeModelType.None
-                        }
-                      >
-                        None
-                      </option>
-                      <option
-                        value={ClaudeModelType.Inherit}
-                        selected={
-                          inlineCompletionModel === ClaudeModelType.Inherit
-                        }
-                      >
-                        Inherit from general settings
-                      </option>
-                      <option
-                        value={ClaudeModelType.Default}
-                        selected={
-                          inlineCompletionModel === ClaudeModelType.Default
-                        }
-                      >
-                        Default (recommended)
-                      </option>
-                      {claudeModels.map(model => (
-                        <option
-                          key={model.id}
-                          value={model.id}
-                          selected={inlineCompletionModel === model.id}
-                        >
-                          {model.name}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="model-config-section">
-            <div className="model-config-section-header">
-              Chat Agent setting sources
-            </div>
-            <div className="model-config-section-body">
-              <div className="model-config-section-row">
-                <div className="model-config-section-column">
-                  <div>
-                    <CheckBoxItem
-                      header={true}
-                      label="User"
-                      checked={checkedValue(
-                        featurePolicies.claude_setting_source_user,
-                        settingSources.includes('user')
-                      )}
-                      disabled={
-                        featurePolicies.claude_setting_source_user.locked
-                      }
-                      tooltip={lockedTip(
-                        featurePolicies.claude_setting_source_user.locked
-                      )}
-                      onClick={() => {
-                        setSettingSources(
-                          settingSources.includes('user')
-                            ? settingSources.filter(
-                                (source: string) => source !== 'user'
-                              )
-                            : [...settingSources, 'user']
-                        );
-                      }}
-                    ></CheckBoxItem>
-                  </div>
-                </div>
-                <div className="model-config-section-column">
-                  <div>
-                    <CheckBoxItem
-                      header={true}
-                      label="Project (Jupyter root directory)"
-                      checked={checkedValue(
-                        featurePolicies.claude_setting_source_project,
-                        settingSources.includes('project')
-                      )}
-                      disabled={
-                        featurePolicies.claude_setting_source_project.locked
-                      }
-                      tooltip={lockedTip(
-                        featurePolicies.claude_setting_source_project.locked
-                      )}
-                      onClick={() => {
-                        setSettingSources(
-                          settingSources.includes('project')
-                            ? settingSources.filter(
-                                (source: string) => source !== 'project'
-                              )
-                            : [...settingSources, 'project']
-                        );
-                      }}
-                    ></CheckBoxItem>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="model-config-section">
-            <div className="model-config-section-header">Chat Agent tools</div>
-            <div className="model-config-section-body">
-              <div className="model-config-section-row">
-                <div className="model-config-section-column">
-                  <div>
-                    <CheckBoxItem
-                      header={true}
-                      label="Claude Code tools"
-                      checked={checkedValue(
-                        featurePolicies.claude_code_tools,
-                        tools.includes(ClaudeToolType.ClaudeCodeTools)
-                      )}
-                      disabled={true}
-                      tooltip={lockedTip(
-                        featurePolicies.claude_code_tools.locked
-                      )}
-                      onClick={() => {
-                        setTools(
-                          tools.includes(ClaudeToolType.ClaudeCodeTools)
-                            ? tools.filter(
-                                (tool: string) =>
-                                  tool !== ClaudeToolType.ClaudeCodeTools
-                              )
-                            : [...tools, ClaudeToolType.ClaudeCodeTools]
-                        );
-                      }}
-                    ></CheckBoxItem>
-                  </div>
-                </div>
-                <div className="model-config-section-column">
-                  <div>
-                    <CheckBoxItem
-                      header={true}
-                      label="Jupyter UI tools"
-                      checked={checkedValue(
-                        featurePolicies.claude_jupyter_ui_tools,
-                        tools.includes(ClaudeToolType.JupyterUITools)
-                      )}
-                      disabled={featurePolicies.claude_jupyter_ui_tools.locked}
-                      tooltip={lockedTip(
-                        featurePolicies.claude_jupyter_ui_tools.locked
-                      )}
-                      onClick={() => {
-                        setTools(
-                          tools.includes(ClaudeToolType.JupyterUITools)
-                            ? tools.filter(
-                                (tool: string) =>
-                                  tool !== ClaudeToolType.JupyterUITools
-                              )
-                            : [...tools, ClaudeToolType.JupyterUITools]
-                        );
-                      }}
-                    ></CheckBoxItem>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="model-config-section">
-            <div className="model-config-section-header">
-              Conversation History
-            </div>
-            <div className="model-config-section-body">
-              <div className="model-config-section-row">
-                <div className="model-config-section-column">
-                  <div>
-                    <CheckBoxItem
-                      header={true}
-                      label="Remember conversation history"
-                      checked={checkedValue(
-                        featurePolicies.claude_continue_conversation,
-                        continueConversation
-                      )}
-                      disabled={
-                        featurePolicies.claude_continue_conversation.locked
-                      }
-                      tooltip={lockedTip(
-                        featurePolicies.claude_continue_conversation.locked
-                      )}
-                      onClick={() => {
-                        setContinueConversation(!continueConversation);
-                      }}
-                    ></CheckBoxItem>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="model-config-section">
-            <div className="model-config-section-header">Claude account</div>
-            <div className="model-config-section-body">
-              <div className="model-config-section-row">
-                <div className="model-config-section-column">
-                  <div className="form-field-row">
-                    <div className="form-field-description">
-                      API Key (optional)
-                    </div>
-                    <input
-                      name="chat-model-id-input"
-                      placeholder={
-                        settingLocks.claude_api_key.locked
-                          ? 'Locked by ANTHROPIC_API_KEY'
-                          : 'API Key'
-                      }
-                      className="jp-mod-styled"
-                      spellCheck={false}
-                      value={settingLocks.claude_api_key.locked ? '' : apiKey}
-                      disabled={settingLocks.claude_api_key.locked}
-                      title={lockedTip(settingLocks.claude_api_key.locked)}
-                      onChange={event => setApiKey(event.target.value)}
-                    />
-                  </div>
-                  <div className="form-field-row">
-                    <div className="form-field-description">
-                      Base URL (optional)
-                    </div>
-                    <input
-                      name="chat-model-id-input"
-                      placeholder={
-                        settingLocks.claude_base_url.locked
-                          ? 'Locked by ANTHROPIC_BASE_URL'
-                          : 'https://api.anthropic.com'
-                      }
-                      className="jp-mod-styled"
-                      spellCheck={false}
-                      value={baseUrl}
-                      disabled={settingLocks.claude_base_url.locked}
-                      title={lockedTip(settingLocks.claude_base_url.locked)}
-                      onChange={event => setBaseUrl(event.target.value)}
-                    />
-                  </div>
+                    disabled={featurePolicies.claude_mode.locked}
+                    tooltip={lockedTip(featurePolicies.claude_mode.locked)}
+                    onClick={() => {
+                      setClaudeEnabled(!claudeEnabled);
+                    }}
+                  ></CheckBoxItem>
                 </div>
               </div>
             </div>
           </div>
         </div>
-      )}
+
+        <div className="model-config-section">
+          <div
+            className="model-config-section-header"
+            style={{ display: 'flex' }}
+          >
+            <div style={{ flexGrow: 1 }}>Models</div>
+            <div>
+              <button
+                className="jp-toast-button jp-mod-small jp-Button"
+                onClick={refreshClaudeModels}
+                disabled={loadingModels}
+              >
+                <div className="jp-Dialog-buttonLabel">
+                  {loadingModels ? 'Loading...' : 'Refresh'}
+                </div>
+              </button>
+            </div>
+          </div>
+          <div className="model-config-section-body">
+            <div className="model-config-section-row">
+              <div className="model-config-section-column">
+                <div>Chat model</div>
+                <div title={lockedTip(settingLocks.claude_chat_model.locked)}>
+                  <select
+                    className="jp-mod-styled"
+                    disabled={settingLocks.claude_chat_model.locked}
+                    onChange={event => setChatModel(event.target.value)}
+                  >
+                    <option
+                      value={ClaudeModelType.Default}
+                      selected={chatModel === ClaudeModelType.Default}
+                    >
+                      Default (recommended)
+                    </option>
+                    {claudeModels.map(model => (
+                      <option
+                        key={model.id}
+                        value={model.id}
+                        selected={chatModel === model.id}
+                      >
+                        {model.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+              <div className="model-config-section-column">
+                <div>Auto-complete model</div>
+                <div
+                  title={lockedTip(
+                    settingLocks.claude_inline_completion_model.locked
+                  )}
+                >
+                  <select
+                    className="jp-mod-styled"
+                    disabled={
+                      settingLocks.claude_inline_completion_model.locked
+                    }
+                    onChange={event =>
+                      setInlineCompletionModel(event.target.value)
+                    }
+                  >
+                    <option
+                      value={ClaudeModelType.None}
+                      selected={inlineCompletionModel === ClaudeModelType.None}
+                    >
+                      None
+                    </option>
+                    <option
+                      value={ClaudeModelType.Inherit}
+                      selected={
+                        inlineCompletionModel === ClaudeModelType.Inherit
+                      }
+                    >
+                      Inherit from general settings
+                    </option>
+                    <option
+                      value={ClaudeModelType.Default}
+                      selected={
+                        inlineCompletionModel === ClaudeModelType.Default
+                      }
+                    >
+                      Default (recommended)
+                    </option>
+                    {claudeModels.map(model => (
+                      <option
+                        key={model.id}
+                        value={model.id}
+                        selected={inlineCompletionModel === model.id}
+                      >
+                        {model.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="model-config-section">
+          <div className="model-config-section-header">
+            Chat Agent setting sources
+          </div>
+          <div className="model-config-section-body">
+            <div className="model-config-section-row">
+              <div className="model-config-section-column">
+                <div>
+                  <CheckBoxItem
+                    header={true}
+                    label="User"
+                    checked={checkedValue(
+                      featurePolicies.claude_setting_source_user,
+                      settingSources.includes('user')
+                    )}
+                    disabled={featurePolicies.claude_setting_source_user.locked}
+                    tooltip={lockedTip(
+                      featurePolicies.claude_setting_source_user.locked
+                    )}
+                    onClick={() => {
+                      setSettingSources(
+                        settingSources.includes('user')
+                          ? settingSources.filter(
+                              (source: string) => source !== 'user'
+                            )
+                          : [...settingSources, 'user']
+                      );
+                    }}
+                  ></CheckBoxItem>
+                </div>
+              </div>
+              <div className="model-config-section-column">
+                <div>
+                  <CheckBoxItem
+                    header={true}
+                    label="Project (Jupyter root directory)"
+                    checked={checkedValue(
+                      featurePolicies.claude_setting_source_project,
+                      settingSources.includes('project')
+                    )}
+                    disabled={
+                      featurePolicies.claude_setting_source_project.locked
+                    }
+                    tooltip={lockedTip(
+                      featurePolicies.claude_setting_source_project.locked
+                    )}
+                    onClick={() => {
+                      setSettingSources(
+                        settingSources.includes('project')
+                          ? settingSources.filter(
+                              (source: string) => source !== 'project'
+                            )
+                          : [...settingSources, 'project']
+                      );
+                    }}
+                  ></CheckBoxItem>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="model-config-section">
+          <div className="model-config-section-header">Chat Agent tools</div>
+          <div className="model-config-section-body">
+            <div className="model-config-section-row">
+              <div className="model-config-section-column">
+                <div>
+                  <CheckBoxItem
+                    header={true}
+                    label="Claude Code tools"
+                    checked={checkedValue(
+                      featurePolicies.claude_code_tools,
+                      tools.includes(ClaudeToolType.ClaudeCodeTools)
+                    )}
+                    disabled={true}
+                    tooltip={lockedTip(
+                      featurePolicies.claude_code_tools.locked
+                    )}
+                    onClick={() => {
+                      setTools(
+                        tools.includes(ClaudeToolType.ClaudeCodeTools)
+                          ? tools.filter(
+                              (tool: string) =>
+                                tool !== ClaudeToolType.ClaudeCodeTools
+                            )
+                          : [...tools, ClaudeToolType.ClaudeCodeTools]
+                      );
+                    }}
+                  ></CheckBoxItem>
+                </div>
+              </div>
+              <div className="model-config-section-column">
+                <div>
+                  <CheckBoxItem
+                    header={true}
+                    label="Jupyter UI tools"
+                    checked={checkedValue(
+                      featurePolicies.claude_jupyter_ui_tools,
+                      tools.includes(ClaudeToolType.JupyterUITools)
+                    )}
+                    disabled={featurePolicies.claude_jupyter_ui_tools.locked}
+                    tooltip={lockedTip(
+                      featurePolicies.claude_jupyter_ui_tools.locked
+                    )}
+                    onClick={() => {
+                      setTools(
+                        tools.includes(ClaudeToolType.JupyterUITools)
+                          ? tools.filter(
+                              (tool: string) =>
+                                tool !== ClaudeToolType.JupyterUITools
+                            )
+                          : [...tools, ClaudeToolType.JupyterUITools]
+                      );
+                    }}
+                  ></CheckBoxItem>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="model-config-section">
+          <div className="model-config-section-header">
+            Conversation History
+          </div>
+          <div className="model-config-section-body">
+            <div className="model-config-section-row">
+              <div className="model-config-section-column">
+                <div>
+                  <CheckBoxItem
+                    header={true}
+                    label="Remember conversation history"
+                    checked={checkedValue(
+                      featurePolicies.claude_continue_conversation,
+                      continueConversation
+                    )}
+                    disabled={
+                      featurePolicies.claude_continue_conversation.locked
+                    }
+                    tooltip={lockedTip(
+                      featurePolicies.claude_continue_conversation.locked
+                    )}
+                    onClick={() => {
+                      setContinueConversation(!continueConversation);
+                    }}
+                  ></CheckBoxItem>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="model-config-section">
+          <div className="model-config-section-header">Claude account</div>
+          <div className="model-config-section-body">
+            <div className="model-config-section-row">
+              <div className="model-config-section-column">
+                <div className="form-field-row">
+                  <div className="form-field-description">
+                    API Key (optional)
+                  </div>
+                  <input
+                    name="chat-model-id-input"
+                    placeholder={
+                      settingLocks.claude_api_key.locked
+                        ? 'Locked by ANTHROPIC_API_KEY'
+                        : 'API Key'
+                    }
+                    className="jp-mod-styled"
+                    spellCheck={false}
+                    value={settingLocks.claude_api_key.locked ? '' : apiKey}
+                    disabled={settingLocks.claude_api_key.locked}
+                    title={lockedTip(settingLocks.claude_api_key.locked)}
+                    onChange={event => setApiKey(event.target.value)}
+                  />
+                </div>
+                <div className="form-field-row">
+                  <div className="form-field-description">
+                    Base URL (optional)
+                  </div>
+                  <input
+                    name="chat-model-id-input"
+                    placeholder={
+                      settingLocks.claude_base_url.locked
+                        ? 'Locked by ANTHROPIC_BASE_URL'
+                        : 'https://api.anthropic.com'
+                    }
+                    className="jp-mod-styled"
+                    spellCheck={false}
+                    value={baseUrl}
+                    disabled={settingLocks.claude_base_url.locked}
+                    title={lockedTip(settingLocks.claude_base_url.locked)}
+                    onChange={event => setBaseUrl(event.target.value)}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/skills-panel.tsx
+++ b/src/components/skills-panel.tsx
@@ -348,7 +348,7 @@ export function SettingsPanelComponentSkills(_props: any): JSX.Element {
   return (
     <div className="config-dialog-body nbi-skills-panel">
       <div className="nbi-skills-header">
-        <div className="nbi-skills-title">Claude Skills</div>
+        <div className="nbi-skills-title">Skills</div>
         <div className="nbi-skills-header-actions">
           {hasManagedSkills && (
             <button
@@ -383,6 +383,12 @@ export function SettingsPanelComponentSkills(_props: any): JSX.Element {
           </button>
         </div>
       </div>
+      {!NBIAPI.config.isInClaudeCodeMode && (
+        <div className="nbi-skills-info-banner" role="note">
+          Skills are consumed by Claude Code. Enable Claude mode in the Claude
+          settings tab to use skills you author here.
+        </div>
+      )}
       {syncMessage && (
         <div className="nbi-skills-sync-message" role="status">
           {syncMessage}

--- a/style/base.css
+++ b/style/base.css
@@ -1536,7 +1536,8 @@ svg.access-token-warning {
   font-size: var(--jp-ui-font-size1);
 }
 
-.nbi-skills-sync-message {
+.nbi-skills-sync-message,
+.nbi-skills-info-banner {
   padding: 6px 12px;
   border-radius: 4px;
   background-color: var(--jp-layout-color2);

--- a/tests/test_skills_handlers.py
+++ b/tests/test_skills_handlers.py
@@ -527,3 +527,48 @@ class TestSkillsReconcileHandler:
             "unchanged": 3,
             "errors": ["boom"],
         }
+
+
+class TestSkillsManagementPolicyGate:
+    """The skills_management policy short-circuits every /skills handler in
+    `prepare()` with 403 when force-off. We test the gate logic directly,
+    bypassing Tornado dispatch (matches the rest of this file's pattern).
+    """
+
+    @staticmethod
+    def _run_prepare(handler):
+        # Patch the superclass prepare to a no-op coroutine — we're only
+        # exercising the skills gate here, not jupyter_server's auth plumbing.
+        from jupyter_server.base.handlers import APIHandler
+
+        async def _noop(_self):
+            return None
+
+        with patch.object(APIHandler, "prepare", _noop):
+            asyncio.run(SkillsBaseHandler.prepare(handler))
+
+    def test_default_attribute_allows(self):
+        assert SkillsBaseHandler.skills_management_enabled is True
+
+    def test_prepare_rejects_when_disabled(self):
+        handler = MagicMock(spec=SkillsListHandler)
+        handler._finished = False
+        handler.skills_management_enabled = False
+
+        def _finish(payload):
+            handler._finished = True
+            handler._finish_payload = payload
+
+        handler.finish.side_effect = _finish
+        self._run_prepare(handler)
+        handler.set_status.assert_called_with(403)
+        body = json.loads(handler._finish_payload)
+        assert "administrator" in body["error"].lower()
+
+    def test_prepare_passes_when_enabled(self):
+        handler = MagicMock(spec=SkillsListHandler)
+        handler._finished = False
+        handler.skills_management_enabled = True
+        self._run_prepare(handler)
+        handler.set_status.assert_not_called()
+        handler.finish.assert_not_called()


### PR DESCRIPTION
## Summary

Resolves #216. Promotes the Skills management UI from a Claude-mode sub-tab to a top-level Settings tab, and adds a new admin policy `skills_management_policy` so org administrators can disable user-authored skills entirely.

## Behavior

**Top-level Skills tab.** Visible regardless of which assistant mode is active. When Claude mode is off, a hint banner explains that skills are consumed by Claude Code and points users to the Claude settings tab. The Claude tab's old Settings/Skills sub-tab bar is removed; Skills was the only consumer.

**`skills_management_policy` (`TraitletEnum`, default `user-choice`).** Set via:

```python
c.NotebookIntelligence.skills_management_policy = "force-off"
```

Or via env: `NBI_SKILLS_MANAGEMENT_POLICY=force-off`. Force-off does three things at once:

- Hides the Skills tab in the Settings panel.
- Returns HTTP 403 from every `/notebook-intelligence/skills/*` route via a single `async prepare()` chokepoint on `SkillsBaseHandler` — covers list/create/edit/delete/rename/import/reconcile/bundle-file in one place.
- Suppresses the [managed-skills reconciler](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/docs/admin-guide.md#managed-claude-skills-token) — the manifest is treated as empty, no `SkillReconciler` is constructed, and no scheduled reconcile runs. The traitlet docstring documents this trade-off; orgs that ship curated skills via `NBI_SKILLS_MANIFEST` should leave the policy on `user-choice`.

`force-on` is preserved for symmetry with the other `feature_policies` but is behaviorally identical to `user-choice` here, since there is no user-toggle to override.

## Implementation notes

- Backend gate uses one async `prepare()` override (await super, check `_finished`, then 403 if disabled). Same `APIHandler` Tornado idiom used by the rest of the file.
- Reconciler suppression happens in `initialize_ai_service` by emptying `manifest_source` before `AIServiceManager` construction — no reconciler instance is created at all.
- New `is_force_off(policies, name)` helper in `feature_flags.py` shared between the prepare-gate wiring and the reconciler suppression so the predicate has one source of truth.
- Frontend `SettingsPanelComponent` reads `featurePolicies.skills_management.enabled` via the existing `useNbiPolicies()` hook (no duplicate subscription). When the policy flips at runtime and the user is on the Skills tab, they're bounced to General.
- Pre-existing render bug fixed: `SettingsPanelTabsComponent` held a local `activeTab` `useState` mirroring the parent's, which never re-synced — made the child fully controlled so policy-driven tab bouncing stays consistent.
- New CSS class `nbi-skills-info-banner` (sibling style of `nbi-skills-sync-message`) so the static informational banner doesn't share a class with async sync-status messages.

## Tests

- New `TestSkillsManagementPolicyGate` class in `tests/test_skills_handlers.py`: default-allows, prepare-rejects-when-disabled (403 + admin-mentioning error), prepare-passes-when-enabled. Patches `APIHandler.prepare` to a no-op coroutine to isolate the gate logic.
- All 39 tests in `test_skills_handlers.py` pass.

## Docs

- New section in `docs/admin-guide.md` under "Restricting features for managed deployments" with the config snippet and the explicit reconciler-trade-off note.
- New row in the env-var/traitlets reference table.
- New row in the Admin policies table in `README.md`.

## Test plan

- [ ] Open Settings → confirm Skills appears as a top-level tab in default-mode and Claude mode
- [ ] Disable Claude mode → confirm hint banner appears in Skills panel
- [ ] Set `c.NotebookIntelligence.skills_management_policy = "force-off"`, restart → confirm tab is gone, `curl /skills` returns 403, no managed-skills reconcile runs
- [ ] Confirm setting `NBI_SKILLS_MANAGEMENT_POLICY=force-off` produces the same result
- [ ] With policy on, confirm existing skills CRUD, GitHub import, managed-skills sync still work