### PR TITLE
feat(settings): add Claude-mode MCP Servers tab + admin policy gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,19 +153,20 @@ Most settings panel toggles can be locked by org administrators. Two shapes:
 
 **Boolean policies** use the `*_POLICY` suffix and accept three values: `user-choice` (default — user toggles freely), `force-on` (locked enabled), `force-off` (locked disabled). When forced, the panel control is disabled with a "Locked by your administrator" tooltip and any client-side write is ignored.
 
-| Env var                                    | Locks the Settings panel control for                                                              |
-| ------------------------------------------ | ------------------------------------------------------------------------------------------------- |
-| `NBI_EXPLAIN_ERROR_POLICY`                 | "Explain cell errors"                                                                             |
-| `NBI_OUTPUT_FOLLOWUP_POLICY`               | "Ask about cell outputs"                                                                          |
-| `NBI_OUTPUT_TOOLBAR_POLICY`                | "Show output toolbar"                                                                             |
-| `NBI_CLAUDE_MODE_POLICY`                   | "Enable Claude mode"                                                                              |
-| `NBI_CLAUDE_CONTINUE_CONVERSATION_POLICY`  | "Remember conversation history"                                                                   |
-| `NBI_CLAUDE_CODE_TOOLS_POLICY`             | "Claude Code tools"                                                                               |
-| `NBI_CLAUDE_JUPYTER_UI_TOOLS_POLICY`       | "Jupyter UI tools"                                                                                |
-| `NBI_CLAUDE_SETTING_SOURCE_USER_POLICY`    | Setting source: User                                                                              |
-| `NBI_CLAUDE_SETTING_SOURCE_PROJECT_POLICY` | Setting source: Project                                                                           |
-| `NBI_STORE_GITHUB_ACCESS_TOKEN_POLICY`     | "Remember my GitHub Copilot access token"                                                         |
-| `NBI_SKILLS_MANAGEMENT_POLICY`             | The Skills tab (force-off hides it and 403s the API; also disables the managed-skills reconciler) |
+| Env var                                    | Locks the Settings panel control for                                                                                         |
+| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| `NBI_EXPLAIN_ERROR_POLICY`                 | "Explain cell errors"                                                                                                        |
+| `NBI_OUTPUT_FOLLOWUP_POLICY`               | "Ask about cell outputs"                                                                                                     |
+| `NBI_OUTPUT_TOOLBAR_POLICY`                | "Show output toolbar"                                                                                                        |
+| `NBI_CLAUDE_MODE_POLICY`                   | "Enable Claude mode"                                                                                                         |
+| `NBI_CLAUDE_CONTINUE_CONVERSATION_POLICY`  | "Remember conversation history"                                                                                              |
+| `NBI_CLAUDE_CODE_TOOLS_POLICY`             | "Claude Code tools"                                                                                                          |
+| `NBI_CLAUDE_JUPYTER_UI_TOOLS_POLICY`       | "Jupyter UI tools"                                                                                                           |
+| `NBI_CLAUDE_SETTING_SOURCE_USER_POLICY`    | Setting source: User                                                                                                         |
+| `NBI_CLAUDE_SETTING_SOURCE_PROJECT_POLICY` | Setting source: Project                                                                                                      |
+| `NBI_STORE_GITHUB_ACCESS_TOKEN_POLICY`     | "Remember my GitHub Copilot access token"                                                                                    |
+| `NBI_SKILLS_MANAGEMENT_POLICY`             | The Skills tab (force-off hides it and 403s the API; also disables the managed-skills reconciler)                            |
+| `NBI_CLAUDE_MCP_MANAGEMENT_POLICY`         | The Claude-mode MCP Servers tab (force-off hides it and 403s `/claude-mcp/*`; independent of the non-Claude MCP Servers tab) |
 
 The first three also have matching traitlets on `NotebookIntelligence` (`explain_error_policy`, `output_followup_policy`, `output_toolbar_policy`); add the others as needed in the same shape:
 

--- a/README.md
+++ b/README.md
@@ -153,18 +153,19 @@ Most settings panel toggles can be locked by org administrators. Two shapes:
 
 **Boolean policies** use the `*_POLICY` suffix and accept three values: `user-choice` (default — user toggles freely), `force-on` (locked enabled), `force-off` (locked disabled). When forced, the panel control is disabled with a "Locked by your administrator" tooltip and any client-side write is ignored.
 
-| Env var                                    | Locks the Settings panel control for      |
-| ------------------------------------------ | ----------------------------------------- |
-| `NBI_EXPLAIN_ERROR_POLICY`                 | "Explain cell errors"                     |
-| `NBI_OUTPUT_FOLLOWUP_POLICY`               | "Ask about cell outputs"                  |
-| `NBI_OUTPUT_TOOLBAR_POLICY`                | "Show output toolbar"                     |
-| `NBI_CLAUDE_MODE_POLICY`                   | "Enable Claude mode"                      |
-| `NBI_CLAUDE_CONTINUE_CONVERSATION_POLICY`  | "Remember conversation history"           |
-| `NBI_CLAUDE_CODE_TOOLS_POLICY`             | "Claude Code tools"                       |
-| `NBI_CLAUDE_JUPYTER_UI_TOOLS_POLICY`       | "Jupyter UI tools"                        |
-| `NBI_CLAUDE_SETTING_SOURCE_USER_POLICY`    | Setting source: User                      |
-| `NBI_CLAUDE_SETTING_SOURCE_PROJECT_POLICY` | Setting source: Project                   |
-| `NBI_STORE_GITHUB_ACCESS_TOKEN_POLICY`     | "Remember my GitHub Copilot access token" |
+| Env var                                    | Locks the Settings panel control for                                                              |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| `NBI_EXPLAIN_ERROR_POLICY`                 | "Explain cell errors"                                                                             |
+| `NBI_OUTPUT_FOLLOWUP_POLICY`               | "Ask about cell outputs"                                                                          |
+| `NBI_OUTPUT_TOOLBAR_POLICY`                | "Show output toolbar"                                                                             |
+| `NBI_CLAUDE_MODE_POLICY`                   | "Enable Claude mode"                                                                              |
+| `NBI_CLAUDE_CONTINUE_CONVERSATION_POLICY`  | "Remember conversation history"                                                                   |
+| `NBI_CLAUDE_CODE_TOOLS_POLICY`             | "Claude Code tools"                                                                               |
+| `NBI_CLAUDE_JUPYTER_UI_TOOLS_POLICY`       | "Jupyter UI tools"                                                                                |
+| `NBI_CLAUDE_SETTING_SOURCE_USER_POLICY`    | Setting source: User                                                                              |
+| `NBI_CLAUDE_SETTING_SOURCE_PROJECT_POLICY` | Setting source: Project                                                                           |
+| `NBI_STORE_GITHUB_ACCESS_TOKEN_POLICY`     | "Remember my GitHub Copilot access token"                                                         |
+| `NBI_SKILLS_MANAGEMENT_POLICY`             | The Skills tab (force-off hides it and 403s the API; also disables the managed-skills reconciler) |
 
 The first three also have matching traitlets on `NotebookIntelligence` (`explain_error_policy`, `output_followup_policy`, `output_toolbar_policy`); add the others as needed in the same shape:
 

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -373,6 +373,23 @@ Force-off does three things at once:
 
 Use this when an org wants to disable user-authored Claude skills entirely.
 
+### Disabling the Claude-mode MCP Servers tab
+
+```python
+c.NotebookIntelligence.claude_mcp_management_policy = "force-off"
+```
+
+Or via env: `NBI_CLAUDE_MCP_MANAGEMENT_POLICY=force-off`.
+
+Force-off:
+
+- Hides the Claude-mode **MCP Servers** tab in the Settings panel (visible only when Claude mode is on and the `claude` CLI is available).
+- Returns HTTP 403 from every `/notebook-intelligence/claude-mcp/*` route.
+
+The Claude-mode tab is **independent** of the existing non-Claude **MCP Servers** tab. The former wraps Claude Code's own config (`~/.claude.json` and project `.mcp.json`); the latter manages NBI's own MCP servers used by the non-Claude chat path. They never appear at the same time — the non-Claude tab is hidden when Claude mode is on, and the Claude-mode tab is hidden when it's off.
+
+Reads come from Claude's JSON config files directly (fast, no health checks). Writes (add / remove) shell out to `claude mcp add` / `claude mcp remove` so Claude remains the source of truth for any side effects (project-trust prompts, OAuth bookkeeping).
+
 ---
 
 ## Multi-tenancy and per-team scoping

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -357,6 +357,22 @@ NBI_ADDITIONAL_SKIPPED_WORKSPACE_DIRECTORIES=tmp,artifacts
 
 The env var **appends** to the traitlet value at server startup (in contrast to `NBI_ALLOW_GITHUB_SKILL_IMPORT` and the `NBI_*_POLICY` env vars, which override). Duplicates are collapsed; both lists are then merged with the built-in skip set on the frontend.
 
