### PR TITLE
feat(chat-sidebar): add "+ New Chat session" button to restart Claude

### DIFF
--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -2988,6 +2988,19 @@ function SidebarComponent(props: any) {
     // have to remember the slash command (issue #237). Also useful when
     // the Claude SDK client is wedged — restarting the session reconnects
     // the agent.
+    if (copilotRequestInProgress) {
+      // Cancel any in-flight response before clearing local state. Without
+      // this, stream deltas tied to the old messageId keep arriving against
+      // an empty chat-messages list and silently re-populate it from the
+      // old conversation.
+      NBIAPI.sendWebSocketMessage(
+        lastMessageId.current,
+        RequestDataType.CancelChatRequest,
+        { chatId }
+      );
+      lastMessageId.current = '';
+      setCopilotRequestInProgress(false);
+    }
     setChatMessages([]);
     setPrompt('');
     setSelectedContextFiles([]);
@@ -3011,7 +3024,13 @@ function SidebarComponent(props: any) {
       setNewChatNoticeVisible(false);
       newChatNoticeTimerRef.current = null;
     }, 3000);
-  }, [chatId, resetChatId, resetPrefixSuggestions]);
+    // Move focus to the prompt textarea so the user can immediately type
+    // their first message in the fresh session. Defer past the React
+    // commit so the input has re-rendered with the cleared prompt value.
+    window.requestAnimationFrame(() => {
+      promptInputRef.current?.focus();
+    });
+  }, [chatId, copilotRequestInProgress, resetChatId, resetPrefixSuggestions]);
 
   useEffect(() => {
     const handler = () => {
@@ -3089,16 +3108,14 @@ function SidebarComponent(props: any) {
           <VscSettingsGear />
         </div>
       </div>
-      <div className="nbi-skills-reloaded-banner-live" aria-live="polite">
+      <div className="nbi-status-banner-live" aria-live="polite">
         {skillsReloadedVisible && (
-          <div className="nbi-skills-reloaded-banner">
+          <div className="nbi-status-banner">
             Skills reloaded — applied to the current session.
           </div>
         )}
         {newChatNoticeVisible && (
-          <div className="nbi-skills-reloaded-banner">
-            New chat session started.
-          </div>
+          <div className="nbi-status-banner">New chat session started.</div>
         )}
       </div>
       {!chatEnabled && !ghLoginRequired && (

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -2171,19 +2171,7 @@ function SidebarComponent(props: any) {
     setChatMessages(newList);
 
     if (submitPrompt.startsWith('/clear')) {
-      setChatMessages([]);
-      setPrompt('');
-      setSelectedContextFiles([]);
-      setShowWorkspaceFilePicker(false);
-      resetChatId();
-      resetPrefixSuggestions();
-      setPromptHistory([]);
-      setPromptHistoryIndex(0);
-      NBIAPI.sendWebSocketMessage(
-        UUID.uuid4(),
-        RequestDataType.ClearChatHistory,
-        { chatId }
-      );
+      startNewChatSession();
       return;
     }
 
@@ -2977,6 +2965,53 @@ function SidebarComponent(props: any) {
   );
   const [chatEnabled, setChatEnabled] = useState(NBIAPI.getChatEnabled());
   const [skillsReloadedVisible, setSkillsReloadedVisible] = useState(false);
+  // Visible for a few seconds after the user starts a new chat session
+  // (either via the header button or `/clear`). The aria-live region
+  // below announces it to assistive tech.
+  const [newChatNoticeVisible, setNewChatNoticeVisible] = useState(false);
+  const newChatNoticeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
+
+  useEffect(() => {
+    return () => {
+      if (newChatNoticeTimerRef.current) {
+        clearTimeout(newChatNoticeTimerRef.current);
+      }
+    };
+  }, []);
+
+  const startNewChatSession = useCallback(() => {
+    // Reset every piece of per-conversation UI state and tell the server
+    // to drop its conversation history. Functionally equivalent to typing
+    // `/clear`, but reachable from the header button so the user doesn't
+    // have to remember the slash command (issue #237). Also useful when
+    // the Claude SDK client is wedged — restarting the session reconnects
+    // the agent.
+    setChatMessages([]);
+    setPrompt('');
+    setSelectedContextFiles([]);
+    setShowWorkspaceFilePicker(false);
+    resetChatId();
+    resetPrefixSuggestions();
+    setPromptHistory([]);
+    setPromptHistoryIndex(0);
+    NBIAPI.sendWebSocketMessage(
+      UUID.uuid4(),
+      RequestDataType.ClearChatHistory,
+      {
+        chatId
+      }
+    );
+    setNewChatNoticeVisible(true);
+    if (newChatNoticeTimerRef.current) {
+      clearTimeout(newChatNoticeTimerRef.current);
+    }
+    newChatNoticeTimerRef.current = setTimeout(() => {
+      setNewChatNoticeVisible(false);
+      newChatNoticeTimerRef.current = null;
+    }, 3000);
+  }, [chatId, resetChatId, resetPrefixSuggestions]);
 
   useEffect(() => {
     const handler = () => {
@@ -3029,13 +3064,23 @@ function SidebarComponent(props: any) {
       <div className="sidebar-header">
         <div className="sidebar-title">Notebook Intelligence</div>
         {NBIAPI.config.isInClaudeCodeMode && (
-          <div
-            className="user-input-footer-button"
-            onClick={() => setShowClaudeSessionPicker(true)}
-            title="Resume previous Claude session"
-          >
-            <VscHistory />
-          </div>
+          <>
+            <div
+              className="user-input-footer-button"
+              onClick={() => startNewChatSession()}
+              title="Start a new chat session (restarts the Claude client)"
+              aria-label="Start a new chat session"
+            >
+              <VscAdd />
+            </div>
+            <div
+              className="user-input-footer-button"
+              onClick={() => setShowClaudeSessionPicker(true)}
+              title="Resume previous Claude session"
+            >
+              <VscHistory />
+            </div>
+          </>
         )}
         <div
           className="user-input-footer-button"
@@ -3048,6 +3093,11 @@ function SidebarComponent(props: any) {
         {skillsReloadedVisible && (
           <div className="nbi-skills-reloaded-banner">
             Skills reloaded — applied to the current session.
+          </div>
+        )}
+        {newChatNoticeVisible && (
+          <div className="nbi-skills-reloaded-banner">
+            New chat session started.
           </div>
         )}
       </div>

--- a/style/base.css
+++ b/style/base.css
@@ -1387,7 +1387,7 @@ svg.access-token-warning {
   cursor: default;
 }
 
-.nbi-skills-reloaded-banner {
+.nbi-status-banner {
   padding: 8px 12px;
   margin: 4px 8px;
   border-radius: 4px;


### PR DESCRIPTION
## Summary

Issue #237 asks for a manual way to restart the Claude SDK client — currently the only path is typing `/clear`. Useful both as a discoverable affordance (the issue describes it as "+ New Chat session") and as a recovery path when the client is wedged or when MCP config has changed outside NBI.

## Solution

Add a "+" button to the chat sidebar header (Claude mode only) that calls a new `startNewChatSession` callback. The callback:

- cancels any in-flight chat response (otherwise stream deltas would arrive against the old `messageId` and re-populate the cleared list),
- clears the local message list / prompt / context / picker state,
- resets `chatId` and prompt history,
- sends `ClearChatHistory` over the WebSocket so the backend drops its conversation history (and the Claude SDK client reconnects),
- shows a transient "New chat session started." banner that auto-dismisses after 3 s, and
- moves keyboard focus to the prompt textarea so the user can immediately type.

The existing `/clear` slash-command path is refactored to call the new callback, so both entry points share one implementation. The banner uses a renamed semantic-neutral `nbi-status-banner` CSS class (was `nbi-skills-reloaded-banner`) shared with the skills-reloaded notice.

## Screenshots

The new chat button:

<img width="250" height="35" alt="New Chat Button" src="https://github.com/user-attachments/assets/d428aea8-ac77-4191-a4c6-26bb1b003ef3" />

The new chat banner:

<img width="250" height="130" alt="New Chat Banner" src="https://github.com/user-attachments/assets/31137126-65f5-4a3e-bbe0-e106f47d7583" />

## Testing

- `jlpm tsc --noEmit`, `jlpm lint:check`, `jlpm jest` all pass.
- Manual: in Claude Code mode, click the "+" button in the sidebar header — the chat clears, the banner appears for 3 s, focus lands on the prompt textarea, and the next message starts a fresh session. Also verified that typing `/clear` exhibits the same behavior.

## Risks / follow-ups

The backend's `ClearChatHistory` handler currently ignores the `chatId` field and wipes all sessions — a pre-existing condition. Today there's only one chat surface, so "wipe all" equals "wipe the current." If a second chat surface is ever added (e.g. a notebook-attached side-panel), restart-from-one will silently affect the other. Worth a follow-up.

Closes #237.