### PR TITLE
fix(settings): show persisted Claude model after JupyterLab restart

### DIFF
--- a/notebook_intelligence/ai_service_manager.py
+++ b/notebook_intelligence/ai_service_manager.py
@@ -5,6 +5,7 @@ import json
 from os import path
 import os
 import sys
+import threading
 from typing import Dict, Optional
 import logging
 from notebook_intelligence import github_copilot
@@ -12,7 +13,7 @@ from notebook_intelligence.api import ButtonData, ChatModel, EmbeddingModel, Inl
 from notebook_intelligence.base_chat_participant import BaseChatParticipant
 from notebook_intelligence.config import NBIConfig
 from notebook_intelligence.github_copilot_chat_participant import GithubCopilotChatParticipant
-from notebook_intelligence.claude import CLAUDE_CODE_CHAT_PARTICIPANT_ID, ClaudeCodeChatParticipant, ClaudeCodeInlineCompletionModel, get_claude_models
+from notebook_intelligence.claude import CLAUDE_CODE_CHAT_PARTICIPANT_ID, ClaudeCodeChatParticipant, ClaudeCodeInlineCompletionModel, fetch_claude_models, get_claude_models
 from notebook_intelligence.llm_providers.github_copilot_llm_provider import GitHubCopilotLLMProvider
 from notebook_intelligence.llm_providers.litellm_compatible_llm_provider import LiteLLMCompatibleLLMProvider
 from notebook_intelligence.llm_providers.ollama_llm_provider import OllamaLLMProvider
@@ -183,6 +184,25 @@ class AIServiceManager(Host):
                 self._inline_completion_model = None
             elif model_cfg != 'inherit':
                 self._inline_completion_model = ClaudeCodeInlineCompletionModel(model_cfg, claude_settings.get('api_key', None), claude_settings.get('base_url', None))
+            # Populate the Claude model cache in the background so the
+            # settings panel's chat-model dropdown has options to render
+            # against the user's persisted ``claude_settings.chat_model``.
+            # Without this, the first /capabilities response after a JL
+            # restart returns an empty model list, the dropdown can only
+            # show "Default (recommended)", and the persisted value the
+            # user previously selected silently displays as Default
+            # (issue #235). The fetch is best-effort: failure (no api
+            # key, offline, rate limit) leaves the cache as-is and the
+            # user can still click "Refresh models" from the panel.
+            if not get_claude_models():
+                threading.Thread(
+                    target=fetch_claude_models,
+                    kwargs={
+                        "api_key": claude_settings.get('api_key', None),
+                        "base_url": claude_settings.get('base_url', None),
+                    },
+                    daemon=True,
+                ).start()
         else:
             self.unregister_chat_participant(self._claude_code_chat_participant)
 

--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -112,8 +112,16 @@ def model_info_from_id(model_id: str) -> dict:
         "context_window": 200000,
     }
 
-# Cache of available Claude models fetched from API
+# Cache of available Claude models fetched from API.
+# `_claude_models_fetch_lock` short-circuits concurrent ``fetch_claude_models``
+# calls: ``AIServiceManager.update_models_from_config`` fires a background
+# fetch each time the cache is empty, and that method runs on every
+# ``/capabilities`` GET and every ``/config`` POST. Without the lock,
+# an in-flight (or recently-failed) fetch lets each subsequent call spawn
+# another doomed thread, hammering api.anthropic.com in parallel when the
+# api_key is missing or wrong.
 _claude_models_cache: list[dict] = []
+_claude_models_fetch_lock = threading.Lock()
 
 def get_claude_models() -> list[dict]:
     """Return the cached list of available Claude models."""
@@ -153,24 +161,37 @@ def _create_anthropic_client(api_key: str = None, base_url: str = None) -> Anthr
 
 
 def fetch_claude_models(api_key: str = None, base_url: str = None) -> list[dict]:
