### PR TITLE
chore(deps): bump react-icons to ~5.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "@jupyterlab/services": "^7.0.0",
         "@jupyterlab/settingregistry": "^4.0.0",
         "monaco-editor": "0.21.3",
-        "react-icons": "~5.4.0",
+        "react-icons": "~5.6.0",
         "react-markdown": "^9.0.1",
         "react-syntax-highlighter": "^15.4.4",
         "remark-gfm": "4.0.0",

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -60,7 +60,7 @@ import {
   VscThumbsdownFilled,
   VscCloudUpload,
   VscAttach
-} from 'react-icons/vsc';
+} from './icons';
 
 import {
   extractLLMGeneratedCode,

--- a/src/components/checkbox.tsx
+++ b/src/components/checkbox.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 
-import { MdOutlineCheckBoxOutlineBlank, MdCheckBox } from 'react-icons/md';
+import { MdOutlineCheckBoxOutlineBlank, MdCheckBox } from '../icons';
 
 export function CheckBoxItem(props: any) {
   const indent = props.indent || 0;

--- a/src/components/claude-session-picker.tsx
+++ b/src/components/claude-session-picker.tsx
@@ -7,7 +7,7 @@ import React, {
   useRef,
   useState
 } from 'react';
-import { VscCheck, VscClose, VscCopy, VscHistory } from 'react-icons/vsc';
+import { VscCheck, VscClose, VscCopy, VscHistory } from '../icons';
 
 import { IClaudeSessionInfo, IClaudeSessionList, NBIAPI } from '../api';
 import { buildResumeCommand, writeTextToClipboard } from '../utils';

--- a/src/components/notebook-generation-popover.tsx
+++ b/src/components/notebook-generation-popover.tsx
@@ -7,7 +7,7 @@ import React, {
   useRef,
   useState
 } from 'react';
-import { VscClose, VscSend, VscSparkle } from 'react-icons/vsc';
+import { VscClose, VscSend, VscSparkle } from '../icons';
 
 import { CheckBoxItem } from './checkbox';
 

--- a/src/components/settings-panel.tsx
+++ b/src/components/settings-panel.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { ReactWidget } from '@jupyterlab/apputils';
-import { VscWarning } from 'react-icons/vsc';
+import { VscWarning } from '../icons';
 import * as path from 'path';
 
 import copySvgstr from '../../style/icons/copy.svg';

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -1,0 +1,65 @@
+// Central re-export of react-icons we use, with React-18-compatible
+// types. react-icons 5.5.0+ types its icons as returning React.ReactNode,
+// which @types/react@18's JSX namespace rejects as a JSX-component
+// return type (TS2786). The runtime is unaffected — this module just
+// re-types the icons through `FC<IIconBaseProps>` so the JSX runtime
+// accepts them under React 18.
+//
+// Import icons from this module (e.g. `import { VscThumbsup } from '../icons'`)
+// rather than directly from `react-icons/vsc`/`react-icons/md`, so a future
+// bump of @types/react to v19+ only requires deleting this shim.
+
+import type { FC, SVGAttributes } from 'react';
+import * as Md from 'react-icons/md';
+import * as Vsc from 'react-icons/vsc';
+
+interface IIconBaseProps extends SVGAttributes<SVGElement> {
+  size?: string | number;
+  color?: string;
+  title?: string;
+}
+
+type IconLike = FC<IIconBaseProps>;
+
+const asIcon = (Component: unknown) => Component as IconLike;
+
+export const VscAdd = asIcon(Vsc.VscAdd);
+export const VscArrowDown = asIcon(Vsc.VscArrowDown);
+export const VscArrowUp = asIcon(Vsc.VscArrowUp);
+export const VscAttach = asIcon(Vsc.VscAttach);
+export const VscCheck = asIcon(Vsc.VscCheck);
+export const VscChevronDown = asIcon(Vsc.VscChevronDown);
+export const VscChevronRight = asIcon(Vsc.VscChevronRight);
+export const VscChevronUp = asIcon(Vsc.VscChevronUp);
+export const VscClose = asIcon(Vsc.VscClose);
+export const VscCloudUpload = asIcon(Vsc.VscCloudUpload);
+export const VscCopy = asIcon(Vsc.VscCopy);
+export const VscEdit = asIcon(Vsc.VscEdit);
+export const VscEye = asIcon(Vsc.VscEye);
+export const VscEyeClosed = asIcon(Vsc.VscEyeClosed);
+export const VscFile = asIcon(Vsc.VscFile);
+export const VscHistory = asIcon(Vsc.VscHistory);
+export const VscInsert = asIcon(Vsc.VscInsert);
+export const VscLink = asIcon(Vsc.VscLink);
+export const VscNewFile = asIcon(Vsc.VscNewFile);
+export const VscNotebook = asIcon(Vsc.VscNotebook);
+export const VscPassFilled = asIcon(Vsc.VscPassFilled);
+export const VscRefresh = asIcon(Vsc.VscRefresh);
+export const VscSend = asIcon(Vsc.VscSend);
+export const VscSettingsGear = asIcon(Vsc.VscSettingsGear);
+export const VscSparkle = asIcon(Vsc.VscSparkle);
+export const VscStopCircle = asIcon(Vsc.VscStopCircle);
+export const VscThumbsdown = asIcon(Vsc.VscThumbsdown);
+export const VscThumbsdownFilled = asIcon(Vsc.VscThumbsdownFilled);
+export const VscThumbsup = asIcon(Vsc.VscThumbsup);
+export const VscThumbsupFilled = asIcon(Vsc.VscThumbsupFilled);
+export const VscTools = asIcon(Vsc.VscTools);
+export const VscTrash = asIcon(Vsc.VscTrash);
+export const VscTriangleDown = asIcon(Vsc.VscTriangleDown);
+export const VscTriangleRight = asIcon(Vsc.VscTriangleRight);
+export const VscWarning = asIcon(Vsc.VscWarning);
+
+export const MdCheckBox = asIcon(Md.MdCheckBox);
+export const MdOutlineCheckBoxOutlineBlank = asIcon(
+  Md.MdOutlineCheckBoxOutlineBlank
+);

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -10,6 +10,7 @@
 // bump of @types/react to v19+ only requires deleting this shim.
 
 import type { FC, SVGAttributes } from 'react';
+import type { IconType } from 'react-icons/lib';
 import * as Md from 'react-icons/md';
 import * as Vsc from 'react-icons/vsc';
 
@@ -21,7 +22,12 @@ interface IIconBaseProps extends SVGAttributes<SVGElement> {
 
 type IconLike = FC<IIconBaseProps>;
 
-const asIcon = (Component: unknown) => Component as IconLike;
+// Typed parameter (IconType, the upstream signature) so a typo in
+// `Vsc.VscFooo` is caught at compile time. The `unknown` indirection
+// is what the TS error message asks for when widening a return type
+// across the React 18 → React 19 ReactNode boundary.
+const asIcon = (Component: IconType): IconLike =>
+  Component as unknown as IconLike;
 
 export const VscAdd = asIcon(Vsc.VscAdd);
 export const VscArrowDown = asIcon(Vsc.VscArrowDown);

--- a/src/markdown-renderer.tsx
+++ b/src/markdown-renderer.tsx
@@ -10,13 +10,7 @@ import {
   oneLight,
   oneDark
 } from 'react-syntax-highlighter/dist/cjs/styles/prism';
-import {
-  VscNewFile,
-  VscInsert,
-  VscCopy,
-  VscNotebook,
-  VscAdd
-} from 'react-icons/vsc';
+import { VscNewFile, VscInsert, VscCopy, VscNotebook, VscAdd } from './icons';
 import { JupyterFrontEnd } from '@jupyterlab/application';
 import { isDarkTheme, writeTextToClipboard } from './utils';
 import { IActiveDocumentInfo } from './tokens';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3326,7 +3326,7 @@ __metadata:
     monaco-editor-webpack-plugin: ^2.0.0
     npm-run-all: ^4.1.5
     prettier: ^3.0.0
-    react-icons: ~5.4.0
+    react-icons: ~5.6.0
     react-markdown: ^9.0.1
     react-syntax-highlighter: ^15.4.4
     remark-gfm: 4.0.0
@@ -9903,12 +9903,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-icons@npm:~5.4.0":
-  version: 5.4.0
-  resolution: "react-icons@npm:5.4.0"
+"react-icons@npm:~5.6.0":
+  version: 5.6.0
+  resolution: "react-icons@npm:5.6.0"
   peerDependencies:
     react: "*"
-  checksum: 6ee5fcda49d9628e33d97e955ed6ec9f30b26226a13b14d0f3f9a698d0d5dd2e3878af7de295e0241bdd8f46af96f16bfea1fd0647beddc447c1de98bdb2178e
+  checksum: 332358dff0926650b82c352c7af1b6da14848738356c7b6d7dc09b9a84d53d2486b38f33c6fea8b1b802a29d5543fc6cfaffd82ca71a11021f1c59128daa8361
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Issue #236 asks for a `react-icons` bump so the chat sidebar picks up the refreshed VS Code codicon set — the thumbs-up / thumbs-down icons in particular are visibly outdated.

Bump from `~5.4.0` to `~5.6.0`, which carries the refreshed codicon SVGs.

## Solution

react-icons 5.5.0+ changed every icon's typed return value from `JSX.Element` to `React.ReactNode`. Under `@types/react@18` (the React 18 type ecosystem JupyterLab 4.x is built on) the JSX namespace's `Element` type rejects `ReactNode`-returning components — every icon usage fails with TS2786. The runtime is unaffected; only the type-system constraint changed.

Rather than cascade-bump `@types/react` to `^19` (which would touch the wider JupyterLab 4.x ecosystem), centralize icon imports in `src/icons.ts` and re-type each icon as `FC<IIconBaseProps>`:

- The shim takes the upstream `IconType` as its parameter so a typo in `Vsc.VscFooo` is still caught at compile time, and widens the return type via `unknown` (the documented workaround for the JSX-runtime mismatch).
- All six existing `react-icons` import sites now import from `./icons` instead of `react-icons/{vsc,md}`. When `@types/react` eventually moves to `^19`, deleting the shim and switching imports back is mechanical.

## Screenshots

<img width="296" height="458" alt="Thumbs in Context" src="https://github.com/user-attachments/assets/ef57c412-e243-406a-94fc-f62345828e22" />

## Testing

- `jlpm tsc --noEmit` and `jlpm lint:check` pass.
- `jlpm jest` — 104 tests pass.

## Risks / follow-ups

Centralizing through `src/icons.ts` adds one indirection per icon import, but the runtime cost is zero (the cast is type-only) and tree-shaking still works (named exports). When upstream moves to `@types/react@19`, the shim becomes a pure pass-through and can be deleted.

Closes #236.