+### Disabling the Skills tab
+
+```python
+c.NotebookIntelligence.skills_management_policy = "force-off"
+```
+
+Or via env: `NBI_SKILLS_MANAGEMENT_POLICY=force-off`.
+
+Force-off does three things at once:
+
+- Hides the **Skills** tab in the Settings panel.
+- Returns HTTP 403 from every `/notebook-intelligence/skills/*` route, so a stale frontend or a direct API caller can't read or write skills.
+- Suppresses the [managed-skills reconciler](#managed-claude-skills-token) — the manifest is treated as empty, no `SkillReconciler` is constructed, and no scheduled reconcile runs. Org-curated skills still on disk are not touched, but new manifests aren't pulled.
+
+Use this when an org wants to disable user-authored Claude skills entirely.
+
 ---
 
 ## Multi-tenancy and per-team scoping

--- a/notebook_intelligence/claude_mcp_manager.py
+++ b/notebook_intelligence/claude_mcp_manager.py
@@ -1,0 +1,289 @@
+# Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+"""Read/write Claude Code's MCP server configuration.
+
+Reads come from the JSON config files Claude maintains itself:
+
+  - User scope:    ``~/.claude.json`` → top-level ``mcpServers``
+  - Local scope:   ``~/.claude.json`` → ``projects.<cwd>.mcpServers``
+  - Project scope: ``<cwd>/.mcp.json``
+
+Writes go through ``claude mcp add`` / ``claude mcp remove`` so Claude
+remains the source of truth for any side effects (project-trust prompts,
+oauth bookkeeping, etc.). The file-based reads are decoupled from the CLI's
+``claude mcp list`` output because that command does live health checks
+that are slow and unstructured (no ``--json``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Literal, Optional
+
+from notebook_intelligence.util import resolve_claude_cli_path
+
+log = logging.getLogger(__name__)
+
+ClaudeMCPScope = Literal["user", "project", "local"]
+VALID_SCOPES: tuple[ClaudeMCPScope, ...] = ("user", "project", "local")
+VALID_TRANSPORTS: tuple[str, ...] = ("stdio", "sse", "http")
+
+CLI_TIMEOUT_SECONDS = 30.0
+
+# Reject names / commands / URLs that start with `-` so the user can't
+# smuggle a Claude CLI flag through their position in argv.
+def _reject_flag_smuggling(*, name: str, command_or_url: str) -> None:
+    for label, value in (("name", name), ("command_or_url", command_or_url)):
+        if value.startswith("-"):
+            raise ValueError(
+                f"Invalid {label} {value!r}: leading '-' is not permitted"
+            )
+
+
+def _redact_argv_for_log(argv: list[str]) -> list[str]:
+    """Drop secret-bearing values (-e KEY=value, -H NAME: value) for logs."""
+    redacted: list[str] = []
+    skip_next = False
+    for token in argv:
+        if skip_next:
+            redacted.append("<redacted>")
+            skip_next = False
+            continue
+        redacted.append(token)
+        if token in ("-e", "--env", "-H", "--header"):
+            skip_next = True
+    return redacted
+
+
+@dataclass(frozen=True)
+class ClaudeMCPServer:
+    name: str
+    scope: ClaudeMCPScope
+    transport: str  # "stdio" | "sse" | "http"
+    command: str = ""  # stdio
+    args: list[str] = field(default_factory=list)  # stdio
+    env: dict[str, str] = field(default_factory=dict)  # stdio
+    url: str = ""  # sse | http
+    headers: dict[str, str] = field(default_factory=dict)  # sse | http
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "scope": self.scope,
+            "transport": self.transport,
+            "command": self.command,
+            "args": list(self.args),
+            "env": dict(self.env),
+            "url": self.url,
+            "headers": dict(self.headers),
+        }
+
+
+def _read_json(path: Path) -> Optional[dict]:
+    try:
+        with path.open("r", encoding="utf-8") as fp:
+            return json.load(fp)
+    except FileNotFoundError:
+        return None
+    except (OSError, json.JSONDecodeError) as exc:
+        log.warning("Failed to read Claude MCP config %s: %s", path, exc)
+        return None
+
+
+def _coerce_str_dict(d: Optional[dict]) -> dict[str, str]:
+    """Stringify keys/values; drop None values so they don't surface as the
+    string "None" in the UI."""
+    if not isinstance(d, dict):
+        return {}
+    return {str(k): str(v) for k, v in d.items() if v is not None}
+
+
+def _coerce_server(name: str, raw: dict, scope: ClaudeMCPScope) -> Optional[ClaudeMCPServer]:
+    if not isinstance(raw, dict):
+        return None
+    transport = raw.get("type") or "stdio"
+    if transport not in VALID_TRANSPORTS:
+        # Unknown transport — pass through untouched so the UI can show it
+        # rather than silently dropping it.
+        transport = str(transport)
+    return ClaudeMCPServer(
+        name=name,
+        scope=scope,
+        transport=transport,
+        command=str(raw.get("command", "")),
+        args=list(raw.get("args") or []),
+        env=_coerce_str_dict(raw.get("env")),
+        url=str(raw.get("url", "")),
+        headers=_coerce_str_dict(raw.get("headers")),
+    )
+
+
+def _gather_from_dict(
+    block: Optional[dict], scope: ClaudeMCPScope
+) -> Iterable[ClaudeMCPServer]:
+    if not isinstance(block, dict):
+        return ()
+    out: list[ClaudeMCPServer] = []
+    for name, raw in block.items():
+        srv = _coerce_server(str(name), raw, scope)
+        if srv is not None:
+            out.append(srv)
+    return out
+
+
+class ClaudeMCPManager:
+    def __init__(self, working_dir: Optional[str] = None):
+        self._working_dir = Path(working_dir) if working_dir else Path.cwd()
+        self._user_config_path = Path.home() / ".claude.json"
+        # Serialize CLI writes within this process. Claude's CLI does
+        # read-modify-write on `~/.claude.json` without a lockfile, so two
+        # in-flight `add`s from the same NBI server can clobber.
+        self._write_lock = asyncio.Lock()
+
+    # --- reads ---------------------------------------------------------
+
+    def list_servers(self) -> list[ClaudeMCPServer]:
+        """Enumerate user + local + project scope servers visible to Claude."""
+        servers: list[ClaudeMCPServer] = []
+        user_doc = _read_json(self._user_config_path) or {}
+
+        servers.extend(_gather_from_dict(user_doc.get("mcpServers"), "user"))
+
+        # Local scope is keyed by absolute working-dir path under `projects`.
+        projects = user_doc.get("projects") or {}
+        local_block = (projects.get(str(self._working_dir)) or {}).get("mcpServers")
+        servers.extend(_gather_from_dict(local_block, "local"))
+
+        # Project scope: ``<cwd>/.mcp.json`` with top-level ``mcpServers``.
+        project_doc = _read_json(self._working_dir / ".mcp.json") or {}
+        servers.extend(_gather_from_dict(project_doc.get("mcpServers"), "project"))
+
+        servers.sort(key=lambda s: (s.name, s.scope))
+        return servers
+
+    def get_server(self, name: str, scope: ClaudeMCPScope) -> Optional[ClaudeMCPServer]:
+        for srv in self.list_servers():
+            if srv.name == name and srv.scope == scope:
+                return srv
+        return None
+
+    # --- writes (CLI shell-outs) ---------------------------------------
+
+    async def add_server(
+        self,
+        *,
+        name: str,
+        scope: ClaudeMCPScope,
+        transport: str,
+        command_or_url: str,
+        args: Optional[list[str]] = None,
+        env: Optional[dict[str, str]] = None,
+        headers: Optional[dict[str, str]] = None,
+    ) -> ClaudeMCPServer:
+        """Run ``claude mcp add`` and return the persisted record."""
+        if scope not in VALID_SCOPES:
+            raise ValueError(f"Invalid scope {scope!r}; expected one of {VALID_SCOPES}")
+        if transport not in VALID_TRANSPORTS:
+            raise ValueError(
+                f"Invalid transport {transport!r}; expected one of {VALID_TRANSPORTS}"
+            )
+        if not name:
+            raise ValueError("Missing server name")
+        if not command_or_url:
+            raise ValueError("Missing command or URL")
+        _reject_flag_smuggling(name=name, command_or_url=command_or_url)
+
+        cmd = self._cli_argv(["mcp", "add", "--scope", scope, "--transport", transport])
+        for key, value in (env or {}).items():
+            cmd.extend(["-e", f"{key}={value}"])
+        for key, value in (headers or {}).items():
+            cmd.extend(["-H", f"{key}: {value}"])
+        cmd.append(name)
+        cmd.append(command_or_url)
+        if args:
+            cmd.append("--")
+            cmd.extend(args)
+
+        async with self._write_lock:
+            await self._run_cli(cmd, write_op=True)
+        srv = self.get_server(name, scope)
+        if srv is None:
+            # Surfaced if Claude wrote elsewhere or our reads missed it. The CLI
+            # already succeeded, so don't 500 — synthesize from the inputs.
+            # Logged as a warning so an operator notices a real read/write
+            # divergence (cwd mismatch, scope misroute, race).
+            log.warning(
+                "claude mcp add succeeded but post-add read missed %r in %s scope; "
+                "returning synthesized record",
+                name,
+                scope,
+            )
+            return ClaudeMCPServer(
+                name=name,
+                scope=scope,
+                transport=transport,
+                command=command_or_url if transport == "stdio" else "",
+                args=list(args or []),
+                env=dict(env or {}),
+                url=command_or_url if transport in ("sse", "http") else "",
+                headers=dict(headers or {}),
+            )
+        return srv
+
+    async def remove_server(self, name: str, scope: ClaudeMCPScope) -> None:
+        if scope not in VALID_SCOPES:
+            raise ValueError(f"Invalid scope {scope!r}; expected one of {VALID_SCOPES}")
+        if not name:
+            raise ValueError("Missing server name")
+        _reject_flag_smuggling(name=name, command_or_url=name)
+        async with self._write_lock:
+            await self._run_cli(
+                self._cli_argv(["mcp", "remove", "--scope", scope, name]),
+                write_op=True,
+            )
+
+    # --- internals -----------------------------------------------------
+
+    def _cli_argv(self, tail: list[str]) -> list[str]:
+        cli = resolve_claude_cli_path()
+        if not cli:
+            raise FileNotFoundError(
+                "Claude Code CLI not found on PATH (set NBI_CLAUDE_CLI_PATH or install `claude`)"
+            )
+        return [cli, *tail]
+
+    async def _run_cli(self, argv: list[str], *, write_op: bool) -> str:
+        log.info(
+            "claude mcp invocation: %s", " ".join(_redact_argv_for_log(argv[1:]))
+        )
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            cwd=str(self._working_dir),
+            # Closed stdin keeps Claude from blocking on a project-trust or
+            # OAuth prompt; it'll fail with a clean nonzero exit instead of
+            # hanging until the timeout.
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=CLI_TIMEOUT_SECONDS
+            )
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            raise TimeoutError(
+                f"`claude mcp` timed out after {CLI_TIMEOUT_SECONDS}s"
+            )
+        out = stdout.decode("utf-8", errors="replace")
+        err = stderr.decode("utf-8", errors="replace")
+        if proc.returncode != 0:
+            # Surface Claude's own error message; drop empty stderr.
+            msg = (err or out).strip() or f"claude mcp failed (exit {proc.returncode})"
+            raise ValueError(msg)
+        return out

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -37,6 +37,7 @@ from notebook_intelligence.feature_flags import (
     VALID_POLICIES,
     apply_claude_policies,
     apply_string_overrides,
+    is_force_off,
     is_locked,
     resolve_feature_flag,
 )
@@ -232,6 +233,11 @@ FEATURE_POLICY_SPEC = (
         "NBI_STORE_GITHUB_ACCESS_TOKEN_POLICY",
         "store_github_access_token_policy",
     ),
+    (
+        "skills_management",
+        "NBI_SKILLS_MANAGEMENT_POLICY",
+        "skills_management_policy",
+    ),
 )
 FEATURE_POLICY_NAMES = tuple(name for name, _, _ in FEATURE_POLICY_SPEC)
 
@@ -275,6 +281,9 @@ def _build_feature_policies_response(policies: dict, nbi_config) -> dict:
         "claude_setting_source_user": "user" in sources,
         "claude_setting_source_project": "project" in sources,
         "store_github_access_token": bool(nbi_config.store_github_access_token),
+        # Admin-only gate; user has no toggle, so user_value is always True.
+        # The policy resolver still applies force-off / force-on correctly.
+        "skills_management": True,
     }
 
     response = {}
@@ -698,6 +707,19 @@ class SkillsBaseHandler(APIHandler):
     """Shared helpers for skills endpoints."""
 
     allow_github_skill_import = True
+    skills_management_enabled = True
+
+    async def prepare(self):
+        # APIHandler.prepare is async (xsrf/auth), so we must await it before
+        # applying the skills_management policy gate.
+        await super().prepare()
+        if self._finished:
+            return
+        if not self.skills_management_enabled:
+            self.set_status(403)
+            self.finish(
+                json.dumps({"error": "Skills management is disabled by your administrator"})
+            )
 
     @property
     def skill_manager(self):
@@ -1850,6 +1872,23 @@ class NotebookIntelligence(ExtensionApp):
         config=True,
     )
 
