### PR TITLE
fix(claude): dedupe /clear in @-mention autocomplete

### DIFF
--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -1128,22 +1128,29 @@ class ClaudeCodeChatParticipant(BaseChatParticipant):
     
     @property
     def commands(self) -> list[ChatCommand]:
-        participant_commands = [
-            ChatCommand(name='clear', description='Clear chat history')
+        # Dedupe by name so a command the Claude SDK now ships as a
+        # built-in (e.g. `/clear`) doesn't appear twice in the @-mention
+        # autocomplete. SDK-provided commands win the description when
+        # both sources list the same name.
+        nbi_built_ins = [
+            ChatCommand(name='clear', description='Clear chat history'),
         ]
         server_info = self._client.server_info
-        if server_info is not None:
-            commands = server_info.get('commands', [])
-            for command in commands:
-                participant_commands.append(ChatCommand(name=command['name'], description=command['description']))
-            return participant_commands
-        else:
+        if server_info is None:
             return [
                 ChatCommand(name='compact', description='Compact chat history'),
                 ChatCommand(name='context', description='Show context of the chat'),
                 ChatCommand(name='cost', description='Show cost of the chat'),
                 ChatCommand(name='clear', description='Clear chat history'),
             ]
+        commands_by_name: dict[str, ChatCommand] = {
+            cmd.name: cmd for cmd in nbi_built_ins
+        }
+        for command in server_info.get('commands', []):
+            commands_by_name[command['name']] = ChatCommand(
+                name=command['name'], description=command['description']
+            )
+        return list(commands_by_name.values())
 
     @property
     def websocket_connector(self) -> ThreadSafeWebSocketConnector:

--- a/tests/test_claude_client.py
+++ b/tests/test_claude_client.py
@@ -1184,3 +1184,40 @@ class TestExtractTextFromContent:
     def test_list_with_non_dict_entries_skipped(self):
         content = [{"type": "text", "text": "valid"}, "raw string", None]
         assert _extract_text_from_content(content) == "valid"
+
+
+class TestParticipantCommandsDedupe:
+    """`ClaudeCodeChatParticipant.commands` merges NBI built-ins with SDK
+    server_info commands. When the SDK now lists a name NBI also ships
+    (e.g. `/clear`), the slash must appear once in @-autocomplete."""
+
+    def test_clear_not_duplicated_when_sdk_lists_it(self):
+        participant = _make_participant()
+        participant._client.server_info = {
+            "commands": [
+                {"name": "clear", "description": "Claude SDK clear"},
+                {"name": "compact", "description": "Compact chat history"},
+            ]
+        }
+        names = [cmd.name for cmd in participant.commands]
+        assert names.count("clear") == 1
+        # SDK description wins when both sources collide.
+        clear = next(cmd for cmd in participant.commands if cmd.name == "clear")
+        assert clear.description == "Claude SDK clear"
+        assert "compact" in names
+
+    def test_sdk_commands_appended_when_no_collision(self):
+        participant = _make_participant()
+        participant._client.server_info = {
+            "commands": [
+                {"name": "cost", "description": "Show cost"},
+            ]
+        }
+        names = [cmd.name for cmd in participant.commands]
+        assert names == ["clear", "cost"]
+
+    def test_fallback_when_server_info_missing(self):
+        participant = _make_participant()
+        participant._client.server_info = None
+        names = [cmd.name for cmd in participant.commands]
+        assert names == ["compact", "context", "cost", "clear"]


### PR DESCRIPTION
## Summary

Issue #234 reports that `/clear` shows up twice in the chat sidebar's slash-command autocomplete in Claude mode. Once the Claude SDK started shipping `clear` as one of its built-in commands, `ClaudeCodeChatParticipant.commands` ended up listing both NBI's hand-authored entry and the SDK's entry side by side.

## Solution

Merge by `name` into an insertion-ordered dict so each name appears at most once. SDK-provided commands overwrite NBI's matching built-in (description-wise) — the SDK is the authoritative source for the commands it ships. The `server_info is None` fallback (used when the agent hasn't connected yet) is left intact.

## Testing

- `pytest tests/test_claude_client.py` — all 55 tests pass.
- New `TestParticipantCommandsDedupe` covers:
  - `/clear` collision dedupes and SDK description wins,
  - SDK commands without a collision append cleanly,
  - `server_info is None` falls back to the hardcoded list.

## Risks / follow-ups

`/clear` is intercepted client-side by the chat sidebar (it triggers a local reset + `ClearChatHistory` over the WebSocket) and never reaches the SDK's `/clear`. So even though the autocomplete row carries the SDK's description after dedupe, the runtime behavior is NBI's. Whether SDK or NBI should win the *description* on collision is a small UX decision; the current PR picks SDK-wins for parity with the rest of the SDK-sourced names. If users misread that description, a one-line flip to NBI-wins is straightforward.

Closes #234.