### PR TITLE
fix(notebook-toolbar): focus prompt textarea when popover opens

### DIFF
--- a/src/components/notebook-generation-popover.tsx
+++ b/src/components/notebook-generation-popover.tsx
@@ -27,7 +27,14 @@ export function NotebookGenerationPopover(
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
-    textareaRef.current?.focus();
+    // Defer to the next frame so the focus call lands after Lumino's
+    // attach lifecycle and JupyterLab's focus tracker have settled —
+    // otherwise the active notebook can win the focus race and the
+    // textarea stays unfocused (issue #231).
+    const handle = window.requestAnimationFrame(() => {
+      textareaRef.current?.focus();
+    });
+    return () => window.cancelAnimationFrame(handle);
   }, []);
 
   const trimmed = prompt.trim();


### PR DESCRIPTION
## Summary

Issue #231 reports that the notebook-update popover opens but keyboard focus doesn't land on the prompt textarea — the user has to click the field manually. The popover already called `textareaRef.current?.focus()` in a mount-time `useEffect`, but the focus call lost a race with JupyterLab's focus tracker: the tracker moves focus back to the active notebook when our Lumino widget attaches, on the same tick. The result was an unfocused textarea on every open.

Six-agent review of the original fix surfaced the same race in `InlinePromptComponent` (the inline-generate prompt over a code cell), so the second commit applies the same defer there.

## Solution

In both `notebook-generation-popover.tsx` and `chat-sidebar.tsx`'s `InlinePromptComponent`, defer the `focus()` call to `requestAnimationFrame` so it lands after Lumino's attach lifecycle and the focus tracker have settled. A keyed `cancelAnimationFrame` in the cleanup keeps the call safe if the popover is closed before the frame fires.

## Testing

- `jlpm tsc --noEmit`, `jlpm lint:check`, `jlpm jest` all pass.
- Manual: open the notebook-update popover via the toolbar; the textarea is focused on first paint. Same for the inline-prompt overlay over a code cell.

## Risks / follow-ups

A11y review flagged unrelated pre-existing gaps in the popover (no `role="dialog"`, no focus trap, close-button is a `div` not a `button`) that are worth a follow-up but are codebase-wide patterns outside this PR's scope.

Closes #231.