+    skills_management_policy = TraitletEnum(
+        list(VALID_POLICIES),
+        default_value=POLICY_USER_CHOICE,
+        help="""
+        Org-wide policy for the Skills management UI. "user-choice" (default)
+        and "force-on" both leave the Skills tab visible — there is no user
+        toggle to override, so the two are behaviorally identical today; the
+        three-value shape is preserved for symmetry with the other
+        feature_policies. "force-off" hides the tab, returns 403 from
+        /skills handlers, and **also disables the managed-skills reconciler**
+        — orgs that ship curated skills via NBI_SKILLS_MANIFEST should leave
+        this on user-choice and rely on filesystem permissions instead.
+        Overridden by the NBI_SKILLS_MANAGEMENT_POLICY env var.
+        """,
+        config=True,
+    )
+
     skills_manifest = Unicode(
         default_value="",
         help="""
@@ -1926,6 +1965,11 @@ class NotebookIntelligence(ExtensionApp):
     ):
         global ai_service_manager
         manifest_source = os.environ.get("NBI_SKILLS_MANIFEST", "").strip() or self.skills_manifest.strip()
+        # When skills management is force-off, suppress the manifest so the
+        # reconciler isn't constructed at all (org-curated skills wouldn't
+        # have a UI surface anyway, and stopping reconcile is the contract).
+        if is_force_off(feature_policies, "skills_management"):
+            manifest_source = ""
         managed_token = (
             os.environ.get("NBI_MANAGED_SKILLS_TOKEN", "").strip()
             or self.managed_skills_token.strip()
@@ -2001,6 +2045,9 @@ class NotebookIntelligence(ExtensionApp):
                 "NBI_ADDITIONAL_SKIPPED_WORKSPACE_DIRECTORIES",
                 self.additional_skipped_workspace_directories,
             )
+        )
+        SkillsBaseHandler.skills_management_enabled = not is_force_off(
+            feature_policies, "skills_management"
         )
         self._publish_policies(feature_policies, string_overrides)
         NotebookIntelligence.handlers = [

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -42,6 +42,7 @@ from notebook_intelligence.feature_flags import (
     resolve_feature_flag,
 )
 from notebook_intelligence.claude import ClaudeCodeChatParticipant, fetch_claude_models
+from notebook_intelligence.claude_mcp_manager import ClaudeMCPManager
 from notebook_intelligence.claude_sessions import (
     NBI_CONTEXT_PREFIX,
     get_sessions_dir as get_claude_sessions_dir,
@@ -238,6 +239,11 @@ FEATURE_POLICY_SPEC = (
         "NBI_SKILLS_MANAGEMENT_POLICY",
         "skills_management_policy",
     ),
+    (
+        "claude_mcp_management",
+        "NBI_CLAUDE_MCP_MANAGEMENT_POLICY",
+        "claude_mcp_management_policy",
+    ),
 )
 FEATURE_POLICY_NAMES = tuple(name for name, _, _ in FEATURE_POLICY_SPEC)
 
@@ -284,6 +290,7 @@ def _build_feature_policies_response(policies: dict, nbi_config) -> dict:
         # Admin-only gate; user has no toggle, so user_value is always True.
         # The policy resolver still applies force-off / force-on correctly.
         "skills_management": True,
+        "claude_mcp_management": True,
     }
 
     response = {}
@@ -701,6 +708,96 @@ class RulesReloadHandler(APIHandler):
         except Exception as e:
             self.set_status(500)
             self.finish(json.dumps({"error": str(e)}))
+
+
+class ClaudeMCPBaseHandler(APIHandler):
+    """Shared helpers + policy gate for Claude-MCP endpoints."""
+
+    claude_mcp_management_enabled = True
+
+    async def prepare(self):
+        # Mirrors SkillsBaseHandler.prepare — see there for the rationale on
+        # awaiting super() and checking _finished.
+        await super().prepare()
+        if self._finished:
+            return
+        if not self.claude_mcp_management_enabled:
+            self.set_status(403)
+            self.finish(
+                json.dumps({"error": "Claude MCP management is disabled by your administrator"})
+            )
+
+    @property
+    def manager(self) -> "ClaudeMCPManager":
+        return ClaudeMCPManager(working_dir=get_jupyter_root_dir() or None)
+
+    def _parse_json_body(self):
+        try:
+            return json.loads(self.request.body)
+        except json.JSONDecodeError as e:
+            self.set_status(400)
+            self.finish(json.dumps({"error": f"Invalid JSON: {e}"}))
+            return None
+
+    def _error(self, exc: Exception):
+        if isinstance(exc, FileNotFoundError):
+            self.set_status(404)
+        elif isinstance(exc, TimeoutError):
+            self.set_status(504)
+        else:
+            self.set_status(400)
+        self.finish(json.dumps({"error": str(exc)}))
+
+
+class ClaudeMCPListHandler(ClaudeMCPBaseHandler):
+    @tornado.web.authenticated
+    def get(self):
+        try:
+            servers = [s.to_dict() for s in self.manager.list_servers()]
+        except Exception as e:
+            self._error(e)
+            return
+        self.finish(json.dumps({"servers": servers}))
+
+    @tornado.web.authenticated
+    async def post(self):
+        data = self._parse_json_body()
+        if data is None:
+            return
+        try:
+            srv = await self.manager.add_server(
+                name=data.get("name", ""),
+                scope=data.get("scope", "user"),
+                transport=data.get("transport", "stdio"),
+                command_or_url=data.get("command_or_url", ""),
+                args=data.get("args"),
+                env=data.get("env"),
+                headers=data.get("headers"),
+            )
+            self.finish(json.dumps({"server": srv.to_dict()}))
+        except (FileNotFoundError, TimeoutError, ValueError) as e:
+            self._error(e)
+
+
+class ClaudeMCPDetailHandler(ClaudeMCPBaseHandler):
+    @tornado.web.authenticated
+    def get(self, scope, name):
+        srv = self.manager.get_server(name, scope)
+        if srv is None:
+            self.set_status(404)
+            self.finish(json.dumps({
+                "error": f"MCP server {name!r} not found in {scope} scope"
+            }))
+            return
+        self.finish(json.dumps({"server": srv.to_dict()}))
+
+    @tornado.web.authenticated
+    async def delete(self, scope, name):
+        try:
+            await self.manager.remove_server(name, scope)
+            self.finish(json.dumps({"success": True}))
+        except (FileNotFoundError, TimeoutError, ValueError) as e:
+            self._error(e)
 
 
 class SkillsBaseHandler(APIHandler):
@@ -1889,6 +1986,22 @@ class NotebookIntelligence(ExtensionApp):
         config=True,
     )
 
+    claude_mcp_management_policy = TraitletEnum(
+        list(VALID_POLICIES),
+        default_value=POLICY_USER_CHOICE,
+        help="""
+        Org-wide policy for the Claude-mode MCP Servers management tab.
+        "user-choice" (default) and "force-on" both leave the tab visible
+        when Claude mode is on and the Claude CLI is available; the two are
+        behaviorally identical here (no user toggle to override). "force-off"
+        hides the tab and returns 403 from /claude-mcp handlers. Independent
+        of the existing non-Claude `MCP Servers` tab, which is governed by
+        `mcp_server_settings` (its own surface). Overridden by the
+        NBI_CLAUDE_MCP_MANAGEMENT_POLICY env var.
+        """,
+        config=True,
+    )
+
     skills_manifest = Unicode(
         default_value="",
         help="""
@@ -2030,6 +2143,10 @@ class NotebookIntelligence(ExtensionApp):
         route_pattern_upload_file = url_path_join(base_url, "notebook-intelligence", "upload-file")
         route_pattern_claude_sessions = url_path_join(base_url, "notebook-intelligence", "claude-sessions")
         route_pattern_claude_sessions_resume = url_path_join(base_url, "notebook-intelligence", "claude-sessions", "resume")
+        route_pattern_claude_mcp = url_path_join(base_url, "notebook-intelligence", "claude-mcp")
+        route_pattern_claude_mcp_detail = url_path_join(
+            base_url, "notebook-intelligence", "claude-mcp", r"(user|project|local)", r"([^/]+)"
+        )
         GetCapabilitiesHandler.disabled_tools = self.disabled_tools
         GetCapabilitiesHandler.allow_enabling_tools_with_env = self.allow_enabling_tools_with_env
         GetCapabilitiesHandler.disabled_providers = self.disabled_providers
@@ -2048,6 +2165,9 @@ class NotebookIntelligence(ExtensionApp):
         )
         SkillsBaseHandler.skills_management_enabled = not is_force_off(
             feature_policies, "skills_management"
+        )
+        ClaudeMCPBaseHandler.claude_mcp_management_enabled = not is_force_off(
+            feature_policies, "claude_mcp_management"
         )
         self._publish_policies(feature_policies, string_overrides)
         NotebookIntelligence.handlers = [
@@ -2078,6 +2198,10 @@ class NotebookIntelligence(ExtensionApp):
             (route_pattern_upload_file, FileUploadHandler),
             (route_pattern_claude_sessions_resume, ClaudeSessionsResumeHandler),
             (route_pattern_claude_sessions, ClaudeSessionsListHandler),
+            # Claude-MCP routes: detail before list so {scope}/{name} doesn't
+            # shadow specialized URLs added later (parallels the skills order).
+            (route_pattern_claude_mcp_detail, ClaudeMCPDetailHandler),
+            (route_pattern_claude_mcp, ClaudeMCPListHandler),
             (route_pattern_copilot, WebsocketCopilotHandler),
         ]
         web_app.add_handlers(host_pattern, NotebookIntelligence.handlers)

--- a/notebook_intelligence/feature_flags.py
+++ b/notebook_intelligence/feature_flags.py
@@ -45,6 +45,16 @@ def is_locked(policy: str) -> bool:
     return policy in (POLICY_FORCE_ON, POLICY_FORCE_OFF)
 
 
