### PR TITLE
fix(launcher): show Claude Code tile whenever the CLI is available

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1107,8 +1107,12 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
       label: 'Claude Code',
       caption: 'Resume or start a Claude Code session',
       icon: claudeIcon,
-      isVisible: () =>
-        NBIAPI.config.isInClaudeCodeMode && NBIAPI.config.isClaudeCliAvailable,
+      // The launcher tile opens a Jupyter terminal that runs the
+      // `claude` CLI directly — it doesn't depend on NBI being in
+      // Claude Code chat mode (which gates the chat-sidebar SDK
+      // backend). CLI presence on PATH is the only real prerequisite
+      // (issue #230).
+      isVisible: () => NBIAPI.config.isClaudeCliAvailable,
       execute: async () => {
         class PickerWidget extends ReactWidget {
           getValue(): void {


### PR DESCRIPTION
## Summary

The Claude Code launcher tile was hidden unless NBI was in Claude Code chat mode. The tile opens a Jupyter terminal that runs the `claude` CLI directly — it does not depend on the chat-sidebar SDK backend that the chat-mode gate is actually about. Issue #230 asks for CLI presence to be the sole gate.

## Solution

Drop `isInClaudeCodeMode` from the `isVisible` predicate. The tile now appears whenever `claude` is on PATH, regardless of which LLM provider the user has selected for the chat sidebar.

## Testing

- `jlpm tsc --noEmit`, `jlpm lint:check`, `jlpm jest` all pass.
- Manual: in OpenAI/Copilot mode with `claude` on PATH, the launcher tile is visible and opens a terminal that runs the CLI.

## Risks / follow-ups

None known. The launcher tile is independent of the chat-sidebar backend; this just stops hiding it when one of the two surfaces is configured for a non-Claude provider.

Closes #230.