### PR TITLE
feat(config): layer additional_skipped_workspace_directories on NBI config

### DIFF
--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -337,25 +337,39 @@ The env var wins over the traitlet and is resolved at server startup. Recognized
 
 ### Tuning the chat-sidebar workspace file picker
 
-**Audience:** server admins. End users can't override this — ask your admin to add or remove entries.
+**Audience:** server admins (and end users who edit `~/.jupyter/nbi/config.json` directly). The setting is not exposed in the Settings dialog.
 
-The @-mention picker in the chat sidebar enumerates files from the JupyterLab working directory and skips a built-in set of directories (`__pycache__`, `node_modules`) plus any dotfiles/dot-directories. Because dot-prefixed names are filtered separately, entries starting with `.` in the list below are no-ops; list non-dot names only.
-
-To extend the directory skip set without editing the codebase:
-
-```python
-c.NotebookIntelligence.additional_skipped_workspace_directories = ["build", "dist", "target"]
-```
+The @-mention picker in the chat sidebar enumerates files from the JupyterLab working directory and skips a built-in set of directories (`__pycache__`, `node_modules`) plus any dotfiles/dot-directories. Because dot-prefixed names are filtered separately, entries starting with `.` are no-ops; list non-dot names only.
 
 Match is by directory name only (not path), case-sensitive. Use this when a project has standard build outputs the picker shouldn't surface.
 
-To vary the list per spawn profile, append entries via env at pod startup:
+Four layers can contribute, all **additive** (each layer can only add new skipped names, never re-expose names skipped by an earlier layer):
 
-```bash
-NBI_ADDITIONAL_SKIPPED_WORKSPACE_DIRECTORIES=tmp,artifacts
-```
+1. **Traitlet** in `jupyter_server_config.py`:
 