+def is_force_off(policies: dict, name: str) -> bool:
+    """True iff ``policies[name]`` is force-off (missing == user-choice).
+
+    The canonical predicate for backend kill-switches: a handler-level prepare
+    gate, a reconciler-init guard, etc. all want the same "is this admin-
+    disabled" answer.
+    """
+    return policies.get(name, POLICY_USER_CHOICE) == POLICY_FORCE_OFF
+
+
 def apply_string_overrides(target: dict, overrides: dict, mapping: tuple) -> dict:
     """Apply value-presence-locks per ``mapping`` to a copy of ``target``.
 

--- a/notebook_intelligence/util.py
+++ b/notebook_intelligence/util.py
@@ -2,7 +2,8 @@
 
 import os
 import base64
-from typing import Set
+import shutil
+from typing import Optional, Set
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from cryptography.fernet import Fernet
@@ -18,6 +19,19 @@ def set_jupyter_root_dir(root_dir: str):
 
 def get_jupyter_root_dir() -> str:
     return _jupyter_root_dir
+
+
+def resolve_claude_cli_path() -> Optional[str]:
+    """Resolve the Claude Code CLI binary path.
+
+    NBI_CLAUDE_CLI_PATH wins when set; otherwise fall back to the first
+    `claude` on PATH. Returns None when nothing is found, so callers can
+    decide between raising and proceeding without the CLI.
+    """
+    explicit = os.getenv("NBI_CLAUDE_CLI_PATH")
+    if explicit:
+        return explicit
+    return shutil.which("claude")
 
 def extract_llm_generated_code(code: str) -> str:
     if code.endswith("```"):

--- a/src/api.ts
+++ b/src/api.ts
@@ -164,7 +164,8 @@ export type FeaturePolicyName =
   | 'claude_jupyter_ui_tools'
   | 'claude_setting_source_user'
   | 'claude_setting_source_project'
-  | 'store_github_access_token';
+  | 'store_github_access_token'
+  | 'skills_management';
 
 export type IFeaturePolicies = Record<
   FeaturePolicyName,
@@ -325,7 +326,8 @@ export class NBIConfig {
       'claude_jupyter_ui_tools',
       'claude_setting_source_user',
       'claude_setting_source_project',
-      'store_github_access_token'
+      'store_github_access_token',
+      'skills_management'
     ];
     const result = {} as IFeaturePolicies;
     for (const name of names) {

--- a/src/api.ts
+++ b/src/api.ts
@@ -66,6 +66,53 @@ export enum ClaudeToolType {
 
 export type SkillScope = 'user' | 'project';
 
+export type ClaudeMCPScope = 'user' | 'project' | 'local';
+export type ClaudeMCPTransport = 'stdio' | 'sse' | 'http';
+
+export interface IClaudeMCPServer {
+  name: string;
+  scope: ClaudeMCPScope;
+  transport: ClaudeMCPTransport | string;
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+  url: string;
+  headers: Record<string, string>;
+}
+
+export interface IClaudeMCPAddInput {
+  name: string;
+  scope: ClaudeMCPScope;
+  transport: ClaudeMCPTransport;
+  commandOrUrl: string;
+  args?: string[];
+  env?: Record<string, string>;
+  headers?: Record<string, string>;
+}
+
+function claudeMCPServerFromWire(wire: any): IClaudeMCPServer {
+  return {
+    name: String(wire?.name ?? ''),
+    scope: (wire?.scope ?? 'user') as ClaudeMCPScope,
+    transport: String(wire?.transport ?? 'stdio'),
+    command: String(wire?.command ?? ''),
+    args: Array.isArray(wire?.args) ? wire.args.map(String) : [],
+    env:
+      wire?.env && typeof wire.env === 'object'
+        ? Object.fromEntries(
+            Object.entries(wire.env).map(([k, v]) => [String(k), String(v)])
+          )
+        : {},
+    url: String(wire?.url ?? ''),
+    headers:
+      wire?.headers && typeof wire.headers === 'object'
+        ? Object.fromEntries(
+            Object.entries(wire.headers).map(([k, v]) => [String(k), String(v)])
+          )
+        : {}
+  };
+}
+
 export interface ISkillSummary {
   scope: SkillScope;
   name: string;
@@ -165,7 +212,8 @@ export type FeaturePolicyName =
   | 'claude_setting_source_user'
   | 'claude_setting_source_project'
   | 'store_github_access_token'
-  | 'skills_management';
+  | 'skills_management'
+  | 'claude_mcp_management';
 
 export type IFeaturePolicies = Record<
   FeaturePolicyName,
@@ -327,7 +375,8 @@ export class NBIConfig {
       'claude_setting_source_user',
       'claude_setting_source_project',
       'store_github_access_token',
-      'skills_management'
+      'skills_management',
+      'claude_mcp_management'
     ];
     const result = {} as IFeaturePolicies;
     for (const name of names) {
@@ -741,6 +790,47 @@ export class NBIAPI {
       body: JSON.stringify(wire)
     });
     return skillFromWire(data.skill);
+  }
+
+  static async listClaudeMCPServers(): Promise<IClaudeMCPServer[]> {
+    const data = await requestAPI<any>('claude-mcp');
+    return Array.isArray(data?.servers)
+      ? data.servers.map(claudeMCPServerFromWire)
+      : [];
+  }
+
+  static async addClaudeMCPServer(
+    input: IClaudeMCPAddInput
+  ): Promise<IClaudeMCPServer> {
+    const body: any = {
+      name: input.name,
+      scope: input.scope,
+      transport: input.transport,
+      command_or_url: input.commandOrUrl
+    };
+    if (input.args && input.args.length) {
+      body.args = input.args;
+    }
+    if (input.env && Object.keys(input.env).length) {
+      body.env = input.env;
+    }
+    if (input.headers && Object.keys(input.headers).length) {
+      body.headers = input.headers;
+    }
+    const data = await requestAPI<any>('claude-mcp', {
+      method: 'POST',
+      body: JSON.stringify(body)
+    });
+    return claudeMCPServerFromWire(data.server);
+  }
+
+  static async removeClaudeMCPServer(
+    name: string,
+    scope: ClaudeMCPScope
+  ): Promise<void> {
+    await requestAPI<any>(`claude-mcp/${scope}/${encodeURIComponent(name)}`, {
+      method: 'DELETE'
+    });
   }
 
   static async reconcileManagedSkills(): Promise<IReconcileResult> {

--- a/src/components/claude-mcp-panel.tsx
+++ b/src/components/claude-mcp-panel.tsx
@@ -1,0 +1,391 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+import React, { useEffect, useState } from 'react';
+import { Dialog, showDialog } from '@jupyterlab/apputils';
+import {
+  ClaudeMCPScope,
+  ClaudeMCPTransport,
+  IClaudeMCPAddInput,
+  IClaudeMCPServer,
+  NBIAPI
+} from '../api';
+
+const SCOPES: ClaudeMCPScope[] = ['user', 'project', 'local'];
+const TRANSPORTS: ClaudeMCPTransport[] = ['stdio', 'sse', 'http'];
+
+const SCOPE_HINT: Record<ClaudeMCPScope, string> = {
+  user: 'available in all your projects',
+  project: 'shared via the project repo (.mcp.json)',
+  local: 'this project, this user only'
+};
+
+export function SettingsPanelComponentClaudeMCP(_props: any): JSX.Element {
+  const [servers, setServers] = useState<IClaudeMCPServer[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [addOpen, setAddOpen] = useState(false);
+  const [pendingRemoval, setPendingRemoval] = useState<IClaudeMCPServer | null>(
+    null
+  );
+
+  const refresh = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const list = await NBIAPI.listClaudeMCPServers();
+      setServers(list);
+    } catch (e: any) {
+      setError(e?.message ?? String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const handleRemove = async (srv: IClaudeMCPServer) => {
+    const ok = await showDialog({
+      title: 'Remove MCP server?',
+      body: `"${srv.name}" will be removed from Claude's ${srv.scope}-scope config.`,
+      buttons: [Dialog.cancelButton(), Dialog.warnButton({ label: 'Remove' })]
+    });
+    if (!ok.button.accept) {
+      return;
+    }
+    setPendingRemoval(srv);
+    try {
+      await NBIAPI.removeClaudeMCPServer(srv.name, srv.scope);
+      await refresh();
+    } catch (e: any) {
+      setError(`Failed to remove: ${e?.message ?? e}`);
+    } finally {
+      setPendingRemoval(null);
+    }
+  };
+
+  const handleAddSubmit = async (input: IClaudeMCPAddInput) => {
+    // Errors are rendered inside the dialog so they're not hidden behind the
+    // modal backdrop; rethrow so the dialog can keep itself open.
+    await NBIAPI.addClaudeMCPServer(input);
+    setAddOpen(false);
+    await refresh();
+  };
+
+  const grouped: Record<ClaudeMCPScope, IClaudeMCPServer[]> = {
+    user: [],
+    project: [],
+    local: []
+  };
+  for (const srv of servers) {
+    (grouped[srv.scope as ClaudeMCPScope] ?? grouped.user).push(srv);
+  }
+
+  return (
+    <div className="config-dialog-body nbi-skills-panel">
+      <div className="nbi-skills-header">
+        <div className="nbi-skills-title">MCP Servers</div>
+        <div className="nbi-skills-header-actions">
+          <button
+            className="jp-Dialog-button jp-mod-reject jp-mod-styled"
+            onClick={refresh}
+            disabled={loading}
+            title="Re-read Claude's MCP config from disk"
+          >
+            <div className="jp-Dialog-buttonLabel">
+              {loading ? 'Refreshing…' : 'Refresh'}
+            </div>
+          </button>
+          <button
+            className="jp-Dialog-button jp-mod-reject jp-mod-styled"
+            onClick={() => setAddOpen(true)}
+          >
+            <div className="jp-Dialog-buttonLabel">Add server</div>
+          </button>
+        </div>
+      </div>
+
+      <div className="nbi-info-banner" role="note">
+        These are Claude Code's own MCP servers (read from{' '}
+        <code>~/.claude.json</code>, project <code>.mcp.json</code>, and the
+        per-user-per-project block). Independent of the NBI MCP Servers tab.
+      </div>
+
+      {error && (
+        <div className="nbi-skills-error" role="alert">
+          {error}
+        </div>
+      )}
+
+      {SCOPES.map(scope => (
+        <ClaudeMCPScopeSection
+          key={scope}
+          scope={scope}
+          servers={grouped[scope]}
+          loading={loading}
+          pendingRemoval={pendingRemoval}
+          onRemove={handleRemove}
+        />
+      ))}
+
+      {addOpen && (
+        <ClaudeMCPAddDialog
+          onCancel={() => setAddOpen(false)}
+          onSubmit={handleAddSubmit}
+        />
+      )}
+    </div>
+  );
+}
+
+function ClaudeMCPScopeSection(props: {
+  scope: ClaudeMCPScope;
+  servers: IClaudeMCPServer[];
+  loading: boolean;
+  pendingRemoval: IClaudeMCPServer | null;
+  onRemove: (srv: IClaudeMCPServer) => void;
+}) {
+  return (
+    <div className="nbi-skills-section">
+      <div
+        className="nbi-skills-section-caption"
+        title={SCOPE_HINT[props.scope]}
+      >
+        {props.scope.toUpperCase()}
+      </div>
+      {props.servers.length === 0 ? (
+        <div className="nbi-skills-empty">
+          {props.loading ? 'Loading…' : 'No servers in this scope.'}
+        </div>
+      ) : (
+        props.servers.map(srv => (
+          <ClaudeMCPRow
+            key={`${srv.scope}-${srv.name}`}
+            srv={srv}
+            removing={
+              props.pendingRemoval?.name === srv.name &&
+              props.pendingRemoval?.scope === srv.scope
+            }
+            onRemove={() => props.onRemove(srv)}
+          />
+        ))
+      )}
+    </div>
+  );
+}
+
+function ClaudeMCPRow(props: {
+  srv: IClaudeMCPServer;
+  removing: boolean;
+  onRemove: () => void;
+}) {
+  const { srv } = props;
+  const summary =
+    srv.transport === 'stdio'
+      ? [srv.command, ...srv.args].filter(Boolean).join(' ')
+      : srv.url;
+  return (
+    <div className="nbi-skill-row">
+      <div className="nbi-skill-row-main">
+        <div className="nbi-skill-row-name">{srv.name}</div>
+        <div className="nbi-skill-row-description">
+          <code>{srv.transport}</code>
+          {summary && <span> — {summary}</span>}
+        </div>
+      </div>
+      <div className="nbi-skill-row-actions" onClick={e => e.stopPropagation()}>
+        <button
+          className="jp-Dialog-button jp-mod-reject jp-mod-styled"
+          onClick={props.onRemove}
+          disabled={props.removing}
+        >
+          <div className="jp-Dialog-buttonLabel">
+            {props.removing ? 'Removing…' : 'Remove'}
+          </div>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ClaudeMCPAddDialog(props: {
+  onCancel: () => void;
+  onSubmit: (input: IClaudeMCPAddInput) => Promise<void>;
+}) {
+  const [scope, setScope] = useState<ClaudeMCPScope>('user');
+  const [transport, setTransport] = useState<ClaudeMCPTransport>('stdio');
+  const [name, setName] = useState('');
+  const [commandOrUrl, setCommandOrUrl] = useState('');
+  const [argsText, setArgsText] = useState('');
+  const [envText, setEnvText] = useState('');
+  const [headersText, setHeadersText] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const canSubmit = name.trim() && commandOrUrl.trim() && !submitting;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) {
+      return;
+    }
+    const argsList = argsText
+      .split('\n')
+      .map(line => line.trim())
+      .filter(Boolean);
+    const parseKVLines = (
+      text: string,
+      separator: string
+    ): Record<string, string> => {
+      const out: Record<string, string> = {};
+      for (const line of text.split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed) {
+          continue;
+        }
+        const idx = trimmed.indexOf(separator);
+        if (idx > 0) {
+          out[trimmed.slice(0, idx).trim()] = trimmed.slice(idx + 1).trim();
+        }
+      }
+      return out;
+    };
+    const envMap = parseKVLines(envText, '=');
+    const headersMap = parseKVLines(headersText, ':');
+    setSubmitError(null);
+    setSubmitting(true);
+    try {
+      await props.onSubmit({
+        name: name.trim(),
+        scope,
+        transport,
+        commandOrUrl: commandOrUrl.trim(),
+        args: transport === 'stdio' ? argsList : undefined,
+        env: transport === 'stdio' ? envMap : undefined,
+        headers: transport === 'stdio' ? undefined : headersMap
+      });
+    } catch (e: any) {
+      setSubmitError(e?.message ?? String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="nbi-modal-backdrop" onClick={props.onCancel}>
+      <div
+        className="nbi-modal-card"
+        role="dialog"
+        aria-modal="true"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="nbi-modal-title">Add MCP server</div>
+        <div className="nbi-modal-body">
+          <div className="nbi-form-field">
+            <label>Name</label>
+            <input
+              type="text"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              placeholder="my-server"
+              autoFocus
+            />
+          </div>
+          <div className="nbi-form-field">
+            <label>Scope</label>
+            <select
+              value={scope}
+              onChange={e => setScope(e.target.value as ClaudeMCPScope)}
+            >
+              {SCOPES.map(s => (
+                <option key={s} value={s}>
+                  {s} — {SCOPE_HINT[s]}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="nbi-form-field">
+            <label>Transport</label>
+            <select
+              value={transport}
+              onChange={e => setTransport(e.target.value as ClaudeMCPTransport)}
+            >
+              {TRANSPORTS.map(t => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="nbi-form-field">
+            <label>{transport === 'stdio' ? 'Command' : 'URL'}</label>
+            <input
+              type="text"
+              value={commandOrUrl}
+              onChange={e => setCommandOrUrl(e.target.value)}
+              placeholder={
+                transport === 'stdio' ? 'npx' : 'https://example.com/mcp'
+              }
+            />
+          </div>
+          {transport === 'stdio' && (
+            <div className="nbi-form-field">
+              <label>Args (one per line)</label>
+              <textarea
+                rows={3}
+                value={argsText}
+                onChange={e => setArgsText(e.target.value)}
+                placeholder={'-y\n@scope/package@latest'}
+              />
+            </div>
+          )}
+          {transport === 'stdio' && (
+            <div className="nbi-form-field">
+              <label>Environment (KEY=value, one per line)</label>
+              <textarea
+                rows={3}
+                value={envText}
+                onChange={e => setEnvText(e.target.value)}
+                placeholder="API_KEY=…"
+              />
+            </div>
+          )}
+          {transport !== 'stdio' && (
+            <div className="nbi-form-field">
+              <label>Headers (Name: value, one per line)</label>
+              <textarea
+                rows={3}
+                value={headersText}
+                onChange={e => setHeadersText(e.target.value)}
+                placeholder="Authorization: Bearer …"
+              />
+            </div>
+          )}
+          {submitError && (
+            <div className="nbi-skills-error" role="alert">
+              {submitError}
+            </div>
+          )}
+        </div>
+        <div className="nbi-modal-actions">
+          <button
+            className="jp-Dialog-button jp-mod-reject jp-mod-styled"
+            onClick={props.onCancel}
+            disabled={submitting}
+          >
+            <div className="jp-Dialog-buttonLabel">Cancel</div>
+          </button>
+          <button
+            className="jp-Dialog-button jp-mod-accept jp-mod-styled"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+          >
+            <div className="jp-Dialog-buttonLabel">
+              {submitting ? 'Adding…' : 'Add'}
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings-panel.tsx
+++ b/src/components/settings-panel.tsx
@@ -18,6 +18,7 @@ import { CheckBoxItem } from './checkbox';
 import { PillItem } from './pill';
 import { mcpServerSettingsToEnabledState } from './mcp-util';
 import { SettingsPanelComponentSkills } from './skills-panel';
+import { SettingsPanelComponentClaudeMCP } from './claude-mcp-panel';
 import { writeTextToClipboard } from '../utils';
 
 const lockedTip = (locked: boolean): string =>
@@ -125,7 +126,29 @@ export class SettingsPanel extends ReactWidget {
 function SettingsPanelComponent(props: any) {
   const [activeTab, setActiveTab] = useState('general');
   const { featurePolicies } = useNbiPolicies();
+  const [isInClaudeCodeMode, setIsInClaudeCodeMode] = useState(
+    NBIAPI.config.isInClaudeCodeMode
+  );
+  const [isClaudeCliAvailable, setIsClaudeCliAvailable] = useState(
+    NBIAPI.config.isClaudeCliAvailable
+  );
+
+  useEffect(() => {
+    const handler = () => {
+      setIsInClaudeCodeMode(NBIAPI.config.isInClaudeCodeMode);
+      setIsClaudeCliAvailable(NBIAPI.config.isClaudeCliAvailable);
+    };
+    NBIAPI.configChanged.connect(handler);
+    return () => {
+      NBIAPI.configChanged.disconnect(handler);
+    };
+  }, []);
+
   const skillsTabVisible = featurePolicies.skills_management.enabled;
+  const claudeMcpTabVisible =
+    featurePolicies.claude_mcp_management.enabled &&
+    isInClaudeCodeMode &&
+    isClaudeCliAvailable;
 
   // Bounce the user off a tab that has just been hidden by an admin policy
   // change so they don't see a blank pane.
@@ -133,7 +156,10 @@ function SettingsPanelComponent(props: any) {
     if (!skillsTabVisible && activeTab === 'skills') {
       setActiveTab('general');
     }
-  }, [skillsTabVisible, activeTab]);
+    if (!claudeMcpTabVisible && activeTab === 'claude-mcp') {
+      setActiveTab('general');
+    }
+  }, [skillsTabVisible, claudeMcpTabVisible, activeTab]);
 
   const onTabSelected = (tab: string) => {
     setActiveTab(tab);
@@ -145,6 +171,7 @@ function SettingsPanelComponent(props: any) {
         onTabSelected={onTabSelected}
         activeTab={activeTab}
         skillsTabVisible={skillsTabVisible}
+        claudeMcpTabVisible={claudeMcpTabVisible}
       />
       <div
         className="nbi-settings-panel-tab-content"
@@ -170,6 +197,9 @@ function SettingsPanelComponent(props: any) {
         )}
         {activeTab === 'skills' && skillsTabVisible && (
           <SettingsPanelComponentSkills />
+        )}
+        {activeTab === 'claude-mcp' && claudeMcpTabVisible && (
+          <SettingsPanelComponentClaudeMCP />
         )}
       </div>
     </div>
@@ -214,6 +244,9 @@ function SettingsPanelTabsComponent(props: any) {
   ];
   if (!isInClaudeCodeMode) {
     tabs.push({ id: 'mcp-servers', label: 'MCP Servers' });
+  }
+  if (props.claudeMcpTabVisible) {
+    tabs.push({ id: 'claude-mcp', label: 'Claude MCP' });
   }
   if (props.skillsTabVisible) {
     tabs.push({ id: 'skills', label: 'Skills' });

--- a/src/components/settings-panel.tsx
+++ b/src/components/settings-panel.tsx
@@ -124,6 +124,16 @@ export class SettingsPanel extends ReactWidget {
 
 function SettingsPanelComponent(props: any) {
   const [activeTab, setActiveTab] = useState('general');
+  const { featurePolicies } = useNbiPolicies();
+  const skillsTabVisible = featurePolicies.skills_management.enabled;
+
+  // Bounce the user off a tab that has just been hidden by an admin policy
+  // change so they don't see a blank pane.
+  useEffect(() => {
+    if (!skillsTabVisible && activeTab === 'skills') {
+      setActiveTab('general');
+    }
+  }, [skillsTabVisible, activeTab]);
 
   const onTabSelected = (tab: string) => {
     setActiveTab(tab);
@@ -134,6 +144,7 @@ function SettingsPanelComponent(props: any) {
       <SettingsPanelTabsComponent
         onTabSelected={onTabSelected}
         activeTab={activeTab}
+        skillsTabVisible={skillsTabVisible}
       />
       <div
         className="nbi-settings-panel-tab-content"
@@ -157,13 +168,20 @@ function SettingsPanelComponent(props: any) {
             onEditMCPConfigClicked={props.onEditMCPConfigClicked}
           />
         )}
+        {activeTab === 'skills' && skillsTabVisible && (
+          <SettingsPanelComponentSkills />
+        )}
       </div>
     </div>
   );
 }
 
 function SettingsPanelTabsComponent(props: any) {
-  const [activeTab, setActiveTab] = useState(props.activeTab);
+  // Fully controlled: parent owns `activeTab`. Reading directly from props
+  // (instead of a local mirror) prevents drift when the parent flips the
+  // tab — e.g. when an admin policy hides the active tab and the parent
+  // bounces the user to `general`.
+  const activeTab = props.activeTab;
   const [isInClaudeCodeMode, setIsInClaudeCodeMode] = useState(
     NBIAPI.config.isInClaudeCodeMode
   );
@@ -197,9 +215,11 @@ function SettingsPanelTabsComponent(props: any) {
   if (!isInClaudeCodeMode) {
     tabs.push({ id: 'mcp-servers', label: 'MCP Servers' });
   }
+  if (props.skillsTabVisible) {
+    tabs.push({ id: 'skills', label: 'Skills' });
+  }
 
   const selectTab = (id: string): void => {
-    setActiveTab(id);
     props.onTabSelected(id);
   };
 
@@ -1158,421 +1178,348 @@ function SettingsPanelComponentClaude(props: any) {
     continueConversation
   ]);
 
-  const [claudeSubTab, setClaudeSubTab] = useState<'settings' | 'skills'>(
-    'settings'
-  );
-
-  useEffect(() => {
-    if (!nbiConfig.isInClaudeCodeMode && claudeSubTab !== 'settings') {
-      setClaudeSubTab('settings');
-    }
-  }, [nbiConfig.isInClaudeCodeMode, claudeSubTab]);
-
-  const subTabs: { id: 'settings' | 'skills'; label: string }[] = [
-    { id: 'settings', label: 'Settings' },
-    { id: 'skills', label: 'Skills' }
-  ];
-
-  const onSubTabKeyDown = useTablistArrowKeys(
-    subTabs,
-    claudeSubTab,
-    id => setClaudeSubTab(id as 'settings' | 'skills'),
-    'horizontal',
-    id => tabId('nbi-claude-subtab', id)
-  );
-
   return (
     <div className="config-dialog claude-mode-config-dialog">
-      {nbiConfig.isInClaudeCodeMode && (
-        <div
-          className="nbi-subtab-bar"
-          role="tablist"
-          aria-label="Claude settings sections"
-          aria-orientation="horizontal"
-          onKeyDown={onSubTabKeyDown}
-        >
-          {subTabs.map(tab => {
-            const selected = claudeSubTab === tab.id;
-            return (
-              <button
-                type="button"
-                key={tab.id}
-                id={tabId('nbi-claude-subtab', tab.id)}
-                className={`nbi-subtab ${selected ? 'active' : ''}`}
-                role="tab"
-                aria-selected={selected}
-                aria-controls={tabId('nbi-claude-subtabpanel', tab.id)}
-                tabIndex={selected ? 0 : -1}
-                onClick={() => setClaudeSubTab(tab.id)}
-              >
-                {tab.label}
-              </button>
-            );
-          })}
-        </div>
-      )}
-      {claudeSubTab === 'skills' && (
-        <div
-          role="tabpanel"
-          id={tabId('nbi-claude-subtabpanel', 'skills')}
-          aria-labelledby={tabId('nbi-claude-subtab', 'skills')}
-        >
-          <SettingsPanelComponentSkills />
-        </div>
-      )}
-      {claudeSubTab === 'settings' && (
-        <div
-          className="config-dialog-body"
-          role="tabpanel"
-          id={tabId('nbi-claude-subtabpanel', 'settings')}
-          aria-labelledby={tabId('nbi-claude-subtab', 'settings')}
-        >
-          <div className="model-config-section">
-            <div className="model-config-section-header">
-              Enable Claude mode
+      <div className="config-dialog-body">
+        <div className="model-config-section">
+          <div className="model-config-section-header">Enable Claude mode</div>
+          <div className="model-config-section-body">
+            <div className="model-config-section-row">
+              <span>
+                This requires a{' '}
+                <a href="https://claude.ai" target="_blank">
+                  Claude
+                </a>{' '}
+                account and{' '}
+                <a href="https://code.claude.com/" target="_blank">
+                  Claude Code
+                </a>{' '}
+                installed in your system.
+              </span>
             </div>
-            <div className="model-config-section-body">
-              <div className="model-config-section-row">
-                <span>
-                  This requires a{' '}
-                  <a href="https://claude.ai" target="_blank">
-                    Claude
-                  </a>{' '}
-                  account and{' '}
-                  <a href="https://code.claude.com/" target="_blank">
-                    Claude Code
-                  </a>{' '}
-                  installed in your system.
-                </span>
-              </div>
-              <div className="model-config-section-row">
-                <div className="model-config-section-column">
-                  <div>
-                    <CheckBoxItem
-                      header={true}
-                      label="Enable Claude mode"
-                      checked={checkedValue(
-                        featurePolicies.claude_mode,
-                        claudeEnabled
-                      )}
-                      disabled={featurePolicies.claude_mode.locked}
-                      tooltip={lockedTip(featurePolicies.claude_mode.locked)}
-                      onClick={() => {
-                        setClaudeEnabled(!claudeEnabled);
-                      }}
-                    ></CheckBoxItem>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="model-config-section">
-            <div
-              className="model-config-section-header"
-              style={{ display: 'flex' }}
-            >
-              <div style={{ flexGrow: 1 }}>Models</div>
-              <div>
-                <button
-                  className="jp-toast-button jp-mod-small jp-Button"
-                  onClick={refreshClaudeModels}
-                  disabled={loadingModels}
-                >
-                  <div className="jp-Dialog-buttonLabel">
-                    {loadingModels ? 'Loading...' : 'Refresh'}
-                  </div>
-                </button>
-              </div>
-            </div>
-            <div className="model-config-section-body">
-              <div className="model-config-section-row">
-                <div className="model-config-section-column">
-                  <div>Chat model</div>
-                  <div title={lockedTip(settingLocks.claude_chat_model.locked)}>
-                    <select
-                      className="jp-mod-styled"
-                      disabled={settingLocks.claude_chat_model.locked}
-                      onChange={event => setChatModel(event.target.value)}
-                    >
-                      <option
-                        value={ClaudeModelType.Default}
-                        selected={chatModel === ClaudeModelType.Default}
-                      >
-                        Default (recommended)
-                      </option>
-                      {claudeModels.map(model => (
-                        <option
-                          key={model.id}
-                          value={model.id}
-                          selected={chatModel === model.id}
-                        >
-                          {model.name}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                </div>
-                <div className="model-config-section-column">
-                  <div>Auto-complete model</div>
-                  <div
-                    title={lockedTip(
-                      settingLocks.claude_inline_completion_model.locked
+            <div className="model-config-section-row">
+              <div className="model-config-section-column">
+                <div>
+                  <CheckBoxItem
+                    header={true}
+                    label="Enable Claude mode"
+                    checked={checkedValue(
+                      featurePolicies.claude_mode,
+                      claudeEnabled
                     )}
-                  >
-                    <select
-                      className="jp-mod-styled"
-                      disabled={
-                        settingLocks.claude_inline_completion_model.locked
-                      }
-                      onChange={event =>
-                        setInlineCompletionModel(event.target.value)
-                      }
-                    >
-                      <option
-                        value={ClaudeModelType.None}
-                        selected={
-                          inlineCompletionModel === ClaudeModelType.None
-                        }
-                      >
-                        None
-                      </option>
-                      <option
-                        value={ClaudeModelType.Inherit}
-                        selected={
-                          inlineCompletionModel === ClaudeModelType.Inherit
-                        }
-                      >
-                        Inherit from general settings
-                      </option>
-                      <option
-                        value={ClaudeModelType.Default}
-                        selected={
-                          inlineCompletionModel === ClaudeModelType.Default
-                        }
-                      >
-                        Default (recommended)
-                      </option>
-                      {claudeModels.map(model => (
-                        <option
-                          key={model.id}
-                          value={model.id}
-                          selected={inlineCompletionModel === model.id}
-                        >
-                          {model.name}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="model-config-section">
-            <div className="model-config-section-header">
-              Chat Agent setting sources
-            </div>
-            <div className="model-config-section-body">
-              <div className="model-config-section-row">
-                <div className="model-config-section-column">
-                  <div>
-                    <CheckBoxItem
-                      header={true}
-                      label="User"
-                      checked={checkedValue(
-                        featurePolicies.claude_setting_source_user,
-                        settingSources.includes('user')
-                      )}
-                      disabled={
-                        featurePolicies.claude_setting_source_user.locked
-                      }
-                      tooltip={lockedTip(
-                        featurePolicies.claude_setting_source_user.locked
-                      )}
-                      onClick={() => {
-                        setSettingSources(
-                          settingSources.includes('user')
-                            ? settingSources.filter(
-                                (source: string) => source !== 'user'
-                              )
-                            : [...settingSources, 'user']
-                        );
-                      }}
-                    ></CheckBoxItem>
-                  </div>
-                </div>
-                <div className="model-config-section-column">
-                  <div>
-                    <CheckBoxItem
-                      header={true}
-                      label="Project (Jupyter root directory)"
-                      checked={checkedValue(
-                        featurePolicies.claude_setting_source_project,
-                        settingSources.includes('project')
-                      )}
-                      disabled={
-                        featurePolicies.claude_setting_source_project.locked
-                      }
-                      tooltip={lockedTip(
-                        featurePolicies.claude_setting_source_project.locked
-                      )}
-                      onClick={() => {
-                        setSettingSources(
-                          settingSources.includes('project')
-                            ? settingSources.filter(
-                                (source: string) => source !== 'project'
-                              )
-                            : [...settingSources, 'project']
-                        );
-                      }}
-                    ></CheckBoxItem>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="model-config-section">
-            <div className="model-config-section-header">Chat Agent tools</div>
-            <div className="model-config-section-body">
-              <div className="model-config-section-row">
-                <div className="model-config-section-column">
-                  <div>
-                    <CheckBoxItem
-                      header={true}
-                      label="Claude Code tools"
-                      checked={checkedValue(
-                        featurePolicies.claude_code_tools,
-                        tools.includes(ClaudeToolType.ClaudeCodeTools)
-                      )}
-                      disabled={true}
-                      tooltip={lockedTip(
-                        featurePolicies.claude_code_tools.locked
-                      )}
-                      onClick={() => {
-                        setTools(
-                          tools.includes(ClaudeToolType.ClaudeCodeTools)
-                            ? tools.filter(
-                                (tool: string) =>
-                                  tool !== ClaudeToolType.ClaudeCodeTools
-                              )
-                            : [...tools, ClaudeToolType.ClaudeCodeTools]
-                        );
-                      }}
-                    ></CheckBoxItem>
-                  </div>
-                </div>
-                <div className="model-config-section-column">
-                  <div>
-                    <CheckBoxItem
-                      header={true}
-                      label="Jupyter UI tools"
-                      checked={checkedValue(
-                        featurePolicies.claude_jupyter_ui_tools,
-                        tools.includes(ClaudeToolType.JupyterUITools)
-                      )}
-                      disabled={featurePolicies.claude_jupyter_ui_tools.locked}
-                      tooltip={lockedTip(
-                        featurePolicies.claude_jupyter_ui_tools.locked
-                      )}
-                      onClick={() => {
-                        setTools(
-                          tools.includes(ClaudeToolType.JupyterUITools)
-                            ? tools.filter(
-                                (tool: string) =>
-                                  tool !== ClaudeToolType.JupyterUITools
-                              )
-                            : [...tools, ClaudeToolType.JupyterUITools]
-                        );
-                      }}
-                    ></CheckBoxItem>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="model-config-section">
-            <div className="model-config-section-header">
-              Conversation History
-            </div>
-            <div className="model-config-section-body">
-              <div className="model-config-section-row">
-                <div className="model-config-section-column">
-                  <div>
-                    <CheckBoxItem
-                      header={true}
-                      label="Remember conversation history"
-                      checked={checkedValue(
-                        featurePolicies.claude_continue_conversation,
-                        continueConversation
-                      )}
-                      disabled={
-                        featurePolicies.claude_continue_conversation.locked
-                      }
-                      tooltip={lockedTip(
-                        featurePolicies.claude_continue_conversation.locked
-                      )}
-                      onClick={() => {
-                        setContinueConversation(!continueConversation);
-                      }}
-                    ></CheckBoxItem>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="model-config-section">
-            <div className="model-config-section-header">Claude account</div>
-            <div className="model-config-section-body">
-              <div className="model-config-section-row">
-                <div className="model-config-section-column">
-                  <div className="form-field-row">
-                    <div className="form-field-description">
-                      API Key (optional)
-                    </div>
-                    <input
-                      name="chat-model-id-input"
-                      placeholder={
-                        settingLocks.claude_api_key.locked
-                          ? 'Locked by ANTHROPIC_API_KEY'
-                          : 'API Key'
-                      }
-                      className="jp-mod-styled"
-                      spellCheck={false}
-                      value={settingLocks.claude_api_key.locked ? '' : apiKey}
-                      disabled={settingLocks.claude_api_key.locked}
-                      title={lockedTip(settingLocks.claude_api_key.locked)}
-                      onChange={event => setApiKey(event.target.value)}
-                    />
-                  </div>
-                  <div className="form-field-row">
-                    <div className="form-field-description">
-                      Base URL (optional)
-                    </div>
-                    <input
-                      name="chat-model-id-input"
-                      placeholder={
-                        settingLocks.claude_base_url.locked
-                          ? 'Locked by ANTHROPIC_BASE_URL'
-                          : 'https://api.anthropic.com'
-                      }
-                      className="jp-mod-styled"
-                      spellCheck={false}
-                      value={baseUrl}
-                      disabled={settingLocks.claude_base_url.locked}
-                      title={lockedTip(settingLocks.claude_base_url.locked)}
-                      onChange={event => setBaseUrl(event.target.value)}
-                    />
-                  </div>
+                    disabled={featurePolicies.claude_mode.locked}
+                    tooltip={lockedTip(featurePolicies.claude_mode.locked)}
+                    onClick={() => {
+                      setClaudeEnabled(!claudeEnabled);
+                    }}
+                  ></CheckBoxItem>
                 </div>
               </div>
             </div>
           </div>
         </div>
-      )}
+
+        <div className="model-config-section">
+          <div
+            className="model-config-section-header"
+            style={{ display: 'flex' }}
+          >
+            <div style={{ flexGrow: 1 }}>Models</div>
+            <div>
+              <button
+                className="jp-toast-button jp-mod-small jp-Button"
+                onClick={refreshClaudeModels}
+                disabled={loadingModels}
+              >
+                <div className="jp-Dialog-buttonLabel">
+                  {loadingModels ? 'Loading...' : 'Refresh'}
+                </div>
+              </button>
+            </div>
+          </div>
+          <div className="model-config-section-body">
+            <div className="model-config-section-row">
+              <div className="model-config-section-column">
+                <div>Chat model</div>
+                <div title={lockedTip(settingLocks.claude_chat_model.locked)}>
+                  <select
+                    className="jp-mod-styled"
+                    disabled={settingLocks.claude_chat_model.locked}
+                    onChange={event => setChatModel(event.target.value)}
+                  >
+                    <option
+                      value={ClaudeModelType.Default}
+                      selected={chatModel === ClaudeModelType.Default}
+                    >
+                      Default (recommended)
+                    </option>
+                    {claudeModels.map(model => (
+                      <option
+                        key={model.id}
+                        value={model.id}
+                        selected={chatModel === model.id}
+                      >
+                        {model.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+              <div className="model-config-section-column">
+                <div>Auto-complete model</div>
+                <div
+                  title={lockedTip(
+                    settingLocks.claude_inline_completion_model.locked
+                  )}
+                >
+                  <select
+                    className="jp-mod-styled"
+                    disabled={
+                      settingLocks.claude_inline_completion_model.locked
+                    }
+                    onChange={event =>
+                      setInlineCompletionModel(event.target.value)
+                    }
+                  >
+                    <option
+                      value={ClaudeModelType.None}
+                      selected={inlineCompletionModel === ClaudeModelType.None}
+                    >
+                      None
+                    </option>
+                    <option
+                      value={ClaudeModelType.Inherit}
+                      selected={
+                        inlineCompletionModel === ClaudeModelType.Inherit
+                      }
+                    >
+                      Inherit from general settings
+                    </option>
+                    <option
+                      value={ClaudeModelType.Default}
+                      selected={
+                        inlineCompletionModel === ClaudeModelType.Default
+                      }
+                    >
+                      Default (recommended)
+                    </option>
+                    {claudeModels.map(model => (
+                      <option
+                        key={model.id}
+                        value={model.id}
+                        selected={inlineCompletionModel === model.id}
+                      >
+                        {model.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="model-config-section">
+          <div className="model-config-section-header">
+            Chat Agent setting sources
+          </div>
+          <div className="model-config-section-body">
+            <div className="model-config-section-row">
+              <div className="model-config-section-column">
+                <div>
+                  <CheckBoxItem
+                    header={true}
+                    label="User"
+                    checked={checkedValue(
+                      featurePolicies.claude_setting_source_user,
+                      settingSources.includes('user')
+                    )}
+                    disabled={featurePolicies.claude_setting_source_user.locked}
+                    tooltip={lockedTip(
+                      featurePolicies.claude_setting_source_user.locked
+                    )}
+                    onClick={() => {
+                      setSettingSources(
+                        settingSources.includes('user')
+                          ? settingSources.filter(
+                              (source: string) => source !== 'user'
+                            )
+                          : [...settingSources, 'user']
+                      );
+                    }}
+                  ></CheckBoxItem>
+                </div>
+              </div>
+              <div className="model-config-section-column">
+                <div>
+                  <CheckBoxItem
+                    header={true}
+                    label="Project (Jupyter root directory)"
+                    checked={checkedValue(
+                      featurePolicies.claude_setting_source_project,
+                      settingSources.includes('project')
+                    )}
+                    disabled={
+                      featurePolicies.claude_setting_source_project.locked
+                    }
+                    tooltip={lockedTip(
+                      featurePolicies.claude_setting_source_project.locked
+                    )}
+                    onClick={() => {
+                      setSettingSources(
+                        settingSources.includes('project')
+                          ? settingSources.filter(
+                              (source: string) => source !== 'project'
+                            )
+                          : [...settingSources, 'project']
+                      );
+                    }}
+                  ></CheckBoxItem>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="model-config-section">
+          <div className="model-config-section-header">Chat Agent tools</div>
+          <div className="model-config-section-body">
+            <div className="model-config-section-row">
+              <div className="model-config-section-column">
+                <div>
+                  <CheckBoxItem
+                    header={true}
+                    label="Claude Code tools"
+                    checked={checkedValue(
+                      featurePolicies.claude_code_tools,
+                      tools.includes(ClaudeToolType.ClaudeCodeTools)
+                    )}
+                    disabled={true}
+                    tooltip={lockedTip(
+                      featurePolicies.claude_code_tools.locked
+                    )}
+                    onClick={() => {
+                      setTools(
+                        tools.includes(ClaudeToolType.ClaudeCodeTools)
+                          ? tools.filter(
+                              (tool: string) =>
+                                tool !== ClaudeToolType.ClaudeCodeTools
+                            )
+                          : [...tools, ClaudeToolType.ClaudeCodeTools]
+                      );
+                    }}
+                  ></CheckBoxItem>
+                </div>
+              </div>
+              <div className="model-config-section-column">
+                <div>
+                  <CheckBoxItem
+                    header={true}
+                    label="Jupyter UI tools"
+                    checked={checkedValue(
+                      featurePolicies.claude_jupyter_ui_tools,
+                      tools.includes(ClaudeToolType.JupyterUITools)
+                    )}
+                    disabled={featurePolicies.claude_jupyter_ui_tools.locked}
+                    tooltip={lockedTip(
+                      featurePolicies.claude_jupyter_ui_tools.locked
+                    )}
+                    onClick={() => {
+                      setTools(
+                        tools.includes(ClaudeToolType.JupyterUITools)
+                          ? tools.filter(
+                              (tool: string) =>
+                                tool !== ClaudeToolType.JupyterUITools
+                            )
+                          : [...tools, ClaudeToolType.JupyterUITools]
+                      );
+                    }}
+                  ></CheckBoxItem>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="model-config-section">
+          <div className="model-config-section-header">
+            Conversation History
+          </div>
+          <div className="model-config-section-body">
+            <div className="model-config-section-row">
+              <div className="model-config-section-column">
+                <div>
+                  <CheckBoxItem
+                    header={true}
+                    label="Remember conversation history"
+                    checked={checkedValue(
+                      featurePolicies.claude_continue_conversation,
+                      continueConversation
+                    )}
+                    disabled={
+                      featurePolicies.claude_continue_conversation.locked
+                    }
+                    tooltip={lockedTip(
+                      featurePolicies.claude_continue_conversation.locked
+                    )}
+                    onClick={() => {
+                      setContinueConversation(!continueConversation);
+                    }}
+                  ></CheckBoxItem>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="model-config-section">
+          <div className="model-config-section-header">Claude account</div>
+          <div className="model-config-section-body">
+            <div className="model-config-section-row">
+              <div className="model-config-section-column">
+                <div className="form-field-row">
+                  <div className="form-field-description">
+                    API Key (optional)
+                  </div>
+                  <input
+                    name="chat-model-id-input"
+                    placeholder={
+                      settingLocks.claude_api_key.locked
+                        ? 'Locked by ANTHROPIC_API_KEY'
+                        : 'API Key'
+                    }
+                    className="jp-mod-styled"
+                    spellCheck={false}
+                    value={settingLocks.claude_api_key.locked ? '' : apiKey}
+                    disabled={settingLocks.claude_api_key.locked}
+                    title={lockedTip(settingLocks.claude_api_key.locked)}
+                    onChange={event => setApiKey(event.target.value)}
+                  />
+                </div>
+                <div className="form-field-row">
+                  <div className="form-field-description">
+                    Base URL (optional)
+                  </div>
+                  <input
+                    name="chat-model-id-input"
+                    placeholder={
+                      settingLocks.claude_base_url.locked
+                        ? 'Locked by ANTHROPIC_BASE_URL'
+                        : 'https://api.anthropic.com'
+                    }
+                    className="jp-mod-styled"
+                    spellCheck={false}
+                    value={baseUrl}
+                    disabled={settingLocks.claude_base_url.locked}
+                    title={lockedTip(settingLocks.claude_base_url.locked)}
+                    onChange={event => setBaseUrl(event.target.value)}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/skills-panel.tsx
+++ b/src/components/skills-panel.tsx
@@ -348,7 +348,7 @@ export function SettingsPanelComponentSkills(_props: any): JSX.Element {
   return (
     <div className="config-dialog-body nbi-skills-panel">
       <div className="nbi-skills-header">
-        <div className="nbi-skills-title">Claude Skills</div>
+        <div className="nbi-skills-title">Skills</div>
         <div className="nbi-skills-header-actions">
           {hasManagedSkills && (
             <button
@@ -383,6 +383,12 @@ export function SettingsPanelComponentSkills(_props: any): JSX.Element {
           </button>
         </div>
       </div>
+      {!NBIAPI.config.isInClaudeCodeMode && (
+        <div className="nbi-skills-info-banner" role="note">
+          Skills are consumed by Claude Code. Enable Claude mode in the Claude
+          settings tab to use skills you author here.
+        </div>
+      )}
       {syncMessage && (
         <div className="nbi-skills-sync-message" role="status">
           {syncMessage}

--- a/style/base.css
+++ b/style/base.css
@@ -1536,7 +1536,8 @@ svg.access-token-warning {
   font-size: var(--jp-ui-font-size1);
 }
 
-.nbi-skills-sync-message {
+.nbi-skills-sync-message,
+.nbi-skills-info-banner {
   padding: 6px 12px;
   border-radius: 4px;
   background-color: var(--jp-layout-color2);

--- a/style/base.css
+++ b/style/base.css
@@ -1537,7 +1537,8 @@ svg.access-token-warning {
 }
 
 .nbi-skills-sync-message,
-.nbi-skills-info-banner {
+.nbi-skills-info-banner,
+.nbi-info-banner {
   padding: 6px 12px;
   border-radius: 4px;
   background-color: var(--jp-layout-color2);

--- a/tests/test_claude_mcp_manager.py
+++ b/tests/test_claude_mcp_manager.py
@@ -1,0 +1,382 @@
+# Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+"""Tests for the ClaudeMCPManager and the management policy gate."""
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import notebook_intelligence.extension as ext_module
+from notebook_intelligence.claude_mcp_manager import (
+    ClaudeMCPManager,
+    ClaudeMCPServer,
+)
+from notebook_intelligence.extension import (
+    ClaudeMCPBaseHandler,
+    ClaudeMCPListHandler,
+)
+
+
+@pytest.fixture
+def claude_home(tmp_path, monkeypatch):
+    """Stand up a fake $HOME with a populated `~/.claude.json`."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    return home
+
+
+@pytest.fixture
+def working_dir(tmp_path):
+    cwd = tmp_path / "project"
+    cwd.mkdir()
+    return cwd
+
+
+def _write_claude_json(home: Path, doc: dict) -> None:
+    (home / ".claude.json").write_text(json.dumps(doc), encoding="utf-8")
+
+
+class TestClaudeMCPManagerListServers:
+    def test_empty_when_no_config(self, claude_home, working_dir):
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        assert manager.list_servers() == []
+
+    def test_user_scope_servers_round_trip(self, claude_home, working_dir):
+        _write_claude_json(
+            claude_home,
+            {
+                "mcpServers": {
+                    "voicemode": {
+                        "type": "stdio",
+                        "command": "uvx",
+                        "args": ["--refresh", "voice-mode"],
+                        "env": {},
+                    },
+                    "sentry": {
+                        "type": "http",
+                        "url": "https://mcp.sentry.dev/mcp",
+                        "headers": {"X-Tenant": "acme"},
+                    },
+                }
+            },
+        )
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        servers = manager.list_servers()
+        names = [(s.name, s.scope, s.transport) for s in servers]
+        assert names == [
+            ("sentry", "user", "http"),
+            ("voicemode", "user", "stdio"),
+        ]
+        sentry = next(s for s in servers if s.name == "sentry")
+        assert sentry.url == "https://mcp.sentry.dev/mcp"
+        assert sentry.headers == {"X-Tenant": "acme"}
+        voicemode = next(s for s in servers if s.name == "voicemode")
+        assert voicemode.command == "uvx"
+        assert voicemode.args == ["--refresh", "voice-mode"]
+
+    def test_local_scope_keyed_by_working_dir(self, claude_home, working_dir):
+        _write_claude_json(
+            claude_home,
+            {
+                "projects": {
+                    str(working_dir): {
+                        "mcpServers": {
+                            "playwright": {
+                                "type": "stdio",
+                                "command": "npx",
+                                "args": ["-y", "@playwright/mcp@latest"],
+                            }
+                        }
+                    },
+                    "/some/other/project": {
+                        "mcpServers": {
+                            "should-not-appear": {
+                                "type": "stdio",
+                                "command": "x",
+                            }
+                        }
+                    },
+                }
+            },
+        )
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        servers = manager.list_servers()
+        assert [(s.name, s.scope) for s in servers] == [("playwright", "local")]
+
+    def test_project_scope_from_dot_mcp_json(self, claude_home, working_dir):
+        (working_dir / ".mcp.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "shared": {
+                            "type": "stdio",
+                            "command": "shared-cmd",
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        servers = manager.list_servers()
+        assert [(s.name, s.scope) for s in servers] == [("shared", "project")]
+
+    def test_all_three_scopes_merged(self, claude_home, working_dir):
+        _write_claude_json(
+            claude_home,
+            {
+                "mcpServers": {
+                    "u-srv": {"type": "stdio", "command": "u"},
+                },
+                "projects": {
+                    str(working_dir): {
+                        "mcpServers": {
+                            "l-srv": {"type": "stdio", "command": "l"},
+                        }
+                    }
+                },
+            },
+        )
+        (working_dir / ".mcp.json").write_text(
+            json.dumps({"mcpServers": {"p-srv": {"type": "stdio", "command": "p"}}}),
+            encoding="utf-8",
+        )
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        scopes = {s.name: s.scope for s in manager.list_servers()}
+        assert scopes == {"u-srv": "user", "l-srv": "local", "p-srv": "project"}
+
+    def test_unknown_transport_passes_through(self, claude_home, working_dir):
+        _write_claude_json(
+            claude_home,
+            {"mcpServers": {"weird": {"type": "websocket", "url": "wss://x"}}},
+        )
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        srv = manager.list_servers()[0]
+        assert srv.transport == "websocket"
+
+
+class TestClaudeMCPManagerWrites:
+    @pytest.mark.parametrize("scope", ["user", "project", "local"])
+    def test_add_invokes_cli_with_correct_args(
+        self, claude_home, working_dir, scope, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "notebook_intelligence.claude_mcp_manager.resolve_claude_cli_path",
+            lambda: "/usr/local/bin/claude",
+        )
+        captured: dict = {}
+
+        async def fake_subprocess(*argv, cwd, stdin, stdout, stderr):
+            captured["argv"] = list(argv)
+            captured["cwd"] = cwd
+            proc = MagicMock()
+
+            async def communicate():
+                return (b"ok", b"")
+
+            proc.communicate = communicate
+            proc.returncode = 0
+            return proc
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subprocess)
+
+        # The post-add re-read should find the server too.
+        _write_claude_json(claude_home, {"mcpServers": {}})
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        result = asyncio.run(
+            manager.add_server(
+                name="my-srv",
+                scope=scope,
+                transport="stdio",
+                command_or_url="npx",
+                args=["-y", "pkg"],
+                env={"K": "v"},
+            )
+        )
+        assert captured["argv"][0] == "/usr/local/bin/claude"
+        assert "mcp" in captured["argv"]
+        assert "add" in captured["argv"]
+        assert "--scope" in captured["argv"]
+        scope_idx = captured["argv"].index("--scope")
+        assert captured["argv"][scope_idx + 1] == scope
+        assert "-e" in captured["argv"]
+        assert "K=v" in captured["argv"]
+        assert captured["argv"][-3:] == ["npx", "--", "-y"] or captured["argv"][
+            -4:
+        ] == ["npx", "--", "-y", "pkg"]
+        # When the CLI succeeds but our re-read finds nothing, we synthesize
+        # from the inputs rather than 500.
+        assert result.name == "my-srv"
+        assert result.scope == scope
+
+    def test_remove_invokes_cli(self, claude_home, working_dir, monkeypatch):
+        monkeypatch.setattr(
+            "notebook_intelligence.claude_mcp_manager.resolve_claude_cli_path",
+            lambda: "/usr/local/bin/claude",
+        )
+        captured: dict = {}
+
+        async def fake_subprocess(*argv, cwd, stdin, stdout, stderr):
+            captured["argv"] = list(argv)
+            proc = MagicMock()
+
+            async def communicate():
+                return (b"", b"")
+
+            proc.communicate = communicate
+            proc.returncode = 0
+            return proc
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subprocess)
+
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        asyncio.run(manager.remove_server("my-srv", "user"))
+        assert captured["argv"][1:] == [
+            "mcp",
+            "remove",
+            "--scope",
+            "user",
+            "my-srv",
+        ]
+
+    def test_cli_failure_raises_with_stderr(
+        self, claude_home, working_dir, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "notebook_intelligence.claude_mcp_manager.resolve_claude_cli_path",
+            lambda: "/usr/local/bin/claude",
+        )
+
+        async def fake_subprocess(*argv, cwd, stdin, stdout, stderr):
+            proc = MagicMock()
+
+            async def communicate():
+                return (b"", b"already exists")
+
+            proc.communicate = communicate
+            proc.returncode = 1
+            return proc
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subprocess)
+
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        with pytest.raises(ValueError, match="already exists"):
+            asyncio.run(manager.remove_server("name", "user"))
+
+    def test_missing_cli_raises_filenotfound(
+        self, claude_home, working_dir, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "notebook_intelligence.claude_mcp_manager.resolve_claude_cli_path",
+            lambda: None,
+        )
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        with pytest.raises(FileNotFoundError):
+            asyncio.run(manager.remove_server("name", "user"))
+
+    def test_leading_dash_name_rejected(self, claude_home, working_dir, monkeypatch):
+        monkeypatch.setattr(
+            "notebook_intelligence.claude_mcp_manager.resolve_claude_cli_path",
+            lambda: "/usr/local/bin/claude",
+        )
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        with pytest.raises(ValueError, match="leading '-'"):
+            asyncio.run(
+                manager.add_server(
+                    name="--scope=user",
+                    scope="user",
+                    transport="stdio",
+                    command_or_url="x",
+                )
+            )
+
+    def test_leading_dash_command_rejected(
+        self, claude_home, working_dir, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "notebook_intelligence.claude_mcp_manager.resolve_claude_cli_path",
+            lambda: "/usr/local/bin/claude",
+        )
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        with pytest.raises(ValueError, match="leading '-'"):
+            asyncio.run(
+                manager.add_server(
+                    name="srv",
+                    scope="user",
+                    transport="stdio",
+                    command_or_url="--whatever",
+                )
+            )
+
+
+class TestRedactArgvForLog:
+    def test_redacts_env_values(self):
+        from notebook_intelligence.claude_mcp_manager import _redact_argv_for_log
+
+        argv = ["claude", "mcp", "add", "-e", "API_KEY=sk-secret", "name", "cmd"]
+        assert _redact_argv_for_log(argv) == [
+            "claude",
+            "mcp",
+            "add",
+            "-e",
+            "<redacted>",
+            "name",
+            "cmd",
+        ]
+
+    def test_redacts_header_values(self):
+        from notebook_intelligence.claude_mcp_manager import _redact_argv_for_log
+
+        argv = ["claude", "mcp", "add", "-H", "Authorization: Bearer abc"]
+        assert _redact_argv_for_log(argv)[-2:] == ["-H", "<redacted>"]
+
+    def test_passes_through_non_secrets(self):
+        from notebook_intelligence.claude_mcp_manager import _redact_argv_for_log
+
+        argv = ["claude", "mcp", "add", "--scope", "user", "name", "npx"]
+        assert _redact_argv_for_log(argv) == argv
+
+
+class TestClaudeMCPManagementPolicyGate:
+    """Mirror of TestSkillsManagementPolicyGate — ensures the prepare()
+    chokepoint short-circuits with 403 when force-off."""
+
+    @staticmethod
+    def _run_prepare(handler):
+        from jupyter_server.base.handlers import APIHandler
+
+        async def _noop(_self):
+            return None
+
+        with patch.object(APIHandler, "prepare", _noop):
+            asyncio.run(ClaudeMCPBaseHandler.prepare(handler))
+
+    def test_default_attribute_allows(self):
+        assert ClaudeMCPBaseHandler.claude_mcp_management_enabled is True
+
+    def test_prepare_rejects_when_disabled(self):
+        handler = MagicMock(spec=ClaudeMCPListHandler)
+        handler._finished = False
+        handler.claude_mcp_management_enabled = False
+
+        def _finish(payload):
+            handler._finished = True
+            handler._finish_payload = payload
+
+        handler.finish.side_effect = _finish
+        self._run_prepare(handler)
+        handler.set_status.assert_called_with(403)
+        body = json.loads(handler._finish_payload)
+        assert "administrator" in body["error"].lower()
+
+    def test_prepare_passes_when_enabled(self):
+        handler = MagicMock(spec=ClaudeMCPListHandler)
+        handler._finished = False
+        handler.claude_mcp_management_enabled = True
+        self._run_prepare(handler)
+        handler.set_status.assert_not_called()
+        handler.finish.assert_not_called()

