### PR TITLE
fix(notebook-toolbar): make update button work outside Claude mode

### DIFF
--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -2657,9 +2657,20 @@ function SidebarComponent(props: any) {
           // through verbatim so the message displayed in chat matches what
           // was sent to the backend.
           message = request.content;
-          if (!request.chatMode) {
-            request.chatMode = chatMode;
-          }
+          // Notebook generation requires agent mode with the notebook-edit
+          // and notebook-execute toolsets — without them the LLM can't
+          // actually mutate cells regardless of how it answers. Override
+          // whatever the user has in the sidebar so the toolbar button
+          // works out-of-the-box in non-Claude modes too (issue #229).
+          request.chatMode = 'agent';
+          request.toolSelections = {
+            builtinToolsets: [
+              BuiltinToolsetType.NotebookEdit,
+              BuiltinToolsetType.NotebookExecute
+            ],
+            mcpServers: {},
+            extensions: {}
+          };
           break;
       }
       const messageId = UUID.uuid4();

--- a/src/notebook-generation-toolbar.tsx
+++ b/src/notebook-generation-toolbar.tsx
@@ -20,7 +20,6 @@ import {
   NOTEBOOK_GENERATION_PROGRESS_EVENT
 } from './notebook-generation';
 import { NotebookGenerationPopover } from './components/notebook-generation-popover';
-import { NBIAPI } from './api';
 
 const TOOLBAR_BUTTON_NAME = 'nbi-generate-notebook';
 const TOOLBAR_STATUS_NAME = 'nbi-generate-notebook-status';
@@ -263,10 +262,12 @@ export class NotebookGenerationToolbarExtension
     const button: ToolbarButton = new ToolbarButton({
       icon: this._options.icon,
       onClick: () => controller.openPopover(button),
-      tooltip: NBIAPI.config.isInClaudeCodeMode
-        ? 'Update active notebook with AI'
-        : 'Update active notebook with AI (only available in Claude Code mode)',
-      enabled: NBIAPI.config.isInClaudeCodeMode
+      // Notebook generation works in any chat mode — the chat-sidebar
+      // handler forces agent mode and the notebook-edit toolset when
+      // routing this request (issue #229). The button used to be gated
+      // on isInClaudeCodeMode here, but that gate undermined the
+      // sidebar-side fix.
+      tooltip: 'Update active notebook with AI'
     });
     button.addClass('nbi-notebook-generation-toolbar-button');
     panel.toolbar.insertAfter('cellType', TOOLBAR_BUTTON_NAME, button);

--- a/src/notebook-generation-toolbar.tsx
+++ b/src/notebook-generation-toolbar.tsx
@@ -146,10 +146,13 @@ class NotebookGenerationToolbarController {
   private _submitPrompt(rawPrompt: string, showInChat: boolean): void {
     const prefixedPrompt = buildNotebookGenerationPrompt(rawPrompt);
     const externalRequestId = UUID.uuid4();
+    // chatMode and toolSelections are forced by the chat-sidebar handler
+    // (NotebookGeneration always needs agent mode + the notebook-edit
+    // toolset). Leaving them off the request keeps the toolbar
+    // independent of the sidebar's current configuration.
     const request: Partial<IRunChatCompletionRequest> = {
       type: RunChatCompletionType.NotebookGeneration,
       content: prefixedPrompt,
-      chatMode: '',
       externalRequestId,
       hideInChat: !showInChat
     };


### PR DESCRIPTION
## Summary

The notebook-update toolbar button (the AI sparkle icon on the notebook toolbar) doesn't work outside Claude mode. Issue #229 reports that even after manually switching to Agent mode and selecting the Notebook edit tool, the request still fails — and Tested with GitHub Copilot.

Two compounding problems:

1. **The button was disabled outside Claude mode.** `NotebookGenerationToolbarExtension` set `enabled: NBIAPI.config.isInClaudeCodeMode` on the toolbar button itself, so non-Claude users couldn't even click it.
2. **The request didn't carry the requirements it needs to succeed.** The toolbar emitted a `NotebookGeneration` request with `chatMode: ''` and no `toolSelections`. The chat-sidebar handler inherited whichever mode the user had open in the sidebar (typically `ask`), and `toolSelections` fell through to `{}` — so the LLM had no notebook-edit tool available even when the user explicitly switched to agent mode before clicking the button.

## Solution

- Drop the `isInClaudeCodeMode` gate on the toolbar button so it's always enabled (`src/notebook-generation-toolbar.tsx`).
- In the chat-sidebar's `promptRequestHandler`, force `chatMode = 'agent'` and `toolSelections = { builtinToolsets: [NotebookEdit, NotebookExecute], ... }` for every `NotebookGeneration` request (`src/chat-sidebar.tsx`).
- Drop the toolbar's now-redundant `chatMode: ''` field — the sidebar handler is the single source of truth for the override.

## Testing

- `jlpm tsc --noEmit`, `jlpm lint:check`, `jlpm jest` all pass.
- Manual: with GitHub Copilot selected as the provider and sidebar set to `ask`, clicking the notebook toolbar button successfully edits the active notebook.

## Risks / follow-ups

The override happens client-side in one switch arm. A future call site that wants to trigger `NotebookGeneration` (e.g. a context-menu action) must leave `chatMode` and `toolSelections` unset and rely on the sidebar handler. A cleaner contract — backend-side autoconfig keyed on a `requestKind` field — is worth pursuing if a third call site appears.

Closes #229.