-The env var **appends** to the traitlet value at server startup (in contrast to `NBI_ALLOW_GITHUB_SKILL_IMPORT` and the `NBI_*_POLICY` env vars, which override). Duplicates are collapsed; both lists are then merged with the built-in skip set on the frontend.
+   ```python
+   c.NotebookIntelligence.additional_skipped_workspace_directories = ["build", "dist", "target"]
+   ```
+
+2. **Env var** at pod startup (per spawn profile):
+
+   ```bash
+   NBI_ADDITIONAL_SKIPPED_WORKSPACE_DIRECTORIES=tmp,artifacts
+   ```
+
+3. **Env-prefix NBI config** at `<env-prefix>/share/jupyter/nbi/config.json` (org-wide, baked into the image — useful when the deployment doesn't manage `jupyter_server_config.py` but does ship a curated config file):
+
+   ```json
+   { "additional_skipped_workspace_directories": ["coverage", "out"] }
+   ```
+
+4. **User NBI config** at `~/.jupyter/nbi/config.json` (per-user extension on top of the admin baseline):
+
+   ```json
+   { "additional_skipped_workspace_directories": [".terraform"] }
+   ```
+
+Duplicates are collapsed; the merged list is then added to the built-in skip set on the frontend. Edits to `config.json` require a JupyterLab restart to take effect, matching the rest of NBI config — there's no UI control (issue #232).
 
 ### Disabling the Skills tab
 

--- a/notebook_intelligence/config.py
+++ b/notebook_intelligence/config.py
@@ -137,6 +137,26 @@ class NBIConfig:
     def mcp_server_settings(self):
         return self.get('mcp_server_settings', {})
 
+    @property
+    def additional_skipped_workspace_directories(self) -> list:
+        """Extra directory names to skip when enumerating workspace files
+        for the chat-sidebar @-mention picker. Layered like every other
+        NBI-config value: the env-prefix file (admin baseline) and the
+        user file (per-user extension) both contribute. The traitlet of
+        the same name and the NBI_ADDITIONAL_SKIPPED_WORKSPACE_DIRECTORIES
+        env var add further layers; the final merge happens in
+        ``extension._setup_handlers``. Returns `[]` when neither layer
+        sets it, or whichever layer's value is a non-list.
+        """
+        env_list = self.env_config.get('additional_skipped_workspace_directories', [])
+        user_list = self.user_config.get('additional_skipped_workspace_directories', [])
+        merged = []
+        for layer in (env_list, user_list):
+            if isinstance(layer, list):
+                merged.extend(name for name in layer if isinstance(name, str) and name.strip())
+        # Dedupe while preserving first-seen order.
+        return list(dict.fromkeys(merged))
+
     def set_feature_policies(self, policies: dict, string_overrides: dict) -> None:
         """Adopt the resolved admin policies + string overrides."""
         self._feature_policies = dict(policies)

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -2374,11 +2374,22 @@ class NotebookIntelligence(ExtensionApp):
         SkillsBaseHandler.allow_github_skill_import = _resolve_bool_with_env(
             "NBI_ALLOW_GITHUB_SKILL_IMPORT", self.allow_github_skill_import
         )
-        GetCapabilitiesHandler.additional_skipped_workspace_directories = (
-            _resolve_csv_appended(
-                "NBI_ADDITIONAL_SKIPPED_WORKSPACE_DIRECTORIES",
-                self.additional_skipped_workspace_directories,
-            )
+        # Three-layer merge for skipped workspace directories: traitlet
+        # (admin baseline) → NBI_ADDITIONAL_SKIPPED_WORKSPACE_DIRECTORIES env
+        # var (per-pod) → nbi_config.json (admin + user). All layers append
+        # rather than override (the policy is set-union semantics so each
+        # layer can only add hidden directories, never re-expose them).
+        # Manual config.json edits require a JupyterLab restart, matching
+        # the rest of NBI config — there's no Settings-dialog control.
+        merged_skipped_dirs = _resolve_csv_appended(
+            "NBI_ADDITIONAL_SKIPPED_WORKSPACE_DIRECTORIES",
+            self.additional_skipped_workspace_directories,
+        )
+        config_skipped = (
+            ai_service_manager.nbi_config.additional_skipped_workspace_directories
+        )
+        GetCapabilitiesHandler.additional_skipped_workspace_directories = list(
+            dict.fromkeys(merged_skipped_dirs + config_skipped)
         )
         SkillsBaseHandler.skills_management_enabled = not is_force_off(
             feature_policies, "skills_management"

--- a/tests/test_config_integration.py
+++ b/tests/test_config_integration.py
@@ -168,6 +168,97 @@ class TestAdditionalSkippedWorkspaceDirectories:
         assert config.additional_skipped_workspace_directories == []
 
 
+class TestAdditionalSkippedWorkspaceDirectoriesFourLayerMerge:
+    """End-to-end merge across all four layers — traitlet, NBI_* env
+    var, env-prefix config.json, user config.json — exercising the
+    expression in `extension._setup_handlers` that publishes the final
+    list onto `GetCapabilitiesHandler`. Reproduces the merge in
+    isolation so a regression in the merge order or dedupe doesn't slip
+    past the two single-layer test suites that already exist."""
+
+    @staticmethod
+    def _merge(traitlet, env_var_value, env_config_layer, user_config_layer,
+               mock_nbi_config, monkeypatch):
+        from notebook_intelligence import extension as ext_module
+
+        if env_var_value is None:
+            monkeypatch.delenv(
+                'NBI_ADDITIONAL_SKIPPED_WORKSPACE_DIRECTORIES', raising=False
+            )
+        else:
+            monkeypatch.setenv(
+                'NBI_ADDITIONAL_SKIPPED_WORKSPACE_DIRECTORIES', env_var_value
+            )
+        mock_nbi_config.env_config = (
+            {'additional_skipped_workspace_directories': env_config_layer}
+            if env_config_layer is not None else {}
+        )
+        mock_nbi_config.user_config = (
+            {'additional_skipped_workspace_directories': user_config_layer}
+            if user_config_layer is not None else {}
+        )
+        merged_traitlet_env = ext_module._resolve_csv_appended(
+            'NBI_ADDITIONAL_SKIPPED_WORKSPACE_DIRECTORIES', traitlet
+        )
+        config_layers = mock_nbi_config.additional_skipped_workspace_directories
+        # Same expression as extension._setup_handlers.
+        return list(dict.fromkeys(merged_traitlet_env + config_layers))
+
+    def test_all_four_layers_union_in_traversal_order(
+        self, mock_nbi_config, monkeypatch
+    ):
+        result = self._merge(
+            traitlet=['from_traitlet'],
+            env_var_value='from_env_var',
+            env_config_layer=['from_env_config'],
+            user_config_layer=['from_user_config'],
+            mock_nbi_config=mock_nbi_config,
+            monkeypatch=monkeypatch,
+        )
+        assert result == [
+            'from_traitlet',
+            'from_env_var',
+            'from_env_config',
+            'from_user_config',
+        ]
+
+    def test_collision_across_layers_keeps_first_seen(
+        self, mock_nbi_config, monkeypatch
+    ):
+        result = self._merge(
+            traitlet=['build'],
+            env_var_value='dist',
+            env_config_layer=['build', 'out'],  # 'build' already from traitlet
+            user_config_layer=['dist', 'venv'],  # 'dist' already from env var
+            mock_nbi_config=mock_nbi_config,
+            monkeypatch=monkeypatch,
+        )
+        # First-seen order from traitlet → env var → env config → user config.
+        assert result == ['build', 'dist', 'out', 'venv']
+
+    def test_only_user_config_set(self, mock_nbi_config, monkeypatch):
+        result = self._merge(
+            traitlet=None,
+            env_var_value=None,
+            env_config_layer=None,
+            user_config_layer=['venv'],
+            mock_nbi_config=mock_nbi_config,
+            monkeypatch=monkeypatch,
+        )
+        assert result == ['venv']
+
+    def test_no_layers_set_yields_empty(self, mock_nbi_config, monkeypatch):
+        result = self._merge(
+            traitlet=None,
+            env_var_value=None,
+            env_config_layer=None,
+            user_config_layer=None,
+            mock_nbi_config=mock_nbi_config,
+            monkeypatch=monkeypatch,
+        )
+        assert result == []
+
+
 class TestNBIConfigPolicyResolution:
     """The boolean policies and string overrides feed through NBIConfig getters
     so SDK consumers (claude.py, ai_service_manager) see resolved values."""

--- a/tests/test_config_integration.py
+++ b/tests/test_config_integration.py
@@ -115,6 +115,59 @@ class TestNBIConfigSaveAndLoad:
             assert saved_config['active_rules'] == {'test.md': True}
 
 
+class TestAdditionalSkippedWorkspaceDirectories:
+    """The setting layers env-prefix and user `config.json` entries.
+    Both contribute (set-union); the final merge with the traitlet
+    and the `NBI_*` env var happens in `_setup_handlers`."""
+
+    def test_returns_empty_when_neither_layer_sets_it(self, mock_nbi_config):
+        config = mock_nbi_config
+        config.env_config = {}
+        config.user_config = {}
+        assert config.additional_skipped_workspace_directories == []
+
+    def test_reads_from_env_config_only(self, mock_nbi_config):
+        config = mock_nbi_config
+        config.env_config = {'additional_skipped_workspace_directories': ['build']}
+        config.user_config = {}
+        assert config.additional_skipped_workspace_directories == ['build']
+
+    def test_reads_from_user_config_only(self, mock_nbi_config):
+        config = mock_nbi_config
+        config.env_config = {}
+        config.user_config = {'additional_skipped_workspace_directories': ['venv']}
+        assert config.additional_skipped_workspace_directories == ['venv']
+
+    def test_merges_env_and_user_layers_preserving_order(self, mock_nbi_config):
+        config = mock_nbi_config
+        config.env_config = {'additional_skipped_workspace_directories': ['build', 'dist']}
+        config.user_config = {'additional_skipped_workspace_directories': ['venv']}
+        assert config.additional_skipped_workspace_directories == [
+            'build', 'dist', 'venv'
+        ]
+
+    def test_dedupes_across_layers(self, mock_nbi_config):
+        config = mock_nbi_config
+        config.env_config = {'additional_skipped_workspace_directories': ['build']}
+        config.user_config = {'additional_skipped_workspace_directories': ['build', 'venv']}
+        assert config.additional_skipped_workspace_directories == ['build', 'venv']
+
+    def test_ignores_non_string_entries(self, mock_nbi_config):
+        config = mock_nbi_config
+        config.env_config = {
+            'additional_skipped_workspace_directories': ['build', None, 42, '']
+        }
+        config.user_config = {}
+        assert config.additional_skipped_workspace_directories == ['build']
+
+    def test_ignores_non_list_payload(self, mock_nbi_config):
+        # A malformed config.json (string instead of list) must not crash.
+        config = mock_nbi_config
+        config.env_config = {'additional_skipped_workspace_directories': 'build,dist'}
+        config.user_config = {}
+        assert config.additional_skipped_workspace_directories == []
+
+
 class TestNBIConfigPolicyResolution:
     """The boolean policies and string overrides feed through NBIConfig getters
     so SDK consumers (claude.py, ai_service_manager) see resolved values."""


### PR DESCRIPTION
## Summary

Issue #232 asks for `additional_skipped_workspace_directories` to be configurable via NBI's `config.json` in addition to the traitlet + `NBI_*` env var that already exist. The motivation: deployments that don't manage `jupyter_server_config.py` (e.g. containers that ship a packaged `config.json`) have no way to extend the skip set, and end users can't self-serve a one-off build directory hide without filing an admin ticket. Not surfaced in the UI — manual `config.json` editing is the intended ergonomics.

## Solution

Add a fourth layer via `NBIConfig.additional_skipped_workspace_directories`, keyed on `additional_skipped_workspace_directories` in both env-prefix and user `config.json`. All four layers are **additive** (set-union — each can add new skipped names, none can re-expose names skipped by another), matching the existing traitlet + env-var polarity.

Merge order: traitlet → `NBI_ADDITIONAL_SKIPPED_WORKSPACE_DIRECTORIES` → env-prefix `config.json` → user `config.json`. The final deduped list is the same value the capabilities response already surfaces to the frontend.

- `NBIConfig`: new property, defensive against non-list / non-string payloads (a malformed `"build,dist"` string instead of a list returns `[]` without crashing).
- `extension._setup_handlers`: extend the existing `_resolve_csv_appended` result with the config layer, dedupe-and-preserve-order.
- Admin guide: rewrite the section to enumerate all four layers and state the manual-edit + restart contract.

## Testing

- `pytest tests/` — all 520 tests pass.
- `tests/test_config_integration.py`:
  - `TestAdditionalSkippedWorkspaceDirectories` (7 cases) pins the env-prefix + user merge in `NBIConfig`.
  - `TestAdditionalSkippedWorkspaceDirectoriesFourLayerMerge` (4 cases) pins the full four-layer merge expression from `_setup_handlers`: union-in-order, first-seen-wins on collisions, single-layer, no-layers.

## Risks / follow-ups

Manual `config.json` edits require a JupyterLab restart to take effect (consistent with the rest of NBI config that isn't UI-mutated). Documented in the admin guide.

Closes #232.