--- a/tests/test_skills_handlers.py
+++ b/tests/test_skills_handlers.py
@@ -527,3 +527,48 @@ class TestSkillsReconcileHandler:
             "unchanged": 3,
             "errors": ["boom"],
         }
+
+
+class TestSkillsManagementPolicyGate:
+    """The skills_management policy short-circuits every /skills handler in
+    `prepare()` with 403 when force-off. We test the gate logic directly,
+    bypassing Tornado dispatch (matches the rest of this file's pattern).
+    """
+
+    @staticmethod
+    def _run_prepare(handler):
+        # Patch the superclass prepare to a no-op coroutine — we're only
+        # exercising the skills gate here, not jupyter_server's auth plumbing.
+        from jupyter_server.base.handlers import APIHandler
+
+        async def _noop(_self):
+            return None
+
+        with patch.object(APIHandler, "prepare", _noop):
+            asyncio.run(SkillsBaseHandler.prepare(handler))
+
+    def test_default_attribute_allows(self):
+        assert SkillsBaseHandler.skills_management_enabled is True
+
+    def test_prepare_rejects_when_disabled(self):
+        handler = MagicMock(spec=SkillsListHandler)
+        handler._finished = False
+        handler.skills_management_enabled = False
+
+        def _finish(payload):
+            handler._finished = True
+            handler._finish_payload = payload
+
+        handler.finish.side_effect = _finish
+        self._run_prepare(handler)
+        handler.set_status.assert_called_with(403)
+        body = json.loads(handler._finish_payload)
+        assert "administrator" in body["error"].lower()
+
+    def test_prepare_passes_when_enabled(self):
+        handler = MagicMock(spec=SkillsListHandler)
+        handler._finished = False
+        handler.skills_management_enabled = True
+        self._run_prepare(handler)
+        handler.set_status.assert_not_called()
+        handler.finish.assert_not_called()