-    """Fetch available models from the Anthropic API and update cache."""
-    try:
-        client = _create_anthropic_client(api_key, base_url)
-        page = client.models.list(limit=100)
-        models = []
-        for model in page.data:
-            models.append({
-                "id": model.id,
-                "name": model.display_name,
-                "context_window": _get_context_window(model.id),
-            })
-        _claude_models_cache.clear()
-        _claude_models_cache.extend(models)
-        log.info(f"Fetched {len(models)} Claude models: {[m['id'] + ' (' + m['name'] + ')' for m in models]}")
-        return models
-    except Exception as e:
-        log.warning(f"Failed to fetch Claude models: {e}")
+    """Fetch available models from the Anthropic API and update cache.
+
+    Single-flight: if another caller is already inside this function (e.g.
+    the daemon thread launched at startup), additional callers return the
+    current cache snapshot without firing a duplicate request. The
+    non-blocking acquire avoids piling up requests when the api_key is
+    missing or wrong and every call would otherwise hit the SDK's
+    timeout in parallel.
+    """
+    if not _claude_models_fetch_lock.acquire(blocking=False):
         return _claude_models_cache
+    try:
+        try:
+            client = _create_anthropic_client(api_key, base_url)
+            page = client.models.list(limit=100)
+            models = []
+            for model in page.data:
+                models.append({
+                    "id": model.id,
+                    "name": model.display_name,
+                    "context_window": _get_context_window(model.id),
+                })
+            _claude_models_cache.clear()
+            _claude_models_cache.extend(models)
+            log.info(f"Fetched {len(models)} Claude models: {[m['id'] + ' (' + m['name'] + ')' for m in models]}")
+            return models
+        except Exception as e:
+            log.warning(f"Failed to fetch Claude models: {e}")
+            return _claude_models_cache
+    finally:
+        _claude_models_fetch_lock.release()
 
 class ClaudeChatModel(ChatModel):
     def __init__(self, model_id: str, api_key: str = None, base_url: str = None):

