### PR TITLE
docs(contributing): document traitlet vs env var vs config-file guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,73 @@ NBI has two halves:
 
 The two halves communicate over the routes registered in `extension.py` (REST and WebSocket). All routes live under `/notebook-intelligence/`. See [`docs/admin-guide.md`](docs/admin-guide.md#http-api-surface) for the full list.
 
+## Configuration mechanisms
+
+NBI has three places a setting can be configured: a Python traitlet, an `NBI_*` environment variable, and an NBI config file (the Settings dialog is a friendly editor for the user-scope copy of the config file). They look similar but they exist for different audiences, and they override each other in a specific order.
+
+Before adding a new knob at all, ask whether you actually need one. Hardcoded defaults are the simplest thing that works, and settings nobody ever changes shouldn't be settings — most candidates fail this gate.
+
+### Who decides the value?
+
+There are three audiences, and the audience picks the mechanism.
+
+**The end user, via the Settings dialog.** They change their own preference and want it to stick across restarts without touching files. Examples: `default_chat_mode`, `store_github_access_token`.
+
+→ Add a getter on `NBIConfig` (which reads `~/.jupyter/nbi/config.json`), surface the value in `/capabilities`, and add a control in `src/components/settings-panel.tsx`. Writes persist immediately.
+
+**A server admin who runs `jupyter lab` directly.** They set an org-wide baseline in `jupyter_server_config.py` — typical for local installs and dev images. Examples: `disabled_providers`, `*_management_policy`.
+
+→ Declare a traitlet on `NotebookIntelligence` in `extension.py`. The `help=` text shows up in `jupyter` CLI output and in generated config templates.
+
+**A deployment admin running JupyterHub / KubeSpawner.** They need the same setting to vary by pod without rebuilding the container image. Editing Python at spawn time is awkward; env vars are how Kubernetes-style deployments wire per-pod policy. Examples: `NBI_ALLOW_GITHUB_SKILL_IMPORT`, `NBI_*_POLICY`.
+
+→ Pair the traitlet with an `NBI_*` env var resolved at server startup. Use one of the fail-loud helpers in `extension.py`: `_resolve_bool_with_env`, `_resolve_policy_with_env`, or `_resolve_csv_appended`. A typo in the env var must surface at server startup, not silently fall through to the default — that's how deployment-admin debugging spirals into half-day investigations.
+
+#### Rule: admin-policy flags must ship with an env var pair
+
+If the setting is an admin-policy flag, the env var pairing isn't optional. A flag counts as an admin-policy flag when all three are true:
+
+- Small shape: boolean, policy enum (e.g. `force-on` / `force-off` / `user-choice`), or short string-list.
+- An admin (not the user) decides the value.
+- The intent is to enforce, allow, or block a behavior.
+
+`allow_github_skill_import` and every `*_management_policy` qualify. Numeric tuning knobs (`skills_manifest_interval`, `inline_completion_debouncer_delay`) don't — they aren't enforcement. Nested configs (`mcp_server_settings`, `claude_settings`) don't either — they're too big for a single env var and live in user `config.json` anyway.
+
+The rule exists because every prior PR that shipped a policy traitlet without an env var pair got a follow-up adding the env var: deployment admins always need per-pod variance for policy flags. Doing the pair once is cheaper than doing it twice.
+
+### How values override each other
+
+When more than one source supplies the same value, NBI resolves them in this order (top wins):
+
+```
+1. NBI_* environment variable
+2. user ~/.jupyter/nbi/config.json
+3. env-prefix <env>/share/jupyter/nbi/config.json
+4. traitlet in jupyter_server_config.py
+5. hardcoded default
+```
+
+The mental model: items 2–5 are a chain of _defaults_, each more specific than the last (a default for everyone → installs → users → "what this user picked"). The env var is different — it's not a default, it's _policy enforcement_. A deployment admin sets an env var when they want to force a value regardless of what the user chose. That's why it sits on top of the user's own preference.
+
+Worked example: a user unchecks "Store GitHub access token" in the Settings dialog. The toggle persists to user `config.json` and the value sticks across restarts — until an admin sets `NBI_STORE_GITHUB_ACCESS_TOKEN_POLICY=force-on` on the pod. After the next server restart, the user's `config.json` still says "off" but the value NBI uses is "on" — the env var wins.
+
+That's the trap to know about: **if you expose a Settings-dialog control for a value that also has an admin override path, the user can see their save "stick" in the UI in-session and watch it silently revert on restart.** Two ways to avoid it:
+
+1. **Don't put it in the dialog at all.** If admins are supposed to enforce the value, the user shouldn't be able to toggle it via the UI. Manual `config.json` editing is fine for niche admin-overridable knobs (issue #232 is an example).
+2. **Use the policy triad and `settingLocks`.** For admin-enforceable settings, follow `*_management_policy`: the admin picks `force-on`, `force-off`, or `user-choice`. When the admin forces a value, the frontend's `settingLocks` shows a lock icon and disables the control — the user can see their choice is overridden rather than fighting an invisible policy.
+
+### When override-semantics are wrong: the additivity carve-out
+
+Most settings overwrite each other (one layer wins). A small number of settings _append_ across layers instead — each layer can add to the resolved value but none can remove from it. `additional_skipped_workspace_directories` (#232) is the only example today: traitlet + env var + env-prefix config + user config all merge into one combined list, deduped.
+
+If you add a new additive setting, document the polarity explicitly in both the traitlet `help=` and the admin-guide entry. Readers assume override-semantics by default; additivity has to be called out or it's a trap.
+
+### Adding a new admin policy is currently tedious
+
+For historical reasons, every new admin policy has to be wired in seven places: the frontend type union (`src/api.ts`), the capabilities response builder (`extension.py`), the policy resolver, the handler class attribute, the README admin policies table, the admin-guide entry, and at least one pinning test. Miss one and the knob breaks in one direction without any error (e.g. the backend enforces but the UI doesn't lock the control, or vice versa).
+
+The comment above `FEATURE_POLICY_SPEC` in `extension.py` lists every site — that's the closest thing to a guardrail today. A future registration helper that derived most of these from a single declaration would be a welcome cleanup.
+
 ## Development install
 
 You'll need Node.js 18 or newer to build the frontend. The `jlpm` command is JupyterLab's pinned version of [yarn](https://yarnpkg.com/) — install JupyterLab first to get it.


### PR DESCRIPTION
## Summary

Issue #233 asks for a contributor-facing guideline on when to use NBI's three configuration mechanisms (traitlets, env vars, NBI `config.json`). The differences — who edits the value, when it's evaluated, whether it's UI-mutable, how it overrides what — have been folklore so far. The most common contributor error is reaching for the wrong mechanism for a given audience; the most common deployment-admin error is a per-user save that silently reverts on restart.

## Solution

Add a "Configuration mechanisms" section to `CONTRIBUTING.md` that:

- **Leads with the should-this-be-configurable-at-all gate.** Most candidates for a new knob fail this; calling it out first saves contributors the trouble of picking the wrong mechanism for a setting that shouldn't exist.
- **Frames the choice as "who decides the value," not a numbered decision tree.** The real axis is audience — end user, server admin running `jupyter lab` directly, deployment admin running JupyterHub / KubeSpawner. Each audience gets a short paragraph that explains *why* the corresponding mechanism exists. Env vars aren't an alternative to traitlets, they're how Kubernetes-style deployments wire per-pod policy where editing Python at spawn time isn't practical.
- **Establishes a rule for admin-policy flags.** Every past PR that landed a policy traitlet without an env var pair got a follow-up adding the env var, so the doc promotes pairing from optional to required for admin-policy flags. The rule is defined by three concrete criteria (small-shape value, admin-decided, used to enforce/allow/block behavior) with positive examples (`*_management_policy`, `allow_github_skill_import`) and counter-examples (numeric tuning knobs like `skills_manifest_interval`, nested config blobs like `mcp_server_settings`).
- **Explains precedence with a mental model.** Items 2–5 in the precedence chain are increasingly-specific *defaults* (everyone → installs → users → "what this user picked"); the env var sits on top because it's *policy enforcement*, not a default. That single framing makes the order rememberable instead of arbitrary, and it explains *why* an admin's env var beats a user's saved preference.
- **Names the silent-revert trap with a worked example.** A user unchecks "Store GitHub access token" in the Settings dialog → admin sets `NBI_STORE_GITHUB_ACCESS_TOKEN_POLICY=force-on` → after restart the user's `config.json` still says "off" but NBI uses "on." Two workarounds documented: don't expose a UI control if the value has an admin override path, or use the `*_management_policy` triad with `settingLocks` so the user sees a lock icon instead of fighting an invisible override.
- **Gives the additivity carve-out its own section.** `additional_skipped_workspace_directories` (#232) is the one exception to override-semantics — all layers append. Documenting append-vs-override polarity on the setting itself is required.
- **Frames the seven-place checklist honestly.** Adding a new admin policy currently requires touching seven sites; the doc calls that out as a maintenance tax worth reducing (a future registration helper) rather than treating it as fact-of-life.

## Testing

- `jlpm prettier:check CONTRIBUTING.md` — passes.

## Risks / follow-ups

Documentation only; no runtime impact. The silent-revert trap and the seven-place tax are descriptive of current behavior, not behavioral changes — both are worth fixing in separate PRs (the policy-triad pattern can be extended to more settings; a registration helper can collapse the seven sites into one declaration). The admin-policy-flag rule applies going forward; auditing existing settings against it isn't part of this PR.

Closes #233.