### PR DESCRIPTION
> **Stacked on top of #224** (Skills tab promotion). Until that lands, this PR's diff is cumulative; after it merges I'll rebase to drop the overlap.

## Summary

Resolves #218. Adds a **Claude MCP** Settings tab that wraps Claude Code's own MCP server config, plus a new admin policy `claude_mcp_management_policy` so org admins can disable the surface entirely.

## Architecture

The Claude-mode MCP store and the existing NBI MCP store solve different problems against different backends:

- **NBI MCP Servers tab** (existing): writes to `nbi_config.user_mcp` in `~/.jupyter/nbi/config.json`, used by NBI's own non-Claude chat path. Hidden when Claude mode is on.
- **Claude MCP tab** (this PR): wraps Claude Code's config — `~/.claude.json` top-level `mcpServers`, the per-cwd `projects.<cwd>.mcpServers` block, and project `<cwd>/.mcp.json`. Used by Claude Code itself, which NBI shells out to.

A single combined panel would have two sources of truth and contradictory reload semantics. The two are deliberately separate. They never appear at the same time — the existing tab's `!isInClaudeCodeMode` predicate hides it in Claude mode; the new tab's `isInClaudeCodeMode && isClaudeCliAvailable` predicate hides it otherwise.

## Implementation

**Reads** (fast, structured): `ClaudeMCPManager.list_servers` parses Claude's JSON config files directly. No `claude mcp list` shell-out — that command does live health checks per server (slow) and emits human-only output.