--- a/src/components/settings-panel.tsx
+++ b/src/components/settings-panel.tsx
@@ -1283,10 +1283,16 @@ function SettingsPanelComponentClaude(props: any) {
           <div className="model-config-section-body">
             <div className="model-config-section-row">
               <div className="model-config-section-column">
-                <div>Chat model</div>
+                <div id="nbi-claude-chat-model-label">Chat model</div>
                 <div title={lockedTip(settingLocks.claude_chat_model.locked)}>
                   <select
                     className="jp-mod-styled"
+                    aria-labelledby="nbi-claude-chat-model-label"
+                    aria-describedby={
+                      settingLocks.claude_chat_model.locked
+                        ? 'nbi-claude-chat-model-lock-reason'
+                        : undefined
+                    }
                     disabled={settingLocks.claude_chat_model.locked}
                     value={chatModel}
                     onChange={event => setChatModel(event.target.value)}
@@ -1294,22 +1300,36 @@ function SettingsPanelComponentClaude(props: any) {
                     <option value={ClaudeModelType.Default}>
                       Default (recommended)
                     </option>
-                    {claudeModels.map(model => (
-                      <option key={model.id} value={model.id}>
-                        {model.name}
-                      </option>
-                    ))}
+                    {/* Placeholder for a persisted model id that hasn't
+                        landed in `claudeModels` yet (empty cache, no api
+                        key, mid-fetch). Rendered just after Default so
+                        the active value sits near the top of the list. */}
                     {chatModel !== ClaudeModelType.Default &&
                       !claudeModels.some(m => m.id === chatModel) && (
                         <option key={chatModel} value={chatModel}>
                           {chatModel}
                         </option>
                       )}
+                    {claudeModels.map(model => (
+                      <option key={model.id} value={model.id}>
+                        {model.name}
+                      </option>
+                    ))}
                   </select>
+                  {settingLocks.claude_chat_model.locked && (
+                    <span
+                      id="nbi-claude-chat-model-lock-reason"
+                      className="nbi-sr-only"
+                    >
+                      Locked by your administrator
+                    </span>
+                  )}
                 </div>
               </div>
               <div className="model-config-section-column">
-                <div>Auto-complete model</div>
+                <div id="nbi-claude-inline-model-label">
+                  Auto-complete model
+                </div>
                 <div
                   title={lockedTip(
                     settingLocks.claude_inline_completion_model.locked
@@ -1317,6 +1337,12 @@ function SettingsPanelComponentClaude(props: any) {
                 >
                   <select
                     className="jp-mod-styled"
+                    aria-labelledby="nbi-claude-inline-model-label"
+                    aria-describedby={
+                      settingLocks.claude_inline_completion_model.locked
+                        ? 'nbi-claude-inline-model-lock-reason'
+                        : undefined
+                    }
                     disabled={
                       settingLocks.claude_inline_completion_model.locked
                     }
@@ -1332,11 +1358,6 @@ function SettingsPanelComponentClaude(props: any) {
                     <option value={ClaudeModelType.Default}>
                       Default (recommended)
                     </option>
-                    {claudeModels.map(model => (
-                      <option key={model.id} value={model.id}>
-                        {model.name}
-                      </option>
-                    ))}
                     {![
                       ClaudeModelType.None,
                       ClaudeModelType.Inherit,
@@ -1352,7 +1373,20 @@ function SettingsPanelComponentClaude(props: any) {
                           {inlineCompletionModel}
                         </option>
                       )}
+                    {claudeModels.map(model => (
+                      <option key={model.id} value={model.id}>
+                        {model.name}
+                      </option>
+                    ))}
                   </select>
+                  {settingLocks.claude_inline_completion_model.locked && (
+                    <span
+                      id="nbi-claude-inline-model-lock-reason"
+                      className="nbi-sr-only"
+                    >
+                      Locked by your administrator
+                    </span>
+                  )}
                 </div>
               </div>
             </div>

--- a/src/components/settings-panel.tsx
+++ b/src/components/settings-panel.tsx
@@ -1288,23 +1288,23 @@ function SettingsPanelComponentClaude(props: any) {
                   <select
                     className="jp-mod-styled"
                     disabled={settingLocks.claude_chat_model.locked}
+                    value={chatModel}
                     onChange={event => setChatModel(event.target.value)}
                   >
-                    <option
-                      value={ClaudeModelType.Default}
-                      selected={chatModel === ClaudeModelType.Default}
-                    >
+                    <option value={ClaudeModelType.Default}>
                       Default (recommended)
                     </option>
                     {claudeModels.map(model => (
-                      <option
-                        key={model.id}
-                        value={model.id}
-                        selected={chatModel === model.id}
-                      >
+                      <option key={model.id} value={model.id}>
                         {model.name}
                       </option>
                     ))}
+                    {chatModel !== ClaudeModelType.Default &&
+                      !claudeModels.some(m => m.id === chatModel) && (
+                        <option key={chatModel} value={chatModel}>
+                          {chatModel}
+                        </option>
+                      )}
                   </select>
                 </div>
               </div>
@@ -1320,41 +1320,38 @@ function SettingsPanelComponentClaude(props: any) {
                     disabled={
                       settingLocks.claude_inline_completion_model.locked
                     }
+                    value={inlineCompletionModel}
                     onChange={event =>
                       setInlineCompletionModel(event.target.value)
                     }
                   >
-                    <option
-                      value={ClaudeModelType.None}
-                      selected={inlineCompletionModel === ClaudeModelType.None}
-                    >
-                      None
-                    </option>
-                    <option
-                      value={ClaudeModelType.Inherit}
-                      selected={
-                        inlineCompletionModel === ClaudeModelType.Inherit
-                      }
-                    >
+                    <option value={ClaudeModelType.None}>None</option>
+                    <option value={ClaudeModelType.Inherit}>
                       Inherit from general settings
                     </option>
-                    <option
-                      value={ClaudeModelType.Default}
-                      selected={
-                        inlineCompletionModel === ClaudeModelType.Default
-                      }
-                    >
+                    <option value={ClaudeModelType.Default}>
                       Default (recommended)
                     </option>
                     {claudeModels.map(model => (
-                      <option
-                        key={model.id}
-                        value={model.id}
-                        selected={inlineCompletionModel === model.id}
-                      >
+                      <option key={model.id} value={model.id}>
                         {model.name}
                       </option>
                     ))}
+                    {![
+                      ClaudeModelType.None,
+                      ClaudeModelType.Inherit,
+                      ClaudeModelType.Default
+                    ].includes(inlineCompletionModel as ClaudeModelType) &&
+                      !claudeModels.some(
+                        m => m.id === inlineCompletionModel
+                      ) && (
+                        <option
+                          key={inlineCompletionModel}
+                          value={inlineCompletionModel}
+                        >
+                          {inlineCompletionModel}
+                        </option>
+                      )}
                   </select>
                 </div>
               </div>

--- a/tests/test_ai_service_manager_integration.py
+++ b/tests/test_ai_service_manager_integration.py
@@ -120,6 +120,35 @@ class TestAIServiceManagerIntegration:
             # Should not raise an exception
             manager.reload_rules()
 
+    # The next three tests target the update_models_from_config Claude
+    # branch directly rather than going through AIServiceManager(), so
+    # we don't get tangled with ClaudeCodeChatParticipant's background
+    # SDK handshake thread (which spawns from ClaudeCodeClient.__init__
+    # and waits up to 15s on the connect resolver — a real headache to
+    # mock through AIServiceManager construction).
+    def _make_manager_for_update_test(self, claude_settings):
+        """Build a minimal AIServiceManager for testing the Claude
+        branch of update_models_from_config in isolation.
+        """
+        with patch('notebook_intelligence.ai_service_manager.NBIConfig') as mock_config_class:
+            mock_config = Mock()
+            mock_config.rules_enabled = False
+            mock_config.mcp = {"mcpServers": {}, "participants": {}}
+            mock_config.user_skills_directory = "/test/user_skills"
+            mock_config.project_skills_directory = lambda _root: "/test/project_skills"
+            mock_config.claude_settings = {}
+            mock_config.chat_model = {"provider": "none", "model": "none"}
+            mock_config.inline_completion_model = {"provider": "none", "model": "none"}
+            mock_config.using_github_copilot_service = False
+            mock_config_class.return_value = mock_config
+            manager = AIServiceManager({"server_root_dir": "/test"})
+        # Now swap in the real Claude settings for update_models_from_config
+        # to read. The participant is already constructed (with an empty
+        # claude_settings dict), so this swap only affects the branch
+        # we're about to exercise.
+        manager.nbi_config.claude_settings = claude_settings
+        return manager
+
     def test_claude_mode_triggers_model_fetch_when_cache_empty(self):
         """When Claude mode is enabled and the model cache is empty,
         update_models_from_config should fire a background fetch so the
@@ -127,44 +156,33 @@ class TestAIServiceManagerIntegration:
         (issue #235: the persisted chat_model showed as Default because
         the dropdown had no options to render against).
         """
-        with patch('notebook_intelligence.ai_service_manager.NBIConfig') as mock_config_class:
-            mock_config = Mock()
-            mock_config.rules_enabled = False
-            mock_config.mcp = {"mcpServers": {}, "participants": {}}
-            mock_config.user_skills_directory = "/test/user_skills"
-            mock_config.project_skills_directory = lambda _root: "/test/project_skills"
-            mock_config.claude_settings = {
-                "enabled": True,
-                "chat_model": "claude-sonnet-4-6",
-                "api_key": "test-key",
-            }
-            mock_config.chat_model = {"provider": "none", "model": "none"}
-            mock_config.inline_completion_model = {"provider": "none", "model": "none"}
-            mock_config.using_github_copilot_service = False
-            mock_config_class.return_value = mock_config
-            with patch(
-                'notebook_intelligence.ai_service_manager.fetch_claude_models'
-            ) as mock_fetch, patch(
-                'notebook_intelligence.ai_service_manager.get_claude_models',
-                return_value=[],
-            ):
-                manager = AIServiceManager({"server_root_dir": "/test"})
-                # __init__ already calls initialize which calls
-                # update_models_from_config; the fetch should have been
-                # scheduled on a background thread.
-                # Poll briefly: the daemon thread starts but the call
-                # itself may be deferred a tick.
-                import time as _t
-                for _ in range(20):
-                    if mock_fetch.call_count >= 1:
-                        break
-                    _t.sleep(0.05)
-                assert mock_fetch.call_count >= 1, (
-                    "Expected fetch_claude_models to be invoked when cache "
-                    "is empty and Claude mode is enabled"
-                )
-                call_kwargs = mock_fetch.call_args.kwargs
-                assert call_kwargs.get("api_key") == "test-key"
+        manager = self._make_manager_for_update_test({
+            "enabled": True,
+            "chat_model": "claude-sonnet-4-6",
+            "api_key": "test-key",
+        })
+        # Patch Thread so target runs inline; sidesteps a poll loop and
+        # the daemon-thread teardown race that flaked the earlier draft.
+        def _run_inline(target=None, kwargs=None, **_):
+            if target is not None:
+                target(**(kwargs or {}))
+            return Mock()
+        with patch(
+            'notebook_intelligence.ai_service_manager.fetch_claude_models'
+        ) as mock_fetch, patch(
+            'notebook_intelligence.ai_service_manager.get_claude_models',
+            return_value=[],
+        ), patch(
+            'notebook_intelligence.ai_service_manager.threading.Thread',
+            side_effect=_run_inline,
+        ):
+            manager.update_models_from_config()
+        assert mock_fetch.call_count >= 1, (
+            "Expected fetch_claude_models to be invoked when cache is "
+            "empty and Claude mode is enabled"
+        )
+        call_kwargs = mock_fetch.call_args.kwargs
+        assert call_kwargs.get("api_key") == "test-key"
 
     def test_claude_mode_skips_fetch_when_cache_already_populated(self):
         """If the Claude model cache is already populated (e.g. a prior
@@ -172,51 +190,30 @@ class TestAIServiceManagerIntegration:
         refresh — the existing list is good enough and the round trip
         wastes a request to the Anthropic API.
         """
-        with patch('notebook_intelligence.ai_service_manager.NBIConfig') as mock_config_class:
-            mock_config = Mock()
-            mock_config.rules_enabled = False
-            mock_config.mcp = {"mcpServers": {}, "participants": {}}
-            mock_config.user_skills_directory = "/test/user_skills"
-            mock_config.project_skills_directory = lambda _root: "/test/project_skills"
-            mock_config.claude_settings = {
-                "enabled": True,
-                "chat_model": "claude-sonnet-4-6",
-                "api_key": "test-key",
-            }
-            mock_config.chat_model = {"provider": "none", "model": "none"}
-            mock_config.inline_completion_model = {"provider": "none", "model": "none"}
-            mock_config.using_github_copilot_service = False
-            mock_config_class.return_value = mock_config
-            with patch(
-                'notebook_intelligence.ai_service_manager.fetch_claude_models'
-            ) as mock_fetch, patch(
-                'notebook_intelligence.ai_service_manager.get_claude_models',
-                return_value=[{"id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6"}],
-            ):
-                AIServiceManager({"server_root_dir": "/test"})
-                # Cache had entries, so no fetch should have fired.
-                assert mock_fetch.call_count == 0
+        manager = self._make_manager_for_update_test({
+            "enabled": True,
+            "chat_model": "claude-sonnet-4-6",
+            "api_key": "test-key",
+        })
+        with patch(
+            'notebook_intelligence.ai_service_manager.fetch_claude_models'
+        ) as mock_fetch, patch(
+            'notebook_intelligence.ai_service_manager.get_claude_models',
+            return_value=[{"id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6"}],
+        ):
+            manager.update_models_from_config()
+        assert mock_fetch.call_count == 0
 
     def test_no_fetch_when_claude_mode_disabled(self):
         """Claude mode disabled = no fetch, regardless of cache state.
         Don't reach out to the Anthropic API for users not using Claude.
         """
-        with patch('notebook_intelligence.ai_service_manager.NBIConfig') as mock_config_class:
-            mock_config = Mock()
-            mock_config.rules_enabled = False
-            mock_config.mcp = {"mcpServers": {}, "participants": {}}
-            mock_config.user_skills_directory = "/test/user_skills"
-            mock_config.project_skills_directory = lambda _root: "/test/project_skills"
-            mock_config.claude_settings = {"enabled": False}
-            mock_config.chat_model = {"provider": "none", "model": "none"}
-            mock_config.inline_completion_model = {"provider": "none", "model": "none"}
-            mock_config.using_github_copilot_service = False
-            mock_config_class.return_value = mock_config
-            with patch(
-                'notebook_intelligence.ai_service_manager.fetch_claude_models'
-            ) as mock_fetch, patch(
-                'notebook_intelligence.ai_service_manager.get_claude_models',
-                return_value=[],
-            ):
-                AIServiceManager({"server_root_dir": "/test"})
-                assert mock_fetch.call_count == 0
+        manager = self._make_manager_for_update_test({"enabled": False})
+        with patch(
+            'notebook_intelligence.ai_service_manager.fetch_claude_models'
+        ) as mock_fetch, patch(
+            'notebook_intelligence.ai_service_manager.get_claude_models',
+            return_value=[],
+        ):
+            manager.update_models_from_config()
+        assert mock_fetch.call_count == 0

--- a/tests/test_ai_service_manager_integration.py
+++ b/tests/test_ai_service_manager_integration.py
@@ -114,8 +114,109 @@ class TestAIServiceManagerIntegration:
             mock_config.project_skills_directory = lambda _root: "/test/project_skills"
             mock_config.claude_settings = {}
             mock_config_class.return_value = mock_config
-            
+
             manager = AIServiceManager({"server_root_dir": "/test"})
-            
+
             # Should not raise an exception
             manager.reload_rules()
+
+    def test_claude_mode_triggers_model_fetch_when_cache_empty(self):
+        """When Claude mode is enabled and the model cache is empty,
+        update_models_from_config should fire a background fetch so the
+        capabilities response surfaces the list to the settings panel
+        (issue #235: the persisted chat_model showed as Default because
+        the dropdown had no options to render against).
+        """
+        with patch('notebook_intelligence.ai_service_manager.NBIConfig') as mock_config_class:
+            mock_config = Mock()
+            mock_config.rules_enabled = False
+            mock_config.mcp = {"mcpServers": {}, "participants": {}}
+            mock_config.user_skills_directory = "/test/user_skills"
+            mock_config.project_skills_directory = lambda _root: "/test/project_skills"
+            mock_config.claude_settings = {
+                "enabled": True,
+                "chat_model": "claude-sonnet-4-6",
+                "api_key": "test-key",
+            }
+            mock_config.chat_model = {"provider": "none", "model": "none"}
+            mock_config.inline_completion_model = {"provider": "none", "model": "none"}
+            mock_config.using_github_copilot_service = False
+            mock_config_class.return_value = mock_config
+            with patch(
+                'notebook_intelligence.ai_service_manager.fetch_claude_models'
+            ) as mock_fetch, patch(
+                'notebook_intelligence.ai_service_manager.get_claude_models',
+                return_value=[],
+            ):
+                manager = AIServiceManager({"server_root_dir": "/test"})
+                # __init__ already calls initialize which calls
+                # update_models_from_config; the fetch should have been
+                # scheduled on a background thread.
+                # Poll briefly: the daemon thread starts but the call
+                # itself may be deferred a tick.
+                import time as _t
+                for _ in range(20):
+                    if mock_fetch.call_count >= 1:
+                        break
+                    _t.sleep(0.05)
+                assert mock_fetch.call_count >= 1, (
+                    "Expected fetch_claude_models to be invoked when cache "
+                    "is empty and Claude mode is enabled"
+                )
+                call_kwargs = mock_fetch.call_args.kwargs
+                assert call_kwargs.get("api_key") == "test-key"
+
+    def test_claude_mode_skips_fetch_when_cache_already_populated(self):
+        """If the Claude model cache is already populated (e.g. a prior
+        startup or a manual refresh), don't re-fetch on every config
+        refresh — the existing list is good enough and the round trip
+        wastes a request to the Anthropic API.
+        """
+        with patch('notebook_intelligence.ai_service_manager.NBIConfig') as mock_config_class:
+            mock_config = Mock()
+            mock_config.rules_enabled = False
+            mock_config.mcp = {"mcpServers": {}, "participants": {}}
+            mock_config.user_skills_directory = "/test/user_skills"
+            mock_config.project_skills_directory = lambda _root: "/test/project_skills"
+            mock_config.claude_settings = {
+                "enabled": True,
+                "chat_model": "claude-sonnet-4-6",
+                "api_key": "test-key",
+            }
+            mock_config.chat_model = {"provider": "none", "model": "none"}
+            mock_config.inline_completion_model = {"provider": "none", "model": "none"}
+            mock_config.using_github_copilot_service = False
+            mock_config_class.return_value = mock_config
+            with patch(
+                'notebook_intelligence.ai_service_manager.fetch_claude_models'
+            ) as mock_fetch, patch(
+                'notebook_intelligence.ai_service_manager.get_claude_models',
+                return_value=[{"id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6"}],
+            ):
+                AIServiceManager({"server_root_dir": "/test"})
+                # Cache had entries, so no fetch should have fired.
+                assert mock_fetch.call_count == 0
+
+    def test_no_fetch_when_claude_mode_disabled(self):
+        """Claude mode disabled = no fetch, regardless of cache state.
+        Don't reach out to the Anthropic API for users not using Claude.
+        """
+        with patch('notebook_intelligence.ai_service_manager.NBIConfig') as mock_config_class:
+            mock_config = Mock()
+            mock_config.rules_enabled = False
+            mock_config.mcp = {"mcpServers": {}, "participants": {}}
+            mock_config.user_skills_directory = "/test/user_skills"
+            mock_config.project_skills_directory = lambda _root: "/test/project_skills"
+            mock_config.claude_settings = {"enabled": False}
+            mock_config.chat_model = {"provider": "none", "model": "none"}
+            mock_config.inline_completion_model = {"provider": "none", "model": "none"}
+            mock_config.using_github_copilot_service = False
+            mock_config_class.return_value = mock_config
+            with patch(
+                'notebook_intelligence.ai_service_manager.fetch_claude_models'
+            ) as mock_fetch, patch(
+                'notebook_intelligence.ai_service_manager.get_claude_models',
+                return_value=[],
+            ):
+                AIServiceManager({"server_root_dir": "/test"})
+                assert mock_fetch.call_count == 0


### PR DESCRIPTION
## Summary

Issue #235 reports that after a JupyterLab restart, the Claude settings panel always shows "Default (recommended)" for the chat model even when a custom model was previously selected and persisted. The original attempt in this PR (a hydration-ref re-sync on `configChanged`) didn't fix it — @mbektas confirmed the dropdown still shows Default after restart.

Reinvestigation found two layered problems, neither of which the hydration ref addressed.

## Root cause

**(1) Empty `claude_models` cache at startup.** `_claude_models_cache` only populates when the user clicks "Refresh models" in the panel, or when `UpdateProviderModelsHandler` runs. On a fresh JL boot the cache is empty, so `/notebook-intelligence/capabilities` returns `claude_models: []`. The settings panel then has only the "Default (recommended)" option to render — no matching `<option>` exists for the persisted `claude_settings.chat_model` value, so it can never appear as the selection.

**(2) `<option selected>` is `defaultSelected`, not a controlled selection.** The dropdown used `<option selected={chatModel === id}>` for each option. React translates `selected` on `<option>` to the `defaultSelected` DOM property, which only takes effect on initial mount. Subsequent re-renders don't update the visible selection. Even when `claudeModels` later arrives via `configChanged` and the matching option flips `selected={true}`, the dropdown's actual selection stays where it was first set.

The hydration-ref approach didn't help because (a) `claudeModels` is still empty after the configChanged re-sync (no fetch had been triggered), and (b) even if the model list arrived, the `<option selected>` pattern doesn't update the visible selection.

## Solution

Two targeted fixes, both required:

1. **Backend auto-fetch.** In `AIServiceManager.update_models_from_config`, when Claude mode is enabled and the cache is empty, fire `fetch_claude_models` on a daemon thread using the persisted `api_key` / `base_url`. Best-effort: if it fails (no key, offline, rate limit) the cache stays empty and the fallback below handles it.

2. **Controlled-component dropdown.** Switch the two Claude `<select>` elements to `<select value={chatModel}>` and drop the `selected={...}` on each option. Add a fallback `<option value={chatModel}>{chatModel}</option>` when the persisted value isn't in `claudeModels`, so the user still sees their selection during the brief window between mount and the fetch arriving — or permanently, for users without an API key.

## Testing

Automated:
- `tests/test_ai_service_manager_integration.py`: three new tests covering fetch-on-empty-cache, no-fetch-when-cache-populated, no-fetch-when-claude-mode-disabled.
- Full pytest sweep (658), `jlpm tsc --noEmit`, `jlpm lint:check`, `jlpm jest` (111) all green.

Manual (via Playwright against a local JL):
- Set `claude_settings.chat_model: "claude-sonnet-4-6"` in `~/.jupyter/nbi/config.json`, restart JL.
- Open Settings → Claude. **Before fix:** dropdown shows "Default (recommended)". **After fix:** dropdown shows `claude-sonnet-4-6`.

## Risks / follow-ups

- The Auto-complete model dropdown got the same controlled-component treatment for consistency, though the reported bug was only about Chat model.
- The General-tab provider/model dropdowns still use `<option selected>`. Same latent issue but a separate scope; tracked as a follow-up.
- Auto-fetch failure modes (no api key, network down) are silent. The placeholder option mitigates the UX impact (user still sees their selection), but admin observability of failed fetches is via existing `log.warning` only.

Closes #235.
