### PR TITLE
feat(settings): add Claude-mode Plugins management tab + admin policy gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,19 +153,20 @@ Most settings panel toggles can be locked by org administrators. Two shapes:
 
 **Boolean policies** use the `*_POLICY` suffix and accept three values: `user-choice` (default — user toggles freely), `force-on` (locked enabled), `force-off` (locked disabled). When forced, the panel control is disabled with a "Locked by your administrator" tooltip and any client-side write is ignored.
 
-| Env var                                    | Locks the Settings panel control for                                                              |
-| ------------------------------------------ | ------------------------------------------------------------------------------------------------- |
-| `NBI_EXPLAIN_ERROR_POLICY`                 | "Explain cell errors"                                                                             |
-| `NBI_OUTPUT_FOLLOWUP_POLICY`               | "Ask about cell outputs"                                                                          |
-| `NBI_OUTPUT_TOOLBAR_POLICY`                | "Show output toolbar"                                                                             |
-| `NBI_CLAUDE_MODE_POLICY`                   | "Enable Claude mode"                                                                              |
-| `NBI_CLAUDE_CONTINUE_CONVERSATION_POLICY`  | "Remember conversation history"                                                                   |
-| `NBI_CLAUDE_CODE_TOOLS_POLICY`             | "Claude Code tools"                                                                               |
-| `NBI_CLAUDE_JUPYTER_UI_TOOLS_POLICY`       | "Jupyter UI tools"                                                                                |
-| `NBI_CLAUDE_SETTING_SOURCE_USER_POLICY`    | Setting source: User                                                                              |
-| `NBI_CLAUDE_SETTING_SOURCE_PROJECT_POLICY` | Setting source: Project                                                                           |
-| `NBI_STORE_GITHUB_ACCESS_TOKEN_POLICY`     | "Remember my GitHub Copilot access token"                                                         |
-| `NBI_SKILLS_MANAGEMENT_POLICY`             | The Skills tab (force-off hides it and 403s the API; also disables the managed-skills reconciler) |
+| Env var                                    | Locks the Settings panel control for                                                                                         |
+| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| `NBI_EXPLAIN_ERROR_POLICY`                 | "Explain cell errors"                                                                                                        |
+| `NBI_OUTPUT_FOLLOWUP_POLICY`               | "Ask about cell outputs"                                                                                                     |
+| `NBI_OUTPUT_TOOLBAR_POLICY`                | "Show output toolbar"                                                                                                        |
+| `NBI_CLAUDE_MODE_POLICY`                   | "Enable Claude mode"                                                                                                         |
+| `NBI_CLAUDE_CONTINUE_CONVERSATION_POLICY`  | "Remember conversation history"                                                                                              |
+| `NBI_CLAUDE_CODE_TOOLS_POLICY`             | "Claude Code tools"                                                                                                          |
+| `NBI_CLAUDE_JUPYTER_UI_TOOLS_POLICY`       | "Jupyter UI tools"                                                                                                           |
+| `NBI_CLAUDE_SETTING_SOURCE_USER_POLICY`    | Setting source: User                                                                                                         |
+| `NBI_CLAUDE_SETTING_SOURCE_PROJECT_POLICY` | Setting source: Project                                                                                                      |
+| `NBI_STORE_GITHUB_ACCESS_TOKEN_POLICY`     | "Remember my GitHub Copilot access token"                                                                                    |
+| `NBI_SKILLS_MANAGEMENT_POLICY`             | The Skills tab (force-off hides it and 403s the API; also disables the managed-skills reconciler)                            |
+| `NBI_CLAUDE_MCP_MANAGEMENT_POLICY`         | The Claude-mode MCP Servers tab (force-off hides it and 403s `/claude-mcp/*`; independent of the non-Claude MCP Servers tab) |
 
 The first three also have matching traitlets on `NotebookIntelligence` (`explain_error_policy`, `output_followup_policy`, `output_toolbar_policy`); add the others as needed in the same shape:
 

--- a/README.md
+++ b/README.md
@@ -153,18 +153,19 @@ Most settings panel toggles can be locked by org administrators. Two shapes:
 
 **Boolean policies** use the `*_POLICY` suffix and accept three values: `user-choice` (default — user toggles freely), `force-on` (locked enabled), `force-off` (locked disabled). When forced, the panel control is disabled with a "Locked by your administrator" tooltip and any client-side write is ignored.
 
-| Env var                                    | Locks the Settings panel control for      |
-| ------------------------------------------ | ----------------------------------------- |
-| `NBI_EXPLAIN_ERROR_POLICY`                 | "Explain cell errors"                     |
-| `NBI_OUTPUT_FOLLOWUP_POLICY`               | "Ask about cell outputs"                  |
-| `NBI_OUTPUT_TOOLBAR_POLICY`                | "Show output toolbar"                     |
-| `NBI_CLAUDE_MODE_POLICY`                   | "Enable Claude mode"                      |
-| `NBI_CLAUDE_CONTINUE_CONVERSATION_POLICY`  | "Remember conversation history"           |
-| `NBI_CLAUDE_CODE_TOOLS_POLICY`             | "Claude Code tools"                       |
-| `NBI_CLAUDE_JUPYTER_UI_TOOLS_POLICY`       | "Jupyter UI tools"                        |
-| `NBI_CLAUDE_SETTING_SOURCE_USER_POLICY`    | Setting source: User                      |
-| `NBI_CLAUDE_SETTING_SOURCE_PROJECT_POLICY` | Setting source: Project                   |
-| `NBI_STORE_GITHUB_ACCESS_TOKEN_POLICY`     | "Remember my GitHub Copilot access token" |
+| Env var                                    | Locks the Settings panel control for                                                              |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| `NBI_EXPLAIN_ERROR_POLICY`                 | "Explain cell errors"                                                                             |
+| `NBI_OUTPUT_FOLLOWUP_POLICY`               | "Ask about cell outputs"                                                                          |
+| `NBI_OUTPUT_TOOLBAR_POLICY`                | "Show output toolbar"                                                                             |
+| `NBI_CLAUDE_MODE_POLICY`                   | "Enable Claude mode"                                                                              |
+| `NBI_CLAUDE_CONTINUE_CONVERSATION_POLICY`  | "Remember conversation history"                                                                   |
+| `NBI_CLAUDE_CODE_TOOLS_POLICY`             | "Claude Code tools"                                                                               |
+| `NBI_CLAUDE_JUPYTER_UI_TOOLS_POLICY`       | "Jupyter UI tools"                                                                                |
+| `NBI_CLAUDE_SETTING_SOURCE_USER_POLICY`    | Setting source: User                                                                              |
+| `NBI_CLAUDE_SETTING_SOURCE_PROJECT_POLICY` | Setting source: Project                                                                           |
+| `NBI_STORE_GITHUB_ACCESS_TOKEN_POLICY`     | "Remember my GitHub Copilot access token"                                                         |
+| `NBI_SKILLS_MANAGEMENT_POLICY`             | The Skills tab (force-off hides it and 403s the API; also disables the managed-skills reconciler) |
 
 The first three also have matching traitlets on `NotebookIntelligence` (`explain_error_policy`, `output_followup_policy`, `output_toolbar_policy`); add the others as needed in the same shape:
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Most settings panel toggles can be locked by org administrators. Two shapes:
 | `NBI_STORE_GITHUB_ACCESS_TOKEN_POLICY`     | "Remember my GitHub Copilot access token"                                                                                    |
 | `NBI_SKILLS_MANAGEMENT_POLICY`             | The Skills tab (force-off hides it and 403s the API; also disables the managed-skills reconciler)                            |
 | `NBI_CLAUDE_MCP_MANAGEMENT_POLICY`         | The Claude-mode MCP Servers tab (force-off hides it and 403s `/claude-mcp/*`; independent of the non-Claude MCP Servers tab) |
-| `NBI_PLUGINS_MANAGEMENT_POLICY`            | The Claude-mode Plugins tab (force-off hides it and 403s `/plugins/*`)                                                       |
+| `NBI_CLAUDE_PLUGINS_MANAGEMENT_POLICY`     | The Claude-mode Plugins tab (force-off hides it and 403s `/plugins/*`)                                                       |
 
 The first three also have matching traitlets on `NotebookIntelligence` (`explain_error_policy`, `output_followup_policy`, `output_toolbar_policy`); add the others as needed in the same shape:
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Most settings panel toggles can be locked by org administrators. Two shapes:
 | `NBI_STORE_GITHUB_ACCESS_TOKEN_POLICY`     | "Remember my GitHub Copilot access token"                                                                                    |
 | `NBI_SKILLS_MANAGEMENT_POLICY`             | The Skills tab (force-off hides it and 403s the API; also disables the managed-skills reconciler)                            |
 | `NBI_CLAUDE_MCP_MANAGEMENT_POLICY`         | The Claude-mode MCP Servers tab (force-off hides it and 403s `/claude-mcp/*`; independent of the non-Claude MCP Servers tab) |
+| `NBI_PLUGINS_MANAGEMENT_POLICY`            | The Claude-mode Plugins tab (force-off hides it and 403s `/plugins/*`)                                                       |
 
 The first three also have matching traitlets on `NotebookIntelligence` (`explain_error_policy`, `output_followup_policy`, `output_toolbar_policy`); add the others as needed in the same shape:
 

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -373,6 +373,23 @@ Force-off does three things at once:
 
 Use this when an org wants to disable user-authored Claude skills entirely.
 
+### Disabling the Claude-mode MCP Servers tab
+
+```python
+c.NotebookIntelligence.claude_mcp_management_policy = "force-off"
+```
+
+Or via env: `NBI_CLAUDE_MCP_MANAGEMENT_POLICY=force-off`.
+
+Force-off:
+
+- Hides the Claude-mode **MCP Servers** tab in the Settings panel (visible only when Claude mode is on and the `claude` CLI is available).
+- Returns HTTP 403 from every `/notebook-intelligence/claude-mcp/*` route.
+
+The Claude-mode tab is **independent** of the existing non-Claude **MCP Servers** tab. The former wraps Claude Code's own config (`~/.claude.json` and project `.mcp.json`); the latter manages NBI's own MCP servers used by the non-Claude chat path. They never appear at the same time — the non-Claude tab is hidden when Claude mode is on, and the Claude-mode tab is hidden when it's off.
+
+Reads come from Claude's JSON config files directly (fast, no health checks). Writes (add / remove) shell out to `claude mcp add` / `claude mcp remove` so Claude remains the source of truth for any side effects (project-trust prompts, OAuth bookkeeping).
+
 ---
 
 ## Multi-tenancy and per-team scoping

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -390,6 +390,8 @@ The Claude-mode tab is **independent** of the existing non-Claude **MCP Servers*
 
 Reads come from Claude's JSON config files directly (fast, no health checks). Writes (add / remove) shell out to `claude mcp add` / `claude mcp remove` so Claude remains the source of truth for any side effects (project-trust prompts, OAuth bookkeeping).
 
+> **Trust model.** MCP servers run as subprocesses (stdio transport) or accept arbitrary URLs (sse/http transport) inside Claude Code sessions; NBI does not validate or sandbox the command, environment, or network endpoint beyond rejecting CLI flag-smuggling. For multi-tenant or regulated deployments, default to `claude_mcp_management_policy = force-off` and ship a curated set of servers via `~/.claude/settings.json` instead.
+
 ### Disabling the Plugins tab
 
 ```python

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -38,7 +38,7 @@ NBI reads configuration from three layers, listed in order of precedence (later 
 2. **User config** — `~/.jupyter/nbi/config.json` and `~/.jupyter/nbi/mcp.json`. The user mutates these via the Settings dialog. Lives on the per-user PVC.
 3. **Environment variables** — `NBI_*` and certain provider variables (see the [reference table](#environment-variables-and-traitlets)). Override at pod startup time.
 
-Traitlets configured via JupyterLab CLI flags or `jupyter_server_config.py` (e.g., `c.NotebookIntelligence.disabled_providers = [...]`) are evaluated at server startup. Where a traitlet has a corresponding env var (e.g., `NBI_ENABLED_PROVIDERS` for `disabled_providers` and `allow_enabling_providers_with_env`), NBI reads the env var at request time.
+Traitlets configured via JupyterLab CLI flags or `jupyter_server_config.py` (e.g., `c.NotebookIntelligence.disabled_providers = [...]`) are evaluated at server startup. Most env-var overrides (`NBI_*_POLICY`, `NBI_ALLOW_GITHUB_*`, `NBI_*_MANAGEMENT_POLICY`, etc.) are also resolved once at startup and cached on the handler classes — flipping them requires a JupyterLab restart. The `NBI_ENABLED_PROVIDERS` and `NBI_ENABLED_BUILTIN_TOOLS` re-enable env vars (gated by `allow_enabling_*_with_env`) are the exception: those are read on every request.
 
 Manual edits to `config.json` while JupyterLab is running require a JupyterLab restart to take effect. Edits via the Settings dialog are picked up live.
 
@@ -369,7 +369,7 @@ Force-off does three things at once:
 
 - Hides the **Skills** tab in the Settings panel.
 - Returns HTTP 403 from every `/notebook-intelligence/skills/*` route, so a stale frontend or a direct API caller can't read or write skills.
-- Suppresses the [managed-skills reconciler](#managed-claude-skills-token) — the manifest is treated as empty, no `SkillReconciler` is constructed, and no scheduled reconcile runs. Org-curated skills still on disk are not touched, but new manifests aren't pulled.
+- Suppresses the [managed-skills reconciler](#managed-claude-skills-token) — the manifest is treated as empty, no `SkillReconciler` is constructed, and no scheduled reconcile runs. Org-curated skills still on disk are not touched, but new manifests aren't pulled. **Takes effect on JupyterLab server restart.** Live config-reload won't stop a reconciler that's already running.
 
 Use this when an org wants to disable user-authored Claude skills entirely.
 
@@ -401,6 +401,8 @@ c.NotebookIntelligence.plugins_management_policy = "force-off"
 Or via env: `NBI_PLUGINS_MANAGEMENT_POLICY=force-off`.
 
 Force-off hides the **Plugins** tab and returns 403 from every `/notebook-intelligence/plugins/*` route. The tab is otherwise visible only when Claude mode is on and the `claude` CLI is available. Both reads (`claude plugin list --json`) and writes (`claude plugin install` / `uninstall` / `enable` / `disable` / `marketplace add` / `marketplace remove`) shell out to the Claude CLI; Claude owns the plugin state under `~/.claude/plugins/`.
+
+> **Blast radius.** Force-off only kills the _management UI_ — already-installed plugins keep loading inside Claude Code sessions because Claude's plugin loader doesn't consult NBI's policy. To stop existing plugins from loading, you'd need to remove them on disk or disable them via the `claude plugin disable` CLI before flipping the policy. Force-off prevents user-driven add/remove/enable/disable through NBI; that's the contract.
 
 To allow user-driven plugin management but block GitHub-sourced marketplaces:
 

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -357,6 +357,22 @@ NBI_ADDITIONAL_SKIPPED_WORKSPACE_DIRECTORIES=tmp,artifacts
 
 The env var **appends** to the traitlet value at server startup (in contrast to `NBI_ALLOW_GITHUB_SKILL_IMPORT` and the `NBI_*_POLICY` env vars, which override). Duplicates are collapsed; both lists are then merged with the built-in skip set on the frontend.
 
+### Disabling the Skills tab
+
+```python
+c.NotebookIntelligence.skills_management_policy = "force-off"
+```
+
+Or via env: `NBI_SKILLS_MANAGEMENT_POLICY=force-off`.
+
+Force-off does three things at once:
+
+- Hides the **Skills** tab in the Settings panel.
+- Returns HTTP 403 from every `/notebook-intelligence/skills/*` route, so a stale frontend or a direct API caller can't read or write skills.
+- Suppresses the [managed-skills reconciler](#managed-claude-skills-token) — the manifest is treated as empty, no `SkillReconciler` is constructed, and no scheduled reconcile runs. Org-curated skills still on disk are not touched, but new manifests aren't pulled.
+
+Use this when an org wants to disable user-authored Claude skills entirely.
+
 ---
 
 ## Multi-tenancy and per-team scoping

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -414,6 +414,20 @@ Or via env: `NBI_ALLOW_GITHUB_PLUGIN_IMPORT=false` (also accepts `true`/`1`/`0`/
 
 > **Trust model.** Plugins installed via `claude plugin install` execute as part of Claude Code sessions; NBI does not signature-verify or sandbox them, and the `claude` CLI's validation is best-effort. The marketplace-add path is a network fetch (server-side) — for multi-tenant or regulated deployments, default to `plugins_management_policy = force-off` and curate plugins server-side, or restrict marketplaces to vetted sources only.
 
+#### GitHub auth for marketplace add
+
+When the marketplace source is a GitHub URL or `owner/repo` shorthand, NBI resolves a token with the same precedence as Skills' GitHub import:
+
+1. `GITHUB_TOKEN` env var (server-process scope)
+2. `GH_TOKEN` env var
+3. `gh auth token` subprocess output (only if `gh` is on PATH)
+
+Resolved tokens are injected into the `claude plugin marketplace add` subprocess via env, never argv — they do not appear in DEBUG logs. The chain is re-evaluated per call, so rotating the token (env update or `gh auth refresh`) takes effect on the next add. Required scope: `repo` for classic PATs, or `contents:read` on the target repo for fine-grained PATs. When `gh` is not installed the third step short-circuits silently; rely on `GITHUB_TOKEN` instead.
+
+The chain only fires for github.com sources today. **GitHub Enterprise instances are not detected** as GitHub by `is_github_marketplace_source`, so a GHE marketplace URL falls through to anonymous git auth — track that as a separate item if your org runs GHE.
+
+For air-gap deployments, marketplace-add inherits the JupyterLab process env, so the same `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `NODE_EXTRA_CA_CERTS` settings documented in [Custom CA certs and corporate proxies](#custom-ca-certs-and-corporate-proxies) apply. Pre-installed plugins (under `~/.claude/plugins/`) keep loading without any network access.
+
 ---
 
 ## Multi-tenancy and per-team scoping

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -395,10 +395,10 @@ Reads come from Claude's JSON config files directly (fast, no health checks). Wr
 ### Disabling the Plugins tab
 
 ```python
-c.NotebookIntelligence.plugins_management_policy = "force-off"
+c.NotebookIntelligence.claude_plugins_management_policy = "force-off"
 ```
 
-Or via env: `NBI_PLUGINS_MANAGEMENT_POLICY=force-off`.
+Or via env: `NBI_CLAUDE_PLUGINS_MANAGEMENT_POLICY=force-off`.
 
 Force-off hides the **Plugins** tab and returns 403 from every `/notebook-intelligence/plugins/*` route. The tab is otherwise visible only when Claude mode is on and the `claude` CLI is available. Both reads (`claude plugin list --json`) and writes (`claude plugin install` / `uninstall` / `enable` / `disable` / `marketplace add` / `marketplace remove`) shell out to the Claude CLI; Claude owns the plugin state under `~/.claude/plugins/`.
 
@@ -410,9 +410,9 @@ To allow user-driven plugin management but block GitHub-sourced marketplaces:
 c.NotebookIntelligence.allow_github_plugin_import = False
 ```
 
-Or via env: `NBI_ALLOW_GITHUB_PLUGIN_IMPORT=false` (also accepts `true`/`1`/`0`/`yes`/`no`/`on`/`off`). When False, the "From GitHub" affordance in the Plugins panel hides itself and the backend rejects marketplace-add requests whose source is a GitHub URL, `owner/repo` shorthand, or `git@github.com:` reference. Local-path and arbitrary-URL sources remain available. This is finer-grained than `plugins_management_policy = force-off`, which kills the entire surface.
+Or via env: `NBI_ALLOW_GITHUB_PLUGIN_IMPORT=false` (also accepts `true`/`1`/`0`/`yes`/`no`/`on`/`off`). When False, the "From GitHub" affordance in the Plugins panel hides itself and the backend rejects marketplace-add requests whose source is a GitHub URL, `owner/repo` shorthand, or `git@github.com:` reference. Local-path and arbitrary-URL sources remain available. This is finer-grained than `claude_plugins_management_policy = force-off`, which kills the entire surface.
 
-> **Trust model.** Plugins installed via `claude plugin install` execute as part of Claude Code sessions; NBI does not signature-verify or sandbox them, and the `claude` CLI's validation is best-effort. The marketplace-add path is a network fetch (server-side) — for multi-tenant or regulated deployments, default to `plugins_management_policy = force-off` and curate plugins server-side, or restrict marketplaces to vetted sources only.
+> **Trust model.** Plugins installed via `claude plugin install` execute as part of Claude Code sessions; NBI does not signature-verify or sandbox them, and the `claude` CLI's validation is best-effort. The marketplace-add path is a network fetch (server-side) — for multi-tenant or regulated deployments, default to `claude_plugins_management_policy = force-off` and curate plugins server-side, or restrict marketplaces to vetted sources only.
 
 #### GitHub auth for marketplace add
 

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -373,6 +373,8 @@ Force-off does three things at once:
 
 Use this when an org wants to disable user-authored Claude skills entirely.
 
+> **Blast radius.** Force-off only kills the _management UI_ — skill bundles already on disk under `~/.claude/skills/` or a project's `.claude/skills/` keep being discovered by Claude Code itself because Claude's skill loader doesn't consult NBI's policy. To stop existing skills from loading, remove them on disk before flipping the policy.
+
 ### Disabling the Claude-mode MCP Servers tab
 
 ```python
@@ -389,6 +391,8 @@ Force-off:
 The Claude-mode tab is **independent** of the existing non-Claude **MCP Servers** tab. The former wraps Claude Code's own config (`~/.claude.json` and project `.mcp.json`); the latter manages NBI's own MCP servers used by the non-Claude chat path. They never appear at the same time — the non-Claude tab is hidden when Claude mode is on, and the Claude-mode tab is hidden when it's off.
 
 Reads come from Claude's JSON config files directly (fast, no health checks). Writes (add / remove) shell out to `claude mcp add` / `claude mcp remove` so Claude remains the source of truth for any side effects (project-trust prompts, OAuth bookkeeping).
+
+> **Blast radius.** Force-off only kills the _management UI_ — MCP servers already configured in `~/.claude.json` or `<cwd>/.mcp.json` keep loading inside Claude Code sessions because Claude's MCP loader doesn't consult NBI's policy. To stop existing servers, remove them on disk (or via the `claude mcp remove` CLI) before flipping the policy.
 
 > **Trust model.** MCP servers run as subprocesses (stdio transport) or accept arbitrary URLs (sse/http transport) inside Claude Code sessions; NBI does not validate or sandbox the command, environment, or network endpoint beyond rejecting CLI flag-smuggling. For multi-tenant or regulated deployments, default to `claude_mcp_management_policy = force-off` and ship a curated set of servers via `~/.claude/settings.json` instead.
 

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -390,6 +390,26 @@ The Claude-mode tab is **independent** of the existing non-Claude **MCP Servers*
 
 Reads come from Claude's JSON config files directly (fast, no health checks). Writes (add / remove) shell out to `claude mcp add` / `claude mcp remove` so Claude remains the source of truth for any side effects (project-trust prompts, OAuth bookkeeping).
 
+### Disabling the Plugins tab
+
+```python
+c.NotebookIntelligence.plugins_management_policy = "force-off"
+```
+
+Or via env: `NBI_PLUGINS_MANAGEMENT_POLICY=force-off`.
+
+Force-off hides the **Plugins** tab and returns 403 from every `/notebook-intelligence/plugins/*` route. The tab is otherwise visible only when Claude mode is on and the `claude` CLI is available. Both reads (`claude plugin list --json`) and writes (`claude plugin install` / `uninstall` / `enable` / `disable` / `marketplace add` / `marketplace remove`) shell out to the Claude CLI; Claude owns the plugin state under `~/.claude/plugins/`.
+
+To allow user-driven plugin management but block GitHub-sourced marketplaces:
+
+```python
+c.NotebookIntelligence.allow_github_plugin_import = False
+```
+
+Or via env: `NBI_ALLOW_GITHUB_PLUGIN_IMPORT=false` (also accepts `true`/`1`/`0`/`yes`/`no`/`on`/`off`). When False, the "From GitHub" affordance in the Plugins panel hides itself and the backend rejects marketplace-add requests whose source is a GitHub URL, `owner/repo` shorthand, or `git@github.com:` reference. Local-path and arbitrary-URL sources remain available. This is finer-grained than `plugins_management_policy = force-off`, which kills the entire surface.
+
+> **Trust model.** Plugins installed via `claude plugin install` execute as part of Claude Code sessions; NBI does not signature-verify or sandbox them, and the `claude` CLI's validation is best-effort. The marketplace-add path is a network fetch (server-side) — for multi-tenant or regulated deployments, default to `plugins_management_policy = force-off` and curate plugins server-side, or restrict marketplaces to vetted sources only.
+
 ---
 
 ## Multi-tenancy and per-team scoping

--- a/notebook_intelligence/_claude_cli.py
+++ b/notebook_intelligence/_claude_cli.py
@@ -24,6 +24,24 @@ log = logging.getLogger(__name__)
 
 CLI_TIMEOUT_DEFAULT_SECONDS = 60.0
 
+# Both managers store config under the same three Claude scopes — kept
+# here so a fourth surface (ACP, hooks, etc.) doesn't redefine the tuple.
+CLAUDE_SCOPES: tuple[str, ...] = ("user", "project", "local")
+
+
+def validate_scope(scope: str, *, allow_none: bool = False) -> None:
+    """Raise ``ValueError`` unless ``scope`` is a recognized Claude scope.
+
+    With ``allow_none=True`` the value ``None`` is accepted (callers that
+    want to omit the ``--scope`` flag entirely).
+    """
+    if scope is None and allow_none:
+        return
+    if scope not in CLAUDE_SCOPES:
+        raise ValueError(
+            f"Invalid scope {scope!r}; expected one of {CLAUDE_SCOPES}"
+        )
+
 # Flags whose value should never appear in logs. Includes the documented
 # secret-bearing flags from the claude CLI's `--help` output even where the
 # managers don't currently pass them — the cost of a forward-compat entry
@@ -91,7 +109,11 @@ async def run_claude_cli(
         ValueError: on non-zero exit (carrying the CLI's stderr/stdout).
     """
     argv = claude_cli_argv(tail)
-    log.info("%s invocation: %s", label, " ".join(redact_argv_for_log(argv[1:])))
+    # Per-invocation log goes to DEBUG: list-style endpoints (`plugin list`,
+    # `mcp list`) fire on every panel mount, and operators rarely care about
+    # individual successful invocations. Failures still raise a `ValueError`
+    # carrying the CLI's own stderr, which callers surface to the user.
+    log.debug("%s invocation: %s", label, " ".join(redact_argv_for_log(argv[1:])))
     proc = await asyncio.create_subprocess_exec(
         *argv,
         cwd=cwd,

--- a/notebook_intelligence/_claude_cli.py
+++ b/notebook_intelligence/_claude_cli.py
@@ -144,6 +144,27 @@ async def run_claude_cli(
     out = stdout.decode("utf-8", errors="replace")
     err = stderr.decode("utf-8", errors="replace")
     if proc.returncode != 0:
-        msg = (err or out).strip() or f"{label} failed (exit {proc.returncode})"
-        raise ValueError(msg)
+        raw = (err or out).strip() or f"{label} failed (exit {proc.returncode})"
+        # The CLI's stderr is forwarded to the browser via the handlers'
+        # `_error()`; scrub any injected secret that the underlying tool
+        # might have echoed (git in verbose mode, curl 401 challenges, etc.).
+        raise ValueError(_scrub_env_overrides(raw, env_overrides))
     return out
+
+
+def _scrub_env_overrides(text: str, env_overrides: Optional[dict[str, str]]) -> str:
+    """Replace any env_overrides values that appear in `text` with `<redacted>`.
+
+    Defense-in-depth: tokens flow via env (not argv) so they don't reach
+    process listings, but a misbehaving downstream tool (git with
+    GIT_TRACE=1, a verbose credential helper) can still echo them into
+    stderr. The handler surfaces stderr to the browser; this scrub prevents
+    the resulting 4xx response body from containing the secret.
+    """
+    if not env_overrides:
+        return text
+    scrubbed = text
+    for value in env_overrides.values():
+        if value and len(value) >= 8:
+            scrubbed = scrubbed.replace(value, "<redacted>")
+    return scrubbed

--- a/notebook_intelligence/_claude_cli.py
+++ b/notebook_intelligence/_claude_cli.py
@@ -1,0 +1,113 @@
+# Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+"""Shared helpers for Claude-CLI shell-outs.
+
+Used by `claude_mcp_manager` and `plugin_manager`. Both wrap subsets of the
+`claude` CLI; this module owns the invariants:
+
+  * Closed stdin so prompts (project-trust, OAuth) fail fast.
+  * Per-call timeout with a clean ``TimeoutError``.
+  * Stderr-preferred error message on non-zero exit.
+  * Argv redaction for secret-bearing flags before logging.
+  * CLI path resolution via ``resolve_claude_cli_path()``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
+
+from notebook_intelligence.util import resolve_claude_cli_path
+
+log = logging.getLogger(__name__)
+
+CLI_TIMEOUT_DEFAULT_SECONDS = 60.0
+
+# Flags whose value should never appear in logs. Includes the documented
+# secret-bearing flags from the claude CLI's `--help` output even where the
+# managers don't currently pass them — the cost of a forward-compat entry
+# is negligible vs an accidental leak.
+_SECRET_BEARING_FLAGS = frozenset(
+    [
+        "-e",
+        "--env",
+        "-H",
+        "--header",
+        "--client-secret",
+        "--client-id",
+        "--token",
+        "--password",
+        "--auth",
+        "--bearer",
+    ]
+)
+
+
+def redact_argv_for_log(argv: list[str]) -> list[str]:
+    """Redact the value following any secret-bearing flag for logs."""
+    redacted: list[str] = []
+    skip_next = False
+    for token in argv:
+        if skip_next:
+            redacted.append("<redacted>")
+            skip_next = False
+            continue
+        redacted.append(token)
+        if token in _SECRET_BEARING_FLAGS:
+            skip_next = True
+    return redacted
+
+
+def reject_flag_smuggling(label: str, value: str) -> None:
+    """Reject values starting with ``-`` so user input can't be parsed as a
+    CLI flag through its position in argv."""
+    if value.startswith("-"):
+        raise ValueError(f"Invalid {label} {value!r}: leading '-' is not permitted")
+
+
+def claude_cli_argv(tail: list[str]) -> list[str]:
+    """Build a full argv list with the resolved Claude CLI as argv[0]."""
+    cli = resolve_claude_cli_path()
+    if not cli:
+        raise FileNotFoundError(
+            "Claude Code CLI not found on PATH (set NBI_CLAUDE_CLI_PATH or install `claude`)"
+        )
+    return [cli, *tail]
+
+
+async def run_claude_cli(
+    tail: list[str],
+    *,
+    cwd: Optional[str] = None,
+    timeout: float = CLI_TIMEOUT_DEFAULT_SECONDS,
+    label: str = "claude",
+) -> str:
+    """Run ``claude <tail...>`` and return its stdout.
+
+    Raises:
+        FileNotFoundError: when the CLI can't be resolved.
+        TimeoutError: when the call exceeds ``timeout``.
+        ValueError: on non-zero exit (carrying the CLI's stderr/stdout).
+    """
+    argv = claude_cli_argv(tail)
+    log.info("%s invocation: %s", label, " ".join(redact_argv_for_log(argv[1:])))
+    proc = await asyncio.create_subprocess_exec(
+        *argv,
+        cwd=cwd,
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()
+        raise TimeoutError(f"`{label}` timed out after {timeout}s")
+    out = stdout.decode("utf-8", errors="replace")
+    err = stderr.decode("utf-8", errors="replace")
+    if proc.returncode != 0:
+        msg = (err or out).strip() or f"{label} failed (exit {proc.returncode})"
+        raise ValueError(msg)
+    return out

--- a/notebook_intelligence/_claude_cli.py
+++ b/notebook_intelligence/_claude_cli.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from typing import Optional
 
 from notebook_intelligence.util import resolve_claude_cli_path
@@ -100,8 +101,15 @@ async def run_claude_cli(
     cwd: Optional[str] = None,
     timeout: float = CLI_TIMEOUT_DEFAULT_SECONDS,
     label: str = "claude",
+    env_overrides: Optional[dict[str, str]] = None,
 ) -> str:
     """Run ``claude <tail...>`` and return its stdout.
+
+    ``env_overrides`` merges into the parent's environment for this call
+    only — used by callers that need to inject auth (e.g., a resolved
+    ``GITHUB_TOKEN`` for marketplace fetches against private repos).
+    Values pass via env, not argv, so they don't appear in the redacted
+    DEBUG log.
 
     Raises:
         FileNotFoundError: when the CLI can't be resolved.
@@ -114,9 +122,15 @@ async def run_claude_cli(
     # individual successful invocations. Failures still raise a `ValueError`
     # carrying the CLI's own stderr, which callers surface to the user.
     log.debug("%s invocation: %s", label, " ".join(redact_argv_for_log(argv[1:])))
+    if env_overrides:
+        # Log only the keys, never the values — answers "did my token get
+        # used?" without leaking the secret.
+        log.debug("%s env injected: %s", label, sorted(env_overrides.keys()))
+    env = {**os.environ, **env_overrides} if env_overrides else None
     proc = await asyncio.create_subprocess_exec(
         *argv,
         cwd=cwd,
+        env=env,
         stdin=asyncio.subprocess.DEVNULL,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,

--- a/notebook_intelligence/ai_service_manager.py
+++ b/notebook_intelligence/ai_service_manager.py
@@ -522,6 +522,7 @@ class AIServiceManager(Host):
         self._mcp_manager.handle_stop_request()
         if self._skill_reconciler is not None:
             self._skill_reconciler.stop()
+        self._skill_manager.stop_watching()
 
     def update_mcp_server_connections(self, disabled_mcp_servers: list[str]):
         self._mcp_manager.update_mcp_server_connections(disabled_mcp_servers)

--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -21,7 +21,7 @@ import logging
 from claude_agent_sdk import AssistantMessage, PermissionResultAllow, PermissionResultDeny, TextBlock, UserMessage, create_sdk_mcp_server, ClaudeAgentOptions, ClaudeSDKClient, tool
 from anthropic.types.text_block import TextBlock as AnthropicTextBlock
 
-from notebook_intelligence.util import ThreadSafeWebSocketConnector, _emit, get_jupyter_root_dir
+from notebook_intelligence.util import ThreadSafeWebSocketConnector, _emit, get_jupyter_root_dir, resolve_claude_cli_path
 
 log = logging.getLogger(__name__)
 
@@ -1242,7 +1242,7 @@ class ClaudeCodeChatParticipant(BaseChatParticipant):
             env=env,
             max_buffer_size=CLAUDE_CODE_MAX_BUFFER_SIZE,
             continue_conversation=continue_conversation,
-            cli_path=os.getenv("NBI_CLAUDE_CLI_PATH", None)
+            cli_path=resolve_claude_cli_path()
         )
         return client_options
 

--- a/notebook_intelligence/claude_mcp_manager.py
+++ b/notebook_intelligence/claude_mcp_manager.py
@@ -45,7 +45,10 @@ def _reject_flag_smuggling(*, name: str, command_or_url: str) -> None:
 
 
 def _redact_argv_for_log(argv: list[str]) -> list[str]:
-    """Drop secret-bearing values (-e KEY=value, -H NAME: value) for logs."""
+    """Drop secret-bearing values (-e/--env/-H/--header/--client-secret/...)
+    for logs. Mirrors the helper in plugin_manager — kept local instead of
+    factored out only because the broader `_run_cli` consolidation between
+    these two managers is a tracked follow-up."""
     redacted: list[str] = []
     skip_next = False
     for token in argv:
@@ -54,7 +57,18 @@ def _redact_argv_for_log(argv: list[str]) -> list[str]:
             skip_next = False
             continue
         redacted.append(token)
-        if token in ("-e", "--env", "-H", "--header"):
+        if token in (
+            "-e",
+            "--env",
+            "-H",
+            "--header",
+            "--client-secret",
+            "--client-id",
+            "--token",
+            "--password",
+            "--auth",
+            "--bearer",
+        ):
             skip_next = True
     return redacted
 

--- a/notebook_intelligence/claude_mcp_manager.py
+++ b/notebook_intelligence/claude_mcp_manager.py
@@ -25,15 +25,15 @@ from pathlib import Path
 from typing import Iterable, Literal, Optional
 
 from notebook_intelligence._claude_cli import (
-    redact_argv_for_log as _redact_argv_for_log,
+    CLAUDE_SCOPES,
     reject_flag_smuggling,
     run_claude_cli,
+    validate_scope,
 )
 
 log = logging.getLogger(__name__)
 
 ClaudeMCPScope = Literal["user", "project", "local"]
-VALID_SCOPES: tuple[ClaudeMCPScope, ...] = ("user", "project", "local")
 VALID_TRANSPORTS: tuple[str, ...] = ("stdio", "sse", "http")
 
 CLI_TIMEOUT_SECONDS = 30.0
@@ -168,8 +168,7 @@ class ClaudeMCPManager:
         headers: Optional[dict[str, str]] = None,
     ) -> ClaudeMCPServer:
         """Run ``claude mcp add`` and return the persisted record."""
-        if scope not in VALID_SCOPES:
-            raise ValueError(f"Invalid scope {scope!r}; expected one of {VALID_SCOPES}")
+        validate_scope(scope)
         if transport not in VALID_TRANSPORTS:
             raise ValueError(
                 f"Invalid transport {transport!r}; expected one of {VALID_TRANSPORTS}"
@@ -222,8 +221,7 @@ class ClaudeMCPManager:
         return srv
 
     async def remove_server(self, name: str, scope: ClaudeMCPScope) -> None:
-        if scope not in VALID_SCOPES:
-            raise ValueError(f"Invalid scope {scope!r}; expected one of {VALID_SCOPES}")
+        validate_scope(scope)
         if not name:
             raise ValueError("Missing server name")
         reject_flag_smuggling("name", name)

--- a/notebook_intelligence/claude_mcp_manager.py
+++ b/notebook_intelligence/claude_mcp_manager.py
@@ -1,0 +1,289 @@
+# Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+"""Read/write Claude Code's MCP server configuration.
+
+Reads come from the JSON config files Claude maintains itself:
+
+  - User scope:    ``~/.claude.json`` → top-level ``mcpServers``
+  - Local scope:   ``~/.claude.json`` → ``projects.<cwd>.mcpServers``
+  - Project scope: ``<cwd>/.mcp.json``
+
+Writes go through ``claude mcp add`` / ``claude mcp remove`` so Claude
+remains the source of truth for any side effects (project-trust prompts,
+oauth bookkeeping, etc.). The file-based reads are decoupled from the CLI's
+``claude mcp list`` output because that command does live health checks
+that are slow and unstructured (no ``--json``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Literal, Optional
+
+from notebook_intelligence.util import resolve_claude_cli_path
+
+log = logging.getLogger(__name__)
+
+ClaudeMCPScope = Literal["user", "project", "local"]
+VALID_SCOPES: tuple[ClaudeMCPScope, ...] = ("user", "project", "local")
+VALID_TRANSPORTS: tuple[str, ...] = ("stdio", "sse", "http")
+
+CLI_TIMEOUT_SECONDS = 30.0
+
+# Reject names / commands / URLs that start with `-` so the user can't
+# smuggle a Claude CLI flag through their position in argv.
+def _reject_flag_smuggling(*, name: str, command_or_url: str) -> None:
+    for label, value in (("name", name), ("command_or_url", command_or_url)):
+        if value.startswith("-"):
+            raise ValueError(
+                f"Invalid {label} {value!r}: leading '-' is not permitted"
+            )
+
+
+def _redact_argv_for_log(argv: list[str]) -> list[str]:
+    """Drop secret-bearing values (-e KEY=value, -H NAME: value) for logs."""
+    redacted: list[str] = []
+    skip_next = False
+    for token in argv:
+        if skip_next:
+            redacted.append("<redacted>")
+            skip_next = False
+            continue
+        redacted.append(token)
+        if token in ("-e", "--env", "-H", "--header"):
+            skip_next = True
+    return redacted
+
+
+@dataclass(frozen=True)
+class ClaudeMCPServer:
+    name: str
+    scope: ClaudeMCPScope
+    transport: str  # "stdio" | "sse" | "http"
+    command: str = ""  # stdio
+    args: list[str] = field(default_factory=list)  # stdio
+    env: dict[str, str] = field(default_factory=dict)  # stdio
+    url: str = ""  # sse | http
+    headers: dict[str, str] = field(default_factory=dict)  # sse | http
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "scope": self.scope,
+            "transport": self.transport,
+            "command": self.command,
+            "args": list(self.args),
+            "env": dict(self.env),
+            "url": self.url,
+            "headers": dict(self.headers),
+        }
+
+
+def _read_json(path: Path) -> Optional[dict]:
+    try:
+        with path.open("r", encoding="utf-8") as fp:
+            return json.load(fp)
+    except FileNotFoundError:
+        return None
+    except (OSError, json.JSONDecodeError) as exc:
+        log.warning("Failed to read Claude MCP config %s: %s", path, exc)
+        return None
+
+
+def _coerce_str_dict(d: Optional[dict]) -> dict[str, str]:
+    """Stringify keys/values; drop None values so they don't surface as the
+    string "None" in the UI."""
+    if not isinstance(d, dict):
+        return {}
+    return {str(k): str(v) for k, v in d.items() if v is not None}
+
+
+def _coerce_server(name: str, raw: dict, scope: ClaudeMCPScope) -> Optional[ClaudeMCPServer]:
+    if not isinstance(raw, dict):
+        return None
+    transport = raw.get("type") or "stdio"
+    if transport not in VALID_TRANSPORTS:
+        # Unknown transport — pass through untouched so the UI can show it
+        # rather than silently dropping it.
+        transport = str(transport)
+    return ClaudeMCPServer(
+        name=name,
+        scope=scope,
+        transport=transport,
+        command=str(raw.get("command", "")),
+        args=list(raw.get("args") or []),
+        env=_coerce_str_dict(raw.get("env")),
+        url=str(raw.get("url", "")),
+        headers=_coerce_str_dict(raw.get("headers")),
+    )
+
+
+def _gather_from_dict(
+    block: Optional[dict], scope: ClaudeMCPScope
+) -> Iterable[ClaudeMCPServer]:
+    if not isinstance(block, dict):
+        return ()
+    out: list[ClaudeMCPServer] = []
+    for name, raw in block.items():
+        srv = _coerce_server(str(name), raw, scope)
+        if srv is not None:
+            out.append(srv)
+    return out
+
+
+class ClaudeMCPManager:
+    def __init__(self, working_dir: Optional[str] = None):
+        self._working_dir = Path(working_dir) if working_dir else Path.cwd()
+        self._user_config_path = Path.home() / ".claude.json"
+        # Serialize CLI writes within this process. Claude's CLI does
+        # read-modify-write on `~/.claude.json` without a lockfile, so two
+        # in-flight `add`s from the same NBI server can clobber.
+        self._write_lock = asyncio.Lock()
+
+    # --- reads ---------------------------------------------------------
+
+    def list_servers(self) -> list[ClaudeMCPServer]:
+        """Enumerate user + local + project scope servers visible to Claude."""
+        servers: list[ClaudeMCPServer] = []
+        user_doc = _read_json(self._user_config_path) or {}
+
+        servers.extend(_gather_from_dict(user_doc.get("mcpServers"), "user"))
+
+        # Local scope is keyed by absolute working-dir path under `projects`.
+        projects = user_doc.get("projects") or {}
+        local_block = (projects.get(str(self._working_dir)) or {}).get("mcpServers")
+        servers.extend(_gather_from_dict(local_block, "local"))
+
+        # Project scope: ``<cwd>/.mcp.json`` with top-level ``mcpServers``.
+        project_doc = _read_json(self._working_dir / ".mcp.json") or {}
+        servers.extend(_gather_from_dict(project_doc.get("mcpServers"), "project"))
+
+        servers.sort(key=lambda s: (s.name, s.scope))
+        return servers
+
+    def get_server(self, name: str, scope: ClaudeMCPScope) -> Optional[ClaudeMCPServer]:
+        for srv in self.list_servers():
+            if srv.name == name and srv.scope == scope:
+                return srv
+        return None
+
+    # --- writes (CLI shell-outs) ---------------------------------------
+
+    async def add_server(
+        self,
+        *,
+        name: str,
+        scope: ClaudeMCPScope,
+        transport: str,
+        command_or_url: str,
+        args: Optional[list[str]] = None,
+        env: Optional[dict[str, str]] = None,
+        headers: Optional[dict[str, str]] = None,
+    ) -> ClaudeMCPServer:
+        """Run ``claude mcp add`` and return the persisted record."""
+        if scope not in VALID_SCOPES:
+            raise ValueError(f"Invalid scope {scope!r}; expected one of {VALID_SCOPES}")
+        if transport not in VALID_TRANSPORTS:
+            raise ValueError(
+                f"Invalid transport {transport!r}; expected one of {VALID_TRANSPORTS}"
+            )
+        if not name:
+            raise ValueError("Missing server name")
+        if not command_or_url:
+            raise ValueError("Missing command or URL")
+        _reject_flag_smuggling(name=name, command_or_url=command_or_url)
+
+        cmd = self._cli_argv(["mcp", "add", "--scope", scope, "--transport", transport])
+        for key, value in (env or {}).items():
+            cmd.extend(["-e", f"{key}={value}"])
+        for key, value in (headers or {}).items():
+            cmd.extend(["-H", f"{key}: {value}"])
+        cmd.append(name)
+        cmd.append(command_or_url)
+        if args:
+            cmd.append("--")
+            cmd.extend(args)
+
+        async with self._write_lock:
+            await self._run_cli(cmd, write_op=True)
+        srv = self.get_server(name, scope)
+        if srv is None:
+            # Surfaced if Claude wrote elsewhere or our reads missed it. The CLI
+            # already succeeded, so don't 500 — synthesize from the inputs.
+            # Logged as a warning so an operator notices a real read/write
+            # divergence (cwd mismatch, scope misroute, race).
+            log.warning(
+                "claude mcp add succeeded but post-add read missed %r in %s scope; "
+                "returning synthesized record",
+                name,
+                scope,
+            )
+            return ClaudeMCPServer(
+                name=name,
+                scope=scope,
+                transport=transport,
+                command=command_or_url if transport == "stdio" else "",
+                args=list(args or []),
+                env=dict(env or {}),
+                url=command_or_url if transport in ("sse", "http") else "",
+                headers=dict(headers or {}),
+            )
+        return srv
+
+    async def remove_server(self, name: str, scope: ClaudeMCPScope) -> None:
+        if scope not in VALID_SCOPES:
+            raise ValueError(f"Invalid scope {scope!r}; expected one of {VALID_SCOPES}")
+        if not name:
+            raise ValueError("Missing server name")
+        _reject_flag_smuggling(name=name, command_or_url=name)
+        async with self._write_lock:
+            await self._run_cli(
+                self._cli_argv(["mcp", "remove", "--scope", scope, name]),
+                write_op=True,
+            )
+
+    # --- internals -----------------------------------------------------
+
+    def _cli_argv(self, tail: list[str]) -> list[str]:
+        cli = resolve_claude_cli_path()
+        if not cli:
+            raise FileNotFoundError(
+                "Claude Code CLI not found on PATH (set NBI_CLAUDE_CLI_PATH or install `claude`)"
+            )
+        return [cli, *tail]
+
+    async def _run_cli(self, argv: list[str], *, write_op: bool) -> str:
+        log.info(
+            "claude mcp invocation: %s", " ".join(_redact_argv_for_log(argv[1:]))
+        )
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            cwd=str(self._working_dir),
+            # Closed stdin keeps Claude from blocking on a project-trust or
+            # OAuth prompt; it'll fail with a clean nonzero exit instead of
+            # hanging until the timeout.
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=CLI_TIMEOUT_SECONDS
+            )
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            raise TimeoutError(
+                f"`claude mcp` timed out after {CLI_TIMEOUT_SECONDS}s"
+            )
+        out = stdout.decode("utf-8", errors="replace")
+        err = stderr.decode("utf-8", errors="replace")
+        if proc.returncode != 0:
+            # Surface Claude's own error message; drop empty stderr.
+            msg = (err or out).strip() or f"claude mcp failed (exit {proc.returncode})"
+            raise ValueError(msg)
+        return out

--- a/notebook_intelligence/claude_mcp_manager.py
+++ b/notebook_intelligence/claude_mcp_manager.py
@@ -136,13 +136,16 @@ def _gather_from_dict(
 
 
 class ClaudeMCPManager:
+    # Class-level so the lock is shared across all ClaudeMCPManager instances
+    # within this process. Handlers construct a fresh manager per request,
+    # so an instance lock wouldn't actually serialize anything. Claude's
+    # CLI does read-modify-write on `~/.claude.json` without a lockfile, so
+    # two in-flight `add`s from the same NBI server can clobber.
+    _write_lock = asyncio.Lock()
+
     def __init__(self, working_dir: Optional[str] = None):
         self._working_dir = Path(working_dir) if working_dir else Path.cwd()
         self._user_config_path = Path.home() / ".claude.json"
-        # Serialize CLI writes within this process. Claude's CLI does
-        # read-modify-write on `~/.claude.json` without a lockfile, so two
-        # in-flight `add`s from the same NBI server can clobber.
-        self._write_lock = asyncio.Lock()
 
     # --- reads ---------------------------------------------------------
 

--- a/notebook_intelligence/claude_mcp_manager.py
+++ b/notebook_intelligence/claude_mcp_manager.py
@@ -24,7 +24,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable, Literal, Optional
 
-from notebook_intelligence.util import resolve_claude_cli_path
+from notebook_intelligence._claude_cli import (
+    redact_argv_for_log as _redact_argv_for_log,
+    reject_flag_smuggling,
+    run_claude_cli,
+)
 
 log = logging.getLogger(__name__)
 
@@ -33,44 +37,6 @@ VALID_SCOPES: tuple[ClaudeMCPScope, ...] = ("user", "project", "local")
 VALID_TRANSPORTS: tuple[str, ...] = ("stdio", "sse", "http")
 
 CLI_TIMEOUT_SECONDS = 30.0
-
-# Reject names / commands / URLs that start with `-` so the user can't
-# smuggle a Claude CLI flag through their position in argv.
-def _reject_flag_smuggling(*, name: str, command_or_url: str) -> None:
-    for label, value in (("name", name), ("command_or_url", command_or_url)):
-        if value.startswith("-"):
-            raise ValueError(
-                f"Invalid {label} {value!r}: leading '-' is not permitted"
-            )
-
-
-def _redact_argv_for_log(argv: list[str]) -> list[str]:
-    """Drop secret-bearing values (-e/--env/-H/--header/--client-secret/...)
-    for logs. Mirrors the helper in plugin_manager — kept local instead of
-    factored out only because the broader `_run_cli` consolidation between
-    these two managers is a tracked follow-up."""
-    redacted: list[str] = []
-    skip_next = False
-    for token in argv:
-        if skip_next:
-            redacted.append("<redacted>")
-            skip_next = False
-            continue
-        redacted.append(token)
-        if token in (
-            "-e",
-            "--env",
-            "-H",
-            "--header",
-            "--client-secret",
-            "--client-id",
-            "--token",
-            "--password",
-            "--auth",
-            "--bearer",
-        ):
-            skip_next = True
-    return redacted
 
 
 @dataclass(frozen=True)
@@ -212,21 +178,25 @@ class ClaudeMCPManager:
             raise ValueError("Missing server name")
         if not command_or_url:
             raise ValueError("Missing command or URL")
-        _reject_flag_smuggling(name=name, command_or_url=command_or_url)
+        reject_flag_smuggling("name", name)
+        reject_flag_smuggling("command_or_url", command_or_url)
 
-        cmd = self._cli_argv(["mcp", "add", "--scope", scope, "--transport", transport])
+        tail = ["mcp", "add", "--scope", scope, "--transport", transport]
         for key, value in (env or {}).items():
-            cmd.extend(["-e", f"{key}={value}"])
+            tail.extend(["-e", f"{key}={value}"])
         for key, value in (headers or {}).items():
-            cmd.extend(["-H", f"{key}: {value}"])
-        cmd.append(name)
-        cmd.append(command_or_url)
+            tail.extend(["-H", f"{key}: {value}"])
+        tail.append(name)
+        tail.append(command_or_url)
         if args:
-            cmd.append("--")
-            cmd.extend(args)
+            # `--` sentinel keeps Claude from re-parsing user-supplied args
+            # as flags; `reject_flag_smuggling` is therefore not needed for
+            # individual `args` entries.
+            tail.append("--")
+            tail.extend(args)
 
         async with self._write_lock:
-            await self._run_cli(cmd, write_op=True)
+            await self._run_cli(tail)
         srv = self.get_server(name, scope)
         if srv is None:
             # Surfaced if Claude wrote elsewhere or our reads missed it. The CLI
@@ -256,51 +226,16 @@ class ClaudeMCPManager:
             raise ValueError(f"Invalid scope {scope!r}; expected one of {VALID_SCOPES}")
         if not name:
             raise ValueError("Missing server name")
-        _reject_flag_smuggling(name=name, command_or_url=name)
+        reject_flag_smuggling("name", name)
         async with self._write_lock:
-            await self._run_cli(
-                self._cli_argv(["mcp", "remove", "--scope", scope, name]),
-                write_op=True,
-            )
+            await self._run_cli(["mcp", "remove", "--scope", scope, name])
 
     # --- internals -----------------------------------------------------
 
-    def _cli_argv(self, tail: list[str]) -> list[str]:
-        cli = resolve_claude_cli_path()
-        if not cli:
-            raise FileNotFoundError(
-                "Claude Code CLI not found on PATH (set NBI_CLAUDE_CLI_PATH or install `claude`)"
-            )
-        return [cli, *tail]
-
-    async def _run_cli(self, argv: list[str], *, write_op: bool) -> str:
-        log.info(
-            "claude mcp invocation: %s", " ".join(_redact_argv_for_log(argv[1:]))
-        )
-        proc = await asyncio.create_subprocess_exec(
-            *argv,
+    async def _run_cli(self, tail: list[str]) -> str:
+        return await run_claude_cli(
+            tail,
             cwd=str(self._working_dir),
-            # Closed stdin keeps Claude from blocking on a project-trust or
-            # OAuth prompt; it'll fail with a clean nonzero exit instead of
-            # hanging until the timeout.
-            stdin=asyncio.subprocess.DEVNULL,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+            timeout=CLI_TIMEOUT_SECONDS,
+            label="claude mcp",
         )
-        try:
-            stdout, stderr = await asyncio.wait_for(
-                proc.communicate(), timeout=CLI_TIMEOUT_SECONDS
-            )
-        except asyncio.TimeoutError:
-            proc.kill()
-            await proc.wait()
-            raise TimeoutError(
-                f"`claude mcp` timed out after {CLI_TIMEOUT_SECONDS}s"
-            )
-        out = stdout.decode("utf-8", errors="replace")
-        err = stderr.decode("utf-8", errors="replace")
-        if proc.returncode != 0:
-            # Surface Claude's own error message; drop empty stderr.
-            msg = (err or out).strip() or f"claude mcp failed (exit {proc.returncode})"
-            raise ValueError(msg)
-        return out

--- a/notebook_intelligence/claude_mcp_manager.py
+++ b/notebook_intelligence/claude_mcp_manager.py
@@ -179,6 +179,25 @@ class ClaudeMCPManager:
             raise ValueError("Missing command or URL")
         reject_flag_smuggling("name", name)
         reject_flag_smuggling("command_or_url", command_or_url)
+        # For network transports, require HTTPS — `http://`/`file://`/etc.
+        # would let a user point Claude at internal endpoints (SSRF) or
+        # exfil credentials in plaintext. Stdio is a subprocess, not a URL.
+        if transport in ("sse", "http"):
+            scheme = command_or_url.split(":", 1)[0].lower()
+            if scheme != "https":
+                raise ValueError(
+                    f"Transport {transport!r} requires https:// URL; got {scheme!r}"
+                )
+        # The CLI parses `-e KEY=VALUE` and `-H NAME: VALUE` as the next
+        # positional argv; a key like `--inject` would either break the
+        # CLI's parser or smuggle in a side-flag depending on version. The
+        # separator (`=` for env, `:` for headers) is also reserved.
+        for key in (env or {}):
+            if not key or key.startswith("-") or "=" in key:
+                raise ValueError(f"Invalid env key {key!r}")
+        for key in (headers or {}):
+            if not key or key.startswith("-") or ":" in key:
+                raise ValueError(f"Invalid header name {key!r}")
 
         tail = ["mcp", "add", "--scope", scope, "--transport", transport]
         for key, value in (env or {}).items():

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -742,6 +742,11 @@ class PolicyGatedHandler(APIHandler):
             self.set_status(403)
             self.finish(json.dumps({"error": self.policy_disabled_message}))
 
+    # Subclasses extend this to map domain-specific exception types to HTTP
+    # statuses. Anything not covered (or in the parent's empty default)
+    # falls through to 400.
+    exception_status_map: dict[type[Exception], int] = {}
+
     def _parse_json_body(self):
         try:
             return json.loads(self.request.body)
@@ -750,6 +755,16 @@ class PolicyGatedHandler(APIHandler):
             self.finish(json.dumps({"error": f"Invalid JSON: {e}"}))
             return None
 
+    def _error(self, exc: Exception):
+        # Walk MRO so a subclass exception inherits its parent's status.
+        for cls, status in self.exception_status_map.items():
+            if isinstance(exc, cls):
+                self.set_status(status)
+                self.finish(json.dumps({"error": str(exc)}))
+                return
+        self.set_status(400)
+        self.finish(json.dumps({"error": str(exc)}))
+
 
 class ClaudeMCPBaseHandler(PolicyGatedHandler):
     """Shared helpers + policy gate for Claude-MCP endpoints."""
@@ -757,19 +772,14 @@ class ClaudeMCPBaseHandler(PolicyGatedHandler):
     claude_mcp_management_enabled = True
     policy_enabled_attr = "claude_mcp_management_enabled"
     policy_disabled_message = "Claude MCP management is disabled by your administrator"
+    exception_status_map = {
+        FileNotFoundError: 404,
+        TimeoutError: 504,
+    }
 
     @property
     def manager(self) -> "ClaudeMCPManager":
         return ClaudeMCPManager(working_dir=get_jupyter_root_dir() or None)
-
-    def _error(self, exc: Exception):
-        if isinstance(exc, FileNotFoundError):
-            self.set_status(404)
-        elif isinstance(exc, TimeoutError):
-            self.set_status(504)
-        else:
-            self.set_status(400)
-        self.finish(json.dumps({"error": str(exc)}))
 
 
 class ClaudeMCPListHandler(ClaudeMCPBaseHandler):
@@ -829,21 +839,15 @@ class PluginsBaseHandler(PolicyGatedHandler):
     plugins_management_enabled = True
     policy_enabled_attr = "plugins_management_enabled"
     policy_disabled_message = "Plugins management is disabled by your administrator"
+    exception_status_map = {
+        FileNotFoundError: 404,
+        PermissionError: 403,
+        TimeoutError: 504,
+    }
 
     @property
     def manager(self) -> "PluginManager":
         return PluginManager()
-
-    def _error(self, exc: Exception):
-        if isinstance(exc, FileNotFoundError):
-            self.set_status(404)
-        elif isinstance(exc, PermissionError):
-            self.set_status(403)
-        elif isinstance(exc, TimeoutError):
-            self.set_status(504)
-        else:
-            self.set_status(400)
-        self.finish(json.dumps({"error": str(exc)}))
 
 
 class PluginsListHandler(PluginsBaseHandler):
@@ -952,6 +956,10 @@ class SkillsBaseHandler(PolicyGatedHandler):
     skills_management_enabled = True
     policy_enabled_attr = "skills_management_enabled"
     policy_disabled_message = "Skills management is disabled by your administrator"
+    exception_status_map = {
+        FileExistsError: 409,
+        FileNotFoundError: 404,
+    }
 
     @property
     def skill_manager(self):
@@ -964,14 +972,6 @@ class SkillsBaseHandler(PolicyGatedHandler):
         self.finish(json.dumps({"error": "GitHub Skill import is disabled by configuration"}))
         return True
 
-    def _error(self, exc):
-        if isinstance(exc, FileExistsError):
-            self.set_status(409)
-        elif isinstance(exc, FileNotFoundError):
-            self.set_status(404)
-        else:
-            self.set_status(400)
-        self.finish(json.dumps({"error": str(exc)}))
 
     def _bundle_rel_path(self):
         rel_path = self.get_query_argument("path", default=None)
@@ -980,14 +980,6 @@ class SkillsBaseHandler(PolicyGatedHandler):
             self.finish(json.dumps({"error": "Missing required 'path' query parameter"}))
             return None
         return rel_path
-
-    def _parse_json_body(self):
-        try:
-            return json.loads(self.request.body)
-        except json.JSONDecodeError as e:
-            self.set_status(400)
-            self.finish(json.dumps({"error": f"Invalid JSON: {e}"}))
-            return None
 
 
 class SkillsListHandler(SkillsBaseHandler):
@@ -2109,14 +2101,15 @@ class NotebookIntelligence(ExtensionApp):
         default_value=POLICY_USER_CHOICE,
         help="""
         Org-wide policy for the Skills management UI. "user-choice" (default)
-        and "force-on" both leave the Skills tab visible — there is no user
-        toggle to override, so the two are behaviorally identical today; the
-        three-value shape is preserved for symmetry with the other
-        feature_policies. "force-off" hides the tab, returns 403 from
-        /skills handlers, and **also disables the managed-skills reconciler**
-        — orgs that ship curated skills via NBI_SKILLS_MANIFEST should leave
-        this on user-choice and rely on filesystem permissions instead.
-        Overridden by the NBI_SKILLS_MANAGEMENT_POLICY env var.
+        and "force-on" both leave the Skills tab visible. There is no user
+        toggle to override, so neither value flips a user-visible setting on
+        its own — the three-value shape is preserved for symmetry with the
+        other feature_policies. "force-off" is the materially different
+        case: hides the tab, returns 403 from /skills handlers, and *also*
+        disables the managed-skills reconciler. Orgs that ship curated
+        skills via NBI_SKILLS_MANIFEST should leave this on user-choice and
+        rely on filesystem permissions instead. Overridden by the
+        NBI_SKILLS_MANAGEMENT_POLICY env var.
         """,
         config=True,
     )

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -200,6 +200,21 @@ def _resolve_bool_with_env(env_var_name: str, fallback: bool | None) -> bool:
 # Single source of truth for the boolean policies. Each entry is
 # ``(policy_name, env_var, traitlet_attr)``. Drives env-var resolution, the
 # capabilities response, and the lock-rejection set in ConfigHandler.
+#
+# Adding a new policy requires updates in *seven* places — keep them all in
+# sync or the policy will silently no-op:
+#   1. A new tuple entry below.
+#   2. A ``TraitletEnum`` declaration on ``NotebookIntelligence`` further
+#      down in this file.
+#   3. A ``user_values`` entry in ``_build_feature_policies_response``
+#      (admin-only gates use ``True``).
+#   4. (For backend gates) An ``is_force_off`` call in ``_setup_handlers``
+#      that sets the resolved bool on the handler class.
+#   5. A row in the Admin policies table in ``README.md``.
+#   6. A section in ``docs/admin-guide.md``.
+#   7. ``FeaturePolicyName`` union + the ``names`` array in
+#      ``src/api.ts`` ``featurePolicies``. Admin-only gates also need an
+#      entry in the ``defaultOpen`` set if they should default visible.
 FEATURE_POLICY_SPEC = (
     ("explain_error", "NBI_EXPLAIN_ERROR_POLICY", "explain_error_policy"),
     ("output_followup", "NBI_OUTPUT_FOLLOWUP_POLICY", "output_followup_policy"),
@@ -720,12 +735,27 @@ class RulesReloadHandler(APIHandler):
 
 
 class PolicyGatedHandler(APIHandler):
-    """APIHandler that short-circuits with 403 in `prepare()` when the
-    associated admin policy is force-off.
+    """APIHandler base used by all NBI management surfaces (Skills,
+    Claude-MCP, Plugins). Owns three concerns:
 
-    Subclasses set ``policy_enabled_attr`` to the class-attribute name that
-    holds the resolved bool (set in ``_setup_handlers``), and
-    ``policy_disabled_message`` for the user-facing error string.
+    1. **Admin policy gate** in ``prepare()``. Short-circuits with 403
+       when the associated ``*_management_policy`` resolves to
+       ``force-off``. Subclasses set ``policy_enabled_attr`` to the
+       class-attribute name holding the resolved bool (mutated in
+       ``_setup_handlers``), and ``policy_disabled_message`` for the
+       user-facing error string.
+
+    2. **JSON request parsing** via ``_parse_json_body``. Returns the
+       decoded body or ``None`` after writing a 400; callers must ``if
+       data is None: return``.
+
+    3. **Domain-aware error mapping** via ``_error`` + the
+       ``exception_status_map`` class attribute (exception class → HTTP
+       status). Most-specific class wins via MRO depth ordering.
+
+    Subclasses also typically expose a ``manager`` property that returns
+    the per-domain CLI/file-backed manager — convention rather than
+    contract since not every handler needs one.
     """
 
     policy_enabled_attr: str = ""
@@ -743,8 +773,10 @@ class PolicyGatedHandler(APIHandler):
             self.finish(json.dumps({"error": self.policy_disabled_message}))
 
     # Subclasses extend this to map domain-specific exception types to HTTP
-    # statuses. Anything not covered (or in the parent's empty default)
-    # falls through to 400.
+    # statuses. Most-specific class wins (we sort by MRO depth at lookup
+    # time), so a subclass that adds ``OSError: 500`` next to an
+    # inherited ``FileNotFoundError: 404`` still routes the latter to 404.
+    # Anything not covered falls through to 400.
     exception_status_map: dict[type[Exception], int] = {}
 
     def _parse_json_body(self):
@@ -756,12 +788,16 @@ class PolicyGatedHandler(APIHandler):
             return None
 
     def _error(self, exc: Exception):
-        # Walk MRO so a subclass exception inherits its parent's status.
-        for cls, status in self.exception_status_map.items():
-            if isinstance(exc, cls):
-                self.set_status(status)
-                self.finish(json.dumps({"error": str(exc)}))
-                return
+        # Sort candidates by MRO depth (deepest = most specific) so
+        # narrower exception classes always win over their bases.
+        candidates = sorted(
+            (cls for cls in self.exception_status_map if isinstance(exc, cls)),
+            key=lambda c: -len(c.__mro__),
+        )
+        if candidates:
+            self.set_status(self.exception_status_map[candidates[0]])
+            self.finish(json.dumps({"error": str(exc)}))
+            return
         self.set_status(400)
         self.finish(json.dumps({"error": str(exc)}))
 

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -37,6 +37,7 @@ from notebook_intelligence.feature_flags import (
     VALID_POLICIES,
     apply_claude_policies,
     apply_string_overrides,
+    is_force_off,
     is_locked,
     resolve_feature_flag,
 )
@@ -232,6 +233,11 @@ FEATURE_POLICY_SPEC = (
         "NBI_STORE_GITHUB_ACCESS_TOKEN_POLICY",
         "store_github_access_token_policy",
     ),
+    (
+        "skills_management",
+        "NBI_SKILLS_MANAGEMENT_POLICY",
+        "skills_management_policy",
+    ),
 )
 FEATURE_POLICY_NAMES = tuple(name for name, _, _ in FEATURE_POLICY_SPEC)
 
@@ -275,6 +281,9 @@ def _build_feature_policies_response(policies: dict, nbi_config) -> dict:
         "claude_setting_source_user": "user" in sources,
         "claude_setting_source_project": "project" in sources,
         "store_github_access_token": bool(nbi_config.store_github_access_token),
+        # Admin-only gate; user has no toggle, so user_value is always True.
+        # The policy resolver still applies force-off / force-on correctly.
+        "skills_management": True,
     }
 
     response = {}
@@ -698,6 +707,19 @@ class SkillsBaseHandler(APIHandler):
     """Shared helpers for skills endpoints."""
 
     allow_github_skill_import = True
+    skills_management_enabled = True
+
+    async def prepare(self):
+        # APIHandler.prepare is async (xsrf/auth), so we must await it before
+        # applying the skills_management policy gate.
+        await super().prepare()
+        if self._finished:
+            return
+        if not self.skills_management_enabled:
+            self.set_status(403)
+            self.finish(
+                json.dumps({"error": "Skills management is disabled by your administrator"})
+            )
 
     @property
     def skill_manager(self):
@@ -1850,6 +1872,23 @@ class NotebookIntelligence(ExtensionApp):
         config=True,
     )
 
+    skills_management_policy = TraitletEnum(
+        list(VALID_POLICIES),
+        default_value=POLICY_USER_CHOICE,
+        help="""
+        Org-wide policy for the Skills management UI. "user-choice" (default)
+        and "force-on" both leave the Skills tab visible — there is no user
+        toggle to override, so the two are behaviorally identical today; the
+        three-value shape is preserved for symmetry with the other
+        feature_policies. "force-off" hides the tab, returns 403 from
+        /skills handlers, and **also disables the managed-skills reconciler**
+        — orgs that ship curated skills via NBI_SKILLS_MANIFEST should leave
+        this on user-choice and rely on filesystem permissions instead.
+        Overridden by the NBI_SKILLS_MANAGEMENT_POLICY env var.
+        """,
+        config=True,
+    )
+
     skills_manifest = Unicode(
         default_value="",
         help="""
@@ -1926,6 +1965,11 @@ class NotebookIntelligence(ExtensionApp):
     ):
         global ai_service_manager
         manifest_source = os.environ.get("NBI_SKILLS_MANIFEST", "").strip() or self.skills_manifest.strip()
+        # When skills management is force-off, suppress the manifest so the
+        # reconciler isn't constructed at all (org-curated skills wouldn't
+        # have a UI surface anyway, and stopping reconcile is the contract).
+        if is_force_off(feature_policies, "skills_management"):
+            manifest_source = ""
         managed_token = (
             os.environ.get("NBI_MANAGED_SKILLS_TOKEN", "").strip()
             or self.managed_skills_token.strip()
@@ -2001,6 +2045,9 @@ class NotebookIntelligence(ExtensionApp):
                 "NBI_ADDITIONAL_SKIPPED_WORKSPACE_DIRECTORIES",
                 self.additional_skipped_workspace_directories,
             )
+        )
+        SkillsBaseHandler.skills_management_enabled = not is_force_off(
+            feature_policies, "skills_management"
         )
         self._publish_policies(feature_policies, string_overrides)
         NotebookIntelligence.handlers = [

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -42,6 +42,7 @@ from notebook_intelligence.feature_flags import (
     resolve_feature_flag,
 )
 from notebook_intelligence.claude import ClaudeCodeChatParticipant, fetch_claude_models
+from notebook_intelligence.claude_mcp_manager import ClaudeMCPManager
 from notebook_intelligence.claude_sessions import (
     NBI_CONTEXT_PREFIX,
     get_sessions_dir as get_claude_sessions_dir,
@@ -238,6 +239,11 @@ FEATURE_POLICY_SPEC = (
         "NBI_SKILLS_MANAGEMENT_POLICY",
         "skills_management_policy",
     ),
+    (
+        "claude_mcp_management",
+        "NBI_CLAUDE_MCP_MANAGEMENT_POLICY",
+        "claude_mcp_management_policy",
+    ),
 )
 FEATURE_POLICY_NAMES = tuple(name for name, _, _ in FEATURE_POLICY_SPEC)
 
@@ -284,6 +290,7 @@ def _build_feature_policies_response(policies: dict, nbi_config) -> dict:
         # Admin-only gate; user has no toggle, so user_value is always True.
         # The policy resolver still applies force-off / force-on correctly.
         "skills_management": True,
+        "claude_mcp_management": True,
     }
 
     response = {}
@@ -701,6 +708,96 @@ class RulesReloadHandler(APIHandler):
         except Exception as e:
             self.set_status(500)
             self.finish(json.dumps({"error": str(e)}))
+
+
+class ClaudeMCPBaseHandler(APIHandler):
+    """Shared helpers + policy gate for Claude-MCP endpoints."""
+
+    claude_mcp_management_enabled = True
+
+    async def prepare(self):
+        # Mirrors SkillsBaseHandler.prepare — see there for the rationale on
+        # awaiting super() and checking _finished.
+        await super().prepare()
+        if self._finished:
+            return
+        if not self.claude_mcp_management_enabled:
+            self.set_status(403)
+            self.finish(
+                json.dumps({"error": "Claude MCP management is disabled by your administrator"})
+            )
+
+    @property
+    def manager(self) -> "ClaudeMCPManager":
+        return ClaudeMCPManager(working_dir=get_jupyter_root_dir() or None)
+
+    def _parse_json_body(self):
+        try:
+            return json.loads(self.request.body)
+        except json.JSONDecodeError as e:
+            self.set_status(400)
+            self.finish(json.dumps({"error": f"Invalid JSON: {e}"}))
+            return None
+
+    def _error(self, exc: Exception):
+        if isinstance(exc, FileNotFoundError):
+            self.set_status(404)
+        elif isinstance(exc, TimeoutError):
+            self.set_status(504)
+        else:
+            self.set_status(400)
+        self.finish(json.dumps({"error": str(exc)}))
+
+
+class ClaudeMCPListHandler(ClaudeMCPBaseHandler):
+    @tornado.web.authenticated
+    def get(self):
+        try:
+            servers = [s.to_dict() for s in self.manager.list_servers()]
+        except Exception as e:
+            self._error(e)
+            return
+        self.finish(json.dumps({"servers": servers}))
+
+    @tornado.web.authenticated
+    async def post(self):
+        data = self._parse_json_body()
+        if data is None:
+            return
+        try:
+            srv = await self.manager.add_server(
+                name=data.get("name", ""),
+                scope=data.get("scope", "user"),
+                transport=data.get("transport", "stdio"),
+                command_or_url=data.get("command_or_url", ""),
+                args=data.get("args"),
+                env=data.get("env"),
+                headers=data.get("headers"),
+            )
+            self.finish(json.dumps({"server": srv.to_dict()}))
+        except (FileNotFoundError, TimeoutError, ValueError) as e:
+            self._error(e)
+
+
+class ClaudeMCPDetailHandler(ClaudeMCPBaseHandler):
+    @tornado.web.authenticated
+    def get(self, scope, name):
+        srv = self.manager.get_server(name, scope)
+        if srv is None:
+            self.set_status(404)
+            self.finish(json.dumps({
+                "error": f"MCP server {name!r} not found in {scope} scope"
+            }))
+            return
+        self.finish(json.dumps({"server": srv.to_dict()}))
+
+    @tornado.web.authenticated
+    async def delete(self, scope, name):
+        try:
+            await self.manager.remove_server(name, scope)
+            self.finish(json.dumps({"success": True}))
+        except (FileNotFoundError, TimeoutError, ValueError) as e:
+            self._error(e)
 
 
 class SkillsBaseHandler(APIHandler):
@@ -1889,6 +1986,22 @@ class NotebookIntelligence(ExtensionApp):
         config=True,
     )
 
+    claude_mcp_management_policy = TraitletEnum(
+        list(VALID_POLICIES),
+        default_value=POLICY_USER_CHOICE,
+        help="""
+        Org-wide policy for the Claude-mode MCP Servers management tab.
+        "user-choice" (default) and "force-on" both leave the tab visible
+        when Claude mode is on and the Claude CLI is available; the two are
+        behaviorally identical here (no user toggle to override). "force-off"
+        hides the tab and returns 403 from /claude-mcp handlers. Independent
+        of the existing non-Claude `MCP Servers` tab, which is governed by
+        `mcp_server_settings` (its own surface). Overridden by the
+        NBI_CLAUDE_MCP_MANAGEMENT_POLICY env var.
+        """,
+        config=True,
+    )
+
     skills_manifest = Unicode(
         default_value="",
         help="""
@@ -2030,6 +2143,10 @@ class NotebookIntelligence(ExtensionApp):
         route_pattern_upload_file = url_path_join(base_url, "notebook-intelligence", "upload-file")
         route_pattern_claude_sessions = url_path_join(base_url, "notebook-intelligence", "claude-sessions")
         route_pattern_claude_sessions_resume = url_path_join(base_url, "notebook-intelligence", "claude-sessions", "resume")
+        route_pattern_claude_mcp = url_path_join(base_url, "notebook-intelligence", "claude-mcp")
+        route_pattern_claude_mcp_detail = url_path_join(
+            base_url, "notebook-intelligence", "claude-mcp", r"(user|project|local)", r"([^/]+)"
+        )
         GetCapabilitiesHandler.disabled_tools = self.disabled_tools
         GetCapabilitiesHandler.allow_enabling_tools_with_env = self.allow_enabling_tools_with_env
         GetCapabilitiesHandler.disabled_providers = self.disabled_providers
@@ -2048,6 +2165,9 @@ class NotebookIntelligence(ExtensionApp):
         )
         SkillsBaseHandler.skills_management_enabled = not is_force_off(
             feature_policies, "skills_management"
+        )
+        ClaudeMCPBaseHandler.claude_mcp_management_enabled = not is_force_off(
+            feature_policies, "claude_mcp_management"
         )
         self._publish_policies(feature_policies, string_overrides)
         NotebookIntelligence.handlers = [
@@ -2078,6 +2198,10 @@ class NotebookIntelligence(ExtensionApp):
             (route_pattern_upload_file, FileUploadHandler),
             (route_pattern_claude_sessions_resume, ClaudeSessionsResumeHandler),
             (route_pattern_claude_sessions, ClaudeSessionsListHandler),
+            # Claude-MCP routes: detail before list so {scope}/{name} doesn't
+            # shadow specialized URLs added later (parallels the skills order).
+            (route_pattern_claude_mcp_detail, ClaudeMCPDetailHandler),
+            (route_pattern_claude_mcp, ClaudeMCPListHandler),
             (route_pattern_copilot, WebsocketCopilotHandler),
         ]
         web_app.add_handlers(host_pattern, NotebookIntelligence.handlers)

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -51,7 +51,7 @@ from notebook_intelligence.claude_sessions import (
 )
 import notebook_intelligence.github_copilot as github_copilot
 from notebook_intelligence.built_in_toolsets import built_in_toolsets
-from notebook_intelligence.util import ThreadSafeWebSocketConnector, get_jupyter_root_dir, set_jupyter_root_dir, is_builtin_tool_enabled_in_env, is_provider_enabled_in_env
+from notebook_intelligence.util import ThreadSafeWebSocketConnector, get_jupyter_root_dir, set_jupyter_root_dir, is_builtin_tool_enabled_in_env, is_provider_enabled_in_env, resolve_claude_cli_path
 from notebook_intelligence.context_factory import RuleContextFactory
 from notebook_intelligence.skillset import SKILL_NAME_REGEX
 

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -261,9 +261,9 @@ FEATURE_POLICY_SPEC = (
         "claude_mcp_management_policy",
     ),
     (
-        "plugins_management",
-        "NBI_PLUGINS_MANAGEMENT_POLICY",
-        "plugins_management_policy",
+        "claude_plugins_management",
+        "NBI_CLAUDE_PLUGINS_MANAGEMENT_POLICY",
+        "claude_plugins_management_policy",
     ),
 )
 FEATURE_POLICY_NAMES = tuple(name for name, _, _ in FEATURE_POLICY_SPEC)
@@ -312,7 +312,7 @@ def _build_feature_policies_response(policies: dict, nbi_config) -> dict:
         # The policy resolver still applies force-off / force-on correctly.
         "skills_management": True,
         "claude_mcp_management": True,
-        "plugins_management": True,
+        "claude_plugins_management": True,
     }
 
     response = {}
@@ -872,8 +872,8 @@ class ClaudeMCPDetailHandler(ClaudeMCPBaseHandler):
 class PluginsBaseHandler(PolicyGatedHandler):
     """Shared helpers + policy gate for plugin endpoints."""
 
-    plugins_management_enabled = True
-    policy_enabled_attr = "plugins_management_enabled"
+    claude_plugins_management_enabled = True
+    policy_enabled_attr = "claude_plugins_management_enabled"
     policy_disabled_message = "Plugins management is disabled by your administrator"
     exception_status_map = {
         FileNotFoundError: 404,
@@ -2166,7 +2166,7 @@ class NotebookIntelligence(ExtensionApp):
         config=True,
     )
 
-    plugins_management_policy = TraitletEnum(
+    claude_plugins_management_policy = TraitletEnum(
         list(VALID_POLICIES),
         default_value=POLICY_USER_CHOICE,
         help="""
@@ -2175,7 +2175,9 @@ class NotebookIntelligence(ExtensionApp):
         when Claude mode is on and the Claude CLI is available; the two are
         behaviorally identical here (no user toggle to override). "force-off"
         hides the tab and returns 403 from /plugins handlers. Overridden by
-        the NBI_PLUGINS_MANAGEMENT_POLICY env var.
+        the NBI_CLAUDE_PLUGINS_MANAGEMENT_POLICY env var. Mirrors the
+        `claude_` prefix on `claude_mcp_management_policy` since both gate
+        Claude-only management surfaces.
         """,
         config=True,
     )
@@ -2372,8 +2374,8 @@ class NotebookIntelligence(ExtensionApp):
         ClaudeMCPBaseHandler.claude_mcp_management_enabled = not is_force_off(
             feature_policies, "claude_mcp_management"
         )
-        PluginsBaseHandler.plugins_management_enabled = not is_force_off(
-            feature_policies, "plugins_management"
+        PluginsBaseHandler.claude_plugins_management_enabled = not is_force_off(
+            feature_policies, "claude_plugins_management"
         )
         env_allow_gh_plugin = os.environ.get(
             "NBI_ALLOW_GITHUB_PLUGIN_IMPORT", ""

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -358,7 +358,6 @@ class GetCapabilitiesHandler(APIHandler):
     enable_chat_feedback = False
     allow_github_skill_import = True
     additional_skipped_workspace_directories = []
-    allow_github_plugin_import = True
     feature_policies = {}
     string_overrides = {}
 
@@ -442,12 +441,12 @@ class GetCapabilitiesHandler(APIHandler):
             ),
             "claude_models": ai_service_manager.claude_models,
             # Drives launcher-tile visibility (issue #183).
-            "claude_cli_available": shutil.which("claude") is not None,
+            "claude_cli_available": resolve_claude_cli_path() is not None,
             "default_chat_mode": nbi_config.default_chat_mode,
             "chat_feedback_enabled": self.enable_chat_feedback,
             "allow_github_skill_import": self.allow_github_skill_import,
             "additional_skipped_workspace_directories": self.additional_skipped_workspace_directories,
-            "allow_github_plugin_import": self.allow_github_plugin_import,
+            "allow_github_plugin_import": PluginsBaseHandler.allow_github_plugin_import,
             "cell_output_features": _build_cell_output_features_response(
                 self.feature_policies.get("explain_error", POLICY_USER_CHOICE),
                 self.feature_policies.get("output_followup", POLICY_USER_CHOICE),
@@ -873,6 +872,7 @@ class PluginsBaseHandler(PolicyGatedHandler):
     """Shared helpers + policy gate for plugin endpoints."""
 
     claude_plugins_management_enabled = True
+    allow_github_plugin_import = True
     policy_enabled_attr = "claude_plugins_management_enabled"
     policy_disabled_message = "Plugins management is disabled by your administrator"
     exception_status_map = {
@@ -943,11 +943,6 @@ class PluginsDetailHandler(PluginsBaseHandler):
 
 
 class PluginsMarketplaceListHandler(PluginsBaseHandler):
-    # Only the marketplace-add path needs the github gate; class-attribute
-    # lives here rather than on the base so unrelated handlers (list,
-    # uninstall, enable/disable) don't carry it.
-    allow_github_plugin_import = True
-
     @tornado.web.authenticated
     async def get(self):
         try:
@@ -2377,19 +2372,9 @@ class NotebookIntelligence(ExtensionApp):
         PluginsBaseHandler.claude_plugins_management_enabled = not is_force_off(
             feature_policies, "claude_plugins_management"
         )
-        env_allow_gh_plugin = os.environ.get(
-            "NBI_ALLOW_GITHUB_PLUGIN_IMPORT", ""
-        ).strip().lower()
-        if env_allow_gh_plugin in ("true", "1", "yes", "on"):
-            allow_github_plugin_import = True
-        elif env_allow_gh_plugin in ("false", "0", "no", "off"):
-            allow_github_plugin_import = False
-        else:
-            allow_github_plugin_import = bool(self.allow_github_plugin_import)
-        PluginsMarketplaceListHandler.allow_github_plugin_import = allow_github_plugin_import
-        # Mirror onto GetCapabilitiesHandler so the frontend can hide the
-        # "From GitHub" affordance — both handlers see the same resolved value.
-        GetCapabilitiesHandler.allow_github_plugin_import = allow_github_plugin_import
+        PluginsBaseHandler.allow_github_plugin_import = _resolve_bool_with_env(
+            "NBI_ALLOW_GITHUB_PLUGIN_IMPORT", self.allow_github_plugin_import
+        )
         self._publish_policies(feature_policies, string_overrides)
         NotebookIntelligence.handlers = [
             (route_pattern_capabilities, GetCapabilitiesHandler),

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -43,6 +43,7 @@ from notebook_intelligence.feature_flags import (
 )
 from notebook_intelligence.claude import ClaudeCodeChatParticipant, fetch_claude_models
 from notebook_intelligence.claude_mcp_manager import ClaudeMCPManager
+from notebook_intelligence.plugin_manager import PluginManager
 from notebook_intelligence.claude_sessions import (
     NBI_CONTEXT_PREFIX,
     get_sessions_dir as get_claude_sessions_dir,
@@ -244,6 +245,11 @@ FEATURE_POLICY_SPEC = (
         "NBI_CLAUDE_MCP_MANAGEMENT_POLICY",
         "claude_mcp_management_policy",
     ),
+    (
+        "plugins_management",
+        "NBI_PLUGINS_MANAGEMENT_POLICY",
+        "plugins_management_policy",
+    ),
 )
 FEATURE_POLICY_NAMES = tuple(name for name, _, _ in FEATURE_POLICY_SPEC)
 
@@ -291,6 +297,7 @@ def _build_feature_policies_response(policies: dict, nbi_config) -> dict:
         # The policy resolver still applies force-off / force-on correctly.
         "skills_management": True,
         "claude_mcp_management": True,
+        "plugins_management": True,
     }
 
     response = {}
@@ -336,6 +343,7 @@ class GetCapabilitiesHandler(APIHandler):
     enable_chat_feedback = False
     allow_github_skill_import = True
     additional_skipped_workspace_directories = []
+    allow_github_plugin_import = True
     feature_policies = {}
     string_overrides = {}
 
@@ -424,6 +432,7 @@ class GetCapabilitiesHandler(APIHandler):
             "chat_feedback_enabled": self.enable_chat_feedback,
             "allow_github_skill_import": self.allow_github_skill_import,
             "additional_skipped_workspace_directories": self.additional_skipped_workspace_directories,
+            "allow_github_plugin_import": self.allow_github_plugin_import,
             "cell_output_features": _build_cell_output_features_response(
                 self.feature_policies.get("explain_error", POLICY_USER_CHOICE),
                 self.feature_policies.get("output_followup", POLICY_USER_CHOICE),
@@ -710,26 +719,28 @@ class RulesReloadHandler(APIHandler):
             self.finish(json.dumps({"error": str(e)}))
 
 
-class ClaudeMCPBaseHandler(APIHandler):
-    """Shared helpers + policy gate for Claude-MCP endpoints."""
+class PolicyGatedHandler(APIHandler):
+    """APIHandler that short-circuits with 403 in `prepare()` when the
+    associated admin policy is force-off.
 
-    claude_mcp_management_enabled = True
+    Subclasses set ``policy_enabled_attr`` to the class-attribute name that
+    holds the resolved bool (set in ``_setup_handlers``), and
+    ``policy_disabled_message`` for the user-facing error string.
+    """
+
+    policy_enabled_attr: str = ""
+    policy_disabled_message: str = "This feature is disabled by your administrator"
 
     async def prepare(self):
-        # Mirrors SkillsBaseHandler.prepare — see there for the rationale on
-        # awaiting super() and checking _finished.
+        # APIHandler.prepare is async (xsrf/auth); must await before applying
+        # the policy gate.
         await super().prepare()
         if self._finished:
             return
-        if not self.claude_mcp_management_enabled:
+        attr = self.policy_enabled_attr
+        if attr and not getattr(self, attr, True):
             self.set_status(403)
-            self.finish(
-                json.dumps({"error": "Claude MCP management is disabled by your administrator"})
-            )
-
-    @property
-    def manager(self) -> "ClaudeMCPManager":
-        return ClaudeMCPManager(working_dir=get_jupyter_root_dir() or None)
+            self.finish(json.dumps({"error": self.policy_disabled_message}))
 
     def _parse_json_body(self):
         try:
@@ -738,6 +749,18 @@ class ClaudeMCPBaseHandler(APIHandler):
             self.set_status(400)
             self.finish(json.dumps({"error": f"Invalid JSON: {e}"}))
             return None
+
+
+class ClaudeMCPBaseHandler(PolicyGatedHandler):
+    """Shared helpers + policy gate for Claude-MCP endpoints."""
+
+    claude_mcp_management_enabled = True
+    policy_enabled_attr = "claude_mcp_management_enabled"
+    policy_disabled_message = "Claude MCP management is disabled by your administrator"
+
+    @property
+    def manager(self) -> "ClaudeMCPManager":
+        return ClaudeMCPManager(working_dir=get_jupyter_root_dir() or None)
 
     def _error(self, exc: Exception):
         if isinstance(exc, FileNotFoundError):
@@ -800,23 +823,135 @@ class ClaudeMCPDetailHandler(ClaudeMCPBaseHandler):
             self._error(e)
 
 
-class SkillsBaseHandler(APIHandler):
+class PluginsBaseHandler(PolicyGatedHandler):
+    """Shared helpers + policy gate for plugin endpoints."""
+
+    plugins_management_enabled = True
+    policy_enabled_attr = "plugins_management_enabled"
+    policy_disabled_message = "Plugins management is disabled by your administrator"
+
+    @property
+    def manager(self) -> "PluginManager":
+        return PluginManager()
+
+    def _error(self, exc: Exception):
+        if isinstance(exc, FileNotFoundError):
+            self.set_status(404)
+        elif isinstance(exc, PermissionError):
+            self.set_status(403)
+        elif isinstance(exc, TimeoutError):
+            self.set_status(504)
+        else:
+            self.set_status(400)
+        self.finish(json.dumps({"error": str(exc)}))
+
+
+class PluginsListHandler(PluginsBaseHandler):
+    @tornado.web.authenticated
+    async def get(self):
+        try:
+            plugins = await self.manager.list_plugins()
+        except (FileNotFoundError, TimeoutError, ValueError) as e:
+            self._error(e)
+            return
+        self.finish(json.dumps({"plugins": plugins}))
+
+    @tornado.web.authenticated
+    async def post(self):
+        data = self._parse_json_body()
+        if data is None:
+            return
+        try:
+            await self.manager.install_plugin(
+                plugin=data.get("plugin", ""),
+                scope=data.get("scope", "user"),
+            )
+            self.finish(json.dumps({"success": True}))
+        except (FileNotFoundError, TimeoutError, ValueError) as e:
+            self._error(e)
+
+
+class PluginsDetailHandler(PluginsBaseHandler):
+    @tornado.web.authenticated
+    async def delete(self, scope, plugin):
+        try:
+            await self.manager.uninstall_plugin(plugin=plugin, scope=scope)
+            self.finish(json.dumps({"success": True}))
+        except (FileNotFoundError, TimeoutError, ValueError) as e:
+            self._error(e)
+
+    @tornado.web.authenticated
+    async def post(self, scope, plugin):
+        # Body: {"action": "enable" | "disable"}.
+        data = self._parse_json_body()
+        if data is None:
+            return
+        action = data.get("action")
+        if action not in ("enable", "disable"):
+            self.set_status(400)
+            self.finish(json.dumps({
+                "error": "Missing or invalid 'action' (must be 'enable' or 'disable')"
+            }))
+            return
+        try:
+            await self.manager.set_plugin_enabled(
+                plugin=plugin, enabled=action == "enable", scope=scope
+            )
+            self.finish(json.dumps({"success": True}))
+        except (FileNotFoundError, TimeoutError, ValueError) as e:
+            self._error(e)
+
+
+class PluginsMarketplaceListHandler(PluginsBaseHandler):
+    # Only the marketplace-add path needs the github gate; class-attribute
+    # lives here rather than on the base so unrelated handlers (list,
+    # uninstall, enable/disable) don't carry it.
+    allow_github_plugin_import = True
+
+    @tornado.web.authenticated
+    async def get(self):
+        try:
+            marketplaces = await self.manager.list_marketplaces()
+        except (FileNotFoundError, TimeoutError, ValueError) as e:
+            self._error(e)
+            return
+        self.finish(json.dumps({"marketplaces": marketplaces}))
+
+    @tornado.web.authenticated
+    async def post(self):
+        data = self._parse_json_body()
+        if data is None:
+            return
+        try:
+            await self.manager.add_marketplace(
+                source=data.get("source", ""),
+                scope=data.get("scope", "user"),
+                allow_github=bool(self.allow_github_plugin_import),
+            )
+            self.finish(json.dumps({"success": True}))
+        except PermissionError as e:
+            self._error(e)
+        except (FileNotFoundError, TimeoutError, ValueError) as e:
+            self._error(e)
+
+
+class PluginsMarketplaceDetailHandler(PluginsBaseHandler):
+    @tornado.web.authenticated
+    async def delete(self, name):
+        try:
+            await self.manager.remove_marketplace(name=name)
+            self.finish(json.dumps({"success": True}))
+        except (FileNotFoundError, TimeoutError, ValueError) as e:
+            self._error(e)
+
+
+class SkillsBaseHandler(PolicyGatedHandler):
     """Shared helpers for skills endpoints."""
 
     allow_github_skill_import = True
     skills_management_enabled = True
-
-    async def prepare(self):
-        # APIHandler.prepare is async (xsrf/auth), so we must await it before
-        # applying the skills_management policy gate.
-        await super().prepare()
-        if self._finished:
-            return
-        if not self.skills_management_enabled:
-            self.set_status(403)
-            self.finish(
-                json.dumps({"error": "Skills management is disabled by your administrator"})
-            )
+    policy_enabled_attr = "skills_management_enabled"
+    policy_disabled_message = "Skills management is disabled by your administrator"
 
     @property
     def skill_manager(self):
@@ -2002,6 +2137,35 @@ class NotebookIntelligence(ExtensionApp):
         config=True,
     )
 
+    plugins_management_policy = TraitletEnum(
+        list(VALID_POLICIES),
+        default_value=POLICY_USER_CHOICE,
+        help="""
+        Org-wide policy for the Claude-mode Plugins management tab.
+        "user-choice" (default) and "force-on" both leave the tab visible
+        when Claude mode is on and the Claude CLI is available; the two are
+        behaviorally identical here (no user toggle to override). "force-off"
+        hides the tab and returns 403 from /plugins handlers. Overridden by
+        the NBI_PLUGINS_MANAGEMENT_POLICY env var.
+        """,
+        config=True,
+    )
+
+    allow_github_plugin_import = Bool(
+        default_value=True,
+        help="""
+        Allow adding plugin marketplaces from GitHub (URL or owner/repo
+        shorthand). Set False to hide the "From GitHub" affordance in the
+        plugins panel and reject backend marketplace-add requests whose
+        source string is a GitHub reference. Local-path and arbitrary-URL
+        sources remain available — this is a fine-grained gate paralleling
+        `allow_github_skill_import`. Overridden by the
+        NBI_ALLOW_GITHUB_PLUGIN_IMPORT env var.
+        """,
+        allow_none=True,
+        config=True,
+    )
+
     skills_manifest = Unicode(
         default_value="",
         help="""
@@ -2147,6 +2311,16 @@ class NotebookIntelligence(ExtensionApp):
         route_pattern_claude_mcp_detail = url_path_join(
             base_url, "notebook-intelligence", "claude-mcp", r"(user|project|local)", r"([^/]+)"
         )
+        route_pattern_plugins = url_path_join(base_url, "notebook-intelligence", "plugins")
+        route_pattern_plugins_detail = url_path_join(
+            base_url, "notebook-intelligence", "plugins", r"(user|project|local)", r"([^/]+)"
+        )
+        route_pattern_plugins_marketplace = url_path_join(
+            base_url, "notebook-intelligence", "plugins", "marketplace"
+        )
+        route_pattern_plugins_marketplace_detail = url_path_join(
+            base_url, "notebook-intelligence", "plugins", "marketplace", r"([^/]+)"
+        )
         GetCapabilitiesHandler.disabled_tools = self.disabled_tools
         GetCapabilitiesHandler.allow_enabling_tools_with_env = self.allow_enabling_tools_with_env
         GetCapabilitiesHandler.disabled_providers = self.disabled_providers
@@ -2169,6 +2343,22 @@ class NotebookIntelligence(ExtensionApp):
         ClaudeMCPBaseHandler.claude_mcp_management_enabled = not is_force_off(
             feature_policies, "claude_mcp_management"
         )
+        PluginsBaseHandler.plugins_management_enabled = not is_force_off(
+            feature_policies, "plugins_management"
+        )
+        env_allow_gh_plugin = os.environ.get(
+            "NBI_ALLOW_GITHUB_PLUGIN_IMPORT", ""
+        ).strip().lower()
+        if env_allow_gh_plugin in ("true", "1", "yes", "on"):
+            allow_github_plugin_import = True
+        elif env_allow_gh_plugin in ("false", "0", "no", "off"):
+            allow_github_plugin_import = False
+        else:
+            allow_github_plugin_import = bool(self.allow_github_plugin_import)
+        PluginsMarketplaceListHandler.allow_github_plugin_import = allow_github_plugin_import
+        # Mirror onto GetCapabilitiesHandler so the frontend can hide the
+        # "From GitHub" affordance — both handlers see the same resolved value.
+        GetCapabilitiesHandler.allow_github_plugin_import = allow_github_plugin_import
         self._publish_policies(feature_policies, string_overrides)
         NotebookIntelligence.handlers = [
             (route_pattern_capabilities, GetCapabilitiesHandler),
@@ -2202,6 +2392,12 @@ class NotebookIntelligence(ExtensionApp):
             # shadow specialized URLs added later (parallels the skills order).
             (route_pattern_claude_mcp_detail, ClaudeMCPDetailHandler),
             (route_pattern_claude_mcp, ClaudeMCPListHandler),
+            # Plugin routes: marketplace endpoints before the {scope}/{plugin}
+            # catch-all so the literal "marketplace" segment isn't eaten.
+            (route_pattern_plugins_marketplace_detail, PluginsMarketplaceDetailHandler),
+            (route_pattern_plugins_marketplace, PluginsMarketplaceListHandler),
+            (route_pattern_plugins_detail, PluginsDetailHandler),
+            (route_pattern_plugins, PluginsListHandler),
             (route_pattern_copilot, WebsocketCopilotHandler),
         ]
         web_app.add_handlers(host_pattern, NotebookIntelligence.handlers)

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -144,18 +144,20 @@ def _resolve_supports_vision(ai_service_manager) -> bool:
 
 
 def _resolve_policy_with_env(env_var_name: str, traitlet_value: str) -> str:
-    """Resolve a feature policy: env var wins if valid, else traitlet."""
+    """Resolve a feature policy: env var wins if valid, else traitlet.
+
+    Raises ValueError on unrecognized env values so a typo can't silently
+    relax a force-off gate. Matches the polarity of `_resolve_bool_with_env`.
+    """
     env_value = os.environ.get(env_var_name, "").strip()
-    if env_value:
-        if env_value in VALID_POLICIES:
-            return env_value
-        log.warning(
-            "Ignoring %s=%r: must be one of %s",
-            env_var_name,
-            env_value,
-            ", ".join(VALID_POLICIES),
-        )
-    return traitlet_value
+    if not env_value:
+        return traitlet_value
+    if env_value in VALID_POLICIES:
+        return env_value
+    raise ValueError(
+        f"Invalid {env_var_name}={env_value!r}: "
+        f"must be one of {', '.join(VALID_POLICIES)}"
+    )
 
 
 _TRUE_VALUES = frozenset({"true", "1", "yes", "on"})
@@ -356,7 +358,6 @@ class GetCapabilitiesHandler(APIHandler):
     disabled_providers = []
     allow_enabling_providers_with_env = False
     enable_chat_feedback = False
-    allow_github_skill_import = True
     additional_skipped_workspace_directories = []
     feature_policies = {}
     string_overrides = {}
@@ -444,7 +445,9 @@ class GetCapabilitiesHandler(APIHandler):
             "claude_cli_available": resolve_claude_cli_path() is not None,
             "default_chat_mode": nbi_config.default_chat_mode,
             "chat_feedback_enabled": self.enable_chat_feedback,
-            "allow_github_skill_import": self.allow_github_skill_import,
+            # Single source of truth lives on each domain's base handler so
+            # `_setup_handlers` only writes one site per flag.
+            "allow_github_skill_import": SkillsBaseHandler.allow_github_skill_import,
             "additional_skipped_workspace_directories": self.additional_skipped_workspace_directories,
             "allow_github_plugin_import": PluginsBaseHandler.allow_github_plugin_import,
             "cell_output_features": _build_cell_output_features_response(
@@ -760,6 +763,22 @@ class PolicyGatedHandler(APIHandler):
     policy_enabled_attr: str = ""
     policy_disabled_message: str = "This feature is disabled by your administrator"
 
+    def __init_subclass__(cls, **kwargs):
+        # Force-off must fail closed; a concrete handler that forgets to
+        # declare `policy_enabled_attr` would silently bypass the gate.
+        # Intermediate `*BaseHandler` classes are allowed to defer the
+        # declaration to the concrete subclass; everything else must set it
+        # explicitly (or its MRO must, which getattr below picks up).
+        super().__init_subclass__(**kwargs)
+        if cls.__name__.endswith("BaseHandler"):
+            return
+        if not getattr(cls, "policy_enabled_attr", ""):
+            raise TypeError(
+                f"{cls.__name__} subclasses PolicyGatedHandler but does not "
+                "declare policy_enabled_attr — set it on the class or on an "
+                "intermediate *BaseHandler"
+            )
+
     async def prepare(self):
         # APIHandler.prepare is async (xsrf/auth); must await before applying
         # the policy gate.
@@ -822,7 +841,7 @@ class ClaudeMCPListHandler(ClaudeMCPBaseHandler):
     def get(self):
         try:
             servers = [s.to_dict() for s in self.manager.list_servers()]
-        except Exception as e:
+        except (FileNotFoundError, TimeoutError, ValueError) as e:
             self._error(e)
             return
         self.finish(json.dumps({"servers": servers}))
@@ -883,7 +902,9 @@ class PluginsBaseHandler(PolicyGatedHandler):
 
     @property
     def manager(self) -> "PluginManager":
-        return PluginManager()
+        # Same as ClaudeMCPBaseHandler: scope=project resolves against the
+        # CLI cwd, so the user's Jupyter root must be passed through.
+        return PluginManager(working_dir=get_jupyter_root_dir() or None)
 
 
 class PluginsListHandler(PluginsBaseHandler):
@@ -964,9 +985,7 @@ class PluginsMarketplaceListHandler(PluginsBaseHandler):
                 allow_github=bool(self.allow_github_plugin_import),
             )
             self.finish(json.dumps({"success": True}))
-        except PermissionError as e:
-            self._error(e)
-        except (FileNotFoundError, TimeoutError, ValueError) as e:
+        except (FileNotFoundError, PermissionError, TimeoutError, ValueError) as e:
             self._error(e)
 
 
@@ -2352,11 +2371,9 @@ class NotebookIntelligence(ExtensionApp):
         GetCapabilitiesHandler.disabled_providers = self.disabled_providers
         GetCapabilitiesHandler.allow_enabling_providers_with_env = self.allow_enabling_providers_with_env
         GetCapabilitiesHandler.enable_chat_feedback = self.enable_chat_feedback
-        allow_github_skill_import = _resolve_bool_with_env(
+        SkillsBaseHandler.allow_github_skill_import = _resolve_bool_with_env(
             "NBI_ALLOW_GITHUB_SKILL_IMPORT", self.allow_github_skill_import
         )
-        GetCapabilitiesHandler.allow_github_skill_import = allow_github_skill_import
-        SkillsBaseHandler.allow_github_skill_import = allow_github_skill_import
         GetCapabilitiesHandler.additional_skipped_workspace_directories = (
             _resolve_csv_appended(
                 "NBI_ADDITIONAL_SKIPPED_WORKSPACE_DIRECTORIES",

--- a/notebook_intelligence/feature_flags.py
+++ b/notebook_intelligence/feature_flags.py
@@ -45,6 +45,16 @@ def is_locked(policy: str) -> bool:
     return policy in (POLICY_FORCE_ON, POLICY_FORCE_OFF)
 
 
+def is_force_off(policies: dict, name: str) -> bool:
+    """True iff ``policies[name]`` is force-off (missing == user-choice).
+
+    The canonical predicate for backend kill-switches: a handler-level prepare
+    gate, a reconciler-init guard, etc. all want the same "is this admin-
+    disabled" answer.
+    """
+    return policies.get(name, POLICY_USER_CHOICE) == POLICY_FORCE_OFF
+
+
 def apply_string_overrides(target: dict, overrides: dict, mapping: tuple) -> dict:
     """Apply value-presence-locks per ``mapping`` to a copy of ``target``.
 

--- a/notebook_intelligence/plugin_manager.py
+++ b/notebook_intelligence/plugin_manager.py
@@ -46,9 +46,28 @@ def _reject_flag_smuggling(label: str, value: str) -> None:
         raise ValueError(f"Invalid {label} {value!r}: leading '-' is not permitted")
 
 
+# Flags whose value should never appear in logs. Includes the documented
+# secret-bearing flags from `claude mcp add --help` even though plugin
+# CLIs don't currently use all of them — the cost of a forward-compat
+# entry is negligible vs an accidental leak.
+_SECRET_BEARING_FLAGS = frozenset(
+    [
+        "-e",
+        "--env",
+        "-H",
+        "--header",
+        "--client-secret",
+        "--client-id",
+        "--token",
+        "--password",
+        "--auth",
+        "--bearer",
+    ]
+)
+
+
 def _redact_argv_for_log(argv: list[str]) -> list[str]:
-    """Plugins don't pass secrets via argv today, but use the same redaction
-    shape as `claude_mcp_manager` so future flags additions are safe."""
+    """Drop secret-bearing values for logs. Used by both managers."""
     redacted: list[str] = []
     skip_next = False
     for token in argv:
@@ -57,38 +76,72 @@ def _redact_argv_for_log(argv: list[str]) -> list[str]:
             skip_next = False
             continue
         redacted.append(token)
-        if token in ("-e", "--env", "-H", "--header"):
+        if token in _SECRET_BEARING_FLAGS:
             skip_next = True
     return redacted
+
+
+_GITHUB_URL_SCHEMES = ("http://", "https://", "git://", "ssh://")
+_GITHUB_PREFIX_SCHEMES = ("github:", "git@github.com:")
+_ALLOWED_NON_GITHUB_SCHEMES = ("https://",)
+_LOCAL_PREFIXES = (".", "/", "~")
 
 
 def is_github_marketplace_source(source: str) -> bool:
     """Best-effort detector for sources that resolve via GitHub.
 
-    Matches `github:owner/repo`, `https://github.com/...`, `git@github.com:...`,
-    and `owner/repo[.git][/]` shorthand. Used to gate marketplace-add when
-    an admin sets `allow_github_plugin_import = False`. Lean toward
-    detection (false positives are merely a UX gate; false negatives let
-    GitHub through despite the policy).
+    Matches ``github:owner/repo``, ``https://github.com/...``,
+    ``http://github.com/...``, ``git://github.com/...``,
+    ``ssh://git@github.com/...``, ``git@github.com:owner/repo``, and bare
+    ``owner/repo[.git][/]`` shorthand. Used to gate marketplace-add when
+    an admin sets ``allow_github_plugin_import = False``. Leans toward
+    detection — false positives are a benign UX gate; false negatives
+    bypass the policy.
     """
     s = source.strip()
     if not s:
         return False
     lower = s.lower()
-    if lower.startswith(("github:", "git@github.com:")):
+    if lower.startswith(_GITHUB_PREFIX_SCHEMES):
         return True
-    if lower.startswith(("http://", "https://")):
-        # `hostname` strips port and lowercases, unlike `netloc`.
+    # ssh://git@github.com/owner/repo — `hostname` returns "github.com".
+    if lower.startswith(_GITHUB_URL_SCHEMES):
         host = (urllib.parse.urlparse(s).hostname or "").lower()
         return host == "github.com" or host.endswith(".github.com")
-    # owner/repo shorthand — Claude treats `owner/repo` as a GitHub
-    # reference. Tolerate trailing slash and `.git` suffix; reject anything
-    # path-like or whitespace-bearing.
-    if "/" in s and not s.startswith((".", "/", "~")) and not any(c.isspace() for c in s):
+    # owner/repo shorthand. Tolerate trailing slash and `.git` suffix;
+    # reject anything path-like or whitespace-bearing.
+    if "/" in s and not s.startswith(_LOCAL_PREFIXES) and not any(c.isspace() for c in s):
         stripped = s.rstrip("/")
         if stripped.endswith(".git"):
             stripped = stripped[: -len(".git")]
         return stripped.count("/") == 1
+    return False
+
+
+def is_acceptable_marketplace_source(source: str) -> bool:
+    """Reject ``http://`` URLs and exotic schemes (file://, ftp://, etc.) so
+    marketplace-add can't be aimed at internal-network HTTP endpoints or
+    used for SSRF-style probes. Accepts: ``https://`` URLs, ``github:``,
+    ``git@github.com:``, ``git://github.com/...``, ``ssh://git@github.com/...``,
+    bare ``owner/repo`` shorthand, and local filesystem paths.
+    """
+    s = source.strip()
+    if not s:
+        return False
+    lower = s.lower()
+    if lower.startswith(_GITHUB_PREFIX_SCHEMES):
+        return True
+    if lower.startswith(_LOCAL_PREFIXES):
+        return True
+    if lower.startswith(_ALLOWED_NON_GITHUB_SCHEMES):
+        return True
+    # git:// and ssh:// are accepted only when the host is GitHub; the
+    # detector above already short-circuits the policy gate for these.
+    if lower.startswith(("git://", "ssh://")):
+        return is_github_marketplace_source(s)
+    # Bare scheme-less form (`owner/repo` or `./local/path`).
+    if "://" not in s and ":" not in s.split("/", 1)[0]:
+        return True
     return False
 
 
@@ -172,6 +225,13 @@ class PluginManager:
         if not source:
             raise ValueError("Missing marketplace source")
         _reject_flag_smuggling("source", source)
+        if not is_acceptable_marketplace_source(source):
+            raise ValueError(
+                f"Invalid marketplace source {source!r}: only https://, "
+                "git@github.com:, github:, ssh://git@github.com, "
+                "git://github.com, owner/repo shorthand, and local paths "
+                "are accepted"
+            )
         if not allow_github and is_github_marketplace_source(source):
             raise PermissionError(
                 "Adding marketplaces from GitHub is disabled by your administrator"

--- a/notebook_intelligence/plugin_manager.py
+++ b/notebook_intelligence/plugin_manager.py
@@ -28,15 +28,14 @@ import urllib.parse
 from typing import Any, Literal, Optional
 
 from notebook_intelligence._claude_cli import (
-    redact_argv_for_log as _redact_argv_for_log,
     reject_flag_smuggling,
     run_claude_cli,
+    validate_scope,
 )
 
 log = logging.getLogger(__name__)
 
 PluginScope = Literal["user", "project", "local"]
-VALID_SCOPES: tuple[PluginScope, ...] = ("user", "project", "local")
 
 CLI_TIMEOUT_SECONDS = 60.0
 # Marketplace-add fetches the source over the network (git clone, HTTPS
@@ -132,8 +131,7 @@ class PluginManager:
     async def install_plugin(
         self, *, plugin: str, scope: PluginScope = "user"
     ) -> None:
-        if scope not in VALID_SCOPES:
-            raise ValueError(f"Invalid scope {scope!r}; expected one of {VALID_SCOPES}")
+        validate_scope(scope)
         if not plugin:
             raise ValueError("Missing plugin reference")
         reject_flag_smuggling("plugin", plugin)
@@ -143,8 +141,7 @@ class PluginManager:
     async def uninstall_plugin(
         self, *, plugin: str, scope: PluginScope = "user"
     ) -> None:
-        if scope not in VALID_SCOPES:
-            raise ValueError(f"Invalid scope {scope!r}; expected one of {VALID_SCOPES}")
+        validate_scope(scope)
         if not plugin:
             raise ValueError("Missing plugin reference")
         reject_flag_smuggling("plugin", plugin)
@@ -160,8 +157,7 @@ class PluginManager:
     ) -> None:
         if not plugin:
             raise ValueError("Missing plugin reference")
-        if scope is not None and scope not in VALID_SCOPES:
-            raise ValueError(f"Invalid scope {scope!r}; expected one of {VALID_SCOPES}")
+        validate_scope(scope, allow_none=True)
         reject_flag_smuggling("plugin", plugin)
         tail = ["plugin", "enable" if enabled else "disable"]
         if scope is not None:
@@ -177,8 +173,7 @@ class PluginManager:
         scope: PluginScope = "user",
         allow_github: bool = True,
     ) -> None:
-        if scope not in VALID_SCOPES:
-            raise ValueError(f"Invalid scope {scope!r}; expected one of {VALID_SCOPES}")
+        validate_scope(scope)
         if not source:
             raise ValueError("Missing marketplace source")
         reject_flag_smuggling("source", source)
@@ -210,8 +205,10 @@ class PluginManager:
 
     # Keys we'll walk to find an array of objects when the CLI returns a
     # wrapper shape. Tolerates the documented `{"installed": [...]}` form
-    # and the obvious near-future variants without hard-coding.
-    _LIST_WRAPPER_KEYS = ("installed", "plugins", "marketplaces", "items", "data")
+    # and the obvious near-future variants without being too greedy —
+    # `data` was deliberately excluded because it's generic enough to
+    # match wrong shapes (e.g. metadata envelopes).
+    _LIST_WRAPPER_KEYS = ("installed", "plugins", "marketplaces", "items")
 
     @staticmethod
     def _parse_json_array(out: str, what: str) -> list[dict[str, Any]]:

--- a/notebook_intelligence/plugin_manager.py
+++ b/notebook_intelligence/plugin_manager.py
@@ -131,8 +131,11 @@ class PluginManager:
     # so an instance lock would fail to serialize concurrent CLI writes.
     _write_lock = asyncio.Lock()
 
-    def __init__(self):
-        pass
+    def __init__(self, working_dir: Optional[str] = None):
+        # `claude plugin {install,marketplace add,…} --scope project` resolves
+        # the project against the CLI's cwd, so the working_dir must be the
+        # user's Jupyter root, not the server process's cwd.
+        self._working_dir = working_dir
 
     # --- reads ---------------------------------------------------------
 
@@ -288,5 +291,6 @@ class PluginManager:
             tail,
             timeout=timeout,
             label="claude plugin",
+            cwd=self._working_dir,
             env_overrides=env_overrides,
         )

--- a/notebook_intelligence/plugin_manager.py
+++ b/notebook_intelligence/plugin_manager.py
@@ -32,6 +32,7 @@ from notebook_intelligence._claude_cli import (
     run_claude_cli,
     validate_scope,
 )
+from notebook_intelligence.util import resolve_github_token
 
 log = logging.getLogger(__name__)
 
@@ -47,6 +48,23 @@ _GITHUB_URL_SCHEMES = ("http://", "https://", "git://", "ssh://")
 _GITHUB_PREFIX_SCHEMES = ("github:", "git@github.com:")
 _ALLOWED_NON_GITHUB_SCHEMES = ("https://",)
 _LOCAL_PREFIXES = (".", "/", "~")
+
+# Substrings the underlying `git`/`claude` produce when auth is missing
+# or wrong. Used to upgrade an opaque CLI error into a remediation hint
+# pointing the user at GITHUB_TOKEN / `gh auth login`.
+_AUTH_FAILURE_MARKERS = (
+    "authentication failed",
+    "could not read username",
+    "could not read password",
+    "permission denied",
+    "401",
+    "403",
+)
+
+
+def _looks_like_auth_failure(err: str) -> bool:
+    lower = err.lower()
+    return any(marker in lower for marker in _AUTH_FAILURE_MARKERS)
 
 
 def is_github_marketplace_source(source: str) -> bool:
@@ -188,11 +206,37 @@ class PluginManager:
             raise PermissionError(
                 "Adding marketplaces from GitHub is disabled by your administrator"
             )
+        # Inject a GitHub token when adding a GitHub-source marketplace so
+        # private repos and corporate-managed GitHub work without asking
+        # the user to set process-level env. Resolution chain matches the
+        # Skills GitHub-import flow: GITHUB_TOKEN → GH_TOKEN → `gh auth
+        # token`. The token never lands in argv (env-only), so DEBUG logs
+        # don't leak it.
+        env_overrides: Optional[dict[str, str]] = None
+        is_github = is_github_marketplace_source(source)
+        if is_github:
+            token = resolve_github_token()
+            if token:
+                env_overrides = {"GITHUB_TOKEN": token, "GH_TOKEN": token}
         async with self._write_lock:
-            await self._run_cli(
-                ["plugin", "marketplace", "add", "--scope", scope, source],
-                timeout=CLI_TIMEOUT_MARKETPLACE_ADD_SECONDS,
-            )
+            try:
+                await self._run_cli(
+                    ["plugin", "marketplace", "add", "--scope", scope, source],
+                    timeout=CLI_TIMEOUT_MARKETPLACE_ADD_SECONDS,
+                    env_overrides=env_overrides,
+                )
+            except ValueError as exc:
+                # Claude/git's auth-failure messages are opaque to a
+                # browser user. When we know the source is GitHub and we
+                # didn't have a token to inject, prepend a remediation
+                # hint so the panel error tells them what to fix.
+                if is_github and env_overrides is None and _looks_like_auth_failure(str(exc)):
+                    raise ValueError(
+                        f"{exc}\n\nNo GitHub token was available — set "
+                        "GITHUB_TOKEN or run `gh auth login` on the "
+                        "Jupyter server, then retry."
+                    ) from exc
+                raise
 
     async def remove_marketplace(self, *, name: str) -> None:
         if not name:
@@ -234,6 +278,15 @@ class PluginManager:
         )
 
     async def _run_cli(
-        self, tail: list[str], *, timeout: float = CLI_TIMEOUT_SECONDS
+        self,
+        tail: list[str],
+        *,
+        timeout: float = CLI_TIMEOUT_SECONDS,
+        env_overrides: Optional[dict[str, str]] = None,
     ) -> str:
-        return await run_claude_cli(tail, timeout=timeout, label="claude plugin")
+        return await run_claude_cli(
+            tail,
+            timeout=timeout,
+            label="claude plugin",
+            env_overrides=env_overrides,
+        )

--- a/notebook_intelligence/plugin_manager.py
+++ b/notebook_intelligence/plugin_manager.py
@@ -1,0 +1,262 @@
+# Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+"""Wrapper around Claude Code's `claude plugin` CLI.
+
+Plugin state is owned by Claude Code itself (under `~/.claude/plugins/`).
+NBI shells out for both reads and writes:
+
+  - `claude plugin list --json` → JSON array of installed plugins
+  - `claude plugin marketplace list --json` → JSON array of marketplaces
+  - `claude plugin install <plugin>[@marketplace] -s <scope>`
+  - `claude plugin uninstall <plugin> -s <scope> -y`  (-y for non-TTY)
+  - `claude plugin enable <plugin> [-s scope]`
+  - `claude plugin disable <plugin> [-s scope]`
+  - `claude plugin marketplace add <source> [--scope <scope>]`
+  - `claude plugin marketplace remove <name>`
+
+The CLI's JSON-output schema is not formally documented; the manager
+forwards parsed objects to the frontend mostly untouched so newer Claude
+releases that add fields don't get truncated.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import urllib.parse
+from typing import Any, Literal, Optional
+
+from notebook_intelligence.util import resolve_claude_cli_path
+
+log = logging.getLogger(__name__)
+
+PluginScope = Literal["user", "project", "local"]
+VALID_SCOPES: tuple[PluginScope, ...] = ("user", "project", "local")
+
+CLI_TIMEOUT_SECONDS = 60.0
+# Marketplace-add fetches the source over the network (git clone, HTTPS
+# manifest pull) so it can outlast the default budget on slow links.
+CLI_TIMEOUT_MARKETPLACE_ADD_SECONDS = 120.0
+
+# Plugin / command / source values must not start with `-` so they can't be
+# parsed as flags through their position in argv.
+def _reject_flag_smuggling(label: str, value: str) -> None:
+    if value.startswith("-"):
+        raise ValueError(f"Invalid {label} {value!r}: leading '-' is not permitted")
+
+
+def _redact_argv_for_log(argv: list[str]) -> list[str]:
+    """Plugins don't pass secrets via argv today, but use the same redaction
+    shape as `claude_mcp_manager` so future flags additions are safe."""
+    redacted: list[str] = []
+    skip_next = False
+    for token in argv:
+        if skip_next:
+            redacted.append("<redacted>")
+            skip_next = False
+            continue
+        redacted.append(token)
+        if token in ("-e", "--env", "-H", "--header"):
+            skip_next = True
+    return redacted
+
+
+def is_github_marketplace_source(source: str) -> bool:
+    """Best-effort detector for sources that resolve via GitHub.
+
+    Matches `github:owner/repo`, `https://github.com/...`, `git@github.com:...`,
+    and `owner/repo[.git][/]` shorthand. Used to gate marketplace-add when
+    an admin sets `allow_github_plugin_import = False`. Lean toward
+    detection (false positives are merely a UX gate; false negatives let
+    GitHub through despite the policy).
+    """
+    s = source.strip()
+    if not s:
+        return False
+    lower = s.lower()
+    if lower.startswith(("github:", "git@github.com:")):
+        return True
+    if lower.startswith(("http://", "https://")):
+        # `hostname` strips port and lowercases, unlike `netloc`.
+        host = (urllib.parse.urlparse(s).hostname or "").lower()
+        return host == "github.com" or host.endswith(".github.com")
+    # owner/repo shorthand — Claude treats `owner/repo` as a GitHub
+    # reference. Tolerate trailing slash and `.git` suffix; reject anything
+    # path-like or whitespace-bearing.
+    if "/" in s and not s.startswith((".", "/", "~")) and not any(c.isspace() for c in s):
+        stripped = s.rstrip("/")
+        if stripped.endswith(".git"):
+            stripped = stripped[: -len(".git")]
+        return stripped.count("/") == 1
+    return False
+
+
+class PluginManager:
+    # Class-level so the lock is shared across all PluginManager instances
+    # within this process. Handlers construct a fresh manager per request,
+    # so an instance lock would fail to serialize concurrent CLI writes.
+    _write_lock = asyncio.Lock()
+
+    def __init__(self):
+        pass
+
+    # --- reads ---------------------------------------------------------
+
+    async def list_plugins(self) -> list[dict[str, Any]]:
+        out = await self._run_cli(self._cli_argv(["plugin", "list", "--json"]))
+        return self._parse_json_array(out, "plugin list")
+
+    async def list_marketplaces(self) -> list[dict[str, Any]]:
+        out = await self._run_cli(
+            self._cli_argv(["plugin", "marketplace", "list", "--json"])
+        )
+        return self._parse_json_array(out, "plugin marketplace list")
+
+    # --- writes (CLI shell-outs) ---------------------------------------
+
+    async def install_plugin(
+        self, *, plugin: str, scope: PluginScope = "user"
+    ) -> None:
+        if scope not in VALID_SCOPES:
+            raise ValueError(f"Invalid scope {scope!r}; expected one of {VALID_SCOPES}")
+        if not plugin:
+            raise ValueError("Missing plugin reference")
+        _reject_flag_smuggling("plugin", plugin)
+        async with self._write_lock:
+            await self._run_cli(
+                self._cli_argv(["plugin", "install", "--scope", scope, plugin])
+            )
+
+    async def uninstall_plugin(
+        self, *, plugin: str, scope: PluginScope = "user"
+    ) -> None:
+        if scope not in VALID_SCOPES:
+            raise ValueError(f"Invalid scope {scope!r}; expected one of {VALID_SCOPES}")
+        if not plugin:
+            raise ValueError("Missing plugin reference")
+        _reject_flag_smuggling("plugin", plugin)
+        async with self._write_lock:
+            # `-y` skips the prune-confirmation prompt that the CLI requires
+            # when stdin isn't a TTY (we're explicitly closing stdin).
+            await self._run_cli(
+                self._cli_argv(
+                    ["plugin", "uninstall", "--scope", scope, "-y", plugin]
+                )
+            )
+
+    async def set_plugin_enabled(
+        self, *, plugin: str, enabled: bool, scope: Optional[PluginScope] = None
+    ) -> None:
+        if not plugin:
+            raise ValueError("Missing plugin reference")
+        if scope is not None and scope not in VALID_SCOPES:
+            raise ValueError(f"Invalid scope {scope!r}; expected one of {VALID_SCOPES}")
+        _reject_flag_smuggling("plugin", plugin)
+        argv = ["plugin", "enable" if enabled else "disable"]
+        if scope is not None:
+            argv.extend(["--scope", scope])
+        argv.append(plugin)
+        async with self._write_lock:
+            await self._run_cli(self._cli_argv(argv))
+
+    async def add_marketplace(
+        self,
+        *,
+        source: str,
+        scope: PluginScope = "user",
+        allow_github: bool = True,
+    ) -> None:
+        if scope not in VALID_SCOPES:
+            raise ValueError(f"Invalid scope {scope!r}; expected one of {VALID_SCOPES}")
+        if not source:
+            raise ValueError("Missing marketplace source")
+        _reject_flag_smuggling("source", source)
+        if not allow_github and is_github_marketplace_source(source):
+            raise PermissionError(
+                "Adding marketplaces from GitHub is disabled by your administrator"
+            )
+        async with self._write_lock:
+            await self._run_cli(
+                self._cli_argv(
+                    ["plugin", "marketplace", "add", "--scope", scope, source]
+                ),
+                timeout=CLI_TIMEOUT_MARKETPLACE_ADD_SECONDS,
+            )
+
+    async def remove_marketplace(self, *, name: str) -> None:
+        if not name:
+            raise ValueError("Missing marketplace name")
+        _reject_flag_smuggling("name", name)
+        async with self._write_lock:
+            await self._run_cli(
+                self._cli_argv(["plugin", "marketplace", "remove", name])
+            )
+
+    # --- internals -----------------------------------------------------
+
+    def _cli_argv(self, tail: list[str]) -> list[str]:
+        cli = resolve_claude_cli_path()
+        if not cli:
+            raise FileNotFoundError(
+                "Claude Code CLI not found on PATH (set NBI_CLAUDE_CLI_PATH or install `claude`)"
+            )
+        return [cli, *tail]
+
+    # Keys we'll walk to find an array of objects when the CLI returns a
+    # wrapper shape. Tolerates the documented `{"installed": [...]}` form
+    # and the obvious near-future variants without hard-coding.
+    _LIST_WRAPPER_KEYS = ("installed", "plugins", "marketplaces", "items", "data")
+
+    @staticmethod
+    def _parse_json_array(out: str, what: str) -> list[dict[str, Any]]:
+        text = out.strip()
+        if not text:
+            return []
+        try:
+            doc = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Could not parse {what} JSON output: {exc}") from exc
+        if isinstance(doc, list):
+            return [d for d in doc if isinstance(d, dict)]
+        if isinstance(doc, dict):
+            for key in PluginManager._LIST_WRAPPER_KEYS:
+                value = doc.get(key)
+                if isinstance(value, list):
+                    return [d for d in value if isinstance(d, dict)]
+        # The CLI returned a non-empty doc we couldn't recognize. Surfacing
+        # an error beats returning `[]` and rendering "no plugins installed"
+        # — that would silently mask a CLI version skew.
+        raise ValueError(
+            f"Unrecognized JSON shape from {what}; the Claude CLI may have rev'd"
+        )
+
+    async def _run_cli(
+        self, argv: list[str], *, timeout: float = CLI_TIMEOUT_SECONDS
+    ) -> str:
+        log.info(
+            "claude plugin invocation: %s",
+            " ".join(_redact_argv_for_log(argv[1:])),
+        )
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=timeout
+            )
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            raise TimeoutError(
+                f"`claude plugin` timed out after {timeout}s"
+            )
+        out = stdout.decode("utf-8", errors="replace")
+        err = stderr.decode("utf-8", errors="replace")
+        if proc.returncode != 0:
+            msg = (err or out).strip() or f"claude plugin failed (exit {proc.returncode})"
+            raise ValueError(msg)
+        return out

--- a/notebook_intelligence/plugin_manager.py
+++ b/notebook_intelligence/plugin_manager.py
@@ -27,7 +27,11 @@ import logging
 import urllib.parse
 from typing import Any, Literal, Optional
 
-from notebook_intelligence.util import resolve_claude_cli_path
+from notebook_intelligence._claude_cli import (
+    redact_argv_for_log as _redact_argv_for_log,
+    reject_flag_smuggling,
+    run_claude_cli,
+)
 
 log = logging.getLogger(__name__)
 
@@ -38,47 +42,6 @@ CLI_TIMEOUT_SECONDS = 60.0
 # Marketplace-add fetches the source over the network (git clone, HTTPS
 # manifest pull) so it can outlast the default budget on slow links.
 CLI_TIMEOUT_MARKETPLACE_ADD_SECONDS = 120.0
-
-# Plugin / command / source values must not start with `-` so they can't be
-# parsed as flags through their position in argv.
-def _reject_flag_smuggling(label: str, value: str) -> None:
-    if value.startswith("-"):
-        raise ValueError(f"Invalid {label} {value!r}: leading '-' is not permitted")
-
-
-# Flags whose value should never appear in logs. Includes the documented
-# secret-bearing flags from `claude mcp add --help` even though plugin
-# CLIs don't currently use all of them — the cost of a forward-compat
-# entry is negligible vs an accidental leak.
-_SECRET_BEARING_FLAGS = frozenset(
-    [
-        "-e",
-        "--env",
-        "-H",
-        "--header",
-        "--client-secret",
-        "--client-id",
-        "--token",
-        "--password",
-        "--auth",
-        "--bearer",
-    ]
-)
-
-
-def _redact_argv_for_log(argv: list[str]) -> list[str]:
-    """Drop secret-bearing values for logs. Used by both managers."""
-    redacted: list[str] = []
-    skip_next = False
-    for token in argv:
-        if skip_next:
-            redacted.append("<redacted>")
-            skip_next = False
-            continue
-        redacted.append(token)
-        if token in _SECRET_BEARING_FLAGS:
-            skip_next = True
-    return redacted
 
 
 _GITHUB_URL_SCHEMES = ("http://", "https://", "git://", "ssh://")
@@ -157,13 +120,11 @@ class PluginManager:
     # --- reads ---------------------------------------------------------
 
     async def list_plugins(self) -> list[dict[str, Any]]:
-        out = await self._run_cli(self._cli_argv(["plugin", "list", "--json"]))
+        out = await self._run_cli(["plugin", "list", "--json"])
         return self._parse_json_array(out, "plugin list")
 
     async def list_marketplaces(self) -> list[dict[str, Any]]:
-        out = await self._run_cli(
-            self._cli_argv(["plugin", "marketplace", "list", "--json"])
-        )
+        out = await self._run_cli(["plugin", "marketplace", "list", "--json"])
         return self._parse_json_array(out, "plugin marketplace list")
 
     # --- writes (CLI shell-outs) ---------------------------------------
@@ -175,11 +136,9 @@ class PluginManager:
             raise ValueError(f"Invalid scope {scope!r}; expected one of {VALID_SCOPES}")
         if not plugin:
             raise ValueError("Missing plugin reference")
-        _reject_flag_smuggling("plugin", plugin)
+        reject_flag_smuggling("plugin", plugin)
         async with self._write_lock:
-            await self._run_cli(
-                self._cli_argv(["plugin", "install", "--scope", scope, plugin])
-            )
+            await self._run_cli(["plugin", "install", "--scope", scope, plugin])
 
     async def uninstall_plugin(
         self, *, plugin: str, scope: PluginScope = "user"
@@ -188,14 +147,12 @@ class PluginManager:
             raise ValueError(f"Invalid scope {scope!r}; expected one of {VALID_SCOPES}")
         if not plugin:
             raise ValueError("Missing plugin reference")
-        _reject_flag_smuggling("plugin", plugin)
+        reject_flag_smuggling("plugin", plugin)
         async with self._write_lock:
             # `-y` skips the prune-confirmation prompt that the CLI requires
             # when stdin isn't a TTY (we're explicitly closing stdin).
             await self._run_cli(
-                self._cli_argv(
-                    ["plugin", "uninstall", "--scope", scope, "-y", plugin]
-                )
+                ["plugin", "uninstall", "--scope", scope, "-y", plugin]
             )
 
     async def set_plugin_enabled(
@@ -205,13 +162,13 @@ class PluginManager:
             raise ValueError("Missing plugin reference")
         if scope is not None and scope not in VALID_SCOPES:
             raise ValueError(f"Invalid scope {scope!r}; expected one of {VALID_SCOPES}")
-        _reject_flag_smuggling("plugin", plugin)
-        argv = ["plugin", "enable" if enabled else "disable"]
+        reject_flag_smuggling("plugin", plugin)
+        tail = ["plugin", "enable" if enabled else "disable"]
         if scope is not None:
-            argv.extend(["--scope", scope])
-        argv.append(plugin)
+            tail.extend(["--scope", scope])
+        tail.append(plugin)
         async with self._write_lock:
-            await self._run_cli(self._cli_argv(argv))
+            await self._run_cli(tail)
 
     async def add_marketplace(
         self,
@@ -224,7 +181,7 @@ class PluginManager:
             raise ValueError(f"Invalid scope {scope!r}; expected one of {VALID_SCOPES}")
         if not source:
             raise ValueError("Missing marketplace source")
-        _reject_flag_smuggling("source", source)
+        reject_flag_smuggling("source", source)
         if not is_acceptable_marketplace_source(source):
             raise ValueError(
                 f"Invalid marketplace source {source!r}: only https://, "
@@ -238,30 +195,18 @@ class PluginManager:
             )
         async with self._write_lock:
             await self._run_cli(
-                self._cli_argv(
-                    ["plugin", "marketplace", "add", "--scope", scope, source]
-                ),
+                ["plugin", "marketplace", "add", "--scope", scope, source],
                 timeout=CLI_TIMEOUT_MARKETPLACE_ADD_SECONDS,
             )
 
     async def remove_marketplace(self, *, name: str) -> None:
         if not name:
             raise ValueError("Missing marketplace name")
-        _reject_flag_smuggling("name", name)
+        reject_flag_smuggling("name", name)
         async with self._write_lock:
-            await self._run_cli(
-                self._cli_argv(["plugin", "marketplace", "remove", name])
-            )
+            await self._run_cli(["plugin", "marketplace", "remove", name])
 
     # --- internals -----------------------------------------------------
-
-    def _cli_argv(self, tail: list[str]) -> list[str]:
-        cli = resolve_claude_cli_path()
-        if not cli:
-            raise FileNotFoundError(
-                "Claude Code CLI not found on PATH (set NBI_CLAUDE_CLI_PATH or install `claude`)"
-            )
-        return [cli, *tail]
 
     # Keys we'll walk to find an array of objects when the CLI returns a
     # wrapper shape. Tolerates the documented `{"installed": [...]}` form
@@ -292,31 +237,6 @@ class PluginManager:
         )
 
     async def _run_cli(
-        self, argv: list[str], *, timeout: float = CLI_TIMEOUT_SECONDS
+        self, tail: list[str], *, timeout: float = CLI_TIMEOUT_SECONDS
     ) -> str:
-        log.info(
-            "claude plugin invocation: %s",
-            " ".join(_redact_argv_for_log(argv[1:])),
-        )
-        proc = await asyncio.create_subprocess_exec(
-            *argv,
-            stdin=asyncio.subprocess.DEVNULL,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        try:
-            stdout, stderr = await asyncio.wait_for(
-                proc.communicate(), timeout=timeout
-            )
-        except asyncio.TimeoutError:
-            proc.kill()
-            await proc.wait()
-            raise TimeoutError(
-                f"`claude plugin` timed out after {timeout}s"
-            )
-        out = stdout.decode("utf-8", errors="replace")
-        err = stderr.decode("utf-8", errors="replace")
-        if proc.returncode != 0:
-            msg = (err or out).strip() or f"claude plugin failed (exit {proc.returncode})"
-            raise ValueError(msg)
-        return out
+        return await run_claude_cli(tail, timeout=timeout, label="claude plugin")

--- a/notebook_intelligence/plugin_manager.py
+++ b/notebook_intelligence/plugin_manager.py
@@ -111,7 +111,7 @@ def is_acceptable_marketplace_source(source: str) -> bool:
     lower = s.lower()
     if lower.startswith(_GITHUB_PREFIX_SCHEMES):
         return True
-    if lower.startswith(_LOCAL_PREFIXES):
+    if s.startswith(_LOCAL_PREFIXES):
         return True
     if lower.startswith(_ALLOWED_NON_GITHUB_SCHEMES):
         return True

--- a/notebook_intelligence/skill_github_import.py
+++ b/notebook_intelligence/skill_github_import.py
@@ -30,6 +30,7 @@ from notebook_intelligence.skillset import (
     _parse_frontmatter,
     list_bundle_files,
 )
+from notebook_intelligence.util import resolve_github_token
 
 log = logging.getLogger(__name__)
 
@@ -165,7 +166,6 @@ def _tarball_url(owner: str, repo: str, ref: Optional[str]) -> str:
     return f"https://api.github.com/repos/{owner}/{repo}/tarball/{ref_path}"
 
 
-from notebook_intelligence.util import resolve_github_token  # noqa: E402
 
 
 def _github_api_headers(override_token: Optional[str] = None) -> dict:

--- a/notebook_intelligence/skill_github_import.py
+++ b/notebook_intelligence/skill_github_import.py
@@ -15,7 +15,6 @@ import json
 import logging
 import os
 import re
-import subprocess
 import tarfile
 import tempfile
 import urllib.error
@@ -163,31 +162,7 @@ def _tarball_url(owner: str, repo: str, ref: Optional[str]) -> str:
     return f"https://api.github.com/repos/{owner}/{repo}/tarball/{ref_path}"
 
 
-def _get_github_token() -> Optional[str]:
-    """Look up a GitHub token for API auth.
-
-    Order matches the gh CLI's own precedence: GITHUB_TOKEN, then GH_TOKEN,
-    then whatever `gh auth token` returns. The gh-CLI fallback lets users in
-    corporate/SSO environments inherit their existing login without setting
-    an env var.
-    """
-    for var in ("GITHUB_TOKEN", "GH_TOKEN"):
-        token = os.environ.get(var)
-        if token and token.strip():
-            return token.strip()
-    try:
-        result = subprocess.run(
-            ["gh", "auth", "token"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
-        return None
-    stdout = result.stdout.strip()
-    if result.returncode == 0 and stdout:
-        return stdout
-    return None
+from notebook_intelligence.util import resolve_github_token  # noqa: E402
 
 
 def _github_api_headers(override_token: Optional[str] = None) -> dict:
@@ -203,7 +178,7 @@ def _github_api_headers(override_token: Optional[str] = None) -> dict:
         "Accept": "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
     }
-    token = override_token if override_token is not None else _get_github_token()
+    token = override_token if override_token is not None else resolve_github_token()
     if token:
         headers["Authorization"] = f"Bearer {token}"
     return headers

--- a/notebook_intelligence/skill_github_import.py
+++ b/notebook_intelligence/skill_github_import.py
@@ -153,7 +153,10 @@ def parse_github_url(url: str) -> GitHubRef:
     subpath = ""
     if len(parts) >= 4 and parts[2] in ("tree", "blob"):
         ref = parts[3]
-        subpath = "/".join(parts[4:])
+        sub_parts = parts[4:]
+        if any(p in ("..", "") for p in sub_parts):
+            raise ValueError("Subpath must not contain '..' or empty segments")
+        subpath = "/".join(sub_parts)
     return GitHubRef(owner=owner, repo=repo, ref=ref, subpath=subpath)
 
 

--- a/notebook_intelligence/skill_manifest.py
+++ b/notebook_intelligence/skill_manifest.py
@@ -22,7 +22,7 @@ from typing import List, Optional
 
 import yaml
 
-from notebook_intelligence.skill_github_import import _get_github_token
+from notebook_intelligence.util import resolve_github_token
 from notebook_intelligence.skillset import SKILL_NAME_PATTERN
 
 log = logging.getLogger(__name__)
@@ -175,7 +175,7 @@ def _fetch_url(url: str, *, token: Optional[str]) -> str:
     # just work when the user already has a GitHub login.
     effective_token = token
     if not effective_token and _is_github_host(url):
-        effective_token = _get_github_token()
+        effective_token = resolve_github_token()
     if effective_token:
         headers["Authorization"] = f"Bearer {effective_token}"
     req = urllib.request.Request(url, headers=headers)

--- a/notebook_intelligence/util.py
+++ b/notebook_intelligence/util.py
@@ -2,7 +2,8 @@
 
 import os
 import base64
-from typing import Set
+import shutil
+from typing import Optional, Set
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from cryptography.fernet import Fernet
@@ -18,6 +19,19 @@ def set_jupyter_root_dir(root_dir: str):
 
 def get_jupyter_root_dir() -> str:
     return _jupyter_root_dir
+
+
+def resolve_claude_cli_path() -> Optional[str]:
+    """Resolve the Claude Code CLI binary path.
+
+    NBI_CLAUDE_CLI_PATH wins when set; otherwise fall back to the first
+    `claude` on PATH. Returns None when nothing is found, so callers can
+    decide between raising and proceeding without the CLI.
+    """
+    explicit = os.getenv("NBI_CLAUDE_CLI_PATH")
+    if explicit:
+        return explicit
+    return shutil.which("claude")
 
 def extract_llm_generated_code(code: str) -> str:
     if code.endswith("```"):

--- a/notebook_intelligence/util.py
+++ b/notebook_intelligence/util.py
@@ -22,17 +22,32 @@ def get_jupyter_root_dir() -> str:
     return _jupyter_root_dir
 
 
+_UNSET = object()
+_cached_which_claude: object = _UNSET
+
+
 def resolve_claude_cli_path() -> Optional[str]:
     """Resolve the Claude Code CLI binary path.
 
     NBI_CLAUDE_CLI_PATH wins when set; otherwise fall back to the first
     `claude` on PATH. Returns None when nothing is found, so callers can
     decide between raising and proceeding without the CLI.
+
+    The PATH lookup is memoized — capabilities is hot and PATH doesn't
+    change at runtime. Use ``invalidate_claude_cli_cache`` from tests.
     """
     explicit = os.getenv("NBI_CLAUDE_CLI_PATH")
     if explicit:
         return explicit
-    return shutil.which("claude")
+    global _cached_which_claude
+    if _cached_which_claude is _UNSET:
+        _cached_which_claude = shutil.which("claude")
+    return _cached_which_claude  # type: ignore[return-value]
+
+
+def invalidate_claude_cli_cache() -> None:
+    global _cached_which_claude
+    _cached_which_claude = _UNSET
 
 
 def resolve_github_token() -> Optional[str]:

--- a/notebook_intelligence/util.py
+++ b/notebook_intelligence/util.py
@@ -3,6 +3,7 @@
 import os
 import base64
 import shutil
+import subprocess
 from typing import Optional, Set
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
@@ -32,6 +33,41 @@ def resolve_claude_cli_path() -> Optional[str]:
     if explicit:
         return explicit
     return shutil.which("claude")
+
+
+def resolve_github_token() -> Optional[str]:
+    """Look up a GitHub token for repo / API auth.
+
+    Order matches the gh CLI's own precedence: GITHUB_TOKEN, then GH_TOKEN,
+    then whatever ``gh auth token`` returns. The gh-CLI fallback lets users
+    in corporate/SSO environments inherit their existing login without
+    setting an env var — important when the JupyterLab server is started
+    by JupyterHub / a service manager that doesn't preserve the user's
+    interactive shell environment.
+    """
+    for var in ("GITHUB_TOKEN", "GH_TOKEN"):
+        token = os.environ.get(var)
+        if token and token.strip():
+            return token.strip()
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "token"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    # `gh auth token` should print one line, but defensively take only the
+    # first non-empty line so a malformed install doesn't smuggle extra
+    # bytes into the token.
+    for line in result.stdout.splitlines():
+        token = line.strip()
+        if token:
+            return token
+    return None
 
 def extract_llm_generated_code(code: str) -> str:
     if code.endswith("```"):

--- a/src/api.ts
+++ b/src/api.ts
@@ -164,7 +164,8 @@ export type FeaturePolicyName =
   | 'claude_jupyter_ui_tools'
   | 'claude_setting_source_user'
   | 'claude_setting_source_project'
-  | 'store_github_access_token';
+  | 'store_github_access_token'
+  | 'skills_management';
 
 export type IFeaturePolicies = Record<
   FeaturePolicyName,
@@ -325,7 +326,8 @@ export class NBIConfig {
       'claude_jupyter_ui_tools',
       'claude_setting_source_user',
       'claude_setting_source_project',
-      'store_github_access_token'
+      'store_github_access_token',
+      'skills_management'
     ];
     const result = {} as IFeaturePolicies;
     for (const name of names) {

--- a/src/api.ts
+++ b/src/api.ts
@@ -410,11 +410,25 @@ export class NBIConfig {
       'claude_mcp_management',
       'plugins_management'
     ];
+    // Admin-only management gates (no per-user toggle) default *open* when
+    // missing — a new frontend hitting an older backend without these
+    // capability fields must keep the tab visible. The other policies pair
+    // with a user-toggle and default closed (a missing field means "no
+    // user pref recorded yet, treat as off"), matching prior semantics.
+    const defaultOpen: ReadonlySet<FeaturePolicyName> = new Set([
+      'skills_management',
+      'claude_mcp_management',
+      'plugins_management'
+    ]);
     const result = {} as IFeaturePolicies;
     for (const name of names) {
+      const entry = v[name];
+      const enabled = defaultOpen.has(name)
+        ? entry?.enabled !== false
+        : entry?.enabled === true;
       result[name] = {
-        enabled: v[name]?.enabled === true,
-        locked: v[name]?.locked === true
+        enabled,
+        locked: entry?.locked === true
       };
     }
     return result;

--- a/src/api.ts
+++ b/src/api.ts
@@ -66,6 +66,53 @@ export enum ClaudeToolType {
 
 export type SkillScope = 'user' | 'project';
 
+export type ClaudeMCPScope = 'user' | 'project' | 'local';
+export type ClaudeMCPTransport = 'stdio' | 'sse' | 'http';
+
+export interface IClaudeMCPServer {
+  name: string;
+  scope: ClaudeMCPScope;
+  transport: ClaudeMCPTransport | string;
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+  url: string;
+  headers: Record<string, string>;
+}
+
+export interface IClaudeMCPAddInput {
+  name: string;
+  scope: ClaudeMCPScope;
+  transport: ClaudeMCPTransport;
+  commandOrUrl: string;
+  args?: string[];
+  env?: Record<string, string>;
+  headers?: Record<string, string>;
+}
+
+function claudeMCPServerFromWire(wire: any): IClaudeMCPServer {
+  return {
+    name: String(wire?.name ?? ''),
+    scope: (wire?.scope ?? 'user') as ClaudeMCPScope,
+    transport: String(wire?.transport ?? 'stdio'),
+    command: String(wire?.command ?? ''),
+    args: Array.isArray(wire?.args) ? wire.args.map(String) : [],
+    env:
+      wire?.env && typeof wire.env === 'object'
+        ? Object.fromEntries(
+            Object.entries(wire.env).map(([k, v]) => [String(k), String(v)])
+          )
+        : {},
+    url: String(wire?.url ?? ''),
+    headers:
+      wire?.headers && typeof wire.headers === 'object'
+        ? Object.fromEntries(
+            Object.entries(wire.headers).map(([k, v]) => [String(k), String(v)])
+          )
+        : {}
+  };
+}
+
 export interface ISkillSummary {
   scope: SkillScope;
   name: string;
@@ -165,7 +212,8 @@ export type FeaturePolicyName =
   | 'claude_setting_source_user'
   | 'claude_setting_source_project'
   | 'store_github_access_token'
-  | 'skills_management';
+  | 'skills_management'
+  | 'claude_mcp_management';
 
 export type IFeaturePolicies = Record<
   FeaturePolicyName,
@@ -327,7 +375,8 @@ export class NBIConfig {
       'claude_setting_source_user',
       'claude_setting_source_project',
       'store_github_access_token',
-      'skills_management'
+      'skills_management',
+      'claude_mcp_management'
     ];
     const result = {} as IFeaturePolicies;
     for (const name of names) {
@@ -741,6 +790,47 @@ export class NBIAPI {
       body: JSON.stringify(wire)
     });
     return skillFromWire(data.skill);
+  }
+
+  static async listClaudeMCPServers(): Promise<IClaudeMCPServer[]> {
+    const data = await requestAPI<any>('claude-mcp');
+    return Array.isArray(data?.servers)
+      ? data.servers.map(claudeMCPServerFromWire)
+      : [];
+  }
+
+  static async addClaudeMCPServer(
+    input: IClaudeMCPAddInput
+  ): Promise<IClaudeMCPServer> {
+    const body: any = {
+      name: input.name,
+      scope: input.scope,
+      transport: input.transport,
+      command_or_url: input.commandOrUrl
+    };
+    if (input.args && input.args.length) {
+      body.args = input.args;
+    }
+    if (input.env && Object.keys(input.env).length) {
+      body.env = input.env;
+    }
+    if (input.headers && Object.keys(input.headers).length) {
+      body.headers = input.headers;
+    }
+    const data = await requestAPI<any>('claude-mcp', {
+      method: 'POST',
+      body: JSON.stringify(body)
+    });
+    return claudeMCPServerFromWire(data.server);
+  }
+
+  static async removeClaudeMCPServer(
+    name: string,
+    scope: ClaudeMCPScope
+  ): Promise<void> {
+    await requestAPI<any>(`claude-mcp/${scope}/${encodeURIComponent(name)}`, {
+      method: 'DELETE'
+    });
   }
 
   static async reconcileManagedSkills(): Promise<IReconcileResult> {

--- a/src/api.ts
+++ b/src/api.ts
@@ -237,7 +237,7 @@ export type FeaturePolicyName =
   | 'store_github_access_token'
   | 'skills_management'
   | 'claude_mcp_management'
-  | 'plugins_management';
+  | 'claude_plugins_management';
 
 export type IFeaturePolicies = Record<
   FeaturePolicyName,
@@ -408,7 +408,7 @@ export class NBIConfig {
       'store_github_access_token',
       'skills_management',
       'claude_mcp_management',
-      'plugins_management'
+      'claude_plugins_management'
     ];
     // Admin-only management gates (no per-user toggle) default *open* when
     // missing — a new frontend hitting an older backend without these
@@ -418,7 +418,7 @@ export class NBIConfig {
     const defaultOpen: ReadonlySet<FeaturePolicyName> = new Set([
       'skills_management',
       'claude_mcp_management',
-      'plugins_management'
+      'claude_plugins_management'
     ]);
     const result = {} as IFeaturePolicies;
     for (const name of names) {

--- a/src/api.ts
+++ b/src/api.ts
@@ -423,9 +423,17 @@ export class NBIConfig {
     const result = {} as IFeaturePolicies;
     for (const name of names) {
       const entry = v[name];
-      const enabled = defaultOpen.has(name)
-        ? entry?.enabled !== false
-        : entry?.enabled === true;
+      // Strict polarity: only default-open when the entry is wholly absent
+      // (old backend). A malformed entry (string "false", null, missing
+      // `enabled` field) falls through to closed for default-closed gates
+      // and stays open only when the field is explicitly true for default-open
+      // gates — never silently land in the open bucket.
+      let enabled: boolean;
+      if (entry === undefined) {
+        enabled = defaultOpen.has(name);
+      } else {
+        enabled = entry.enabled === true;
+      }
       result[name] = {
         enabled,
         locked: entry?.locked === true

--- a/src/api.ts
+++ b/src/api.ts
@@ -69,6 +69,29 @@ export type SkillScope = 'user' | 'project';
 export type ClaudeMCPScope = 'user' | 'project' | 'local';
 export type ClaudeMCPTransport = 'stdio' | 'sse' | 'http';
 
+export type PluginScope = 'user' | 'project' | 'local';
+
+// Claude's `claude plugin list --json` output schema isn't formally
+// documented; we forward the raw object and let the panel fish out fields
+// it cares about. Defining only the fields we observe today as optional
+// keeps newer Claude releases from getting truncated.
+export interface IPluginInfo {
+  name?: string;
+  scope?: PluginScope | string;
+  enabled?: boolean;
+  marketplace?: string;
+  version?: string;
+  description?: string;
+  [key: string]: unknown;
+}
+
+export interface IPluginMarketplaceInfo {
+  name?: string;
+  source?: string;
+  scope?: PluginScope | string;
+  [key: string]: unknown;
+}
+
 export interface IClaudeMCPServer {
   name: string;
   scope: ClaudeMCPScope;
@@ -213,7 +236,8 @@ export type FeaturePolicyName =
   | 'claude_setting_source_project'
   | 'store_github_access_token'
   | 'skills_management'
-  | 'claude_mcp_management';
+  | 'claude_mcp_management'
+  | 'plugins_management';
 
 export type IFeaturePolicies = Record<
   FeaturePolicyName,
@@ -344,6 +368,13 @@ export class NBIConfig {
     return Array.isArray(v) ? v : [];
   }
 
+  get allowGithubPluginImport(): boolean {
+    // Default-open: missing/undefined means the org hasn't gated this, so
+    // older backends without the flag continue to allow the GitHub
+    // affordance. Mirrors `cellOutputFeatures` polarity.
+    return this.capabilities.allow_github_plugin_import !== false;
+  }
+
   get cellOutputFeatures(): ICellOutputFeatures {
     const v = this.capabilities.cell_output_features ?? {};
     return {
@@ -376,7 +407,8 @@ export class NBIConfig {
       'claude_setting_source_project',
       'store_github_access_token',
       'skills_management',
-      'claude_mcp_management'
+      'claude_mcp_management',
+      'plugins_management'
     ];
     const result = {} as IFeaturePolicies;
     for (const name of names) {
@@ -829,6 +861,64 @@ export class NBIAPI {
     scope: ClaudeMCPScope
   ): Promise<void> {
     await requestAPI<any>(`claude-mcp/${scope}/${encodeURIComponent(name)}`, {
+      method: 'DELETE'
+    });
+  }
+
+  static async listPlugins(): Promise<IPluginInfo[]> {
+    const data = await requestAPI<any>('plugins');
+    return Array.isArray(data?.plugins) ? (data.plugins as IPluginInfo[]) : [];
+  }
+
+  static async installPlugin(
+    plugin: string,
+    scope: PluginScope = 'user'
+  ): Promise<void> {
+    await requestAPI<any>('plugins', {
+      method: 'POST',
+      body: JSON.stringify({ plugin, scope })
+    });
+  }
+
+  static async uninstallPlugin(
+    plugin: string,
+    scope: PluginScope = 'user'
+  ): Promise<void> {
+    await requestAPI<any>(`plugins/${scope}/${encodeURIComponent(plugin)}`, {
+      method: 'DELETE'
+    });
+  }
+
+  static async setPluginEnabled(
+    plugin: string,
+    scope: PluginScope,
+    enabled: boolean
+  ): Promise<void> {
+    await requestAPI<any>(`plugins/${scope}/${encodeURIComponent(plugin)}`, {
+      method: 'POST',
+      body: JSON.stringify({ action: enabled ? 'enable' : 'disable' })
+    });
+  }
+
+  static async listPluginMarketplaces(): Promise<IPluginMarketplaceInfo[]> {
+    const data = await requestAPI<any>('plugins/marketplace');
+    return Array.isArray(data?.marketplaces)
+      ? (data.marketplaces as IPluginMarketplaceInfo[])
+      : [];
+  }
+
+  static async addPluginMarketplace(
+    source: string,
+    scope: PluginScope = 'user'
+  ): Promise<void> {
+    await requestAPI<any>('plugins/marketplace', {
+      method: 'POST',
+      body: JSON.stringify({ source, scope })
+    });
+  }
+
+  static async removePluginMarketplace(name: string): Promise<void> {
+    await requestAPI<any>(`plugins/marketplace/${encodeURIComponent(name)}`, {
       method: 'DELETE'
     });
   }

--- a/src/components/claude-mcp-panel.tsx
+++ b/src/components/claude-mcp-panel.tsx
@@ -85,7 +85,7 @@ export function SettingsPanelComponentClaudeMCP(_props: any): JSX.Element {
   return (
     <div className="config-dialog-body nbi-skills-panel">
       <div className="nbi-skills-header">
-        <div className="nbi-skills-title">MCP Servers</div>
+        <div className="nbi-skills-title">Claude MCP</div>
         <div className="nbi-skills-header-actions">
           <button
             className="jp-Dialog-button jp-mod-reject jp-mod-styled"
@@ -278,6 +278,12 @@ function ClaudeMCPAddDialog(props: {
         role="dialog"
         aria-modal="true"
         onClick={e => e.stopPropagation()}
+        onKeyDown={e => {
+          if (e.key === 'Escape' && !submitting) {
+            props.onCancel();
+          }
+        }}
+        tabIndex={-1}
       >
         <div className="nbi-modal-title">Add MCP server</div>
         <div className="nbi-modal-body">

--- a/src/components/claude-mcp-panel.tsx
+++ b/src/components/claude-mcp-panel.tsx
@@ -1,0 +1,391 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+import React, { useEffect, useState } from 'react';
+import { Dialog, showDialog } from '@jupyterlab/apputils';
+import {
+  ClaudeMCPScope,
+  ClaudeMCPTransport,
+  IClaudeMCPAddInput,
+  IClaudeMCPServer,
+  NBIAPI
+} from '../api';
+
+const SCOPES: ClaudeMCPScope[] = ['user', 'project', 'local'];
+const TRANSPORTS: ClaudeMCPTransport[] = ['stdio', 'sse', 'http'];
+
+const SCOPE_HINT: Record<ClaudeMCPScope, string> = {
+  user: 'available in all your projects',
+  project: 'shared via the project repo (.mcp.json)',
+  local: 'this project, this user only'
+};
+
+export function SettingsPanelComponentClaudeMCP(_props: any): JSX.Element {
+  const [servers, setServers] = useState<IClaudeMCPServer[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [addOpen, setAddOpen] = useState(false);
+  const [pendingRemoval, setPendingRemoval] = useState<IClaudeMCPServer | null>(
+    null
+  );
+
+  const refresh = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const list = await NBIAPI.listClaudeMCPServers();
+      setServers(list);
+    } catch (e: any) {
+      setError(e?.message ?? String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const handleRemove = async (srv: IClaudeMCPServer) => {
+    const ok = await showDialog({
+      title: 'Remove MCP server?',
+      body: `"${srv.name}" will be removed from Claude's ${srv.scope}-scope config.`,
+      buttons: [Dialog.cancelButton(), Dialog.warnButton({ label: 'Remove' })]
+    });
+    if (!ok.button.accept) {
+      return;
+    }
+    setPendingRemoval(srv);
+    try {
+      await NBIAPI.removeClaudeMCPServer(srv.name, srv.scope);
+      await refresh();
+    } catch (e: any) {
+      setError(`Failed to remove: ${e?.message ?? e}`);
+    } finally {
+      setPendingRemoval(null);
+    }
+  };
+
+  const handleAddSubmit = async (input: IClaudeMCPAddInput) => {
+    // Errors are rendered inside the dialog so they're not hidden behind the
+    // modal backdrop; rethrow so the dialog can keep itself open.
+    await NBIAPI.addClaudeMCPServer(input);
+    setAddOpen(false);
+    await refresh();
+  };
+
+  const grouped: Record<ClaudeMCPScope, IClaudeMCPServer[]> = {
+    user: [],
+    project: [],
+    local: []
+  };
+  for (const srv of servers) {
+    (grouped[srv.scope as ClaudeMCPScope] ?? grouped.user).push(srv);
+  }
+
+  return (
+    <div className="config-dialog-body nbi-skills-panel">
+      <div className="nbi-skills-header">
+        <div className="nbi-skills-title">MCP Servers</div>
+        <div className="nbi-skills-header-actions">
+          <button
+            className="jp-Dialog-button jp-mod-reject jp-mod-styled"
+            onClick={refresh}
+            disabled={loading}
+            title="Re-read Claude's MCP config from disk"
+          >
+            <div className="jp-Dialog-buttonLabel">
+              {loading ? 'Refreshing…' : 'Refresh'}
+            </div>
+          </button>
+          <button
+            className="jp-Dialog-button jp-mod-reject jp-mod-styled"
+            onClick={() => setAddOpen(true)}
+          >
+            <div className="jp-Dialog-buttonLabel">Add server</div>
+          </button>
+        </div>
+      </div>
+
+      <div className="nbi-info-banner" role="note">
+        These are Claude Code's own MCP servers (read from{' '}
+        <code>~/.claude.json</code>, project <code>.mcp.json</code>, and the
+        per-user-per-project block). Independent of the NBI MCP Servers tab.
+      </div>
+
+      {error && (
+        <div className="nbi-skills-error" role="alert">
+          {error}
+        </div>
+      )}
+
+      {SCOPES.map(scope => (
+        <ClaudeMCPScopeSection
+          key={scope}
+          scope={scope}
+          servers={grouped[scope]}
+          loading={loading}
+          pendingRemoval={pendingRemoval}
+          onRemove={handleRemove}
+        />
+      ))}
+
+      {addOpen && (
+        <ClaudeMCPAddDialog
+          onCancel={() => setAddOpen(false)}
+          onSubmit={handleAddSubmit}
+        />
+      )}
+    </div>
+  );
+}
+
+function ClaudeMCPScopeSection(props: {
+  scope: ClaudeMCPScope;
+  servers: IClaudeMCPServer[];
+  loading: boolean;
+  pendingRemoval: IClaudeMCPServer | null;
+  onRemove: (srv: IClaudeMCPServer) => void;
+}) {
+  return (
+    <div className="nbi-skills-section">
+      <div
+        className="nbi-skills-section-caption"
+        title={SCOPE_HINT[props.scope]}
+      >
+        {props.scope.toUpperCase()}
+      </div>
+      {props.servers.length === 0 ? (
+        <div className="nbi-skills-empty">
+          {props.loading ? 'Loading…' : 'No servers in this scope.'}
+        </div>
+      ) : (
+        props.servers.map(srv => (
+          <ClaudeMCPRow
+            key={`${srv.scope}-${srv.name}`}
+            srv={srv}
+            removing={
+              props.pendingRemoval?.name === srv.name &&
+              props.pendingRemoval?.scope === srv.scope
+            }
+            onRemove={() => props.onRemove(srv)}
+          />
+        ))
+      )}
+    </div>
+  );
+}
+
+function ClaudeMCPRow(props: {
+  srv: IClaudeMCPServer;
+  removing: boolean;
+  onRemove: () => void;
+}) {
+  const { srv } = props;
+  const summary =
+    srv.transport === 'stdio'
+      ? [srv.command, ...srv.args].filter(Boolean).join(' ')
+      : srv.url;
+  return (
+    <div className="nbi-skill-row">
+      <div className="nbi-skill-row-main">
+        <div className="nbi-skill-row-name">{srv.name}</div>
+        <div className="nbi-skill-row-description">
+          <code>{srv.transport}</code>
+          {summary && <span> — {summary}</span>}
+        </div>
+      </div>
+      <div className="nbi-skill-row-actions" onClick={e => e.stopPropagation()}>
+        <button
+          className="jp-Dialog-button jp-mod-reject jp-mod-styled"
+          onClick={props.onRemove}
+          disabled={props.removing}
+        >
+          <div className="jp-Dialog-buttonLabel">
+            {props.removing ? 'Removing…' : 'Remove'}
+          </div>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ClaudeMCPAddDialog(props: {
+  onCancel: () => void;
+  onSubmit: (input: IClaudeMCPAddInput) => Promise<void>;
+}) {
+  const [scope, setScope] = useState<ClaudeMCPScope>('user');
+  const [transport, setTransport] = useState<ClaudeMCPTransport>('stdio');
+  const [name, setName] = useState('');
+  const [commandOrUrl, setCommandOrUrl] = useState('');
+  const [argsText, setArgsText] = useState('');
+  const [envText, setEnvText] = useState('');
+  const [headersText, setHeadersText] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const canSubmit = name.trim() && commandOrUrl.trim() && !submitting;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) {
+      return;
+    }
+    const argsList = argsText
+      .split('\n')
+      .map(line => line.trim())
+      .filter(Boolean);
+    const parseKVLines = (
+      text: string,
+      separator: string
+    ): Record<string, string> => {
+      const out: Record<string, string> = {};
+      for (const line of text.split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed) {
+          continue;
+        }
+        const idx = trimmed.indexOf(separator);
+        if (idx > 0) {
+          out[trimmed.slice(0, idx).trim()] = trimmed.slice(idx + 1).trim();
+        }
+      }
+      return out;
+    };
+    const envMap = parseKVLines(envText, '=');
+    const headersMap = parseKVLines(headersText, ':');
+    setSubmitError(null);
+    setSubmitting(true);
+    try {
+      await props.onSubmit({
+        name: name.trim(),
+        scope,
+        transport,
+        commandOrUrl: commandOrUrl.trim(),
+        args: transport === 'stdio' ? argsList : undefined,
+        env: transport === 'stdio' ? envMap : undefined,
+        headers: transport === 'stdio' ? undefined : headersMap
+      });
+    } catch (e: any) {
+      setSubmitError(e?.message ?? String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="nbi-modal-backdrop" onClick={props.onCancel}>
+      <div
+        className="nbi-modal-card"
+        role="dialog"
+        aria-modal="true"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="nbi-modal-title">Add MCP server</div>
+        <div className="nbi-modal-body">
+          <div className="nbi-form-field">
+            <label>Name</label>
+            <input
+              type="text"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              placeholder="my-server"
+              autoFocus
+            />
+          </div>
+          <div className="nbi-form-field">
+            <label>Scope</label>
+            <select
+              value={scope}
+              onChange={e => setScope(e.target.value as ClaudeMCPScope)}
+            >
+              {SCOPES.map(s => (
+                <option key={s} value={s}>
+                  {s} — {SCOPE_HINT[s]}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="nbi-form-field">
+            <label>Transport</label>
+            <select
+              value={transport}
+              onChange={e => setTransport(e.target.value as ClaudeMCPTransport)}
+            >
+              {TRANSPORTS.map(t => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="nbi-form-field">
+            <label>{transport === 'stdio' ? 'Command' : 'URL'}</label>
+            <input
+              type="text"
+              value={commandOrUrl}
+              onChange={e => setCommandOrUrl(e.target.value)}
+              placeholder={
+                transport === 'stdio' ? 'npx' : 'https://example.com/mcp'
+              }
+            />
+          </div>
+          {transport === 'stdio' && (
+            <div className="nbi-form-field">
+              <label>Args (one per line)</label>
+              <textarea
+                rows={3}
+                value={argsText}
+                onChange={e => setArgsText(e.target.value)}
+                placeholder={'-y\n@scope/package@latest'}
+              />
+            </div>
+          )}
+          {transport === 'stdio' && (
+            <div className="nbi-form-field">
+              <label>Environment (KEY=value, one per line)</label>
+              <textarea
+                rows={3}
+                value={envText}
+                onChange={e => setEnvText(e.target.value)}
+                placeholder="API_KEY=…"
+              />
+            </div>
+          )}
+          {transport !== 'stdio' && (
+            <div className="nbi-form-field">
+              <label>Headers (Name: value, one per line)</label>
+              <textarea
+                rows={3}
+                value={headersText}
+                onChange={e => setHeadersText(e.target.value)}
+                placeholder="Authorization: Bearer …"
+              />
+            </div>
+          )}
+          {submitError && (
+            <div className="nbi-skills-error" role="alert">
+              {submitError}
+            </div>
+          )}
+        </div>
+        <div className="nbi-modal-actions">
+          <button
+            className="jp-Dialog-button jp-mod-reject jp-mod-styled"
+            onClick={props.onCancel}
+            disabled={submitting}
+          >
+            <div className="jp-Dialog-buttonLabel">Cancel</div>
+          </button>
+          <button
+            className="jp-Dialog-button jp-mod-accept jp-mod-styled"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+          >
+            <div className="jp-Dialog-buttonLabel">
+              {submitting ? 'Adding…' : 'Add'}
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/claude-mcp-panel.tsx
+++ b/src/components/claude-mcp-panel.tsx
@@ -9,6 +9,7 @@ import {
   IClaudeMCPServer,
   NBIAPI
 } from '../api';
+import { FormDialog } from './form-dialog';
 
 const SCOPES: ClaudeMCPScope[] = ['user', 'project', 'local'];
 const TRANSPORTS: ClaudeMCPTransport[] = ['stdio', 'sse', 'http'];
@@ -272,126 +273,96 @@ function ClaudeMCPAddDialog(props: {
   };
 
   return (
-    <div className="nbi-modal-backdrop" onClick={props.onCancel}>
-      <div
-        className="nbi-modal-card"
-        role="dialog"
-        aria-modal="true"
-        onClick={e => e.stopPropagation()}
-        onKeyDown={e => {
-          if (e.key === 'Escape' && !submitting) {
-            props.onCancel();
-          }
-        }}
-        tabIndex={-1}
-      >
-        <div className="nbi-modal-title">Add MCP server</div>
-        <div className="nbi-modal-body">
-          <div className="nbi-form-field">
-            <label>Name</label>
-            <input
-              type="text"
-              value={name}
-              onChange={e => setName(e.target.value)}
-              placeholder="my-server"
-              autoFocus
-            />
-          </div>
-          <div className="nbi-form-field">
-            <label>Scope</label>
-            <select
-              value={scope}
-              onChange={e => setScope(e.target.value as ClaudeMCPScope)}
-            >
-              {SCOPES.map(s => (
-                <option key={s} value={s}>
-                  {s} — {SCOPE_HINT[s]}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div className="nbi-form-field">
-            <label>Transport</label>
-            <select
-              value={transport}
-              onChange={e => setTransport(e.target.value as ClaudeMCPTransport)}
-            >
-              {TRANSPORTS.map(t => (
-                <option key={t} value={t}>
-                  {t}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div className="nbi-form-field">
-            <label>{transport === 'stdio' ? 'Command' : 'URL'}</label>
-            <input
-              type="text"
-              value={commandOrUrl}
-              onChange={e => setCommandOrUrl(e.target.value)}
-              placeholder={
-                transport === 'stdio' ? 'npx' : 'https://example.com/mcp'
-              }
-            />
-          </div>
-          {transport === 'stdio' && (
-            <div className="nbi-form-field">
-              <label>Args (one per line)</label>
-              <textarea
-                rows={3}
-                value={argsText}
-                onChange={e => setArgsText(e.target.value)}
-                placeholder={'-y\n@scope/package@latest'}
-              />
-            </div>
-          )}
-          {transport === 'stdio' && (
-            <div className="nbi-form-field">
-              <label>Environment (KEY=value, one per line)</label>
-              <textarea
-                rows={3}
-                value={envText}
-                onChange={e => setEnvText(e.target.value)}
-                placeholder="API_KEY=…"
-              />
-            </div>
-          )}
-          {transport !== 'stdio' && (
-            <div className="nbi-form-field">
-              <label>Headers (Name: value, one per line)</label>
-              <textarea
-                rows={3}
-                value={headersText}
-                onChange={e => setHeadersText(e.target.value)}
-                placeholder="Authorization: Bearer …"
-              />
-            </div>
-          )}
-          {submitError && (
-            <div className="nbi-skills-error" role="alert">
-              {submitError}
-            </div>
-          )}
-        </div>
-        <div className="nbi-modal-actions">
-          <button
-            className="jp-Dialog-button jp-mod-reject jp-mod-styled"
-            onClick={props.onCancel}
-            disabled={submitting}
-          >
-            <div className="jp-Dialog-buttonLabel">Cancel</div>
-          </button>
-          <button
-            className="jp-Dialog-button jp-mod-accept jp-mod-styled"
-            onClick={handleSubmit}
-            disabled={!canSubmit}
-          >
-            <div className="jp-Dialog-buttonLabel">
-              {submitting ? 'Adding…' : 'Add'}
-            </div>
-          </button>
-        </div>
+    <FormDialog
+      title="Add MCP server"
+      submitLabel="Add"
+      submitInProgressLabel="Adding…"
+      canSubmit={Boolean(canSubmit)}
+      submitting={submitting}
+      error={submitError}
+      onCancel={props.onCancel}
+      onSubmit={handleSubmit}
+    >
+      <div className="nbi-form-field">
+        <label>Name</label>
+        <input
+          type="text"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          placeholder="my-server"
+          autoFocus
+        />
       </div>
-    </div>
+      <div className="nbi-form-field">
+        <label>Scope</label>
+        <select
+          value={scope}
+          onChange={e => setScope(e.target.value as ClaudeMCPScope)}
+        >
+          {SCOPES.map(s => (
+            <option key={s} value={s}>
+              {s} — {SCOPE_HINT[s]}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="nbi-form-field">
+        <label>Transport</label>
+        <select
+          value={transport}
+          onChange={e => setTransport(e.target.value as ClaudeMCPTransport)}
+        >
+          {TRANSPORTS.map(t => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="nbi-form-field">
+        <label>{transport === 'stdio' ? 'Command' : 'URL'}</label>
+        <input
+          type="text"
+          value={commandOrUrl}
+          onChange={e => setCommandOrUrl(e.target.value)}
+          placeholder={
+            transport === 'stdio' ? 'npx' : 'https://example.com/mcp'
+          }
+        />
+      </div>
+      {transport === 'stdio' && (
+        <div className="nbi-form-field">
+          <label>Args (one per line)</label>
+          <textarea
+            rows={3}
+            value={argsText}
+            onChange={e => setArgsText(e.target.value)}
+            placeholder={'-y\n@scope/package@latest'}
+          />
+        </div>
+      )}
+      {transport === 'stdio' && (
+        <div className="nbi-form-field">
+          <label>Environment (KEY=value, one per line)</label>
+          <textarea
+            rows={3}
+            value={envText}
+            onChange={e => setEnvText(e.target.value)}
+            placeholder="API_KEY=…"
+          />
+        </div>
+      )}
+      {transport !== 'stdio' && (
+        <div className="nbi-form-field">
+          <label>Headers (Name: value, one per line)</label>
+          <textarea
+            rows={3}
+            value={headersText}
+            onChange={e => setHeadersText(e.target.value)}
+            placeholder="Authorization: Bearer …"
+          />
+        </div>
+      )}
+    </FormDialog>
   );
 }

--- a/src/components/form-dialog.tsx
+++ b/src/components/form-dialog.tsx
@@ -22,15 +22,10 @@ export function FormDialog(props: {
   canSubmit: boolean;
   submitting: boolean;
   error?: string | null;
-  primary?: 'accept' | 'reject';
   onCancel: () => void;
   onSubmit: () => void;
   children: ReactNode;
 }): JSX.Element {
-  const primaryClass =
-    props.primary === 'reject'
-      ? 'jp-Dialog-button jp-mod-reject jp-mod-styled'
-      : 'jp-Dialog-button jp-mod-accept jp-mod-styled';
   return (
     <div className="nbi-modal-backdrop" onClick={props.onCancel}>
       <div
@@ -63,7 +58,7 @@ export function FormDialog(props: {
             <div className="jp-Dialog-buttonLabel">Cancel</div>
           </button>
           <button
-            className={primaryClass}
+            className="jp-Dialog-button jp-mod-accept jp-mod-styled"
             onClick={props.onSubmit}
             disabled={!props.canSubmit}
           >

--- a/src/components/form-dialog.tsx
+++ b/src/components/form-dialog.tsx
@@ -1,0 +1,80 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+import React, { ReactNode } from 'react';
+
+/**
+ * Modal-form shell shared by the simple add/install dialogs across the
+ * Claude-MCP and Plugins panels. Owns:
+ *   * backdrop + card layout (cancel-on-backdrop-click)
+ *   * title / body / actions slots
+ *   * Escape-to-cancel keyboard handler
+ *   * inline error rendering when ``error`` is non-null
+ *   * primary button label transitions for the submitting state
+ *
+ * Multi-step flows (e.g. the GitHub-import preview-then-install dialog in
+ * ``skills-panel.tsx``) keep their own shell since fitting them here
+ * would bloat the abstraction.
+ */
+export function FormDialog(props: {
+  title: string;
+  submitLabel: string;
+  submitInProgressLabel?: string;
+  canSubmit: boolean;
+  submitting: boolean;
+  error?: string | null;
+  primary?: 'accept' | 'reject';
+  onCancel: () => void;
+  onSubmit: () => void;
+  children: ReactNode;
+}): JSX.Element {
+  const primaryClass =
+    props.primary === 'reject'
+      ? 'jp-Dialog-button jp-mod-reject jp-mod-styled'
+      : 'jp-Dialog-button jp-mod-accept jp-mod-styled';
+  return (
+    <div className="nbi-modal-backdrop" onClick={props.onCancel}>
+      <div
+        className="nbi-modal-card"
+        role="dialog"
+        aria-modal="true"
+        onClick={e => e.stopPropagation()}
+        onKeyDown={e => {
+          if (e.key === 'Escape' && !props.submitting) {
+            props.onCancel();
+          }
+        }}
+        tabIndex={-1}
+      >
+        <div className="nbi-modal-title">{props.title}</div>
+        <div className="nbi-modal-body">
+          {props.children}
+          {props.error && (
+            <div className="nbi-skills-error" role="alert">
+              {props.error}
+            </div>
+          )}
+        </div>
+        <div className="nbi-modal-actions">
+          <button
+            className="jp-Dialog-button jp-mod-reject jp-mod-styled"
+            onClick={props.onCancel}
+            disabled={props.submitting}
+          >
+            <div className="jp-Dialog-buttonLabel">Cancel</div>
+          </button>
+          <button
+            className={primaryClass}
+            onClick={props.onSubmit}
+            disabled={!props.canSubmit}
+          >
+            <div className="jp-Dialog-buttonLabel">
+              {props.submitting
+                ? (props.submitInProgressLabel ?? `${props.submitLabel}…`)
+                : props.submitLabel}
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/plugins-panel.tsx
+++ b/src/components/plugins-panel.tsx
@@ -172,9 +172,8 @@ export function SettingsPanelComponentPlugins(_props: any): JSX.Element {
       </div>
 
       <div className="nbi-info-banner" role="note">
-        Plugins are managed by the <code>claude</code> CLI; this panel is a thin
-        wrapper. Install / uninstall / enable / disable shell out to{' '}
-        <code>claude plugin</code>.
+        Add a marketplace to discover plugins, then install one to extend Claude
+        Code with new commands, agents, and tool integrations.
       </div>
 
       {error && (
@@ -396,6 +395,12 @@ function PluginInstallDialog(props: {
         role="dialog"
         aria-modal="true"
         onClick={e => e.stopPropagation()}
+        onKeyDown={e => {
+          if (e.key === 'Escape' && !submitting) {
+            props.onCancel();
+          }
+        }}
+        tabIndex={-1}
       >
         <div className="nbi-modal-title">Install plugin</div>
         <div className="nbi-modal-body">
@@ -491,6 +496,12 @@ function MarketplaceAddDialog(props: {
         role="dialog"
         aria-modal="true"
         onClick={e => e.stopPropagation()}
+        onKeyDown={e => {
+          if (e.key === 'Escape' && !submitting) {
+            props.onCancel();
+          }
+        }}
+        tabIndex={-1}
       >
         <div className="nbi-modal-title">Add plugin marketplace</div>
         <div className="nbi-modal-body">

--- a/src/components/plugins-panel.tsx
+++ b/src/components/plugins-panel.tsx
@@ -1,0 +1,557 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+import React, { useEffect, useState } from 'react';
+import { Dialog, showDialog } from '@jupyterlab/apputils';
+import {
+  IPluginInfo,
+  IPluginMarketplaceInfo,
+  NBIAPI,
+  PluginScope
+} from '../api';
+
+const SCOPES: PluginScope[] = ['user', 'project', 'local'];
+const SCOPE_HINT: Record<PluginScope, string> = {
+  user: 'available in all your projects',
+  project: 'shared via the project repo',
+  local: 'this project, this user only'
+};
+
+export function SettingsPanelComponentPlugins(_props: any): JSX.Element {
+  const [plugins, setPlugins] = useState<IPluginInfo[]>([]);
+  const [marketplaces, setMarketplaces] = useState<IPluginMarketplaceInfo[]>(
+    []
+  );
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [installOpen, setInstallOpen] = useState(false);
+  const [marketplaceOpen, setMarketplaceOpen] = useState(false);
+  // Composite key (`scope:name`) so a user-scope plugin and a project-scope
+  // plugin sharing a name don't clobber each other's busy indicators.
+  const [busyPluginKey, setBusyPluginKey] = useState<string | null>(null);
+  const [busyMarketplace, setBusyMarketplace] = useState<string | null>(null);
+  const [allowGithubImport, setAllowGithubImport] = useState(
+    NBIAPI.config.allowGithubPluginImport
+  );
+
+  const refresh = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [p, m] = await Promise.all([
+        NBIAPI.listPlugins(),
+        NBIAPI.listPluginMarketplaces()
+      ]);
+      setPlugins(p);
+      setMarketplaces(m);
+    } catch (e: any) {
+      setError(e?.message ?? String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+    const handler = () => {
+      setAllowGithubImport(NBIAPI.config.allowGithubPluginImport);
+    };
+    NBIAPI.configChanged.connect(handler);
+    return () => {
+      NBIAPI.configChanged.disconnect(handler);
+    };
+  }, []);
+
+  const handleUninstall = async (p: IPluginInfo) => {
+    const name = String(p.name ?? '');
+    const scope = (p.scope as PluginScope) ?? 'user';
+    if (!name) {
+      return;
+    }
+    const ok = await showDialog({
+      title: 'Uninstall plugin?',
+      body: `"${name}" will be removed from Claude's ${scope}-scope config.`,
+      buttons: [
+        Dialog.cancelButton(),
+        Dialog.warnButton({ label: 'Uninstall' })
+      ]
+    });
+    if (!ok.button.accept) {
+      return;
+    }
+    const busyKey = `${scope}:${name}`;
+    setBusyPluginKey(busyKey);
+    try {
+      await NBIAPI.uninstallPlugin(name, scope);
+      await refresh();
+    } catch (e: any) {
+      setError(`Failed to uninstall: ${e?.message ?? e}`);
+    } finally {
+      setBusyPluginKey(null);
+    }
+  };
+
+  const handleToggleEnabled = async (p: IPluginInfo) => {
+    const name = String(p.name ?? '');
+    const scope = (p.scope as PluginScope) ?? 'user';
+    if (!name) {
+      return;
+    }
+    const busyKey = `${scope}:${name}`;
+    setBusyPluginKey(busyKey);
+    try {
+      await NBIAPI.setPluginEnabled(name, scope, !p.enabled);
+      await refresh();
+    } catch (e: any) {
+      setError(`Failed to update: ${e?.message ?? e}`);
+    } finally {
+      setBusyPluginKey(null);
+    }
+  };
+
+  const handleRemoveMarketplace = async (m: IPluginMarketplaceInfo) => {
+    const name = String(m.name ?? '');
+    if (!name) {
+      return;
+    }
+    const ok = await showDialog({
+      title: 'Remove marketplace?',
+      body: `"${name}" will be removed from Claude's plugin marketplaces.`,
+      buttons: [Dialog.cancelButton(), Dialog.warnButton({ label: 'Remove' })]
+    });
+    if (!ok.button.accept) {
+      return;
+    }
+    setBusyMarketplace(name);
+    try {
+      await NBIAPI.removePluginMarketplace(name);
+      await refresh();
+    } catch (e: any) {
+      setError(`Failed to remove: ${e?.message ?? e}`);
+    } finally {
+      setBusyMarketplace(null);
+    }
+  };
+
+  const grouped: Record<PluginScope, IPluginInfo[]> = {
+    user: [],
+    project: [],
+    local: []
+  };
+  for (const p of plugins) {
+    const scope = (p.scope as PluginScope) ?? 'user';
+    (grouped[scope] ?? grouped.user).push(p);
+  }
+
+  return (
+    <div className="config-dialog-body nbi-skills-panel">
+      <div className="nbi-skills-header">
+        <div className="nbi-skills-title">Plugins</div>
+        <div className="nbi-skills-header-actions">
+          <button
+            className="jp-Dialog-button jp-mod-reject jp-mod-styled"
+            onClick={refresh}
+            disabled={loading}
+          >
+            <div className="jp-Dialog-buttonLabel">
+              {loading ? 'Refreshing…' : 'Refresh'}
+            </div>
+          </button>
+          <button
+            className="jp-Dialog-button jp-mod-reject jp-mod-styled"
+            onClick={() => setMarketplaceOpen(true)}
+          >
+            <div className="jp-Dialog-buttonLabel">Add marketplace</div>
+          </button>
+          <button
+            className="jp-Dialog-button jp-mod-accept jp-mod-styled"
+            onClick={() => setInstallOpen(true)}
+          >
+            <div className="jp-Dialog-buttonLabel">Install plugin</div>
+          </button>
+        </div>
+      </div>
+
+      <div className="nbi-info-banner" role="note">
+        Plugins are managed by the <code>claude</code> CLI; this panel is a thin
+        wrapper. Install / uninstall / enable / disable shell out to{' '}
+        <code>claude plugin</code>.
+      </div>
+
+      {error && (
+        <div className="nbi-skills-error" role="alert">
+          {error}
+        </div>
+      )}
+
+      <div className="nbi-skills-section">
+        <div className="nbi-skills-section-caption">MARKETPLACES</div>
+        {marketplaces.length === 0 ? (
+          <div className="nbi-skills-empty">
+            {loading
+              ? 'Loading…'
+              : 'No marketplaces configured. Add one to discover plugins.'}
+          </div>
+        ) : (
+          marketplaces.map((m, i) => (
+            <MarketplaceRow
+              key={String(m.name ?? m.source ?? i)}
+              info={m}
+              busy={busyMarketplace === String(m.name ?? '')}
+              onRemove={() => handleRemoveMarketplace(m)}
+            />
+          ))
+        )}
+      </div>
+
+      {SCOPES.map(scope => (
+        <PluginScopeSection
+          key={scope}
+          scope={scope}
+          plugins={grouped[scope]}
+          loading={loading}
+          busyPluginKey={busyPluginKey}
+          onUninstall={handleUninstall}
+          onToggle={handleToggleEnabled}
+        />
+      ))}
+
+      {installOpen && (
+        <PluginInstallDialog
+          marketplaces={marketplaces}
+          onCancel={() => setInstallOpen(false)}
+          onSubmit={async ({ plugin, scope }) => {
+            await NBIAPI.installPlugin(plugin, scope);
+            setInstallOpen(false);
+            await refresh();
+          }}
+        />
+      )}
+
+      {marketplaceOpen && (
+        <MarketplaceAddDialog
+          allowGithubImport={allowGithubImport}
+          onCancel={() => setMarketplaceOpen(false)}
+          onSubmit={async ({ source, scope }) => {
+            await NBIAPI.addPluginMarketplace(source, scope);
+            setMarketplaceOpen(false);
+            await refresh();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function PluginScopeSection(props: {
+  scope: PluginScope;
+  plugins: IPluginInfo[];
+  loading: boolean;
+  busyPluginKey: string | null;
+  onUninstall: (p: IPluginInfo) => void;
+  onToggle: (p: IPluginInfo) => void;
+}) {
+  return (
+    <div className="nbi-skills-section">
+      <div
+        className="nbi-skills-section-caption"
+        title={SCOPE_HINT[props.scope]}
+      >
+        {props.scope.toUpperCase()}
+      </div>
+      {props.plugins.length === 0 ? (
+        <div className="nbi-skills-empty">
+          {props.loading ? 'Loading…' : 'No plugins in this scope.'}
+        </div>
+      ) : (
+        props.plugins.map(p => {
+          const scope = (p.scope as PluginScope) ?? props.scope;
+          const name = String(p.name ?? '');
+          const rowKey = `${scope}:${name}`;
+          return (
+            <PluginRow
+              key={rowKey}
+              plugin={p}
+              busy={props.busyPluginKey === rowKey}
+              onUninstall={() => props.onUninstall(p)}
+              onToggle={() => props.onToggle(p)}
+            />
+          );
+        })
+      )}
+    </div>
+  );
+}
+
+function PluginRow(props: {
+  plugin: IPluginInfo;
+  busy: boolean;
+  onUninstall: () => void;
+  onToggle: () => void;
+}) {
+  const { plugin } = props;
+  const description = [plugin.version, plugin.marketplace, plugin.description]
+    .filter(Boolean)
+    .map(String)
+    .join(' · ');
+  const enabled = plugin.enabled !== false;
+  return (
+    <div className="nbi-skill-row">
+      <div className="nbi-skill-row-main">
+        <div className="nbi-skill-row-name">
+          {String(plugin.name ?? '(unnamed)')}
+          {!enabled && <span> — disabled</span>}
+        </div>
+        {description && (
+          <div className="nbi-skill-row-description">{description}</div>
+        )}
+      </div>
+      <div className="nbi-skill-row-actions" onClick={e => e.stopPropagation()}>
+        <button
+          className="jp-Dialog-button jp-mod-reject jp-mod-styled"
+          onClick={props.onToggle}
+          disabled={props.busy}
+        >
+          <div className="jp-Dialog-buttonLabel">
+            {enabled ? 'Disable' : 'Enable'}
+          </div>
+        </button>
+        <button
+          className="jp-Dialog-button jp-mod-reject jp-mod-styled"
+          onClick={props.onUninstall}
+          disabled={props.busy}
+        >
+          <div className="jp-Dialog-buttonLabel">
+            {props.busy ? 'Working…' : 'Uninstall'}
+          </div>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function MarketplaceRow(props: {
+  info: IPluginMarketplaceInfo;
+  busy: boolean;
+  onRemove: () => void;
+}) {
+  const { info } = props;
+  return (
+    <div className="nbi-skill-row">
+      <div className="nbi-skill-row-main">
+        <div className="nbi-skill-row-name">
+          {String(info.name ?? '(unnamed)')}
+        </div>
+        {info.source && (
+          <div className="nbi-skill-row-description">
+            <code>{String(info.source)}</code>
+          </div>
+        )}
+      </div>
+      <div className="nbi-skill-row-actions" onClick={e => e.stopPropagation()}>
+        <button
+          className="jp-Dialog-button jp-mod-reject jp-mod-styled"
+          onClick={props.onRemove}
+          disabled={props.busy}
+        >
+          <div className="jp-Dialog-buttonLabel">
+            {props.busy ? 'Removing…' : 'Remove'}
+          </div>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function PluginInstallDialog(props: {
+  marketplaces: IPluginMarketplaceInfo[];
+  onCancel: () => void;
+  onSubmit: (input: { plugin: string; scope: PluginScope }) => Promise<void>;
+}) {
+  const [pluginRef, setPluginRef] = useState('');
+  const [scope, setScope] = useState<PluginScope>('user');
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const canSubmit = pluginRef.trim() && !submitting;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) {
+      return;
+    }
+    setSubmitError(null);
+    setSubmitting(true);
+    try {
+      await props.onSubmit({ plugin: pluginRef.trim(), scope });
+    } catch (e: any) {
+      setSubmitError(e?.message ?? String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="nbi-modal-backdrop" onClick={props.onCancel}>
+      <div
+        className="nbi-modal-card"
+        role="dialog"
+        aria-modal="true"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="nbi-modal-title">Install plugin</div>
+        <div className="nbi-modal-body">
+          <div className="nbi-form-field">
+            <label>Plugin</label>
+            <input
+              type="text"
+              value={pluginRef}
+              onChange={e => setPluginRef(e.target.value)}
+              placeholder="plugin-name or plugin@marketplace"
+              autoFocus
+            />
+          </div>
+          {props.marketplaces.length === 0 && (
+            <div className="nbi-form-hint">
+              No marketplaces are configured. Add one before installing, or
+              specify <code>plugin@marketplace</code> with a known source.
+            </div>
+          )}
+          <div className="nbi-form-field">
+            <label>Scope</label>
+            <select
+              value={scope}
+              onChange={e => setScope(e.target.value as PluginScope)}
+            >
+              {SCOPES.map(s => (
+                <option key={s} value={s}>
+                  {s} — {SCOPE_HINT[s]}
+                </option>
+              ))}
+            </select>
+          </div>
+          {submitError && (
+            <div className="nbi-skills-error" role="alert">
+              {submitError}
+            </div>
+          )}
+        </div>
+        <div className="nbi-modal-actions">
+          <button
+            className="jp-Dialog-button jp-mod-reject jp-mod-styled"
+            onClick={props.onCancel}
+            disabled={submitting}
+          >
+            <div className="jp-Dialog-buttonLabel">Cancel</div>
+          </button>
+          <button
+            className="jp-Dialog-button jp-mod-accept jp-mod-styled"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+          >
+            <div className="jp-Dialog-buttonLabel">
+              {submitting ? 'Installing…' : 'Install'}
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MarketplaceAddDialog(props: {
+  allowGithubImport: boolean;
+  onCancel: () => void;
+  onSubmit: (input: { source: string; scope: PluginScope }) => Promise<void>;
+}) {
+  const [source, setSource] = useState('');
+  const [scope, setScope] = useState<PluginScope>('user');
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const canSubmit = source.trim() && !submitting;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) {
+      return;
+    }
+    setSubmitError(null);
+    setSubmitting(true);
+    try {
+      await props.onSubmit({ source: source.trim(), scope });
+    } catch (e: any) {
+      setSubmitError(e?.message ?? String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="nbi-modal-backdrop" onClick={props.onCancel}>
+      <div
+        className="nbi-modal-card"
+        role="dialog"
+        aria-modal="true"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="nbi-modal-title">Add plugin marketplace</div>
+        <div className="nbi-modal-body">
+          <div className="nbi-form-field">
+            <label>Source</label>
+            <input
+              type="text"
+              value={source}
+              onChange={e => setSource(e.target.value)}
+              placeholder={
+                props.allowGithubImport
+                  ? 'owner/repo, https://github.com/owner/repo, or local path'
+                  : 'https://… or local path'
+              }
+              autoFocus
+            />
+          </div>
+          {!props.allowGithubImport && (
+            <div className="nbi-form-hint">
+              GitHub-sourced marketplaces are disabled by your administrator.
+              Use a non-GitHub URL or a local filesystem path.
+            </div>
+          )}
+          <div className="nbi-form-field">
+            <label>Scope</label>
+            <select
+              value={scope}
+              onChange={e => setScope(e.target.value as PluginScope)}
+            >
+              {SCOPES.map(s => (
+                <option key={s} value={s}>
+                  {s} — {SCOPE_HINT[s]}
+                </option>
+              ))}
+            </select>
+          </div>
+          {submitError && (
+            <div className="nbi-skills-error" role="alert">
+              {submitError}
+            </div>
+          )}
+        </div>
+        <div className="nbi-modal-actions">
+          <button
+            className="jp-Dialog-button jp-mod-reject jp-mod-styled"
+            onClick={props.onCancel}
+            disabled={submitting}
+          >
+            <div className="jp-Dialog-buttonLabel">Cancel</div>
+          </button>
+          <button
+            className="jp-Dialog-button jp-mod-accept jp-mod-styled"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+          >
+            <div className="jp-Dialog-buttonLabel">
+              {submitting ? 'Adding…' : 'Add'}
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/plugins-panel.tsx
+++ b/src/components/plugins-panel.tsx
@@ -8,6 +8,7 @@ import {
   NBIAPI,
   PluginScope
 } from '../api';
+import { FormDialog } from './form-dialog';
 
 const SCOPES: PluginScope[] = ['user', 'project', 'local'];
 const SCOPE_HINT: Record<PluginScope, string> = {
@@ -389,76 +390,46 @@ function PluginInstallDialog(props: {
   };
 
   return (
-    <div className="nbi-modal-backdrop" onClick={props.onCancel}>
-      <div
-        className="nbi-modal-card"
-        role="dialog"
-        aria-modal="true"
-        onClick={e => e.stopPropagation()}
-        onKeyDown={e => {
-          if (e.key === 'Escape' && !submitting) {
-            props.onCancel();
-          }
-        }}
-        tabIndex={-1}
-      >
-        <div className="nbi-modal-title">Install plugin</div>
-        <div className="nbi-modal-body">
-          <div className="nbi-form-field">
-            <label>Plugin</label>
-            <input
-              type="text"
-              value={pluginRef}
-              onChange={e => setPluginRef(e.target.value)}
-              placeholder="plugin-name or plugin@marketplace"
-              autoFocus
-            />
-          </div>
-          {props.marketplaces.length === 0 && (
-            <div className="nbi-form-hint">
-              No marketplaces are configured. Add one before installing, or
-              specify <code>plugin@marketplace</code> with a known source.
-            </div>
-          )}
-          <div className="nbi-form-field">
-            <label>Scope</label>
-            <select
-              value={scope}
-              onChange={e => setScope(e.target.value as PluginScope)}
-            >
-              {SCOPES.map(s => (
-                <option key={s} value={s}>
-                  {s} — {SCOPE_HINT[s]}
-                </option>
-              ))}
-            </select>
-          </div>
-          {submitError && (
-            <div className="nbi-skills-error" role="alert">
-              {submitError}
-            </div>
-          )}
-        </div>
-        <div className="nbi-modal-actions">
-          <button
-            className="jp-Dialog-button jp-mod-reject jp-mod-styled"
-            onClick={props.onCancel}
-            disabled={submitting}
-          >
-            <div className="jp-Dialog-buttonLabel">Cancel</div>
-          </button>
-          <button
-            className="jp-Dialog-button jp-mod-accept jp-mod-styled"
-            onClick={handleSubmit}
-            disabled={!canSubmit}
-          >
-            <div className="jp-Dialog-buttonLabel">
-              {submitting ? 'Installing…' : 'Install'}
-            </div>
-          </button>
-        </div>
+    <FormDialog
+      title="Install plugin"
+      submitLabel="Install"
+      submitInProgressLabel="Installing…"
+      canSubmit={Boolean(canSubmit)}
+      submitting={submitting}
+      error={submitError}
+      onCancel={props.onCancel}
+      onSubmit={handleSubmit}
+    >
+      <div className="nbi-form-field">
+        <label>Plugin</label>
+        <input
+          type="text"
+          value={pluginRef}
+          onChange={e => setPluginRef(e.target.value)}
+          placeholder="plugin-name or plugin@marketplace"
+          autoFocus
+        />
       </div>
-    </div>
+      {props.marketplaces.length === 0 && (
+        <div className="nbi-form-hint">
+          No marketplaces are configured. Add one before installing, or specify{' '}
+          <code>plugin@marketplace</code> with a known source.
+        </div>
+      )}
+      <div className="nbi-form-field">
+        <label>Scope</label>
+        <select
+          value={scope}
+          onChange={e => setScope(e.target.value as PluginScope)}
+        >
+          {SCOPES.map(s => (
+            <option key={s} value={s}>
+              {s} — {SCOPE_HINT[s]}
+            </option>
+          ))}
+        </select>
+      </div>
+    </FormDialog>
   );
 }
 
@@ -490,79 +461,49 @@ function MarketplaceAddDialog(props: {
   };
 
   return (
-    <div className="nbi-modal-backdrop" onClick={props.onCancel}>
-      <div
-        className="nbi-modal-card"
-        role="dialog"
-        aria-modal="true"
-        onClick={e => e.stopPropagation()}
-        onKeyDown={e => {
-          if (e.key === 'Escape' && !submitting) {
-            props.onCancel();
+    <FormDialog
+      title="Add plugin marketplace"
+      submitLabel="Add"
+      submitInProgressLabel="Adding…"
+      canSubmit={Boolean(canSubmit)}
+      submitting={submitting}
+      error={submitError}
+      onCancel={props.onCancel}
+      onSubmit={handleSubmit}
+    >
+      <div className="nbi-form-field">
+        <label>Source</label>
+        <input
+          type="text"
+          value={source}
+          onChange={e => setSource(e.target.value)}
+          placeholder={
+            props.allowGithubImport
+              ? 'owner/repo, https://github.com/owner/repo, or local path'
+              : 'https://… or local path'
           }
-        }}
-        tabIndex={-1}
-      >
-        <div className="nbi-modal-title">Add plugin marketplace</div>
-        <div className="nbi-modal-body">
-          <div className="nbi-form-field">
-            <label>Source</label>
-            <input
-              type="text"
-              value={source}
-              onChange={e => setSource(e.target.value)}
-              placeholder={
-                props.allowGithubImport
-                  ? 'owner/repo, https://github.com/owner/repo, or local path'
-                  : 'https://… or local path'
-              }
-              autoFocus
-            />
-          </div>
-          {!props.allowGithubImport && (
-            <div className="nbi-form-hint">
-              GitHub-sourced marketplaces are disabled by your administrator.
-              Use a non-GitHub URL or a local filesystem path.
-            </div>
-          )}
-          <div className="nbi-form-field">
-            <label>Scope</label>
-            <select
-              value={scope}
-              onChange={e => setScope(e.target.value as PluginScope)}
-            >
-              {SCOPES.map(s => (
-                <option key={s} value={s}>
-                  {s} — {SCOPE_HINT[s]}
-                </option>
-              ))}
-            </select>
-          </div>
-          {submitError && (
-            <div className="nbi-skills-error" role="alert">
-              {submitError}
-            </div>
-          )}
-        </div>
-        <div className="nbi-modal-actions">
-          <button
-            className="jp-Dialog-button jp-mod-reject jp-mod-styled"
-            onClick={props.onCancel}
-            disabled={submitting}
-          >
-            <div className="jp-Dialog-buttonLabel">Cancel</div>
-          </button>
-          <button
-            className="jp-Dialog-button jp-mod-accept jp-mod-styled"
-            onClick={handleSubmit}
-            disabled={!canSubmit}
-          >
-            <div className="jp-Dialog-buttonLabel">
-              {submitting ? 'Adding…' : 'Add'}
-            </div>
-          </button>
-        </div>
+          autoFocus
+        />
       </div>
-    </div>
+      {!props.allowGithubImport && (
+        <div className="nbi-form-hint">
+          GitHub-sourced marketplaces are disabled by your administrator. Use a
+          non-GitHub URL or a local filesystem path.
+        </div>
+      )}
+      <div className="nbi-form-field">
+        <label>Scope</label>
+        <select
+          value={scope}
+          onChange={e => setScope(e.target.value as PluginScope)}
+        >
+          {SCOPES.map(s => (
+            <option key={s} value={s}>
+              {s} — {SCOPE_HINT[s]}
+            </option>
+          ))}
+        </select>
+      </div>
+    </FormDialog>
   );
 }

--- a/src/components/plugins-panel.tsx
+++ b/src/components/plugins-panel.tsx
@@ -485,7 +485,12 @@ function MarketplaceAddDialog(props: {
           autoFocus
         />
       </div>
-      {!props.allowGithubImport && (
+      {props.allowGithubImport ? (
+        <div className="nbi-form-hint">
+          Private GitHub sources work if <code>GITHUB_TOKEN</code> is set or{' '}
+          <code>gh auth login</code> is configured on the Jupyter server.
+        </div>
+      ) : (
         <div className="nbi-form-hint">
           GitHub-sourced marketplaces are disabled by your administrator. Use a
           non-GitHub URL or a local filesystem path.

--- a/src/components/settings-panel.tsx
+++ b/src/components/settings-panel.tsx
@@ -124,6 +124,87 @@ export class SettingsPanel extends ReactWidget {
   private _onEditMCPConfigClicked: () => void;
 }
 
+// Tab declaration. Adding a new tab is one entry here plus an icon
+// (optional). The `visible` predicate runs against {featurePolicies,
+// isInClaudeCodeMode, isClaudeCliAvailable} so policy / mode changes
+// propagate through the registry without wiring extra props.
+type TabSpec = {
+  id: string;
+  label: string;
+  icon?: () => JSX.Element;
+  visible: (ctx: TabVisibilityContext) => boolean;
+  render: (props: any) => JSX.Element;
+};
+type TabVisibilityContext = {
+  featurePolicies: import('../api').IFeaturePolicies;
+  isInClaudeCodeMode: boolean;
+  isClaudeCliAvailable: boolean;
+};
+
+const TABS: TabSpec[] = [
+  {
+    id: 'general',
+    label: 'General',
+    visible: () => true,
+    render: props => (
+      <SettingsPanelComponentGeneral
+        onSave={props.onSave}
+        onEditMCPConfigClicked={props.onEditMCPConfigClicked}
+      />
+    )
+  },
+  {
+    id: 'claude',
+    label: 'Claude',
+    icon: () => (
+      <span
+        className="claude-icon"
+        dangerouslySetInnerHTML={{ __html: claudeSvgStr }}
+      ></span>
+    ),
+    visible: () => true,
+    render: props => (
+      <SettingsPanelComponentClaude
+        onEditMCPConfigClicked={props.onEditMCPConfigClicked}
+      />
+    )
+  },
+  {
+    id: 'mcp-servers',
+    label: 'MCP Servers',
+    visible: ctx => !ctx.isInClaudeCodeMode,
+    render: props => (
+      <SettingsPanelComponentMCPServers
+        onEditMCPConfigClicked={props.onEditMCPConfigClicked}
+      />
+    )
+  },
+  {
+    id: 'claude-mcp',
+    label: 'Claude MCP',
+    visible: ctx =>
+      ctx.featurePolicies.claude_mcp_management.enabled &&
+      ctx.isInClaudeCodeMode &&
+      ctx.isClaudeCliAvailable,
+    render: () => <SettingsPanelComponentClaudeMCP />
+  },
+  {
+    id: 'plugins',
+    label: 'Plugins',
+    visible: ctx =>
+      ctx.featurePolicies.plugins_management.enabled &&
+      ctx.isInClaudeCodeMode &&
+      ctx.isClaudeCliAvailable,
+    render: () => <SettingsPanelComponentPlugins />
+  },
+  {
+    id: 'skills',
+    label: 'Skills',
+    visible: ctx => ctx.featurePolicies.skills_management.enabled,
+    render: () => <SettingsPanelComponentSkills />
+  }
+];
+
 function SettingsPanelComponent(props: any) {
   const [activeTab, setActiveTab] = useState('general');
   const { featurePolicies } = useNbiPolicies();
@@ -145,42 +226,27 @@ function SettingsPanelComponent(props: any) {
     };
   }, []);
 
-  const skillsTabVisible = featurePolicies.skills_management.enabled;
-  const claudeMcpTabVisible =
-    featurePolicies.claude_mcp_management.enabled &&
-    isInClaudeCodeMode &&
-    isClaudeCliAvailable;
-  const pluginsTabVisible =
-    featurePolicies.plugins_management.enabled &&
-    isInClaudeCodeMode &&
-    isClaudeCliAvailable;
-
-  // Bounce the user off a tab that has just been hidden by an admin policy
-  // change so they don't see a blank pane.
-  useEffect(() => {
-    if (!skillsTabVisible && activeTab === 'skills') {
-      setActiveTab('general');
-    }
-    if (!claudeMcpTabVisible && activeTab === 'claude-mcp') {
-      setActiveTab('general');
-    }
-    if (!pluginsTabVisible && activeTab === 'plugins') {
-      setActiveTab('general');
-    }
-  }, [skillsTabVisible, claudeMcpTabVisible, pluginsTabVisible, activeTab]);
-
-  const onTabSelected = (tab: string) => {
-    setActiveTab(tab);
+  const ctx: TabVisibilityContext = {
+    featurePolicies,
+    isInClaudeCodeMode,
+    isClaudeCliAvailable
   };
+  const visibleTabs = TABS.filter(t => t.visible(ctx));
+  const activeTabSpec = visibleTabs.find(t => t.id === activeTab);
+
+  // Bounce off a tab that just disappeared (admin policy flip, mode toggle).
+  useEffect(() => {
+    if (!activeTabSpec) {
+      setActiveTab('general');
+    }
+  }, [activeTabSpec]);
 
   return (
     <div className="nbi-settings-panel">
       <SettingsPanelTabsComponent
-        onTabSelected={onTabSelected}
+        tabs={visibleTabs}
         activeTab={activeTab}
-        skillsTabVisible={skillsTabVisible}
-        claudeMcpTabVisible={claudeMcpTabVisible}
-        pluginsTabVisible={pluginsTabVisible}
+        onTabSelected={setActiveTab}
       />
       <div
         className="nbi-settings-panel-tab-content"
@@ -188,93 +254,21 @@ function SettingsPanelComponent(props: any) {
         id={tabId('nbi-settings-tabpanel', activeTab)}
         aria-labelledby={tabId('nbi-settings-tab', activeTab)}
       >
-        {activeTab === 'general' && (
-          <SettingsPanelComponentGeneral
-            onSave={props.onSave}
-            onEditMCPConfigClicked={props.onEditMCPConfigClicked}
-          />
-        )}
-        {activeTab === 'mcp-servers' && (
-          <SettingsPanelComponentMCPServers
-            onEditMCPConfigClicked={props.onEditMCPConfigClicked}
-          />
-        )}
-        {activeTab === 'claude' && (
-          <SettingsPanelComponentClaude
-            onEditMCPConfigClicked={props.onEditMCPConfigClicked}
-          />
-        )}
-        {activeTab === 'skills' && skillsTabVisible && (
-          <SettingsPanelComponentSkills />
-        )}
-        {activeTab === 'claude-mcp' && claudeMcpTabVisible && (
-          <SettingsPanelComponentClaudeMCP />
-        )}
-        {activeTab === 'plugins' && pluginsTabVisible && (
-          <SettingsPanelComponentPlugins />
-        )}
+        {activeTabSpec && activeTabSpec.render(props)}
       </div>
     </div>
   );
 }
 
-function SettingsPanelTabsComponent(props: any) {
-  // Fully controlled: parent owns `activeTab`. Reading directly from props
-  // (instead of a local mirror) prevents drift when the parent flips the
-  // tab — e.g. when an admin policy hides the active tab and the parent
-  // bounces the user to `general`.
-  const activeTab = props.activeTab;
-  const [isInClaudeCodeMode, setIsInClaudeCodeMode] = useState(
-    NBIAPI.config.isInClaudeCodeMode
-  );
-
-  useEffect(() => {
-    const handler = () => {
-      setIsInClaudeCodeMode(NBIAPI.config.isInClaudeCodeMode);
-    };
-    NBIAPI.configChanged.connect(handler);
-    return () => {
-      NBIAPI.configChanged.disconnect(handler);
-    };
-  }, []);
-
-  const tabs: { id: string; label: React.ReactNode }[] = [
-    { id: 'general', label: 'General' },
-    {
-      id: 'claude',
-      label: (
-        <>
-          <span
-            className="claude-icon"
-            aria-hidden="true"
-            dangerouslySetInnerHTML={{ __html: claudeSvgStr }}
-          ></span>
-          Claude
-        </>
-      )
-    }
-  ];
-  if (!isInClaudeCodeMode) {
-    tabs.push({ id: 'mcp-servers', label: 'MCP Servers' });
-  }
-  if (props.claudeMcpTabVisible) {
-    tabs.push({ id: 'claude-mcp', label: 'Claude MCP' });
-  }
-  if (props.pluginsTabVisible) {
-    tabs.push({ id: 'plugins', label: 'Plugins' });
-  }
-  if (props.skillsTabVisible) {
-    tabs.push({ id: 'skills', label: 'Skills' });
-  }
-
-  const selectTab = (id: string): void => {
-    props.onTabSelected(id);
-  };
-
+function SettingsPanelTabsComponent(props: {
+  tabs: TabSpec[];
+  activeTab: string;
+  onTabSelected: (tab: string) => void;
+}) {
   const onKeyDown = useTablistArrowKeys(
-    tabs,
-    activeTab,
-    selectTab,
+    props.tabs,
+    props.activeTab,
+    props.onTabSelected,
     'vertical',
     id => tabId('nbi-settings-tab', id)
   );
@@ -287,8 +281,8 @@ function SettingsPanelTabsComponent(props: any) {
       aria-label="Settings sections"
       onKeyDown={onKeyDown}
     >
-      {tabs.map(tab => {
-        const selected = activeTab === tab.id;
+      {props.tabs.map(tab => {
+        const selected = tab.id === props.activeTab;
         return (
           <button
             type="button"
@@ -299,8 +293,9 @@ function SettingsPanelTabsComponent(props: any) {
             aria-selected={selected}
             aria-controls={tabId('nbi-settings-tabpanel', tab.id)}
             tabIndex={selected ? 0 : -1}
-            onClick={() => selectTab(tab.id)}
+            onClick={() => props.onTabSelected(tab.id)}
           >
+            {tab.icon && tab.icon()}
             {tab.label}
           </button>
         );

--- a/src/components/settings-panel.tsx
+++ b/src/components/settings-panel.tsx
@@ -18,6 +18,7 @@ import { CheckBoxItem } from './checkbox';
 import { PillItem } from './pill';
 import { mcpServerSettingsToEnabledState } from './mcp-util';
 import { SettingsPanelComponentSkills } from './skills-panel';
+import { SettingsPanelComponentClaudeMCP } from './claude-mcp-panel';
 import { writeTextToClipboard } from '../utils';
 
 const lockedTip = (locked: boolean): string =>
@@ -125,7 +126,29 @@ export class SettingsPanel extends ReactWidget {
 function SettingsPanelComponent(props: any) {
   const [activeTab, setActiveTab] = useState('general');
   const { featurePolicies } = useNbiPolicies();
+  const [isInClaudeCodeMode, setIsInClaudeCodeMode] = useState(
+    NBIAPI.config.isInClaudeCodeMode
+  );
+  const [isClaudeCliAvailable, setIsClaudeCliAvailable] = useState(
+    NBIAPI.config.isClaudeCliAvailable
+  );
+
+  useEffect(() => {
+    const handler = () => {
+      setIsInClaudeCodeMode(NBIAPI.config.isInClaudeCodeMode);
+      setIsClaudeCliAvailable(NBIAPI.config.isClaudeCliAvailable);
+    };
+    NBIAPI.configChanged.connect(handler);
+    return () => {
+      NBIAPI.configChanged.disconnect(handler);
+    };
+  }, []);
+
   const skillsTabVisible = featurePolicies.skills_management.enabled;
+  const claudeMcpTabVisible =
+    featurePolicies.claude_mcp_management.enabled &&
+    isInClaudeCodeMode &&
+    isClaudeCliAvailable;
 
   // Bounce the user off a tab that has just been hidden by an admin policy
   // change so they don't see a blank pane.
@@ -133,7 +156,10 @@ function SettingsPanelComponent(props: any) {
     if (!skillsTabVisible && activeTab === 'skills') {
       setActiveTab('general');
     }
-  }, [skillsTabVisible, activeTab]);
+    if (!claudeMcpTabVisible && activeTab === 'claude-mcp') {
+      setActiveTab('general');
+    }
+  }, [skillsTabVisible, claudeMcpTabVisible, activeTab]);
 
   const onTabSelected = (tab: string) => {
     setActiveTab(tab);
@@ -145,6 +171,7 @@ function SettingsPanelComponent(props: any) {
         onTabSelected={onTabSelected}
         activeTab={activeTab}
         skillsTabVisible={skillsTabVisible}
+        claudeMcpTabVisible={claudeMcpTabVisible}
       />
       <div
         className="nbi-settings-panel-tab-content"
@@ -170,6 +197,9 @@ function SettingsPanelComponent(props: any) {
         )}
         {activeTab === 'skills' && skillsTabVisible && (
           <SettingsPanelComponentSkills />
+        )}
+        {activeTab === 'claude-mcp' && claudeMcpTabVisible && (
+          <SettingsPanelComponentClaudeMCP />
         )}
       </div>
     </div>
@@ -214,6 +244,9 @@ function SettingsPanelTabsComponent(props: any) {
   ];
   if (!isInClaudeCodeMode) {
     tabs.push({ id: 'mcp-servers', label: 'MCP Servers' });
+  }
+  if (props.claudeMcpTabVisible) {
+    tabs.push({ id: 'claude-mcp', label: 'Claude MCP' });
   }
   if (props.skillsTabVisible) {
     tabs.push({ id: 'skills', label: 'Skills' });

--- a/src/components/settings-panel.tsx
+++ b/src/components/settings-panel.tsx
@@ -124,6 +124,16 @@ export class SettingsPanel extends ReactWidget {
 
 function SettingsPanelComponent(props: any) {
   const [activeTab, setActiveTab] = useState('general');
+  const { featurePolicies } = useNbiPolicies();
+  const skillsTabVisible = featurePolicies.skills_management.enabled;
+
+  // Bounce the user off a tab that has just been hidden by an admin policy
+  // change so they don't see a blank pane.
+  useEffect(() => {
+    if (!skillsTabVisible && activeTab === 'skills') {
+      setActiveTab('general');
+    }
+  }, [skillsTabVisible, activeTab]);
 
   const onTabSelected = (tab: string) => {
     setActiveTab(tab);
@@ -134,6 +144,7 @@ function SettingsPanelComponent(props: any) {
       <SettingsPanelTabsComponent
         onTabSelected={onTabSelected}
         activeTab={activeTab}
+        skillsTabVisible={skillsTabVisible}
       />
       <div
         className="nbi-settings-panel-tab-content"
@@ -157,13 +168,20 @@ function SettingsPanelComponent(props: any) {
             onEditMCPConfigClicked={props.onEditMCPConfigClicked}
           />
         )}
+        {activeTab === 'skills' && skillsTabVisible && (
+          <SettingsPanelComponentSkills />
+        )}
       </div>
     </div>
   );
 }
 
 function SettingsPanelTabsComponent(props: any) {
-  const [activeTab, setActiveTab] = useState(props.activeTab);
+  // Fully controlled: parent owns `activeTab`. Reading directly from props
+  // (instead of a local mirror) prevents drift when the parent flips the
+  // tab — e.g. when an admin policy hides the active tab and the parent
+  // bounces the user to `general`.
+  const activeTab = props.activeTab;
   const [isInClaudeCodeMode, setIsInClaudeCodeMode] = useState(
     NBIAPI.config.isInClaudeCodeMode
   );
@@ -197,9 +215,11 @@ function SettingsPanelTabsComponent(props: any) {
   if (!isInClaudeCodeMode) {
     tabs.push({ id: 'mcp-servers', label: 'MCP Servers' });
   }
+  if (props.skillsTabVisible) {
+    tabs.push({ id: 'skills', label: 'Skills' });
+  }
 
   const selectTab = (id: string): void => {
-    setActiveTab(id);
     props.onTabSelected(id);
   };
 
@@ -1158,421 +1178,348 @@ function SettingsPanelComponentClaude(props: any) {
     continueConversation
   ]);
 
-  const [claudeSubTab, setClaudeSubTab] = useState<'settings' | 'skills'>(
-    'settings'
-  );
-
-  useEffect(() => {
-    if (!nbiConfig.isInClaudeCodeMode && claudeSubTab !== 'settings') {
-      setClaudeSubTab('settings');
-    }
-  }, [nbiConfig.isInClaudeCodeMode, claudeSubTab]);
-
-  const subTabs: { id: 'settings' | 'skills'; label: string }[] = [
-    { id: 'settings', label: 'Settings' },
-    { id: 'skills', label: 'Skills' }
-  ];
-
-  const onSubTabKeyDown = useTablistArrowKeys(
-    subTabs,
-    claudeSubTab,
-    id => setClaudeSubTab(id as 'settings' | 'skills'),
-    'horizontal',
-    id => tabId('nbi-claude-subtab', id)
-  );
-
   return (
     <div className="config-dialog claude-mode-config-dialog">
-      {nbiConfig.isInClaudeCodeMode && (
-        <div
-          className="nbi-subtab-bar"
-          role="tablist"
-          aria-label="Claude settings sections"
-          aria-orientation="horizontal"
-          onKeyDown={onSubTabKeyDown}
-        >
-          {subTabs.map(tab => {
-            const selected = claudeSubTab === tab.id;
-            return (
-              <button
-                type="button"
-                key={tab.id}
-                id={tabId('nbi-claude-subtab', tab.id)}
-                className={`nbi-subtab ${selected ? 'active' : ''}`}
-                role="tab"
-                aria-selected={selected}
-                aria-controls={tabId('nbi-claude-subtabpanel', tab.id)}
-                tabIndex={selected ? 0 : -1}
-                onClick={() => setClaudeSubTab(tab.id)}
-              >
-                {tab.label}
-              </button>
-            );
-          })}
-        </div>
-      )}
-      {claudeSubTab === 'skills' && (
-        <div
-          role="tabpanel"
-          id={tabId('nbi-claude-subtabpanel', 'skills')}
-          aria-labelledby={tabId('nbi-claude-subtab', 'skills')}
-        >
-          <SettingsPanelComponentSkills />
-        </div>
-      )}
-      {claudeSubTab === 'settings' && (
-        <div
-          className="config-dialog-body"
-          role="tabpanel"
-          id={tabId('nbi-claude-subtabpanel', 'settings')}
-          aria-labelledby={tabId('nbi-claude-subtab', 'settings')}
-        >
-          <div className="model-config-section">
-            <div className="model-config-section-header">
-              Enable Claude mode
+      <div className="config-dialog-body">
+        <div className="model-config-section">
+          <div className="model-config-section-header">Enable Claude mode</div>
+          <div className="model-config-section-body">
+            <div className="model-config-section-row">
+              <span>
+                This requires a{' '}
+                <a href="https://claude.ai" target="_blank">
+                  Claude
+                </a>{' '}
+                account and{' '}
+                <a href="https://code.claude.com/" target="_blank">
+                  Claude Code
+                </a>{' '}
+                installed in your system.
+              </span>
             </div>
-            <div className="model-config-section-body">
-              <div className="model-config-section-row">
-                <span>
-                  This requires a{' '}
-                  <a href="https://claude.ai" target="_blank">
-                    Claude
-                  </a>{' '}
-                  account and{' '}
-                  <a href="https://code.claude.com/" target="_blank">
-                    Claude Code
-                  </a>{' '}
-                  installed in your system.
-                </span>
-              </div>
-              <div className="model-config-section-row">
-                <div className="model-config-section-column">
-                  <div>
-                    <CheckBoxItem
-                      header={true}
-                      label="Enable Claude mode"
-                      checked={checkedValue(
-                        featurePolicies.claude_mode,
-                        claudeEnabled
-                      )}
-                      disabled={featurePolicies.claude_mode.locked}
-                      tooltip={lockedTip(featurePolicies.claude_mode.locked)}
-                      onClick={() => {
-                        setClaudeEnabled(!claudeEnabled);
-                      }}
-                    ></CheckBoxItem>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="model-config-section">
-            <div
-              className="model-config-section-header"
-              style={{ display: 'flex' }}
-            >
-              <div style={{ flexGrow: 1 }}>Models</div>
-              <div>
-                <button
-                  className="jp-toast-button jp-mod-small jp-Button"
-                  onClick={refreshClaudeModels}
-                  disabled={loadingModels}
-                >
-                  <div className="jp-Dialog-buttonLabel">
-                    {loadingModels ? 'Loading...' : 'Refresh'}
-                  </div>
-                </button>
-              </div>
-            </div>
-            <div className="model-config-section-body">
-              <div className="model-config-section-row">
-                <div className="model-config-section-column">
-                  <div>Chat model</div>
-                  <div title={lockedTip(settingLocks.claude_chat_model.locked)}>
-                    <select
-                      className="jp-mod-styled"
-                      disabled={settingLocks.claude_chat_model.locked}
-                      onChange={event => setChatModel(event.target.value)}
-                    >
-                      <option
-                        value={ClaudeModelType.Default}
-                        selected={chatModel === ClaudeModelType.Default}
-                      >
-                        Default (recommended)
-                      </option>
-                      {claudeModels.map(model => (
-                        <option
-                          key={model.id}
-                          value={model.id}
-                          selected={chatModel === model.id}
-                        >
-                          {model.name}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                </div>
-                <div className="model-config-section-column">
-                  <div>Auto-complete model</div>
-                  <div
-                    title={lockedTip(
-                      settingLocks.claude_inline_completion_model.locked
+            <div className="model-config-section-row">
+              <div className="model-config-section-column">
+                <div>
+                  <CheckBoxItem
+                    header={true}
+                    label="Enable Claude mode"
+                    checked={checkedValue(
+                      featurePolicies.claude_mode,
+                      claudeEnabled
                     )}
-                  >
-                    <select
-                      className="jp-mod-styled"
-                      disabled={
-                        settingLocks.claude_inline_completion_model.locked
-                      }
-                      onChange={event =>
-                        setInlineCompletionModel(event.target.value)
-                      }
-                    >
-                      <option
-                        value={ClaudeModelType.None}
-                        selected={
-                          inlineCompletionModel === ClaudeModelType.None
-                        }
-                      >
-                        None
-                      </option>
-                      <option
-                        value={ClaudeModelType.Inherit}
-                        selected={
-                          inlineCompletionModel === ClaudeModelType.Inherit
-                        }
-                      >
-                        Inherit from general settings
-                      </option>
-                      <option
-                        value={ClaudeModelType.Default}
-                        selected={
-                          inlineCompletionModel === ClaudeModelType.Default
-                        }
-                      >
-                        Default (recommended)
-                      </option>
-                      {claudeModels.map(model => (
-                        <option
-                          key={model.id}
-                          value={model.id}
-                          selected={inlineCompletionModel === model.id}
-                        >
-                          {model.name}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="model-config-section">
-            <div className="model-config-section-header">
-              Chat Agent setting sources
-            </div>
-            <div className="model-config-section-body">
-              <div className="model-config-section-row">
-                <div className="model-config-section-column">
-                  <div>
-                    <CheckBoxItem
-                      header={true}
-                      label="User"
-                      checked={checkedValue(
-                        featurePolicies.claude_setting_source_user,
-                        settingSources.includes('user')
-                      )}
-                      disabled={
-                        featurePolicies.claude_setting_source_user.locked
-                      }
-                      tooltip={lockedTip(
-                        featurePolicies.claude_setting_source_user.locked
-                      )}
-                      onClick={() => {
-                        setSettingSources(
-                          settingSources.includes('user')
-                            ? settingSources.filter(
-                                (source: string) => source !== 'user'
-                              )
-                            : [...settingSources, 'user']
-                        );
-                      }}
-                    ></CheckBoxItem>
-                  </div>
-                </div>
-                <div className="model-config-section-column">
-                  <div>
-                    <CheckBoxItem
-                      header={true}
-                      label="Project (Jupyter root directory)"
-                      checked={checkedValue(
-                        featurePolicies.claude_setting_source_project,
-                        settingSources.includes('project')
-                      )}
-                      disabled={
-                        featurePolicies.claude_setting_source_project.locked
-                      }
-                      tooltip={lockedTip(
-                        featurePolicies.claude_setting_source_project.locked
-                      )}
-                      onClick={() => {
-                        setSettingSources(
-                          settingSources.includes('project')
-                            ? settingSources.filter(
-                                (source: string) => source !== 'project'
-                              )
-                            : [...settingSources, 'project']
-                        );
-                      }}
-                    ></CheckBoxItem>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="model-config-section">
-            <div className="model-config-section-header">Chat Agent tools</div>
-            <div className="model-config-section-body">
-              <div className="model-config-section-row">
-                <div className="model-config-section-column">
-                  <div>
-                    <CheckBoxItem
-                      header={true}
-                      label="Claude Code tools"
-                      checked={checkedValue(
-                        featurePolicies.claude_code_tools,
-                        tools.includes(ClaudeToolType.ClaudeCodeTools)
-                      )}
-                      disabled={true}
-                      tooltip={lockedTip(
-                        featurePolicies.claude_code_tools.locked
-                      )}
-                      onClick={() => {
-                        setTools(
-                          tools.includes(ClaudeToolType.ClaudeCodeTools)
-                            ? tools.filter(
-                                (tool: string) =>
-                                  tool !== ClaudeToolType.ClaudeCodeTools
-                              )
-                            : [...tools, ClaudeToolType.ClaudeCodeTools]
-                        );
-                      }}
-                    ></CheckBoxItem>
-                  </div>
-                </div>
-                <div className="model-config-section-column">
-                  <div>
-                    <CheckBoxItem
-                      header={true}
-                      label="Jupyter UI tools"
-                      checked={checkedValue(
-                        featurePolicies.claude_jupyter_ui_tools,
-                        tools.includes(ClaudeToolType.JupyterUITools)
-                      )}
-                      disabled={featurePolicies.claude_jupyter_ui_tools.locked}
-                      tooltip={lockedTip(
-                        featurePolicies.claude_jupyter_ui_tools.locked
-                      )}
-                      onClick={() => {
-                        setTools(
-                          tools.includes(ClaudeToolType.JupyterUITools)
-                            ? tools.filter(
-                                (tool: string) =>
-                                  tool !== ClaudeToolType.JupyterUITools
-                              )
-                            : [...tools, ClaudeToolType.JupyterUITools]
-                        );
-                      }}
-                    ></CheckBoxItem>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="model-config-section">
-            <div className="model-config-section-header">
-              Conversation History
-            </div>
-            <div className="model-config-section-body">
-              <div className="model-config-section-row">
-                <div className="model-config-section-column">
-                  <div>
-                    <CheckBoxItem
-                      header={true}
-                      label="Remember conversation history"
-                      checked={checkedValue(
-                        featurePolicies.claude_continue_conversation,
-                        continueConversation
-                      )}
-                      disabled={
-                        featurePolicies.claude_continue_conversation.locked
-                      }
-                      tooltip={lockedTip(
-                        featurePolicies.claude_continue_conversation.locked
-                      )}
-                      onClick={() => {
-                        setContinueConversation(!continueConversation);
-                      }}
-                    ></CheckBoxItem>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="model-config-section">
-            <div className="model-config-section-header">Claude account</div>
-            <div className="model-config-section-body">
-              <div className="model-config-section-row">
-                <div className="model-config-section-column">
-                  <div className="form-field-row">
-                    <div className="form-field-description">
-                      API Key (optional)
-                    </div>
-                    <input
-                      name="chat-model-id-input"
-                      placeholder={
-                        settingLocks.claude_api_key.locked
-                          ? 'Locked by ANTHROPIC_API_KEY'
-                          : 'API Key'
-                      }
-                      className="jp-mod-styled"
-                      spellCheck={false}
-                      value={settingLocks.claude_api_key.locked ? '' : apiKey}
-                      disabled={settingLocks.claude_api_key.locked}
-                      title={lockedTip(settingLocks.claude_api_key.locked)}
-                      onChange={event => setApiKey(event.target.value)}
-                    />
-                  </div>
-                  <div className="form-field-row">
-                    <div className="form-field-description">
-                      Base URL (optional)
-                    </div>
-                    <input
-                      name="chat-model-id-input"
-                      placeholder={
-                        settingLocks.claude_base_url.locked
-                          ? 'Locked by ANTHROPIC_BASE_URL'
-                          : 'https://api.anthropic.com'
-                      }
-                      className="jp-mod-styled"
-                      spellCheck={false}
-                      value={baseUrl}
-                      disabled={settingLocks.claude_base_url.locked}
-                      title={lockedTip(settingLocks.claude_base_url.locked)}
-                      onChange={event => setBaseUrl(event.target.value)}
-                    />
-                  </div>
+                    disabled={featurePolicies.claude_mode.locked}
+                    tooltip={lockedTip(featurePolicies.claude_mode.locked)}
+                    onClick={() => {
+                      setClaudeEnabled(!claudeEnabled);
+                    }}
+                  ></CheckBoxItem>
                 </div>
               </div>
             </div>
           </div>
         </div>
-      )}
+
+        <div className="model-config-section">
+          <div
+            className="model-config-section-header"
+            style={{ display: 'flex' }}
+          >
+            <div style={{ flexGrow: 1 }}>Models</div>
+            <div>
+              <button
+                className="jp-toast-button jp-mod-small jp-Button"
+                onClick={refreshClaudeModels}
+                disabled={loadingModels}
+              >
+                <div className="jp-Dialog-buttonLabel">
+                  {loadingModels ? 'Loading...' : 'Refresh'}
+                </div>
+              </button>
+            </div>
+          </div>
+          <div className="model-config-section-body">
+            <div className="model-config-section-row">
+              <div className="model-config-section-column">
+                <div>Chat model</div>
+                <div title={lockedTip(settingLocks.claude_chat_model.locked)}>
+                  <select
+                    className="jp-mod-styled"
+                    disabled={settingLocks.claude_chat_model.locked}
+                    onChange={event => setChatModel(event.target.value)}
+                  >
+                    <option
+                      value={ClaudeModelType.Default}
+                      selected={chatModel === ClaudeModelType.Default}
+                    >
+                      Default (recommended)
+                    </option>
+                    {claudeModels.map(model => (
+                      <option
+                        key={model.id}
+                        value={model.id}
+                        selected={chatModel === model.id}
+                      >
+                        {model.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+              <div className="model-config-section-column">
+                <div>Auto-complete model</div>
+                <div
+                  title={lockedTip(
+                    settingLocks.claude_inline_completion_model.locked
+                  )}
+                >
+                  <select
+                    className="jp-mod-styled"
+                    disabled={
+                      settingLocks.claude_inline_completion_model.locked
+                    }
+                    onChange={event =>
+                      setInlineCompletionModel(event.target.value)
+                    }
+                  >
+                    <option
+                      value={ClaudeModelType.None}
+                      selected={inlineCompletionModel === ClaudeModelType.None}
+                    >
+                      None
+                    </option>
+                    <option
+                      value={ClaudeModelType.Inherit}
+                      selected={
+                        inlineCompletionModel === ClaudeModelType.Inherit
+                      }
+                    >
+                      Inherit from general settings
+                    </option>
+                    <option
+                      value={ClaudeModelType.Default}
+                      selected={
+                        inlineCompletionModel === ClaudeModelType.Default
+                      }
+                    >
+                      Default (recommended)
+                    </option>
+                    {claudeModels.map(model => (
+                      <option
+                        key={model.id}
+                        value={model.id}
+                        selected={inlineCompletionModel === model.id}
+                      >
+                        {model.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="model-config-section">
+          <div className="model-config-section-header">
+            Chat Agent setting sources
+          </div>
+          <div className="model-config-section-body">
+            <div className="model-config-section-row">
+              <div className="model-config-section-column">
+                <div>
+                  <CheckBoxItem
+                    header={true}
+                    label="User"
+                    checked={checkedValue(
+                      featurePolicies.claude_setting_source_user,
+                      settingSources.includes('user')
+                    )}
+                    disabled={featurePolicies.claude_setting_source_user.locked}
+                    tooltip={lockedTip(
+                      featurePolicies.claude_setting_source_user.locked
+                    )}
+                    onClick={() => {
+                      setSettingSources(
+                        settingSources.includes('user')
+                          ? settingSources.filter(
+                              (source: string) => source !== 'user'
+                            )
+                          : [...settingSources, 'user']
+                      );
+                    }}
+                  ></CheckBoxItem>
+                </div>
+              </div>
+              <div className="model-config-section-column">
+                <div>
+                  <CheckBoxItem
+                    header={true}
+                    label="Project (Jupyter root directory)"
+                    checked={checkedValue(
+                      featurePolicies.claude_setting_source_project,
+                      settingSources.includes('project')
+                    )}
+                    disabled={
+                      featurePolicies.claude_setting_source_project.locked
+                    }
+                    tooltip={lockedTip(
+                      featurePolicies.claude_setting_source_project.locked
+                    )}
+                    onClick={() => {
+                      setSettingSources(
+                        settingSources.includes('project')
+                          ? settingSources.filter(
+                              (source: string) => source !== 'project'
+                            )
+                          : [...settingSources, 'project']
+                      );
+                    }}
+                  ></CheckBoxItem>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="model-config-section">
+          <div className="model-config-section-header">Chat Agent tools</div>
+          <div className="model-config-section-body">
+            <div className="model-config-section-row">
+              <div className="model-config-section-column">
+                <div>
+                  <CheckBoxItem
+                    header={true}
+                    label="Claude Code tools"
+                    checked={checkedValue(
+                      featurePolicies.claude_code_tools,
+                      tools.includes(ClaudeToolType.ClaudeCodeTools)
+                    )}
+                    disabled={true}
+                    tooltip={lockedTip(
+                      featurePolicies.claude_code_tools.locked
+                    )}
+                    onClick={() => {
+                      setTools(
+                        tools.includes(ClaudeToolType.ClaudeCodeTools)
+                          ? tools.filter(
+                              (tool: string) =>
+                                tool !== ClaudeToolType.ClaudeCodeTools
+                            )
+                          : [...tools, ClaudeToolType.ClaudeCodeTools]
+                      );
+                    }}
+                  ></CheckBoxItem>
+                </div>
+              </div>
+              <div className="model-config-section-column">
+                <div>
+                  <CheckBoxItem
+                    header={true}
+                    label="Jupyter UI tools"
+                    checked={checkedValue(
+                      featurePolicies.claude_jupyter_ui_tools,
+                      tools.includes(ClaudeToolType.JupyterUITools)
+                    )}
+                    disabled={featurePolicies.claude_jupyter_ui_tools.locked}
+                    tooltip={lockedTip(
+                      featurePolicies.claude_jupyter_ui_tools.locked
+                    )}
+                    onClick={() => {
+                      setTools(
+                        tools.includes(ClaudeToolType.JupyterUITools)
+                          ? tools.filter(
+                              (tool: string) =>
+                                tool !== ClaudeToolType.JupyterUITools
+                            )
+                          : [...tools, ClaudeToolType.JupyterUITools]
+                      );
+                    }}
+                  ></CheckBoxItem>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="model-config-section">
+          <div className="model-config-section-header">
+            Conversation History
+          </div>
+          <div className="model-config-section-body">
+            <div className="model-config-section-row">
+              <div className="model-config-section-column">
+                <div>
+                  <CheckBoxItem
+                    header={true}
+                    label="Remember conversation history"
+                    checked={checkedValue(
+                      featurePolicies.claude_continue_conversation,
+                      continueConversation
+                    )}
+                    disabled={
+                      featurePolicies.claude_continue_conversation.locked
+                    }
+                    tooltip={lockedTip(
+                      featurePolicies.claude_continue_conversation.locked
+                    )}
+                    onClick={() => {
+                      setContinueConversation(!continueConversation);
+                    }}
+                  ></CheckBoxItem>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="model-config-section">
+          <div className="model-config-section-header">Claude account</div>
+          <div className="model-config-section-body">
+            <div className="model-config-section-row">
+              <div className="model-config-section-column">
+                <div className="form-field-row">
+                  <div className="form-field-description">
+                    API Key (optional)
+                  </div>
+                  <input
+                    name="chat-model-id-input"
+                    placeholder={
+                      settingLocks.claude_api_key.locked
+                        ? 'Locked by ANTHROPIC_API_KEY'
+                        : 'API Key'
+                    }
+                    className="jp-mod-styled"
+                    spellCheck={false}
+                    value={settingLocks.claude_api_key.locked ? '' : apiKey}
+                    disabled={settingLocks.claude_api_key.locked}
+                    title={lockedTip(settingLocks.claude_api_key.locked)}
+                    onChange={event => setApiKey(event.target.value)}
+                  />
+                </div>
+                <div className="form-field-row">
+                  <div className="form-field-description">
+                    Base URL (optional)
+                  </div>
+                  <input
+                    name="chat-model-id-input"
+                    placeholder={
+                      settingLocks.claude_base_url.locked
+                        ? 'Locked by ANTHROPIC_BASE_URL'
+                        : 'https://api.anthropic.com'
+                    }
+                    className="jp-mod-styled"
+                    spellCheck={false}
+                    value={baseUrl}
+                    disabled={settingLocks.claude_base_url.locked}
+                    title={lockedTip(settingLocks.claude_base_url.locked)}
+                    onChange={event => setBaseUrl(event.target.value)}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/settings-panel.tsx
+++ b/src/components/settings-panel.tsx
@@ -19,6 +19,7 @@ import { PillItem } from './pill';
 import { mcpServerSettingsToEnabledState } from './mcp-util';
 import { SettingsPanelComponentSkills } from './skills-panel';
 import { SettingsPanelComponentClaudeMCP } from './claude-mcp-panel';
+import { SettingsPanelComponentPlugins } from './plugins-panel';
 import { writeTextToClipboard } from '../utils';
 
 const lockedTip = (locked: boolean): string =>
@@ -149,6 +150,10 @@ function SettingsPanelComponent(props: any) {
     featurePolicies.claude_mcp_management.enabled &&
     isInClaudeCodeMode &&
     isClaudeCliAvailable;
+  const pluginsTabVisible =
+    featurePolicies.plugins_management.enabled &&
+    isInClaudeCodeMode &&
+    isClaudeCliAvailable;
 
   // Bounce the user off a tab that has just been hidden by an admin policy
   // change so they don't see a blank pane.
@@ -159,7 +164,10 @@ function SettingsPanelComponent(props: any) {
     if (!claudeMcpTabVisible && activeTab === 'claude-mcp') {
       setActiveTab('general');
     }
-  }, [skillsTabVisible, claudeMcpTabVisible, activeTab]);
+    if (!pluginsTabVisible && activeTab === 'plugins') {
+      setActiveTab('general');
+    }
+  }, [skillsTabVisible, claudeMcpTabVisible, pluginsTabVisible, activeTab]);
 
   const onTabSelected = (tab: string) => {
     setActiveTab(tab);
@@ -172,6 +180,7 @@ function SettingsPanelComponent(props: any) {
         activeTab={activeTab}
         skillsTabVisible={skillsTabVisible}
         claudeMcpTabVisible={claudeMcpTabVisible}
+        pluginsTabVisible={pluginsTabVisible}
       />
       <div
         className="nbi-settings-panel-tab-content"
@@ -200,6 +209,9 @@ function SettingsPanelComponent(props: any) {
         )}
         {activeTab === 'claude-mcp' && claudeMcpTabVisible && (
           <SettingsPanelComponentClaudeMCP />
+        )}
+        {activeTab === 'plugins' && pluginsTabVisible && (
+          <SettingsPanelComponentPlugins />
         )}
       </div>
     </div>
@@ -247,6 +259,9 @@ function SettingsPanelTabsComponent(props: any) {
   }
   if (props.claudeMcpTabVisible) {
     tabs.push({ id: 'claude-mcp', label: 'Claude MCP' });
+  }
+  if (props.pluginsTabVisible) {
+    tabs.push({ id: 'plugins', label: 'Plugins' });
   }
   if (props.skillsTabVisible) {
     tabs.push({ id: 'skills', label: 'Skills' });

--- a/src/components/settings-panel.tsx
+++ b/src/components/settings-panel.tsx
@@ -192,7 +192,7 @@ const TABS: TabSpec[] = [
     id: 'plugins',
     label: 'Plugins',
     visible: ctx =>
-      ctx.featurePolicies.plugins_management.enabled &&
+      ctx.featurePolicies.claude_plugins_management.enabled &&
       ctx.isInClaudeCodeMode &&
       ctx.isClaudeCliAvailable,
     render: () => <SettingsPanelComponentPlugins />

--- a/src/components/skills-panel.tsx
+++ b/src/components/skills-panel.tsx
@@ -348,7 +348,7 @@ export function SettingsPanelComponentSkills(_props: any): JSX.Element {
   return (
     <div className="config-dialog-body nbi-skills-panel">
       <div className="nbi-skills-header">
-        <div className="nbi-skills-title">Claude Skills</div>
+        <div className="nbi-skills-title">Skills</div>
         <div className="nbi-skills-header-actions">
           {hasManagedSkills && (
             <button
@@ -383,6 +383,12 @@ export function SettingsPanelComponentSkills(_props: any): JSX.Element {
           </button>
         </div>
       </div>
+      {!NBIAPI.config.isInClaudeCodeMode && (
+        <div className="nbi-skills-info-banner" role="note">
+          Skills are consumed by Claude Code. Enable Claude mode in the Claude
+          settings tab to use skills you author here.
+        </div>
+      )}
       {syncMessage && (
         <div className="nbi-skills-sync-message" role="status">
           {syncMessage}

--- a/src/components/skills-panel.tsx
+++ b/src/components/skills-panel.tsx
@@ -555,8 +555,10 @@ function GitHubImportDialog(props: {
                   placeholder="https://github.com/owner/repo or .../tree/main/path/to/skill"
                 />
                 <div className="nbi-form-hint">
-                  Public repos only. Link to the repo root, a branch, or a
-                  subdirectory containing <code>SKILL.md</code>.
+                  Link to the repo root, a branch, or a subdirectory containing{' '}
+                  <code>SKILL.md</code>. Private repos work if{' '}
+                  <code>GITHUB_TOKEN</code> is set or <code>gh auth login</code>{' '}
+                  is configured on the Jupyter server.
                 </div>
               </div>
               <div className="nbi-form-field">

--- a/style/base.css
+++ b/style/base.css
@@ -1536,7 +1536,8 @@ svg.access-token-warning {
   font-size: var(--jp-ui-font-size1);
 }
 
-.nbi-skills-sync-message {
+.nbi-skills-sync-message,
+.nbi-skills-info-banner {
   padding: 6px 12px;
   border-radius: 4px;
   background-color: var(--jp-layout-color2);

--- a/style/base.css
+++ b/style/base.css
@@ -1537,7 +1537,8 @@ svg.access-token-warning {
 }
 
 .nbi-skills-sync-message,
-.nbi-skills-info-banner {
+.nbi-skills-info-banner,
+.nbi-info-banner {
   padding: 6px 12px;
   border-radius: 4px;
   background-color: var(--jp-layout-color2);

--- a/style/base.css
+++ b/style/base.css
@@ -1332,6 +1332,7 @@ svg.access-token-warning {
   gap: 10px;
   padding: 10px;
   width: 150px;
+
   /* Hold the column width when a panel renders wide non-wrapping content
      (e.g. the Skills panel's project-skills filesystem path) — without
      this, flex-shrink lets the right pane squeeze the sidebar and labels

--- a/style/base.css
+++ b/style/base.css
@@ -1332,6 +1332,11 @@ svg.access-token-warning {
   gap: 10px;
   padding: 10px;
   width: 150px;
+  /* Hold the column width when a panel renders wide non-wrapping content
+     (e.g. the Skills panel's project-skills filesystem path) — without
+     this, flex-shrink lets the right pane squeeze the sidebar and labels
+     like "Claude MCP" wrap mid-word. */
+  flex-shrink: 0;
   background-color: var(--jp-layout-color2);
 }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,45 @@
+import asyncio
 import io
 import pytest
 import tarfile
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from notebook_intelligence.ruleset import RuleContext
 from notebook_intelligence.config import NBIConfig
+
+
+def stub_claude_subprocess(
+    monkeypatch,
+    *,
+    captured: dict,
+    stdout: bytes = b"",
+    returncode: int = 0,
+):
+    """Patch ``asyncio.create_subprocess_exec`` for Claude-CLI shellouts.
+
+    Used by both the Claude-MCP and plugin manager tests; lives here to keep
+    the fake's signature consistent across files. ``captured`` is a dict the
+    test inspects after the call; ``stdout``/``returncode`` shape the fake
+    process's outputs.
+    """
+    out_bytes = stdout
+    rc = returncode
+
+    async def fake_subprocess(*argv, **kwargs):
+        captured["argv"] = list(argv)
+        captured["kwargs"] = kwargs
+        proc = MagicMock()
+
+        async def communicate():
+            return (out_bytes, b"")
+
+        proc.communicate = communicate
+        proc.returncode = rc
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subprocess)
 
 
 def build_tarball(file_map: dict) -> bytes:

--- a/tests/test_cell_output_features_response.py
+++ b/tests/test_cell_output_features_response.py
@@ -6,6 +6,7 @@ and value-presence-locks to the frontend."""
 from types import SimpleNamespace
 
 from notebook_intelligence.extension import (
+    FEATURE_POLICY_NAMES,
     _build_cell_output_features_response,
     _build_feature_policies_response,
     _build_setting_locks_response,
@@ -158,6 +159,14 @@ class TestBuildFeaturePoliciesResponse:
         assert response["claude_mode"]["enabled"] is False
         assert response["claude_continue_conversation"]["enabled"] is False
         assert response["claude_code_tools"]["enabled"] is False
+
+    def test_response_includes_every_known_policy_name(self):
+        # Pins the wire contract: the response must expose exactly the
+        # FEATURE_POLICY_NAMES set so the frontend's iteration over the
+        # capabilities entries lines up. Catches drift when a new policy
+        # is added to the spec but not to the response builder.
+        response = _build_feature_policies_response({}, _config())
+        assert set(response.keys()) == set(FEATURE_POLICY_NAMES)
 
 
 class TestBuildSettingLocksResponse:

--- a/tests/test_claude_mcp_manager.py
+++ b/tests/test_claude_mcp_manager.py
@@ -160,6 +160,57 @@ class TestClaudeMCPManagerListServers:
 
 
 class TestClaudeMCPManagerWrites:
+    def test_add_returns_canonical_record_when_post_read_succeeds(
+        self, claude_home, working_dir, monkeypatch
+    ):
+        """When the post-add re-read finds the freshly-written server, the
+        canonical record (parsed from disk) is returned — *not* the
+        synthesized fallback. This pins the preference: a regression that
+        always synthesized would silently lose any field-level rewriting
+        Claude does (e.g. inferring transport from the URL)."""
+        monkeypatch.setattr(
+            "notebook_intelligence._claude_cli.resolve_claude_cli_path",
+            lambda: "/usr/local/bin/claude",
+        )
+
+        async def fake_subprocess(*argv, **kwargs):
+            # Simulate Claude actually writing the server to ~/.claude.json.
+            doc = {
+                "mcpServers": {
+                    "my-srv": {
+                        "type": "stdio",
+                        "command": "claude-rewrote-this",
+                        "args": ["--from", "claude"],
+                        "env": {"CLAUDE": "added"},
+                    }
+                }
+            }
+            (claude_home / ".claude.json").write_text(json.dumps(doc))
+            proc = MagicMock()
+
+            async def communicate():
+                return (b"", b"")
+
+            proc.communicate = communicate
+            proc.returncode = 0
+            return proc
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subprocess)
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        result = asyncio.run(
+            manager.add_server(
+                name="my-srv",
+                scope="user",
+                transport="stdio",
+                command_or_url="user-supplied-cmd",
+                args=["--user-arg"],
+            )
+        )
+        # Canonical fields from disk, not synthesized from inputs.
+        assert result.command == "claude-rewrote-this"
+        assert result.args == ["--from", "claude"]
+        assert result.env == {"CLAUDE": "added"}
+
     @pytest.mark.parametrize("scope", ["user", "project", "local"])
     def test_add_invokes_cli_with_correct_args(
         self, claude_home, working_dir, scope, monkeypatch
@@ -315,7 +366,7 @@ class TestClaudeMCPManagerWrites:
 
 class TestRedactArgvForLog:
     def test_redacts_env_values(self):
-        from notebook_intelligence.claude_mcp_manager import _redact_argv_for_log
+        from notebook_intelligence._claude_cli import redact_argv_for_log as _redact_argv_for_log
 
         argv = ["claude", "mcp", "add", "-e", "API_KEY=sk-secret", "name", "cmd"]
         assert _redact_argv_for_log(argv) == [
@@ -329,13 +380,13 @@ class TestRedactArgvForLog:
         ]
 
     def test_redacts_header_values(self):
-        from notebook_intelligence.claude_mcp_manager import _redact_argv_for_log
+        from notebook_intelligence._claude_cli import redact_argv_for_log as _redact_argv_for_log
 
         argv = ["claude", "mcp", "add", "-H", "Authorization: Bearer abc"]
         assert _redact_argv_for_log(argv)[-2:] == ["-H", "<redacted>"]
 
     def test_passes_through_non_secrets(self):
-        from notebook_intelligence.claude_mcp_manager import _redact_argv_for_log
+        from notebook_intelligence._claude_cli import redact_argv_for_log as _redact_argv_for_log
 
         argv = ["claude", "mcp", "add", "--scope", "user", "name", "npx"]
         assert _redact_argv_for_log(argv) == argv

--- a/tests/test_claude_mcp_manager.py
+++ b/tests/test_claude_mcp_manager.py
@@ -1,0 +1,382 @@
+# Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+"""Tests for the ClaudeMCPManager and the management policy gate."""
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import notebook_intelligence.extension as ext_module
+from notebook_intelligence.claude_mcp_manager import (
+    ClaudeMCPManager,
+    ClaudeMCPServer,
+)
+from notebook_intelligence.extension import (
+    ClaudeMCPBaseHandler,
+    ClaudeMCPListHandler,
+)
+
+
+@pytest.fixture
+def claude_home(tmp_path, monkeypatch):
+    """Stand up a fake $HOME with a populated `~/.claude.json`."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    return home
+
+
+@pytest.fixture
+def working_dir(tmp_path):
+    cwd = tmp_path / "project"
+    cwd.mkdir()
+    return cwd
+
+
+def _write_claude_json(home: Path, doc: dict) -> None:
+    (home / ".claude.json").write_text(json.dumps(doc), encoding="utf-8")
+
+
+class TestClaudeMCPManagerListServers:
+    def test_empty_when_no_config(self, claude_home, working_dir):
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        assert manager.list_servers() == []
+
+    def test_user_scope_servers_round_trip(self, claude_home, working_dir):
+        _write_claude_json(
+            claude_home,
+            {
+                "mcpServers": {
+                    "voicemode": {
+                        "type": "stdio",
+                        "command": "uvx",
+                        "args": ["--refresh", "voice-mode"],
+                        "env": {},
+                    },
+                    "sentry": {
+                        "type": "http",
+                        "url": "https://mcp.sentry.dev/mcp",
+                        "headers": {"X-Tenant": "acme"},
+                    },
+                }
+            },
+        )
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        servers = manager.list_servers()
+        names = [(s.name, s.scope, s.transport) for s in servers]
+        assert names == [
+            ("sentry", "user", "http"),
+            ("voicemode", "user", "stdio"),
+        ]
+        sentry = next(s for s in servers if s.name == "sentry")
+        assert sentry.url == "https://mcp.sentry.dev/mcp"
+        assert sentry.headers == {"X-Tenant": "acme"}
+        voicemode = next(s for s in servers if s.name == "voicemode")
+        assert voicemode.command == "uvx"
+        assert voicemode.args == ["--refresh", "voice-mode"]
+
+    def test_local_scope_keyed_by_working_dir(self, claude_home, working_dir):
+        _write_claude_json(
+            claude_home,
+            {
+                "projects": {
+                    str(working_dir): {
+                        "mcpServers": {
+                            "playwright": {
+                                "type": "stdio",
+                                "command": "npx",
+                                "args": ["-y", "@playwright/mcp@latest"],
+                            }
+                        }
+                    },
+                    "/some/other/project": {
+                        "mcpServers": {
+                            "should-not-appear": {
+                                "type": "stdio",
+                                "command": "x",
+                            }
+                        }
+                    },
+                }
+            },
+        )
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        servers = manager.list_servers()
+        assert [(s.name, s.scope) for s in servers] == [("playwright", "local")]
+
+    def test_project_scope_from_dot_mcp_json(self, claude_home, working_dir):
+        (working_dir / ".mcp.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "shared": {
+                            "type": "stdio",
+                            "command": "shared-cmd",
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        servers = manager.list_servers()
+        assert [(s.name, s.scope) for s in servers] == [("shared", "project")]
+
+    def test_all_three_scopes_merged(self, claude_home, working_dir):
+        _write_claude_json(
+            claude_home,
+            {
+                "mcpServers": {
+                    "u-srv": {"type": "stdio", "command": "u"},
+                },
+                "projects": {
+                    str(working_dir): {
+                        "mcpServers": {
+                            "l-srv": {"type": "stdio", "command": "l"},
+                        }
+                    }
+                },
+            },
+        )
+        (working_dir / ".mcp.json").write_text(
+            json.dumps({"mcpServers": {"p-srv": {"type": "stdio", "command": "p"}}}),
+            encoding="utf-8",
+        )
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        scopes = {s.name: s.scope for s in manager.list_servers()}
+        assert scopes == {"u-srv": "user", "l-srv": "local", "p-srv": "project"}
+
+    def test_unknown_transport_passes_through(self, claude_home, working_dir):
+        _write_claude_json(
+            claude_home,
+            {"mcpServers": {"weird": {"type": "websocket", "url": "wss://x"}}},
+        )
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        srv = manager.list_servers()[0]
+        assert srv.transport == "websocket"
+
+
+class TestClaudeMCPManagerWrites:
+    @pytest.mark.parametrize("scope", ["user", "project", "local"])
+    def test_add_invokes_cli_with_correct_args(
+        self, claude_home, working_dir, scope, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "notebook_intelligence.claude_mcp_manager.resolve_claude_cli_path",
+            lambda: "/usr/local/bin/claude",
+        )
+        captured: dict = {}
+
+        async def fake_subprocess(*argv, cwd, stdin, stdout, stderr):
+            captured["argv"] = list(argv)
+            captured["cwd"] = cwd
+            proc = MagicMock()
+
+            async def communicate():
+                return (b"ok", b"")
+
+            proc.communicate = communicate
+            proc.returncode = 0
+            return proc
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subprocess)
+
+        # The post-add re-read should find the server too.
+        _write_claude_json(claude_home, {"mcpServers": {}})
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        result = asyncio.run(
+            manager.add_server(
+                name="my-srv",
+                scope=scope,
+                transport="stdio",
+                command_or_url="npx",
+                args=["-y", "pkg"],
+                env={"K": "v"},
+            )
+        )
+        assert captured["argv"][0] == "/usr/local/bin/claude"
+        assert "mcp" in captured["argv"]
+        assert "add" in captured["argv"]
+        assert "--scope" in captured["argv"]
+        scope_idx = captured["argv"].index("--scope")
+        assert captured["argv"][scope_idx + 1] == scope
+        assert "-e" in captured["argv"]
+        assert "K=v" in captured["argv"]
+        assert captured["argv"][-3:] == ["npx", "--", "-y"] or captured["argv"][
+            -4:
+        ] == ["npx", "--", "-y", "pkg"]
+        # When the CLI succeeds but our re-read finds nothing, we synthesize
+        # from the inputs rather than 500.
+        assert result.name == "my-srv"
+        assert result.scope == scope
+
+    def test_remove_invokes_cli(self, claude_home, working_dir, monkeypatch):
+        monkeypatch.setattr(
+            "notebook_intelligence.claude_mcp_manager.resolve_claude_cli_path",
+            lambda: "/usr/local/bin/claude",
+        )
+        captured: dict = {}
+
+        async def fake_subprocess(*argv, cwd, stdin, stdout, stderr):
+            captured["argv"] = list(argv)
+            proc = MagicMock()
+
+            async def communicate():
+                return (b"", b"")
+
+            proc.communicate = communicate
+            proc.returncode = 0
+            return proc
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subprocess)
+
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        asyncio.run(manager.remove_server("my-srv", "user"))
+        assert captured["argv"][1:] == [
+            "mcp",
+            "remove",
+            "--scope",
+            "user",
+            "my-srv",
+        ]
+
+    def test_cli_failure_raises_with_stderr(
+        self, claude_home, working_dir, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "notebook_intelligence.claude_mcp_manager.resolve_claude_cli_path",
+            lambda: "/usr/local/bin/claude",
+        )
+
+        async def fake_subprocess(*argv, cwd, stdin, stdout, stderr):
+            proc = MagicMock()
+
+            async def communicate():
+                return (b"", b"already exists")
+
+            proc.communicate = communicate
+            proc.returncode = 1
+            return proc
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subprocess)
+
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        with pytest.raises(ValueError, match="already exists"):
+            asyncio.run(manager.remove_server("name", "user"))
+
+    def test_missing_cli_raises_filenotfound(
+        self, claude_home, working_dir, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "notebook_intelligence.claude_mcp_manager.resolve_claude_cli_path",
+            lambda: None,
+        )
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        with pytest.raises(FileNotFoundError):
+            asyncio.run(manager.remove_server("name", "user"))
+
+    def test_leading_dash_name_rejected(self, claude_home, working_dir, monkeypatch):
+        monkeypatch.setattr(
+            "notebook_intelligence.claude_mcp_manager.resolve_claude_cli_path",
+            lambda: "/usr/local/bin/claude",
+        )
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        with pytest.raises(ValueError, match="leading '-'"):
+            asyncio.run(
+                manager.add_server(
+                    name="--scope=user",
+                    scope="user",
+                    transport="stdio",
+                    command_or_url="x",
+                )
+            )
+
+    def test_leading_dash_command_rejected(
+        self, claude_home, working_dir, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "notebook_intelligence.claude_mcp_manager.resolve_claude_cli_path",
+            lambda: "/usr/local/bin/claude",
+        )
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        with pytest.raises(ValueError, match="leading '-'"):
+            asyncio.run(
+                manager.add_server(
+                    name="srv",
+                    scope="user",
+                    transport="stdio",
+                    command_or_url="--whatever",
+                )
+            )
+
+
+class TestRedactArgvForLog:
+    def test_redacts_env_values(self):
+        from notebook_intelligence.claude_mcp_manager import _redact_argv_for_log
+
+        argv = ["claude", "mcp", "add", "-e", "API_KEY=sk-secret", "name", "cmd"]
+        assert _redact_argv_for_log(argv) == [
+            "claude",
+            "mcp",
+            "add",
+            "-e",
+            "<redacted>",
+            "name",
+            "cmd",
+        ]
+
+    def test_redacts_header_values(self):
+        from notebook_intelligence.claude_mcp_manager import _redact_argv_for_log
+
+        argv = ["claude", "mcp", "add", "-H", "Authorization: Bearer abc"]
+        assert _redact_argv_for_log(argv)[-2:] == ["-H", "<redacted>"]
+
+    def test_passes_through_non_secrets(self):
+        from notebook_intelligence.claude_mcp_manager import _redact_argv_for_log
+
+        argv = ["claude", "mcp", "add", "--scope", "user", "name", "npx"]
+        assert _redact_argv_for_log(argv) == argv
+
+
+class TestClaudeMCPManagementPolicyGate:
+    """Mirror of TestSkillsManagementPolicyGate — ensures the prepare()
+    chokepoint short-circuits with 403 when force-off."""
+
+    @staticmethod
+    def _run_prepare(handler):
+        from jupyter_server.base.handlers import APIHandler
+
+        async def _noop(_self):
+            return None
+
+        with patch.object(APIHandler, "prepare", _noop):
+            asyncio.run(ClaudeMCPBaseHandler.prepare(handler))
+
+    def test_default_attribute_allows(self):
+        assert ClaudeMCPBaseHandler.claude_mcp_management_enabled is True
+
+    def test_prepare_rejects_when_disabled(self):
+        handler = MagicMock(spec=ClaudeMCPListHandler)
+        handler._finished = False
+        handler.claude_mcp_management_enabled = False
+
+        def _finish(payload):
+            handler._finished = True
+            handler._finish_payload = payload
+
+        handler.finish.side_effect = _finish
+        self._run_prepare(handler)
+        handler.set_status.assert_called_with(403)
+        body = json.loads(handler._finish_payload)
+        assert "administrator" in body["error"].lower()
+
+    def test_prepare_passes_when_enabled(self):
+        handler = MagicMock(spec=ClaudeMCPListHandler)
+        handler._finished = False
+        handler.claude_mcp_management_enabled = True
+        self._run_prepare(handler)
+        handler.set_status.assert_not_called()
+        handler.finish.assert_not_called()

--- a/tests/test_claude_mcp_manager.py
+++ b/tests/test_claude_mcp_manager.py
@@ -341,6 +341,52 @@ class TestRedactArgvForLog:
         assert _redact_argv_for_log(argv) == argv
 
 
+class TestLockSerialization:
+    """Two concurrent writes against the (process-shared) lock must not
+    interleave at the subprocess layer."""
+
+    def test_concurrent_add_server_calls_are_serialized(
+        self, claude_home, working_dir, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "notebook_intelligence.claude_mcp_manager.resolve_claude_cli_path",
+            lambda: "/usr/local/bin/claude",
+        )
+        events: list[str] = []
+
+        async def fake_subprocess(*argv, **kwargs):
+            proc = MagicMock()
+            # `claude mcp add ... <name> <commandOrUrl>` — name is second-to-last.
+            tag = argv[-2]
+
+            async def communicate():
+                events.append(f"start:{tag}")
+                await asyncio.sleep(0.01)
+                events.append(f"end:{tag}")
+                return (b"", b"")
+
+            proc.communicate = communicate
+            proc.returncode = 0
+            return proc
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subprocess)
+
+        async def driver():
+            m1 = ClaudeMCPManager(working_dir=str(working_dir))
+            m2 = ClaudeMCPManager(working_dir=str(working_dir))
+            await asyncio.gather(
+                m1.add_server(name="A", scope="user", transport="stdio", command_or_url="x"),
+                m2.add_server(name="B", scope="user", transport="stdio", command_or_url="y"),
+            )
+
+        asyncio.run(driver())
+        assert len(events) == 4
+        assert events[0].startswith("start:")
+        assert events[1] == events[0].replace("start:", "end:")
+        assert events[2].startswith("start:")
+        assert events[3] == events[2].replace("start:", "end:")
+
+
 class TestClaudeMCPManagementPolicyGate:
     """Mirror of TestSkillsManagementPolicyGate — ensures the prepare()
     chokepoint short-circuits with 403 when force-off."""

--- a/tests/test_claude_mcp_manager.py
+++ b/tests/test_claude_mcp_manager.py
@@ -221,9 +221,9 @@ class TestClaudeMCPManagerWrites:
         )
         captured: dict = {}
 
-        async def fake_subprocess(*argv, cwd, stdin, stdout, stderr):
+        async def fake_subprocess(*argv, **kwargs):
             captured["argv"] = list(argv)
-            captured["cwd"] = cwd
+            captured["cwd"] = kwargs.get("cwd")
             proc = MagicMock()
 
             async def communicate():
@@ -271,7 +271,7 @@ class TestClaudeMCPManagerWrites:
         )
         captured: dict = {}
 
-        async def fake_subprocess(*argv, cwd, stdin, stdout, stderr):
+        async def fake_subprocess(*argv, **kwargs):
             captured["argv"] = list(argv)
             proc = MagicMock()
 
@@ -302,7 +302,7 @@ class TestClaudeMCPManagerWrites:
             lambda: "/usr/local/bin/claude",
         )
 
-        async def fake_subprocess(*argv, cwd, stdin, stdout, stderr):
+        async def fake_subprocess(*argv, **kwargs):
             proc = MagicMock()
 
             async def communicate():

--- a/tests/test_claude_mcp_manager.py
+++ b/tests/test_claude_mcp_manager.py
@@ -165,7 +165,7 @@ class TestClaudeMCPManagerWrites:
         self, claude_home, working_dir, scope, monkeypatch
     ):
         monkeypatch.setattr(
-            "notebook_intelligence.claude_mcp_manager.resolve_claude_cli_path",
+            "notebook_intelligence._claude_cli.resolve_claude_cli_path",
             lambda: "/usr/local/bin/claude",
         )
         captured: dict = {}
@@ -215,7 +215,7 @@ class TestClaudeMCPManagerWrites:
 
     def test_remove_invokes_cli(self, claude_home, working_dir, monkeypatch):
         monkeypatch.setattr(
-            "notebook_intelligence.claude_mcp_manager.resolve_claude_cli_path",
+            "notebook_intelligence._claude_cli.resolve_claude_cli_path",
             lambda: "/usr/local/bin/claude",
         )
         captured: dict = {}
@@ -247,7 +247,7 @@ class TestClaudeMCPManagerWrites:
         self, claude_home, working_dir, monkeypatch
     ):
         monkeypatch.setattr(
-            "notebook_intelligence.claude_mcp_manager.resolve_claude_cli_path",
+            "notebook_intelligence._claude_cli.resolve_claude_cli_path",
             lambda: "/usr/local/bin/claude",
         )
 
@@ -271,7 +271,7 @@ class TestClaudeMCPManagerWrites:
         self, claude_home, working_dir, monkeypatch
     ):
         monkeypatch.setattr(
-            "notebook_intelligence.claude_mcp_manager.resolve_claude_cli_path",
+            "notebook_intelligence._claude_cli.resolve_claude_cli_path",
             lambda: None,
         )
         manager = ClaudeMCPManager(working_dir=str(working_dir))
@@ -280,7 +280,7 @@ class TestClaudeMCPManagerWrites:
 
     def test_leading_dash_name_rejected(self, claude_home, working_dir, monkeypatch):
         monkeypatch.setattr(
-            "notebook_intelligence.claude_mcp_manager.resolve_claude_cli_path",
+            "notebook_intelligence._claude_cli.resolve_claude_cli_path",
             lambda: "/usr/local/bin/claude",
         )
         manager = ClaudeMCPManager(working_dir=str(working_dir))
@@ -298,7 +298,7 @@ class TestClaudeMCPManagerWrites:
         self, claude_home, working_dir, monkeypatch
     ):
         monkeypatch.setattr(
-            "notebook_intelligence.claude_mcp_manager.resolve_claude_cli_path",
+            "notebook_intelligence._claude_cli.resolve_claude_cli_path",
             lambda: "/usr/local/bin/claude",
         )
         manager = ClaudeMCPManager(working_dir=str(working_dir))
@@ -349,7 +349,7 @@ class TestLockSerialization:
         self, claude_home, working_dir, monkeypatch
     ):
         monkeypatch.setattr(
-            "notebook_intelligence.claude_mcp_manager.resolve_claude_cli_path",
+            "notebook_intelligence._claude_cli.resolve_claude_cli_path",
             lambda: "/usr/local/bin/claude",
         )
         events: list[str] = []
@@ -387,47 +387,6 @@ class TestLockSerialization:
         assert events[3] == events[2].replace("start:", "end:")
 
 
-class TestClaudeMCPManagementPolicyGate:
-    """Mirror of TestSkillsManagementPolicyGate — ensures the prepare()
-    chokepoint short-circuits with 403 when force-off."""
-
-    @staticmethod
-    def _run_prepare(handler):
-        from jupyter_server.base.handlers import APIHandler
-
-        async def _noop(_self):
-            return None
-
-        with patch.object(APIHandler, "prepare", _noop):
-            asyncio.run(ClaudeMCPBaseHandler.prepare(handler))
-
-    def test_default_attribute_allows(self):
-        assert ClaudeMCPBaseHandler.claude_mcp_management_enabled is True
-
-    def test_prepare_rejects_when_disabled(self):
-        handler = MagicMock(spec=ClaudeMCPListHandler)
-        handler._finished = False
-        handler.policy_enabled_attr = "claude_mcp_management_enabled"
-        handler.policy_disabled_message = (
-            "Claude MCP management is disabled by your administrator"
-        )
-        handler.claude_mcp_management_enabled = False
-
-        def _finish(payload):
-            handler._finished = True
-            handler._finish_payload = payload
-
-        handler.finish.side_effect = _finish
-        self._run_prepare(handler)
-        handler.set_status.assert_called_with(403)
-        body = json.loads(handler._finish_payload)
-        assert "administrator" in body["error"].lower()
-
-    def test_prepare_passes_when_enabled(self):
-        handler = MagicMock(spec=ClaudeMCPListHandler)
-        handler._finished = False
-        handler.policy_enabled_attr = "claude_mcp_management_enabled"
-        handler.claude_mcp_management_enabled = True
-        self._run_prepare(handler)
-        handler.set_status.assert_not_called()
-        handler.finish.assert_not_called()
+# Per-family policy-gate coverage lives in `tests/test_policy_gate.py`,
+# parametrized across SkillsBaseHandler / ClaudeMCPBaseHandler /
+# PluginsBaseHandler.

--- a/tests/test_claude_mcp_manager.py
+++ b/tests/test_claude_mcp_manager.py
@@ -264,6 +264,69 @@ class TestClaudeMCPManagerWrites:
         assert result.name == "my-srv"
         assert result.scope == scope
 
+    @pytest.mark.parametrize(
+        "env_key",
+        ["-flag", "--inject", "BAD=KEY"],
+    )
+    def test_add_rejects_env_key_that_could_smuggle_flag(
+        self, claude_home, working_dir, env_key
+    ):
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        with pytest.raises(ValueError, match="env key"):
+            asyncio.run(
+                manager.add_server(
+                    name="s",
+                    scope="user",
+                    transport="stdio",
+                    command_or_url="npx",
+                    env={env_key: "v"},
+                )
+            )
+
+    @pytest.mark.parametrize(
+        "header_key",
+        ["-flag", "--inject", "Bad:Name"],
+    )
+    def test_add_rejects_header_name_that_could_smuggle_flag(
+        self, claude_home, working_dir, header_key
+    ):
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        with pytest.raises(ValueError, match="header name"):
+            asyncio.run(
+                manager.add_server(
+                    name="s",
+                    scope="user",
+                    transport="http",
+                    command_or_url="https://example.com",
+                    headers={header_key: "v"},
+                )
+            )
+
+    @pytest.mark.parametrize("transport", ["sse", "http"])
+    @pytest.mark.parametrize(
+        "bad_url",
+        [
+            "http://example.com",
+            "http://169.254.169.254/latest/meta-data/",
+            "file:///etc/passwd",
+            "ftp://example.com",
+        ],
+    )
+    def test_add_rejects_non_https_network_transport(
+        self, claude_home, working_dir, transport, bad_url
+    ):
+        # SSRF defense: sse/http transports must be https only.
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        with pytest.raises(ValueError, match="https"):
+            asyncio.run(
+                manager.add_server(
+                    name="s",
+                    scope="user",
+                    transport=transport,
+                    command_or_url=bad_url,
+                )
+            )
+
     def test_remove_invokes_cli(self, claude_home, working_dir, monkeypatch):
         monkeypatch.setattr(
             "notebook_intelligence._claude_cli.resolve_claude_cli_path",

--- a/tests/test_claude_mcp_manager.py
+++ b/tests/test_claude_mcp_manager.py
@@ -361,6 +361,10 @@ class TestClaudeMCPManagementPolicyGate:
     def test_prepare_rejects_when_disabled(self):
         handler = MagicMock(spec=ClaudeMCPListHandler)
         handler._finished = False
+        handler.policy_enabled_attr = "claude_mcp_management_enabled"
+        handler.policy_disabled_message = (
+            "Claude MCP management is disabled by your administrator"
+        )
         handler.claude_mcp_management_enabled = False
 
         def _finish(payload):
@@ -376,6 +380,7 @@ class TestClaudeMCPManagementPolicyGate:
     def test_prepare_passes_when_enabled(self):
         handler = MagicMock(spec=ClaudeMCPListHandler)
         handler._finished = False
+        handler.policy_enabled_attr = "claude_mcp_management_enabled"
         handler.claude_mcp_management_enabled = True
         self._run_prepare(handler)
         handler.set_status.assert_not_called()

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -12,11 +12,11 @@ from notebook_intelligence.extension import (
     PluginsBaseHandler,
     PluginsListHandler,
 )
+from notebook_intelligence._claude_cli import redact_argv_for_log
 from notebook_intelligence.plugin_manager import (
     PluginManager,
-    is_github_marketplace_source,
     is_acceptable_marketplace_source,
-    _redact_argv_for_log,
+    is_github_marketplace_source,
 )
 
 
@@ -161,7 +161,6 @@ class TestPluginManagerReads:
             b'{"installed":[{"name":"a"}]}',
             b'{"plugins":[{"name":"a"}]}',
             b'{"items":[{"name":"a"}]}',
-            b'{"data":[{"name":"a"}]}',
         ],
     )
     def test_list_plugins_handles_wrapper_shapes(
@@ -170,6 +169,18 @@ class TestPluginManagerReads:
         _stub_subprocess(monkeypatch, captured={}, stdout=wrapper)
         manager = PluginManager()
         assert asyncio.run(manager.list_plugins()) == [{"name": "a"}]
+
+    def test_list_plugins_rejects_generic_data_wrapper(
+        self, fake_cli, monkeypatch
+    ):
+        # `data` is generic enough to mean a metadata envelope rather than
+        # a plugin list, so the parser does not walk into it.
+        _stub_subprocess(
+            monkeypatch, captured={}, stdout=b'{"data":[{"name":"a"}]}'
+        )
+        manager = PluginManager()
+        with pytest.raises(ValueError, match="Unrecognized JSON shape"):
+            asyncio.run(manager.list_plugins())
 
     def test_list_plugins_unknown_shape_raises(self, fake_cli, monkeypatch):
         # Surface CLI version skew explicitly rather than masquerading as
@@ -256,6 +267,46 @@ class TestPluginManagerWrites:
                     source="acme/repo", scope="user", allow_github=False
                 )
             )
+
+    def test_github_gate_independent_of_policy_gate(
+        self, fake_cli, monkeypatch
+    ):
+        """The two gates compose: ``allow_github=False`` rejects a GitHub
+        source with ``PermissionError`` regardless of policy state, and a
+        non-GitHub source with ``allow_github=False`` still proceeds. The
+        policy gate (force-off → 403 in the handler's ``prepare()``)
+        sits *above* the manager and is independent — exercised by
+        ``test_policy_gate.py``. This test pins the manager-layer
+        contract: ``allow_github`` is the only thing that affects the
+        manager's permission decision."""
+        captured: dict = {}
+        _stub_subprocess(monkeypatch, captured=captured)
+        manager = PluginManager()
+
+        # GitHub source + allow_github=False → PermissionError, no CLI call.
+        captured.clear()
+        with pytest.raises(PermissionError):
+            asyncio.run(
+                manager.add_marketplace(
+                    source="acme/repo", scope="user", allow_github=False
+                )
+            )
+        assert captured.get("argv") is None
+
+        # Non-GitHub source + allow_github=False → CLI call proceeds.
+        asyncio.run(
+            manager.add_marketplace(
+                source="https://example.com/manifest",
+                scope="user",
+                allow_github=False,
+            )
+        )
+        assert captured["argv"][1:5] == [
+            "plugin",
+            "marketplace",
+            "add",
+            "--scope",
+        ]
 
     def test_add_marketplace_allows_non_github_when_disabled(
         self, fake_cli, monkeypatch
@@ -375,7 +426,7 @@ class TestLockSerialization:
 class TestRedactArgvForLog:
     def test_redacts_env_and_header_values(self):
         argv = ["claude", "plugin", "install", "-e", "K=v", "-H", "Auth: token"]
-        assert _redact_argv_for_log(argv) == [
+        assert redact_argv_for_log(argv) == [
             "claude",
             "plugin",
             "install",
@@ -384,6 +435,32 @@ class TestRedactArgvForLog:
             "-H",
             "<redacted>",
         ]
+
+    @pytest.mark.parametrize(
+        "flag",
+        [
+            "--client-secret",
+            "--client-id",
+            "--token",
+            "--password",
+            "--auth",
+            "--bearer",
+        ],
+    )
+    def test_redacts_forward_compat_secret_flags(self, flag):
+        argv = ["claude", "plugin", "install", flag, "supersecret", "name"]
+        assert redact_argv_for_log(argv) == [
+            "claude",
+            "plugin",
+            "install",
+            flag,
+            "<redacted>",
+            "name",
+        ]
+
+    def test_passes_through_non_secret_flags(self):
+        argv = ["claude", "plugin", "install", "--scope", "user", "name"]
+        assert redact_argv_for_log(argv) == argv
 
 
 # Per-family policy-gate coverage lives in `tests/test_policy_gate.py`,

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -15,6 +15,7 @@ from notebook_intelligence.extension import (
 from notebook_intelligence.plugin_manager import (
     PluginManager,
     is_github_marketplace_source,
+    is_acceptable_marketplace_source,
     _redact_argv_for_log,
 )
 
@@ -27,25 +28,7 @@ def fake_cli(monkeypatch):
     )
 
 
-def _stub_subprocess(
-    monkeypatch, *, captured: dict, stdout: bytes = b"[]", returncode: int = 0
-):
-    out_bytes = stdout
-    rc = returncode
-
-    async def fake_subprocess(*argv, **kwargs):
-        captured["argv"] = list(argv)
-        captured["kwargs"] = kwargs
-        proc = MagicMock()
-
-        async def communicate():
-            return (out_bytes, b"")
-
-        proc.communicate = communicate
-        proc.returncode = rc
-        return proc
-
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subprocess)
+from tests.conftest import stub_claude_subprocess as _stub_subprocess  # noqa: E402
 
 
 class TestIsGithubMarketplaceSource:
@@ -62,6 +45,9 @@ class TestIsGithubMarketplaceSource:
             "owner/repo.git",  # .git suffix on shorthand
             "https://github.com:443/owner/repo",  # explicit port
             "HTTPS://GitHub.com/owner/repo",  # case variation
+            "https://www.github.com/owner/repo",  # www subdomain
+            "git://github.com/owner/repo",  # deprecated git protocol
+            "ssh://git@github.com/owner/repo",  # ssh protocol
         ],
     )
     def test_recognizes_github(self, source):
@@ -75,11 +61,49 @@ class TestIsGithubMarketplaceSource:
             "~/home/path",
             "https://example.com/marketplace",
             "owner/repo/extra",  # too many slashes — not bare shorthand
+            "https://github.org/owner/repo",  # similar but not GitHub
+            "https://gitfake.com/owner/repo",
             "",
         ],
     )
     def test_rejects_non_github(self, source):
         assert is_github_marketplace_source(source) is False
+
+
+class TestIsAcceptableMarketplaceSource:
+    @pytest.mark.parametrize(
+        "source",
+        [
+            "https://example.com/manifest",
+            "https://github.com/owner/repo",
+            "github:owner/repo",
+            "ssh://git@github.com/owner/repo",
+            "git://github.com/owner/repo",
+            "git@github.com:owner/repo",
+            "owner/repo",
+            "/abs/path/to/marketplace",
+            "./relative/path",
+            "~/home/path",
+        ],
+    )
+    def test_accepts(self, source):
+        assert is_acceptable_marketplace_source(source) is True
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            "http://internal.attacker/manifest",  # plain http blocked (SSRF)
+            "http://169.254.169.254/latest/",  # IMDS-style probe
+            "file:///etc/passwd",
+            "ftp://example.com/manifest",
+            "gopher://example.com",
+            "git://example.com/repo",  # non-github git://
+            "ssh://git@gitlab.com/owner/repo",  # non-github ssh://
+            "",
+        ],
+    )
+    def test_rejects(self, source):
+        assert is_acceptable_marketplace_source(source) is False
 
 
 class TestPluginManagerReads:
@@ -303,6 +327,49 @@ class TestPluginManagerWrites:
                 asyncio.run(manager.add_marketplace(source=value, scope="user"))
             else:
                 asyncio.run(manager.remove_marketplace(name=value))
+
+
+class TestLockSerialization:
+    """Two concurrent writes against the (process-shared) lock must not
+    interleave at the subprocess layer. Catches a regression where the
+    asyncio.Lock gets demoted back to instance-level."""
+
+    def test_concurrent_install_calls_are_serialized(self, fake_cli, monkeypatch):
+        events: list[str] = []
+
+        async def fake_subprocess(*argv, **kwargs):
+            proc = MagicMock()
+            tag = argv[-1]
+
+            async def communicate():
+                events.append(f"start:{tag}")
+                await asyncio.sleep(0.01)
+                events.append(f"end:{tag}")
+                return (b"", b"")
+
+            proc.communicate = communicate
+            proc.returncode = 0
+            return proc
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subprocess)
+
+        async def driver():
+            m1 = PluginManager()
+            m2 = PluginManager()
+            await asyncio.gather(
+                m1.install_plugin(plugin="A", scope="user"),
+                m2.install_plugin(plugin="B", scope="user"),
+            )
+
+        asyncio.run(driver())
+        # No interleaving: each start is followed by its own end before the
+        # next start. We don't assert which won the race, just that they
+        # didn't overlap.
+        assert len(events) == 4
+        assert events[0].startswith("start:")
+        assert events[1] == events[0].replace("start:", "end:")
+        assert events[2].startswith("start:")
+        assert events[3] == events[2].replace("start:", "end:")
 
 
 class TestRedactArgvForLog:

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -23,7 +23,7 @@ from notebook_intelligence.plugin_manager import (
 @pytest.fixture
 def fake_cli(monkeypatch):
     monkeypatch.setattr(
-        "notebook_intelligence.plugin_manager.resolve_claude_cli_path",
+        "notebook_intelligence._claude_cli.resolve_claude_cli_path",
         lambda: "/usr/local/bin/claude",
     )
 
@@ -285,7 +285,7 @@ class TestPluginManagerWrites:
         ]
 
     def test_cli_failure_raises_with_stderr(self, fake_cli, monkeypatch):
-        async def fake_subprocess(*argv, stdin, stdout, stderr):
+        async def fake_subprocess(*argv, **kwargs):
             proc = MagicMock()
 
             async def communicate():
@@ -302,7 +302,7 @@ class TestPluginManagerWrites:
 
     def test_missing_cli_raises_filenotfound(self, monkeypatch):
         monkeypatch.setattr(
-            "notebook_intelligence.plugin_manager.resolve_claude_cli_path",
+            "notebook_intelligence._claude_cli.resolve_claude_cli_path",
             lambda: None,
         )
         manager = PluginManager()
@@ -386,44 +386,6 @@ class TestRedactArgvForLog:
         ]
 
 
-class TestPluginsManagementPolicyGate:
-    @staticmethod
-    def _run_prepare(handler):
-        from jupyter_server.base.handlers import APIHandler
-
-        async def _noop(_self):
-            return None
-
-        with patch.object(APIHandler, "prepare", _noop):
-            asyncio.run(PluginsBaseHandler.prepare(handler))
-
-    def test_default_attribute_allows(self):
-        assert PluginsBaseHandler.plugins_management_enabled is True
-
-    def test_prepare_rejects_when_disabled(self):
-        handler = MagicMock(spec=PluginsListHandler)
-        handler._finished = False
-        handler.policy_enabled_attr = "plugins_management_enabled"
-        handler.policy_disabled_message = (
-            "Plugins management is disabled by your administrator"
-        )
-        handler.plugins_management_enabled = False
-
-        def _finish(payload):
-            handler._finished = True
-            handler._finish_payload = payload
-
-        handler.finish.side_effect = _finish
-        self._run_prepare(handler)
-        handler.set_status.assert_called_with(403)
-        body = json.loads(handler._finish_payload)
-        assert "administrator" in body["error"].lower()
-
-    def test_prepare_passes_when_enabled(self):
-        handler = MagicMock(spec=PluginsListHandler)
-        handler._finished = False
-        handler.policy_enabled_attr = "plugins_management_enabled"
-        handler.plugins_management_enabled = True
-        self._run_prepare(handler)
-        handler.set_status.assert_not_called()
-        handler.finish.assert_not_called()
+# Per-family policy-gate coverage lives in `tests/test_policy_gate.py`,
+# parametrized across SkillsBaseHandler / ClaudeMCPBaseHandler /
+# PluginsBaseHandler.

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -268,6 +268,132 @@ class TestPluginManagerWrites:
                 )
             )
 
+    def test_add_marketplace_injects_github_token_for_github_source(
+        self, fake_cli, monkeypatch
+    ):
+        captured: dict = {}
+        _stub_subprocess(monkeypatch, captured=captured)
+        # Force the token resolver to return a known value (skip env / gh).
+        monkeypatch.setattr(
+            "notebook_intelligence.plugin_manager.resolve_github_token",
+            lambda: "ghp_testtoken",
+        )
+        manager = PluginManager()
+        asyncio.run(
+            manager.add_marketplace(source="acme/repo", scope="user")
+        )
+        # Token flows through env, not argv — kept out of DEBUG logs.
+        env = captured["kwargs"]["env"]
+        assert env["GITHUB_TOKEN"] == "ghp_testtoken"
+        assert env["GH_TOKEN"] == "ghp_testtoken"
+        assert "ghp_testtoken" not in " ".join(captured["argv"])
+
+    def test_add_marketplace_skips_token_injection_for_local_source(
+        self, fake_cli, monkeypatch
+    ):
+        captured: dict = {}
+        _stub_subprocess(monkeypatch, captured=captured)
+        monkeypatch.setattr(
+            "notebook_intelligence.plugin_manager.resolve_github_token",
+            lambda: "ghp_testtoken",
+        )
+        manager = PluginManager()
+        asyncio.run(
+            manager.add_marketplace(
+                source="/abs/path/marketplace", scope="user"
+            )
+        )
+        # Local path → no env-overrides → subprocess inherits parent env
+        # unchanged (None signals "don't override"). The token shouldn't
+        # leak into requests for non-GitHub sources.
+        assert captured["kwargs"]["env"] is None
+
+    def test_add_marketplace_skips_token_injection_when_unavailable(
+        self, fake_cli, monkeypatch
+    ):
+        captured: dict = {}
+        _stub_subprocess(monkeypatch, captured=captured)
+        monkeypatch.setattr(
+            "notebook_intelligence.plugin_manager.resolve_github_token",
+            lambda: None,
+        )
+        # Belt-and-suspenders: scrub real GitHub envs so a stale or
+        # accidentally-broken patch can't leak the developer's token into
+        # the test process.
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        manager = PluginManager()
+        asyncio.run(
+            manager.add_marketplace(source="acme/repo", scope="user")
+        )
+        assert captured["kwargs"]["env"] is None
+
+    def test_add_marketplace_skips_token_for_non_github_https(
+        self, fake_cli, monkeypatch
+    ):
+        captured: dict = {}
+        _stub_subprocess(monkeypatch, captured=captured)
+        monkeypatch.setattr(
+            "notebook_intelligence.plugin_manager.resolve_github_token",
+            lambda: "ghp_should_not_be_used",
+        )
+        manager = PluginManager()
+        asyncio.run(
+            manager.add_marketplace(
+                source="https://example.com/manifest", scope="user"
+            )
+        )
+        # Non-GitHub HTTPS source must not receive a github.com PAT.
+        assert captured["kwargs"]["env"] is None
+
+    def test_add_marketplace_env_overrides_win_over_inherited(
+        self, fake_cli, monkeypatch
+    ):
+        captured: dict = {}
+        _stub_subprocess(monkeypatch, captured=captured)
+        monkeypatch.setenv("GITHUB_TOKEN", "stale_from_parent_env")
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
+        monkeypatch.setattr(
+            "notebook_intelligence.plugin_manager.resolve_github_token",
+            lambda: "fresh_resolved",
+        )
+        manager = PluginManager()
+        asyncio.run(
+            manager.add_marketplace(source="acme/repo", scope="user")
+        )
+        env = captured["kwargs"]["env"]
+        # Override wins on collision.
+        assert env["GITHUB_TOKEN"] == "fresh_resolved"
+        # Inherited keys survive the merge.
+        assert env["PATH"] == "/usr/bin:/bin"
+
+    def test_add_marketplace_remediation_hint_on_auth_failure(
+        self, fake_cli, monkeypatch
+    ):
+        # CLI fails with a typical git-auth-missing message; we should
+        # wrap the error with an actionable hint when the source is
+        # GitHub and we had no token to inject.
+        async def fake_subprocess(*argv, **kwargs):
+            proc = MagicMock()
+
+            async def communicate():
+                return (b"", b"fatal: could not read Username for 'https://github.com'")
+
+            proc.communicate = communicate
+            proc.returncode = 1
+            return proc
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subprocess)
+        monkeypatch.setattr(
+            "notebook_intelligence.plugin_manager.resolve_github_token",
+            lambda: None,
+        )
+        manager = PluginManager()
+        with pytest.raises(ValueError, match="GITHUB_TOKEN"):
+            asyncio.run(
+                manager.add_marketplace(source="acme/repo", scope="user")
+            )
+
     def test_github_gate_independent_of_policy_gate(
         self, fake_cli, monkeypatch
     ):

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -477,6 +477,68 @@ class TestPluginManagerWrites:
         with pytest.raises(ValueError, match="plugin not found"):
             asyncio.run(manager.uninstall_plugin(plugin="x", scope="user"))
 
+    def test_cli_failure_scrubs_injected_token_from_stderr(
+        self, fake_cli, monkeypatch
+    ):
+        # If a downstream tool (git, curl in verbose mode, a misconfigured
+        # credential helper) echoes the injected token into stderr, the
+        # ValueError surfaced to the browser via `_error()` would otherwise
+        # leak the secret. `_claude_cli` must scrub `env_overrides` values
+        # before raising.
+        secret = "ghp_supersecrettoken1234567890"
+
+        async def fake_subprocess(*argv, **kwargs):
+            proc = MagicMock()
+
+            async def communicate():
+                return (
+                    b"",
+                    f"auth failed: tried {secret} but expired".encode(),
+                )
+
+            proc.communicate = communicate
+            proc.returncode = 1
+            return proc
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subprocess)
+        monkeypatch.setenv("GITHUB_TOKEN", secret)
+        manager = PluginManager()
+        try:
+            asyncio.run(
+                manager.add_marketplace(
+                    source="https://github.com/owner/repo",
+                    scope="user",
+                    allow_github=True,
+                )
+            )
+        except ValueError as exc:
+            assert secret not in str(exc), "Token leaked in error message"
+            assert "<redacted>" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+    def test_passes_cwd_to_cli(self, fake_cli, monkeypatch):
+        # Project-scope writes must resolve against the user's working
+        # directory, not the Jupyter server's cwd. A missing cwd means
+        # `--scope project` lands the manifest in the wrong tree.
+        captured: dict = {}
+
+        async def fake_subprocess(*argv, **kwargs):
+            captured["cwd"] = kwargs.get("cwd")
+            proc = MagicMock()
+
+            async def communicate():
+                return (b"[]", b"")
+
+            proc.communicate = communicate
+            proc.returncode = 0
+            return proc
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subprocess)
+        manager = PluginManager(working_dir="/home/user/work")
+        asyncio.run(manager.list_plugins())
+        assert captured["cwd"] == "/home/user/work"
+
     def test_missing_cli_raises_filenotfound(self, monkeypatch):
         monkeypatch.setattr(
             "notebook_intelligence._claude_cli.resolve_claude_cli_path",

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -1,0 +1,362 @@
+# Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+"""Tests for the PluginManager and the plugins management policy gate."""
+
+import asyncio
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from notebook_intelligence.extension import (
+    PluginsBaseHandler,
+    PluginsListHandler,
+)
+from notebook_intelligence.plugin_manager import (
+    PluginManager,
+    is_github_marketplace_source,
+    _redact_argv_for_log,
+)
+
+
+@pytest.fixture
+def fake_cli(monkeypatch):
+    monkeypatch.setattr(
+        "notebook_intelligence.plugin_manager.resolve_claude_cli_path",
+        lambda: "/usr/local/bin/claude",
+    )
+
+
+def _stub_subprocess(
+    monkeypatch, *, captured: dict, stdout: bytes = b"[]", returncode: int = 0
+):
+    out_bytes = stdout
+    rc = returncode
+
+    async def fake_subprocess(*argv, **kwargs):
+        captured["argv"] = list(argv)
+        captured["kwargs"] = kwargs
+        proc = MagicMock()
+
+        async def communicate():
+            return (out_bytes, b"")
+
+        proc.communicate = communicate
+        proc.returncode = rc
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subprocess)
+
+
+class TestIsGithubMarketplaceSource:
+    @pytest.mark.parametrize(
+        "source",
+        [
+            "github:owner/repo",
+            "https://github.com/owner/repo",
+            "https://github.com/owner/repo.git",
+            "http://github.com/owner/repo",
+            "git@github.com:owner/repo.git",
+            "owner/repo",
+            "owner/repo/",  # trailing slash on shorthand
+            "owner/repo.git",  # .git suffix on shorthand
+            "https://github.com:443/owner/repo",  # explicit port
+            "HTTPS://GitHub.com/owner/repo",  # case variation
+        ],
+    )
+    def test_recognizes_github(self, source):
+        assert is_github_marketplace_source(source) is True
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            "/abs/path/to/marketplace",
+            "./relative/path",
+            "~/home/path",
+            "https://example.com/marketplace",
+            "owner/repo/extra",  # too many slashes — not bare shorthand
+            "",
+        ],
+    )
+    def test_rejects_non_github(self, source):
+        assert is_github_marketplace_source(source) is False
+
+
+class TestPluginManagerReads:
+    def test_list_plugins_parses_json_array(self, fake_cli, monkeypatch):
+        captured: dict = {}
+        _stub_subprocess(
+            monkeypatch,
+            captured=captured,
+            stdout=b'[{"name":"a","scope":"user","enabled":true}]',
+        )
+        manager = PluginManager()
+        result = asyncio.run(manager.list_plugins())
+        assert result == [{"name": "a", "scope": "user", "enabled": True}]
+        assert captured["argv"][1:] == ["plugin", "list", "--json"]
+
+    def test_list_marketplaces_parses_json_array(self, fake_cli, monkeypatch):
+        captured: dict = {}
+        _stub_subprocess(
+            monkeypatch,
+            captured=captured,
+            stdout=b'[{"name":"acme","source":"github:acme/marketplace"}]',
+        )
+        manager = PluginManager()
+        result = asyncio.run(manager.list_marketplaces())
+        assert result == [{"name": "acme", "source": "github:acme/marketplace"}]
+
+    def test_list_plugins_handles_installed_object_shape(self, fake_cli, monkeypatch):
+        # `claude plugin list --available --json` returns an object — the
+        # bare `--json` form returns an array, but tolerate both.
+        _stub_subprocess(
+            monkeypatch,
+            captured={},
+            stdout=json.dumps(
+                {"installed": [{"name": "a"}], "available": [{"name": "b"}]}
+            ).encode(),
+        )
+        manager = PluginManager()
+        result = asyncio.run(manager.list_plugins())
+        assert result == [{"name": "a"}]
+
+    def test_list_plugins_empty_output(self, fake_cli, monkeypatch):
+        _stub_subprocess(monkeypatch, captured={}, stdout=b"")
+        manager = PluginManager()
+        assert asyncio.run(manager.list_plugins()) == []
+
+    def test_list_plugins_invalid_json_raises(self, fake_cli, monkeypatch):
+        _stub_subprocess(monkeypatch, captured={}, stdout=b"not json")
+        manager = PluginManager()
+        with pytest.raises(ValueError, match="Could not parse"):
+            asyncio.run(manager.list_plugins())
+
+    @pytest.mark.parametrize(
+        "wrapper",
+        [
+            b'{"installed":[{"name":"a"}]}',
+            b'{"plugins":[{"name":"a"}]}',
+            b'{"items":[{"name":"a"}]}',
+            b'{"data":[{"name":"a"}]}',
+        ],
+    )
+    def test_list_plugins_handles_wrapper_shapes(
+        self, fake_cli, monkeypatch, wrapper
+    ):
+        _stub_subprocess(monkeypatch, captured={}, stdout=wrapper)
+        manager = PluginManager()
+        assert asyncio.run(manager.list_plugins()) == [{"name": "a"}]
+
+    def test_list_plugins_unknown_shape_raises(self, fake_cli, monkeypatch):
+        # Surface CLI version skew explicitly rather than masquerading as
+        # "no plugins installed".
+        _stub_subprocess(
+            monkeypatch, captured={}, stdout=b'{"unknownKey":[{"name":"a"}]}'
+        )
+        manager = PluginManager()
+        with pytest.raises(ValueError, match="Unrecognized JSON shape"):
+            asyncio.run(manager.list_plugins())
+
+
+class TestPluginManagerWrites:
+    def test_install_invokes_cli_with_scope(self, fake_cli, monkeypatch):
+        captured: dict = {}
+        _stub_subprocess(monkeypatch, captured=captured)
+        manager = PluginManager()
+        asyncio.run(manager.install_plugin(plugin="my-plugin", scope="project"))
+        assert captured["argv"][1:] == [
+            "plugin",
+            "install",
+            "--scope",
+            "project",
+            "my-plugin",
+        ]
+
+    def test_uninstall_passes_yes_flag_for_non_tty(self, fake_cli, monkeypatch):
+        captured: dict = {}
+        _stub_subprocess(monkeypatch, captured=captured)
+        manager = PluginManager()
+        asyncio.run(manager.uninstall_plugin(plugin="my-plugin", scope="user"))
+        assert captured["argv"][1:] == [
+            "plugin",
+            "uninstall",
+            "--scope",
+            "user",
+            "-y",
+            "my-plugin",
+        ]
+
+    @pytest.mark.parametrize("enabled,verb", [(True, "enable"), (False, "disable")])
+    def test_set_plugin_enabled_invokes_correct_verb(
+        self, fake_cli, monkeypatch, enabled, verb
+    ):
+        captured: dict = {}
+        _stub_subprocess(monkeypatch, captured=captured)
+        manager = PluginManager()
+        asyncio.run(
+            manager.set_plugin_enabled(plugin="p", enabled=enabled, scope="user")
+        )
+        assert captured["argv"][1:] == ["plugin", verb, "--scope", "user", "p"]
+
+    def test_set_plugin_enabled_omits_scope_when_none(
+        self, fake_cli, monkeypatch
+    ):
+        captured: dict = {}
+        _stub_subprocess(monkeypatch, captured=captured)
+        manager = PluginManager()
+        asyncio.run(manager.set_plugin_enabled(plugin="p", enabled=True))
+        assert captured["argv"][1:] == ["plugin", "enable", "p"]
+
+    def test_add_marketplace_passes_source(self, fake_cli, monkeypatch):
+        captured: dict = {}
+        _stub_subprocess(monkeypatch, captured=captured)
+        manager = PluginManager()
+        asyncio.run(manager.add_marketplace(source="acme/repo", scope="user"))
+        assert captured["argv"][1:] == [
+            "plugin",
+            "marketplace",
+            "add",
+            "--scope",
+            "user",
+            "acme/repo",
+        ]
+
+    def test_add_marketplace_blocks_github_when_disabled(
+        self, fake_cli, monkeypatch
+    ):
+        _stub_subprocess(monkeypatch, captured={})
+        manager = PluginManager()
+        with pytest.raises(PermissionError, match="GitHub"):
+            asyncio.run(
+                manager.add_marketplace(
+                    source="acme/repo", scope="user", allow_github=False
+                )
+            )
+
+    def test_add_marketplace_allows_non_github_when_disabled(
+        self, fake_cli, monkeypatch
+    ):
+        captured: dict = {}
+        _stub_subprocess(monkeypatch, captured=captured)
+        manager = PluginManager()
+        asyncio.run(
+            manager.add_marketplace(
+                source="https://example.com/marketplace",
+                scope="user",
+                allow_github=False,
+            )
+        )
+        assert "marketplace" in captured["argv"]
+
+    def test_remove_marketplace_invokes_cli(self, fake_cli, monkeypatch):
+        captured: dict = {}
+        _stub_subprocess(monkeypatch, captured=captured)
+        manager = PluginManager()
+        asyncio.run(manager.remove_marketplace(name="acme"))
+        assert captured["argv"][1:] == [
+            "plugin",
+            "marketplace",
+            "remove",
+            "acme",
+        ]
+
+    def test_cli_failure_raises_with_stderr(self, fake_cli, monkeypatch):
+        async def fake_subprocess(*argv, stdin, stdout, stderr):
+            proc = MagicMock()
+
+            async def communicate():
+                return (b"", b"plugin not found")
+
+            proc.communicate = communicate
+            proc.returncode = 1
+            return proc
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subprocess)
+        manager = PluginManager()
+        with pytest.raises(ValueError, match="plugin not found"):
+            asyncio.run(manager.uninstall_plugin(plugin="x", scope="user"))
+
+    def test_missing_cli_raises_filenotfound(self, monkeypatch):
+        monkeypatch.setattr(
+            "notebook_intelligence.plugin_manager.resolve_claude_cli_path",
+            lambda: None,
+        )
+        manager = PluginManager()
+        with pytest.raises(FileNotFoundError):
+            asyncio.run(manager.list_plugins())
+
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            ("plugin", "--evil"),
+            ("source", "-x"),
+            ("name", "--remove-everything"),
+        ],
+    )
+    def test_leading_dash_rejected(self, fake_cli, monkeypatch, field, value):
+        _stub_subprocess(monkeypatch, captured={})
+        manager = PluginManager()
+        with pytest.raises(ValueError, match="leading '-'"):
+            if field == "plugin":
+                asyncio.run(manager.install_plugin(plugin=value, scope="user"))
+            elif field == "source":
+                asyncio.run(manager.add_marketplace(source=value, scope="user"))
+            else:
+                asyncio.run(manager.remove_marketplace(name=value))
+
+
+class TestRedactArgvForLog:
+    def test_redacts_env_and_header_values(self):
+        argv = ["claude", "plugin", "install", "-e", "K=v", "-H", "Auth: token"]
+        assert _redact_argv_for_log(argv) == [
+            "claude",
+            "plugin",
+            "install",
+            "-e",
+            "<redacted>",
+            "-H",
+            "<redacted>",
+        ]
+
+
+class TestPluginsManagementPolicyGate:
+    @staticmethod
+    def _run_prepare(handler):
+        from jupyter_server.base.handlers import APIHandler
+
+        async def _noop(_self):
+            return None
+
+        with patch.object(APIHandler, "prepare", _noop):
+            asyncio.run(PluginsBaseHandler.prepare(handler))
+
+    def test_default_attribute_allows(self):
+        assert PluginsBaseHandler.plugins_management_enabled is True
+
+    def test_prepare_rejects_when_disabled(self):
+        handler = MagicMock(spec=PluginsListHandler)
+        handler._finished = False
+        handler.policy_enabled_attr = "plugins_management_enabled"
+        handler.policy_disabled_message = (
+            "Plugins management is disabled by your administrator"
+        )
+        handler.plugins_management_enabled = False
+
+        def _finish(payload):
+            handler._finished = True
+            handler._finish_payload = payload
+
+        handler.finish.side_effect = _finish
+        self._run_prepare(handler)
+        handler.set_status.assert_called_with(403)
+        body = json.loads(handler._finish_payload)
+        assert "administrator" in body["error"].lower()
+
+    def test_prepare_passes_when_enabled(self):
+        handler = MagicMock(spec=PluginsListHandler)
+        handler._finished = False
+        handler.policy_enabled_attr = "plugins_management_enabled"
+        handler.plugins_management_enabled = True
+        self._run_prepare(handler)
+        handler.set_status.assert_not_called()
+        handler.finish.assert_not_called()

--- a/tests/test_policy_gate.py
+++ b/tests/test_policy_gate.py
@@ -106,109 +106,93 @@ class TestPolicyGate:
 
 
 class TestPolicyGateIntegration(AsyncHTTPTestCase):
-    """End-to-end dispatch test for the gate's contract. Doesn't go
-    through APIHandler — we synthesize a minimal subclass that exposes
-    the same `prepare()` shape as `PolicyGatedHandler` over a plain
-    `RequestHandler`, then drive real Tornado dispatch to assert:
+    """End-to-end dispatch test that uses the *real* PolicyGatedHandler.
 
-      * gate runs after super().prepare() and respects an already-finished
-        request (no double-finish, no overwriting an earlier status)
+    Earlier versions of this test re-implemented the gate body in the test
+    itself, so a regression in production would not have been caught. We
+    now subclass ``PolicyGatedHandler`` directly and patch only the
+    auth-bearing ``APIHandler.prepare`` to a no-op coroutine — that lets us
+    drive the real prepare() chokepoint without setting up cookie_secret
+    and identity_provider for every test.
+
+    Asserts:
+      * gate runs *after* ``await super().prepare()``
+      * gate respects an already-finished request (the ``_finished`` guard)
       * gate short-circuits with 403 + JSON error on force-off
       * gate is a no-op when enabled (handler method runs)
-
-    Catches a regression where someone reorders prepare() so the gate
-    runs *before* `await super().prepare()`, or removes the `_finished`
-    guard.
     """
 
     DISABLED_MESSAGE = "the gate is force-off"
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        from jupyter_server.base.handlers import APIHandler
+
+        async def _noop(_self):
+            return None
+
+        cls._api_handler_patcher = patch.object(APIHandler, "prepare", _noop)
+        cls._api_handler_patcher.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._api_handler_patcher.stop()
+        super().tearDownClass()
+
     def get_app(self):
-        from tornado.web import Application, RequestHandler
+        from notebook_intelligence.extension import PolicyGatedHandler
+        from tornado.web import Application
 
-        class _ParentEarlyFinish(RequestHandler):
-            """Stand-in for an APIHandler whose `prepare` finishes early
-            (e.g. auth rejection). The gate must not overwrite this."""
-
-            async def prepare(self):
-                self.set_status(401)
-                self.finish(json.dumps({"error": "from parent"}))
-
-        class _ParentPassThrough(RequestHandler):
-            async def prepare(self):
-                return
-
-        # Mirror the PolicyGatedHandler contract verbatim so any future
-        # change there must be reflected here — keeping the test honest.
-        async def _gate_prepare(self):
-            await super(self.__class__.__mro__[0], self).prepare()
-            if self._finished:
-                return
-            attr = self.policy_enabled_attr
-            if attr and not getattr(self, attr, True):
-                self.set_status(403)
-                self.finish(json.dumps({"error": self.policy_disabled_message}))
-
-        class _GateOverPassThrough(_ParentPassThrough):
+        class _PassthroughGate(PolicyGatedHandler):  # type: ignore[misc]
             policy_enabled_attr = "gate_enabled"
             policy_disabled_message = TestPolicyGateIntegration.DISABLED_MESSAGE
             gate_enabled = True
-
-            async def prepare(self):
-                await _ParentPassThrough.prepare(self)
-                if self._finished:
-                    return
-                if not getattr(self, self.policy_enabled_attr, True):
-                    self.set_status(403)
-                    self.finish(
-                        json.dumps({"error": self.policy_disabled_message})
-                    )
 
             async def get(self):
                 self.set_status(200)
                 self.finish(json.dumps({"ok": True}))
 
-        class _GateOverEarlyFinish(_ParentEarlyFinish):
+        class _ParentFinishesEarly(PolicyGatedHandler):  # type: ignore[misc]
+            """Override prepare to finish before the gate body runs via
+            super, simulating an APIHandler that rejected auth. The gate
+            must not overwrite the early finish."""
+
             policy_enabled_attr = "gate_enabled"
             policy_disabled_message = TestPolicyGateIntegration.DISABLED_MESSAGE
-            gate_enabled = False  # Force-off, but parent finishes first.
+            gate_enabled = False  # force-off — but parent finishes first
 
             async def prepare(self):
-                await _ParentEarlyFinish.prepare(self)
-                if self._finished:
-                    return  # The guard under test.
-                if not getattr(self, self.policy_enabled_attr, True):
-                    self.set_status(403)
-                    self.finish(
-                        json.dumps({"error": self.policy_disabled_message})
-                    )
+                self.set_status(401)
+                self.finish(json.dumps({"error": "from parent"}))
+                # Now invoke the real chokepoint via super — it must respect
+                # ``_finished`` and not overwrite the 401 with 403.
+                await super().prepare()
 
             async def get(self):
                 self.set_status(200)
 
-        self._enabled_cls = _GateOverPassThrough
+        self._passthrough_cls = _PassthroughGate
         return Application(
             [
-                (r"/gate-pass", _GateOverPassThrough),
-                (r"/gate-parent-finished", _GateOverEarlyFinish),
+                (r"/gate-pass", _PassthroughGate),
+                (r"/gate-parent-finished", _ParentFinishesEarly),
             ]
         )
 
     def test_passes_through_when_enabled(self):
-        self._enabled_cls.gate_enabled = True
+        self._passthrough_cls.gate_enabled = True
         response = self.fetch("/gate-pass")
         assert response.code == 200
         assert json.loads(response.body) == {"ok": True}
 
     def test_short_circuits_when_disabled(self):
-        self._enabled_cls.gate_enabled = False
+        self._passthrough_cls.gate_enabled = False
         response = self.fetch("/gate-pass")
         assert response.code == 403
         assert json.loads(response.body) == {"error": self.DISABLED_MESSAGE}
 
     def test_respects_parent_early_finish(self):
-        # Even with the gate force-off, the parent's earlier 401 must win
-        # — no double-finish, no overwrite.
         response = self.fetch("/gate-parent-finished")
         assert response.code == 401
         assert json.loads(response.body) == {"error": "from parent"}

--- a/tests/test_policy_gate.py
+++ b/tests/test_policy_gate.py
@@ -196,3 +196,63 @@ class TestPolicyGateIntegration(AsyncHTTPTestCase):
         response = self.fetch("/gate-parent-finished")
         assert response.code == 401
         assert json.loads(response.body) == {"error": "from parent"}
+
+
+class TestPolicyGatedHandlerErrorMap:
+    """Direct unit coverage for ``PolicyGatedHandler._error`` MRO walking.
+
+    The mixin sorts mapped exception classes by MRO depth so a narrower
+    subclass wins over its base. This was previously only exercised
+    transitively by the skills handler tests; pin it directly so a
+    regression in the sort key surfaces here.
+    """
+
+    def _stub_handler(self, exception_status_map):
+        from notebook_intelligence.extension import PolicyGatedHandler
+
+        handler = MagicMock(spec=PolicyGatedHandler)
+        handler.exception_status_map = exception_status_map
+        captured: dict = {}
+
+        def _finish(payload):
+            captured["body"] = payload
+
+        handler.set_status.side_effect = lambda code: captured.setdefault(
+            "status", code
+        )
+        handler.finish.side_effect = _finish
+        return handler, captured
+
+    def test_most_specific_class_wins_via_mro_depth(self):
+        from notebook_intelligence.extension import PolicyGatedHandler
+
+        handler, captured = self._stub_handler(
+            {OSError: 500, FileNotFoundError: 404}
+        )
+        PolicyGatedHandler._error(handler, FileNotFoundError("missing"))
+        assert captured["status"] == 404
+
+    def test_unmapped_exception_falls_back_to_400(self):
+        from notebook_intelligence.extension import PolicyGatedHandler
+
+        handler, captured = self._stub_handler({FileNotFoundError: 404})
+        PolicyGatedHandler._error(handler, RuntimeError("oops"))
+        assert captured["status"] == 400
+        assert json.loads(captured["body"]) == {"error": "oops"}
+
+    def test_subclass_extends_inherited_map(self):
+        from notebook_intelligence.extension import PolicyGatedHandler
+
+        # Mimics a handler that adds KeyError to an inherited
+        # PermissionError mapping. Each entry must be honored.
+        handler, captured = self._stub_handler(
+            {PermissionError: 403, KeyError: 422}
+        )
+        PolicyGatedHandler._error(handler, KeyError("k"))
+        assert captured["status"] == 422
+
+        handler, captured = self._stub_handler(
+            {PermissionError: 403, KeyError: 422}
+        )
+        PolicyGatedHandler._error(handler, PermissionError("nope"))
+        assert captured["status"] == 403

--- a/tests/test_policy_gate.py
+++ b/tests/test_policy_gate.py
@@ -256,3 +256,39 @@ class TestPolicyGatedHandlerErrorMap:
         )
         PolicyGatedHandler._error(handler, PermissionError("nope"))
         assert captured["status"] == 403
+
+
+class TestPolicyGatedHandlerSubclassGuard:
+    """The mixin's `__init_subclass__` refuses concrete subclasses that
+    forget to declare `policy_enabled_attr` — force-off must fail closed,
+    so a silent bypass would be a security regression worth catching at
+    import time."""
+
+    def test_concrete_subclass_without_attr_raises(self):
+        from notebook_intelligence.extension import PolicyGatedHandler
+
+        with pytest.raises(TypeError, match="policy_enabled_attr"):
+            # NOTE: not suffixed BaseHandler — should error.
+            class _Forgotten(PolicyGatedHandler):
+                pass
+
+    def test_intermediate_base_class_is_allowed_to_defer(self):
+        from notebook_intelligence.extension import PolicyGatedHandler
+
+        # An intermediate *BaseHandler can defer; concrete subclasses must
+        # still set the attribute themselves (or inherit it).
+        class _IntermediateBaseHandler(PolicyGatedHandler):
+            pass
+
+        with pytest.raises(TypeError, match="policy_enabled_attr"):
+            class _ConcreteChild(_IntermediateBaseHandler):
+                pass
+
+        class _AnotherBaseHandler(PolicyGatedHandler):
+            policy_enabled_attr = "something_enabled"
+
+        # OK: concrete subclass inherits the attribute.
+        class _ConcreteOK(_AnotherBaseHandler):
+            pass
+
+        assert _ConcreteOK.policy_enabled_attr == "something_enabled"

--- a/tests/test_policy_gate.py
+++ b/tests/test_policy_gate.py
@@ -44,9 +44,9 @@ HANDLER_FAMILIES = [
     pytest.param(
         PluginsBaseHandler,
         PluginsListHandler,
-        "plugins_management_enabled",
+        "claude_plugins_management_enabled",
         "Plugins management is disabled by your administrator",
-        id="plugins",
+        id="claude_plugins",
     ),
 ]
 

--- a/tests/test_policy_gate.py
+++ b/tests/test_policy_gate.py
@@ -1,0 +1,214 @@
+# Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+"""Parametrized coverage for the `PolicyGatedHandler.prepare()` chokepoint
+across all three management surfaces (Skills, Claude MCP, Plugins).
+
+Each handler family wires its own attribute name into `policy_enabled_attr`
+and its own user-facing message into `policy_disabled_message`. The mixin's
+job is uniform: short-circuit with 403 when force-off and pass through
+otherwise. Three parameter sets exercise that contract once per family.
+"""
+
+import asyncio
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from tornado.testing import AsyncHTTPTestCase
+
+from notebook_intelligence.extension import (
+    ClaudeMCPBaseHandler,
+    ClaudeMCPListHandler,
+    PluginsBaseHandler,
+    PluginsListHandler,
+    SkillsBaseHandler,
+    SkillsListHandler,
+)
+
+
+HANDLER_FAMILIES = [
+    pytest.param(
+        SkillsBaseHandler,
+        SkillsListHandler,
+        "skills_management_enabled",
+        "Skills management is disabled by your administrator",
+        id="skills",
+    ),
+    pytest.param(
+        ClaudeMCPBaseHandler,
+        ClaudeMCPListHandler,
+        "claude_mcp_management_enabled",
+        "Claude MCP management is disabled by your administrator",
+        id="claude_mcp",
+    ),
+    pytest.param(
+        PluginsBaseHandler,
+        PluginsListHandler,
+        "plugins_management_enabled",
+        "Plugins management is disabled by your administrator",
+        id="plugins",
+    ),
+]
+
+
+def _run_prepare(base_cls, handler):
+    """Drive the mixin's `prepare()` with the parent's `prepare` stubbed
+    out — bypasses jupyter_server's auth plumbing so we exercise just the
+    gate."""
+    from jupyter_server.base.handlers import APIHandler
+
+    async def _noop(_self):
+        return None
+
+    with patch.object(APIHandler, "prepare", _noop):
+        asyncio.run(base_cls.prepare(handler))
+
+
+@pytest.mark.parametrize("base_cls,list_cls,attr,message", HANDLER_FAMILIES)
+class TestPolicyGate:
+    def test_default_attribute_allows(self, base_cls, list_cls, attr, message):
+        assert getattr(base_cls, attr) is True
+
+    def test_default_message_matches_subclass(
+        self, base_cls, list_cls, attr, message
+    ):
+        assert base_cls.policy_disabled_message == message
+
+    def test_prepare_rejects_when_disabled(
+        self, base_cls, list_cls, attr, message
+    ):
+        handler = MagicMock(spec=list_cls)
+        handler._finished = False
+        handler.policy_enabled_attr = attr
+        handler.policy_disabled_message = message
+        setattr(handler, attr, False)
+
+        def _finish(payload):
+            handler._finished = True
+            handler._finish_payload = payload
+
+        handler.finish.side_effect = _finish
+        _run_prepare(base_cls, handler)
+        handler.set_status.assert_called_with(403)
+        body = json.loads(handler._finish_payload)
+        assert body["error"] == message
+
+    def test_prepare_passes_when_enabled(
+        self, base_cls, list_cls, attr, message
+    ):
+        handler = MagicMock(spec=list_cls)
+        handler._finished = False
+        handler.policy_enabled_attr = attr
+        setattr(handler, attr, True)
+        _run_prepare(base_cls, handler)
+        handler.set_status.assert_not_called()
+        handler.finish.assert_not_called()
+
+
+class TestPolicyGateIntegration(AsyncHTTPTestCase):
+    """End-to-end dispatch test for the gate's contract. Doesn't go
+    through APIHandler — we synthesize a minimal subclass that exposes
+    the same `prepare()` shape as `PolicyGatedHandler` over a plain
+    `RequestHandler`, then drive real Tornado dispatch to assert:
+
+      * gate runs after super().prepare() and respects an already-finished
+        request (no double-finish, no overwriting an earlier status)
+      * gate short-circuits with 403 + JSON error on force-off
+      * gate is a no-op when enabled (handler method runs)
+
+    Catches a regression where someone reorders prepare() so the gate
+    runs *before* `await super().prepare()`, or removes the `_finished`
+    guard.
+    """
+
+    DISABLED_MESSAGE = "the gate is force-off"
+
+    def get_app(self):
+        from tornado.web import Application, RequestHandler
+
+        class _ParentEarlyFinish(RequestHandler):
+            """Stand-in for an APIHandler whose `prepare` finishes early
+            (e.g. auth rejection). The gate must not overwrite this."""
+
+            async def prepare(self):
+                self.set_status(401)
+                self.finish(json.dumps({"error": "from parent"}))
+
+        class _ParentPassThrough(RequestHandler):
+            async def prepare(self):
+                return
+
+        # Mirror the PolicyGatedHandler contract verbatim so any future
+        # change there must be reflected here — keeping the test honest.
+        async def _gate_prepare(self):
+            await super(self.__class__.__mro__[0], self).prepare()
+            if self._finished:
+                return
+            attr = self.policy_enabled_attr
+            if attr and not getattr(self, attr, True):
+                self.set_status(403)
+                self.finish(json.dumps({"error": self.policy_disabled_message}))
+
+        class _GateOverPassThrough(_ParentPassThrough):
+            policy_enabled_attr = "gate_enabled"
+            policy_disabled_message = TestPolicyGateIntegration.DISABLED_MESSAGE
+            gate_enabled = True
+
+            async def prepare(self):
+                await _ParentPassThrough.prepare(self)
+                if self._finished:
+                    return
+                if not getattr(self, self.policy_enabled_attr, True):
+                    self.set_status(403)
+                    self.finish(
+                        json.dumps({"error": self.policy_disabled_message})
+                    )
+
+            async def get(self):
+                self.set_status(200)
+                self.finish(json.dumps({"ok": True}))
+
+        class _GateOverEarlyFinish(_ParentEarlyFinish):
+            policy_enabled_attr = "gate_enabled"
+            policy_disabled_message = TestPolicyGateIntegration.DISABLED_MESSAGE
+            gate_enabled = False  # Force-off, but parent finishes first.
+
+            async def prepare(self):
+                await _ParentEarlyFinish.prepare(self)
+                if self._finished:
+                    return  # The guard under test.
+                if not getattr(self, self.policy_enabled_attr, True):
+                    self.set_status(403)
+                    self.finish(
+                        json.dumps({"error": self.policy_disabled_message})
+                    )
+
+            async def get(self):
+                self.set_status(200)
+
+        self._enabled_cls = _GateOverPassThrough
+        return Application(
+            [
+                (r"/gate-pass", _GateOverPassThrough),
+                (r"/gate-parent-finished", _GateOverEarlyFinish),
+            ]
+        )
+
+    def test_passes_through_when_enabled(self):
+        self._enabled_cls.gate_enabled = True
+        response = self.fetch("/gate-pass")
+        assert response.code == 200
+        assert json.loads(response.body) == {"ok": True}
+
+    def test_short_circuits_when_disabled(self):
+        self._enabled_cls.gate_enabled = False
+        response = self.fetch("/gate-pass")
+        assert response.code == 403
+        assert json.loads(response.body) == {"error": self.DISABLED_MESSAGE}
+
+    def test_respects_parent_early_finish(self):
+        # Even with the gate force-off, the parent's earlier 401 must win
+        # — no double-finish, no overwrite.
+        response = self.fetch("/gate-parent-finished")
+        assert response.code == 401
+        assert json.loads(response.body) == {"error": "from parent"}

--- a/tests/test_skill_github_import.py
+++ b/tests/test_skill_github_import.py
@@ -287,6 +287,23 @@ class TestGetGitHubToken:
             ):
                 assert resolve_github_token() is None
 
+    def test_gh_cli_strips_extra_lines(self):
+        # Defensive: a misbehaving gh install could prepend warnings or
+        # trailing whitespace. Take the first non-empty line so we don't
+        # smuggle unrelated bytes into the token.
+        with patch.dict("os.environ", {}, clear=True):
+            fake = subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout="\n  \nrealtoken\n\nextra\n",
+                stderr="",
+            )
+            with patch(
+                "notebook_intelligence.util.subprocess.run",
+                return_value=fake,
+            ):
+                assert resolve_github_token() == "realtoken"
+
 
 class _FakeUrlopenResponse:
     def __enter__(self):

--- a/tests/test_skill_github_import.py
+++ b/tests/test_skill_github_import.py
@@ -10,11 +10,11 @@ from notebook_intelligence.skill_github_import import (
     _derive_name,
     _extract_skill,
     _fetch_tarball,
-    _get_github_token,
     _slug,
     parse_github_url,
     stage_skill_from_github,
 )
+from notebook_intelligence.util import resolve_github_token
 from tests.conftest import build_tarball
 
 
@@ -228,26 +228,26 @@ class TestGetGitHubToken:
         with patch.dict(
             "os.environ", {"GITHUB_TOKEN": "from-github-token", "GH_TOKEN": "other"}
         ):
-            assert _get_github_token() == "from-github-token"
+            assert resolve_github_token() == "from-github-token"
 
     def test_falls_back_to_gh_token_env(self):
         env = {"GH_TOKEN": "from-gh-token"}
         # Clear GITHUB_TOKEN if present in the real env.
         with patch.dict("os.environ", env, clear=True):
-            assert _get_github_token() == "from-gh-token"
+            assert resolve_github_token() == "from-gh-token"
 
     def test_strips_whitespace(self):
         with patch.dict("os.environ", {"GITHUB_TOKEN": "  padded  "}, clear=True):
-            assert _get_github_token() == "padded"
+            assert resolve_github_token() == "padded"
 
     def test_ignores_empty_env(self):
         # Empty env var should not short-circuit; fall through to gh CLI (mocked missing).
         with patch.dict("os.environ", {"GITHUB_TOKEN": "   "}, clear=True):
             with patch(
-                "notebook_intelligence.skill_github_import.subprocess.run",
+                "notebook_intelligence.util.subprocess.run",
                 side_effect=FileNotFoundError,
             ):
-                assert _get_github_token() is None
+                assert resolve_github_token() is None
 
     def test_falls_back_to_gh_cli(self):
         with patch.dict("os.environ", {}, clear=True):
@@ -255,18 +255,18 @@ class TestGetGitHubToken:
                 args=[], returncode=0, stdout="gh-cli-token\n", stderr=""
             )
             with patch(
-                "notebook_intelligence.skill_github_import.subprocess.run",
+                "notebook_intelligence.util.subprocess.run",
                 return_value=fake,
             ):
-                assert _get_github_token() == "gh-cli-token"
+                assert resolve_github_token() == "gh-cli-token"
 
     def test_gh_cli_missing_returns_none(self):
         with patch.dict("os.environ", {}, clear=True):
             with patch(
-                "notebook_intelligence.skill_github_import.subprocess.run",
+                "notebook_intelligence.util.subprocess.run",
                 side_effect=FileNotFoundError,
             ):
-                assert _get_github_token() is None
+                assert resolve_github_token() is None
 
     def test_gh_cli_error_returns_none(self):
         with patch.dict("os.environ", {}, clear=True):
@@ -274,18 +274,18 @@ class TestGetGitHubToken:
                 args=[], returncode=1, stdout="", stderr="not logged in"
             )
             with patch(
-                "notebook_intelligence.skill_github_import.subprocess.run",
+                "notebook_intelligence.util.subprocess.run",
                 return_value=fake,
             ):
-                assert _get_github_token() is None
+                assert resolve_github_token() is None
 
     def test_gh_cli_timeout_returns_none(self):
         with patch.dict("os.environ", {}, clear=True):
             with patch(
-                "notebook_intelligence.skill_github_import.subprocess.run",
+                "notebook_intelligence.util.subprocess.run",
                 side_effect=subprocess.TimeoutExpired(cmd=["gh"], timeout=5),
             ):
-                assert _get_github_token() is None
+                assert resolve_github_token() is None
 
 
 class _FakeUrlopenResponse:
@@ -320,7 +320,7 @@ class TestFetchTarballAuth:
     def test_adds_auth_header_when_token_present(self):
         captured = {}
         with patch(
-            "notebook_intelligence.skill_github_import._get_github_token",
+            "notebook_intelligence.skill_github_import.resolve_github_token",
             return_value="secret-token",
         ):
             with patch(
@@ -338,7 +338,7 @@ class TestFetchTarballAuth:
     def test_no_auth_header_when_no_token(self):
         captured = {}
         with patch(
-            "notebook_intelligence.skill_github_import._get_github_token",
+            "notebook_intelligence.skill_github_import.resolve_github_token",
             return_value=None,
         ):
             with patch(
@@ -352,7 +352,7 @@ class TestFetchTarballAuth:
 
     def test_401_without_token_prompts_for_auth(self):
         with patch(
-            "notebook_intelligence.skill_github_import._get_github_token",
+            "notebook_intelligence.skill_github_import.resolve_github_token",
             return_value=None,
         ):
             with patch(
@@ -364,7 +364,7 @@ class TestFetchTarballAuth:
 
     def test_403_with_token_reports_rejection(self):
         with patch(
-            "notebook_intelligence.skill_github_import._get_github_token",
+            "notebook_intelligence.skill_github_import.resolve_github_token",
             return_value="bad-token",
         ):
             with patch(
@@ -376,7 +376,7 @@ class TestFetchTarballAuth:
 
     def test_404_without_token_hints_private(self):
         with patch(
-            "notebook_intelligence.skill_github_import._get_github_token",
+            "notebook_intelligence.skill_github_import.resolve_github_token",
             return_value=None,
         ):
             with patch(
@@ -388,7 +388,7 @@ class TestFetchTarballAuth:
 
     def test_404_with_token_no_private_hint(self):
         with patch(
-            "notebook_intelligence.skill_github_import._get_github_token",
+            "notebook_intelligence.skill_github_import.resolve_github_token",
             return_value="some-token",
         ):
             with patch(

--- a/tests/test_skill_manifest.py
+++ b/tests/test_skill_manifest.py
@@ -151,7 +151,7 @@ class TestUrlLoading:
     def test_github_host_uses_gh_token_fallback(self):
         body = b"skills: []\n"
         with patch(
-            "notebook_intelligence.skill_manifest._get_github_token",
+            "notebook_intelligence.skill_manifest.resolve_github_token",
             return_value="gh_fallback",
         ), patch(
             "notebook_intelligence.skill_manifest._urlopen_no_redirect"
@@ -166,7 +166,7 @@ class TestUrlLoading:
     def test_non_github_host_skips_gh_token_fallback(self):
         body = b"skills: []\n"
         with patch(
-            "notebook_intelligence.skill_manifest._get_github_token",
+            "notebook_intelligence.skill_manifest.resolve_github_token",
             return_value="gh_fallback",
         ) as probe, patch(
             "notebook_intelligence.skill_manifest._urlopen_no_redirect"
@@ -180,7 +180,7 @@ class TestUrlLoading:
     def test_explicit_token_wins_over_gh_token_fallback(self):
         body = b"skills: []\n"
         with patch(
-            "notebook_intelligence.skill_manifest._get_github_token",
+            "notebook_intelligence.skill_manifest.resolve_github_token",
             return_value="gh_fallback",
         ) as probe, patch(
             "notebook_intelligence.skill_manifest._urlopen_no_redirect"

--- a/tests/test_skills_handlers.py
+++ b/tests/test_skills_handlers.py
@@ -56,6 +56,8 @@ def _make_handler(handler_cls, body: bytes = b"", query_args: dict | None = None
         lambda: SkillsBaseHandler._reject_if_github_import_disabled(handler)
     )
     handler.allow_github_skill_import = SkillsBaseHandler.allow_github_skill_import
+    # `_error` reads the real dict, not the spec'd mock proxy.
+    handler.exception_status_map = SkillsBaseHandler.exception_status_map
     return handler
 
 

--- a/tests/test_skills_handlers.py
+++ b/tests/test_skills_handlers.py
@@ -534,3 +534,31 @@ class TestSkillsReconcileHandler:
 # Per-family policy-gate coverage lives in `tests/test_policy_gate.py`,
 # parametrized across SkillsBaseHandler / ClaudeMCPBaseHandler /
 # PluginsBaseHandler.
+
+
+class TestSkillsForceOffSuppressesReconciler:
+    """When ``skills_management_policy = force-off``, NBI must not
+    construct a ``SkillReconciler`` — even if a manifest is configured.
+    Pins the contract documented in the policy's docstring."""
+
+    @pytest.mark.parametrize(
+        "policy,expect_empty_manifest",
+        [
+            ("user-choice", False),
+            ("force-on", False),
+            ("force-off", True),
+        ],
+    )
+    def test_force_off_empties_manifest_source(self, policy, expect_empty_manifest):
+        from notebook_intelligence.feature_flags import is_force_off
+
+        # The relevant logic in `initialize_ai_service` is:
+        #     if is_force_off(feature_policies, "skills_management"):
+        #         manifest_source = ""
+        # Asserting the predicate directly + the post-condition is lighter
+        # than spinning up a real NotebookIntelligence instance.
+        feature_policies = {"skills_management": policy}
+        manifest_source = "https://example.com/m.yaml"
+        if is_force_off(feature_policies, "skills_management"):
+            manifest_source = ""
+        assert (manifest_source == "") is expect_empty_manifest

--- a/tests/test_skills_handlers.py
+++ b/tests/test_skills_handlers.py
@@ -527,3 +527,48 @@ class TestSkillsReconcileHandler:
             "unchanged": 3,
             "errors": ["boom"],
         }
+
+
+class TestSkillsManagementPolicyGate:
+    """The skills_management policy short-circuits every /skills handler in
+    `prepare()` with 403 when force-off. We test the gate logic directly,
+    bypassing Tornado dispatch (matches the rest of this file's pattern).
+    """
+
+    @staticmethod
+    def _run_prepare(handler):
+        # Patch the superclass prepare to a no-op coroutine — we're only
+        # exercising the skills gate here, not jupyter_server's auth plumbing.
+        from jupyter_server.base.handlers import APIHandler
+
+        async def _noop(_self):
+            return None
+
+        with patch.object(APIHandler, "prepare", _noop):
+            asyncio.run(SkillsBaseHandler.prepare(handler))
+
+    def test_default_attribute_allows(self):
+        assert SkillsBaseHandler.skills_management_enabled is True
+
+    def test_prepare_rejects_when_disabled(self):
+        handler = MagicMock(spec=SkillsListHandler)
+        handler._finished = False
+        handler.skills_management_enabled = False
+
+        def _finish(payload):
+            handler._finished = True
+            handler._finish_payload = payload
+
+        handler.finish.side_effect = _finish
+        self._run_prepare(handler)
+        handler.set_status.assert_called_with(403)
+        body = json.loads(handler._finish_payload)
+        assert "administrator" in body["error"].lower()
+
+    def test_prepare_passes_when_enabled(self):
+        handler = MagicMock(spec=SkillsListHandler)
+        handler._finished = False
+        handler.skills_management_enabled = True
+        self._run_prepare(handler)
+        handler.set_status.assert_not_called()
+        handler.finish.assert_not_called()

--- a/tests/test_skills_handlers.py
+++ b/tests/test_skills_handlers.py
@@ -553,6 +553,10 @@ class TestSkillsManagementPolicyGate:
     def test_prepare_rejects_when_disabled(self):
         handler = MagicMock(spec=SkillsListHandler)
         handler._finished = False
+        handler.policy_enabled_attr = "skills_management_enabled"
+        handler.policy_disabled_message = (
+            "Skills management is disabled by your administrator"
+        )
         handler.skills_management_enabled = False
 
         def _finish(payload):
@@ -568,6 +572,7 @@ class TestSkillsManagementPolicyGate:
     def test_prepare_passes_when_enabled(self):
         handler = MagicMock(spec=SkillsListHandler)
         handler._finished = False
+        handler.policy_enabled_attr = "skills_management_enabled"
         handler.skills_management_enabled = True
         self._run_prepare(handler)
         handler.set_status.assert_not_called()

--- a/tests/test_skills_handlers.py
+++ b/tests/test_skills_handlers.py
@@ -531,51 +531,6 @@ class TestSkillsReconcileHandler:
         }
 
 
-class TestSkillsManagementPolicyGate:
-    """The skills_management policy short-circuits every /skills handler in
-    `prepare()` with 403 when force-off. We test the gate logic directly,
-    bypassing Tornado dispatch (matches the rest of this file's pattern).
-    """
-
-    @staticmethod
-    def _run_prepare(handler):
-        # Patch the superclass prepare to a no-op coroutine — we're only
-        # exercising the skills gate here, not jupyter_server's auth plumbing.
-        from jupyter_server.base.handlers import APIHandler
-
-        async def _noop(_self):
-            return None
-
-        with patch.object(APIHandler, "prepare", _noop):
-            asyncio.run(SkillsBaseHandler.prepare(handler))
-
-    def test_default_attribute_allows(self):
-        assert SkillsBaseHandler.skills_management_enabled is True
-
-    def test_prepare_rejects_when_disabled(self):
-        handler = MagicMock(spec=SkillsListHandler)
-        handler._finished = False
-        handler.policy_enabled_attr = "skills_management_enabled"
-        handler.policy_disabled_message = (
-            "Skills management is disabled by your administrator"
-        )
-        handler.skills_management_enabled = False
-
-        def _finish(payload):
-            handler._finished = True
-            handler._finish_payload = payload
-
-        handler.finish.side_effect = _finish
-        self._run_prepare(handler)
-        handler.set_status.assert_called_with(403)
-        body = json.loads(handler._finish_payload)
-        assert "administrator" in body["error"].lower()
-
-    def test_prepare_passes_when_enabled(self):
-        handler = MagicMock(spec=SkillsListHandler)
-        handler._finished = False
-        handler.policy_enabled_attr = "skills_management_enabled"
-        handler.skills_management_enabled = True
-        self._run_prepare(handler)
-        handler.set_status.assert_not_called()
-        handler.finish.assert_not_called()
+# Per-family policy-gate coverage lives in `tests/test_policy_gate.py`,
+# parametrized across SkillsBaseHandler / ClaudeMCPBaseHandler /
+# PluginsBaseHandler.

--- a/tests/test_skills_handlers.py
+++ b/tests/test_skills_handlers.py
@@ -400,6 +400,34 @@ class TestResolveCsvAppended:
             ) == ["build", "foo", "dist"]
 
 
+class TestResolvePolicyWithEnv:
+    """``_resolve_policy_with_env`` must fail loud on typos so a misspelled
+    ``NBI_SKILLS_MANAGEMENT_POLICY=forceoff`` doesn't silently boot with
+    the (lax) traitlet default. Matches the contract of
+    ``_resolve_bool_with_env``."""
+
+    ENV = "NBI_TEST_POLICY"
+
+    def test_unset_env_returns_traitlet(self, monkeypatch):
+        monkeypatch.delenv(self.ENV, raising=False)
+        assert (
+            ext_module._resolve_policy_with_env(self.ENV, "force-off")
+            == "force-off"
+        )
+
+    def test_valid_env_overrides_traitlet(self):
+        with patch.dict("os.environ", {self.ENV: "force-on"}):
+            assert (
+                ext_module._resolve_policy_with_env(self.ENV, "force-off")
+                == "force-on"
+            )
+
+    def test_invalid_env_raises(self):
+        with patch.dict("os.environ", {self.ENV: "forceoff"}):
+            with pytest.raises(ValueError, match=self.ENV):
+                ext_module._resolve_policy_with_env(self.ENV, "user-choice")
+
+
 class TestSkillBundleFileHandler:
     def test_write_and_read_bundle_file(self, skill_manager):
         skill_manager.create_skill("user", "bun", "d", [], "")


### PR DESCRIPTION
> **Stacked on top of #224 and #225.** The diff against `main` is cumulative until those land. After they merge in order, this PR's diff shrinks to its own changes (~1553 LOC). What's *actually new in this PR* is described below; everything else in the diff is review surface for the prerequisites.

## Summary

Resolves #217. Adds a **Plugins** Settings tab that wraps Claude Code's `claude plugin` CLI surface, plus a new admin policy `plugins_management_policy` and a finer-grained `allow_github_plugin_import` Bool gate. This is the third of three tabs (#216 Skills, #218 Claude MCP, #217 Plugins) that share a common admin-gating shape.

## What's new in this PR

**Plugins tab** (Claude mode only, hidden when CLI absent or policy force-off):

- List installed plugins, grouped by scope (user / project / local)
- Install dialog (plugin reference + scope)
- Uninstall (with confirm)
- Enable / Disable toggle per plugin
- Marketplaces sub-section: list, add (URL / local path / `owner/repo` shorthand / `github:owner/repo`), remove

**Two admin gates**:

- `plugins_management_policy` (`TraitletEnum`, default `user-choice`, env `NBI_PLUGINS_MANAGEMENT_POLICY`). Force-off hides the tab and 403s every `/notebook-intelligence/plugins/*` route.
- `allow_github_plugin_import` (`Bool`, default `True`, env `NBI_ALLOW_GITHUB_PLUGIN_IMPORT`). Finer-grained: lets users install plugins, but rejects marketplace-add when the source is a GitHub reference. Mirrors `allow_github_skill_import`'s shape.

**Refactor**: extracts `PolicyGatedHandler` mixin from `SkillsBaseHandler` (PR #224) and `ClaudeMCPBaseHandler` (PR #225). The mixin owns the async `prepare()` chokepoint and `_parse_json_body`. PR 3's `PluginsBaseHandler` joins them — three call sites consolidated into one.

## Architecture

Reads and writes both shell out to `claude plugin …`. `claude plugin list --json` is a documented option, so unlike Claude-MCP we get structured output. The wrapper module is `notebook_intelligence/plugin_manager.py`.

## Hardening

- `stdin=asyncio.subprocess.DEVNULL` — install prompts (project-trust, OAuth) fail fast instead of hanging until timeout.
- **`asyncio.Lock` is now a class attribute** on both `PluginManager` and `ClaudeMCPManager`. The handler property creates a fresh manager per request, so an *instance* lock failed to serialize concurrent CLI writes — bug fixed for both managers in this PR.
- Argv log redaction for `-e`/`-H` value pairs (preventive parity with the MCP wrapper).
- Reject leading `-` on user-controlled positional argv (plugin name, marketplace source, marketplace name) to defend against CLI flag smuggling.
- Per-call subprocess timeout. Default 60s; **120s for `marketplace add`** since it does network I/O.
- **Defensive JSON parser** walks common wrapper keys (`installed`, `plugins`, `items`, `data`) and raises `ValueError` on unknown non-empty shapes — surfaces CLI version skew rather than silently rendering "no plugins installed."

## GitHub-source detection

`is_github_marketplace_source(source)` uses `urlparse(...).hostname` (handles port + case), tolerates `.git`/trailing-slash on `owner/repo` shorthand, case-insensitive scheme prefix. Leans toward detection — false negatives would let GitHub through despite policy, false positives only inconvenience the user.

## Trust model

The admin guide adds a paragraph noting that plugins installed via this tab execute as part of Claude Code sessions and that NBI does not signature-verify or sandbox them. For multi-tenant or regulated deployments, the recommendation is `plugins_management_policy = force-off` + curated server-side delivery, or restricting marketplaces to vetted sources.

## Tests

- 39 new tests in `tests/test_plugin_manager.py`: GitHub-source detection (recognized + rejected forms), CLI invocation argv assembly for each verb, JSON parser shapes (array, wrapper keys, unknown-shape raises), flag-smuggling rejection, log redaction, missing-CLI handling, the policy-gate `prepare()` short-circuit.
- 5 small test updates in `test_skills_handlers.py` and `test_claude_mcp_manager.py` after the `PolicyGatedHandler` mixin extraction.
- 103/103 tests pass.

## Docs

- New section in `docs/admin-guide.md` under "Restricting features for managed deployments".
- New row in the Admin policies table in `README.md`.

## Test plan

- [ ] Enable Claude mode → confirm Plugins tab appears
- [ ] Add a marketplace (any non-GitHub URL or local path), confirm it appears
- [ ] Install a plugin from the marketplace, confirm install + appears in list
- [ ] Toggle the enabled state, uninstall, confirm in `claude plugin list --json` separately
- [ ] Set `NBI_PLUGINS_MANAGEMENT_POLICY=force-off`, restart, confirm tab is gone and `curl /plugins` returns 403
- [ ] Set `NBI_ALLOW_GITHUB_PLUGIN_IMPORT=false`, attempt to add a `owner/repo`-shorthand marketplace, confirm 403 with the admin-disabled error string