**Writes** (CLI shell-out): `add_server` / `remove_server` invoke `claude mcp add` / `claude mcp remove` via `asyncio.create_subprocess_exec`. Claude remains the source of truth for any side effects (project-trust prompts, OAuth bookkeeping, etc.).

**Policy gate**: `claude_mcp_management_policy` (`TraitletEnum`, default `user-choice`). Force-off hides the tab and returns 403 from `/notebook-intelligence/claude-mcp/*` via an async `prepare()` chokepoint on `ClaudeMCPBaseHandler` — same pattern PR #224 uses for `SkillsBaseHandler`. Env override: `NBI_CLAUDE_MCP_MANAGEMENT_POLICY`.

## Hardening (from review)

- **`stdin=asyncio.subprocess.DEVNULL`** so a project-trust or OAuth prompt fails fast with a clean nonzero exit instead of hanging until the 30s timeout.
- **`asyncio.Lock` per manager instance** — Claude's CLI does read-modify-write on `~/.claude.json` without a lockfile, so two in-flight `add`s from the same NBI server can clobber.
- **Argv log redaction** — `-e KEY=value` and `-H Name: value` pairs are redacted before logging so API keys / bearer tokens never land in `log.info` output.
- **Reject leading `-` on `name` and `command_or_url`** to defend against CLI flag smuggling through user-controlled positional argv.
- **Lift `resolve_claude_cli_path()` to `notebook_intelligence/util.py`** so future call sites get the same `NBI_CLAUDE_CLI_PATH` env-var → `shutil.which("claude")` fallback chain.

## Frontend

`claude-mcp-panel.tsx` lists servers grouped by scope (user / project / local). Add dialog supports all three transports (stdio / sse / http). For stdio: command + args + env. For sse/http: URL + headers. Errors render inline in the dialog so the user can correct and retry without losing context (rather than behind the modal backdrop). Tab is labeled **Claude MCP** to disambiguate from the non-Claude **MCP Servers** tab.

## Tests

- `tests/test_claude_mcp_manager.py` (new, 20 tests): scope-merge round trip, transport pass-through for unknown types, CLI-failure stderr surfacing, `FileNotFoundError` when CLI is absent, leading-dash rejection, `-e`/`-H` argv redaction, and the prepare() policy-gate (default-allows, rejects-when-disabled, passes-when-enabled).
- 59/59 tests pass.

## Docs

- New section in `docs/admin-guide.md` under "Restricting features for managed deployments".
- New row in the Admin policies table in `README.md`.

## Test plan

- [ ] Enable Claude mode → confirm the Claude MCP tab appears
- [ ] Add a stdio server (`name`, `command`, optional args/env), confirm it appears in the list and `claude mcp list` confirms
- [ ] Add a sse/http server with a header, confirm it persists and `claude mcp get` shows the right headers
- [ ] Remove a server, confirm it's gone from the list and from Claude's config
- [ ] Set `NBI_CLAUDE_MCP_MANAGEMENT_POLICY=force-off`, restart, confirm tab is gone and `curl /claude-mcp` returns 403
- [ ] Confirm the existing NBI MCP Servers tab still works in non-Claude mode