### PR TITLE
fix(claude): stabilize is_connected() against the worker-spawn resurrection race

### DIFF
--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -383,6 +383,17 @@ class ClaudeCodeClient():
         self._continue_conversation = value
 
     def is_connected(self):
+        # Status check guards the post-handshake window: when the worker
+        # raises in _client_thread_func, it sets FailedToConnect *before*
+        # signalling _connect_resolved, so any is_connected() call ordered
+        # after a connect() wait sees the failure. Without this check, a
+        # publish-after-start race in _start_worker_thread can resurrect a
+        # dead Thread reference whose is_alive() still reads True for the
+        # brief Python cleanup window, sending query() down the dead-thread
+        # path with the stale "Claude agent is not running" error instead
+        # of the intended "is not connected" path.
+        if self._status == ClaudeAgentClientStatus.FailedToConnect:
+            return False
         return self._client_thread is not None and self._client_thread.is_alive()
 
     def _create_client_thread_event_loop(self) -> asyncio.AbstractEventLoop:

--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -383,15 +383,13 @@ class ClaudeCodeClient():
         self._continue_conversation = value
 
     def is_connected(self):
-        # Status check guards the post-handshake window: when the worker
-        # raises in _client_thread_func, it sets FailedToConnect *before*
-        # signalling _connect_resolved, so any is_connected() call ordered
-        # after a connect() wait sees the failure. Without this check, a
-        # publish-after-start race in _start_worker_thread can resurrect a
-        # dead Thread reference whose is_alive() still reads True for the
-        # brief Python cleanup window, sending query() down the dead-thread
-        # path with the stale "Claude agent is not running" error instead
-        # of the intended "is not connected" path.
+        # `_client_thread_func` sets FailedToConnect *before* signalling
+        # `_connect_resolved`, so this short-circuit is reliable for any
+        # `is_connected()` call ordered after a `connect()` wait. Without
+        # it, the publish-after-start race in `_start_worker_thread` can
+        # resurrect a dead Thread reference whose `is_alive()` reads True
+        # for Python's brief cleanup window, sending `query()` down the
+        # dead-thread path with a misleading error.
         if self._status == ClaudeAgentClientStatus.FailedToConnect:
             return False
         return self._client_thread is not None and self._client_thread.is_alive()

--- a/tests/test_claude_client.py
+++ b/tests/test_claude_client.py
@@ -79,6 +79,24 @@ class TestIsConnected:
             stop.set()
             thread.join(timeout=1)
 
+    def test_returns_false_when_status_is_failed_to_connect(self):
+        # `is_connected()` must respect the FailedToConnect status even
+        # when the thread reference happens to be alive. The
+        # publish-after-start race in `_start_worker_thread` can briefly
+        # resurrect a dead thread reference whose `is_alive()` reads True;
+        # the status check is the post-handshake truth.
+        client = _make_client()
+        stop = threading.Event()
+        thread = threading.Thread(target=stop.wait, daemon=True)
+        thread.start()
+        try:
+            client._client_thread = thread
+            client._status = ClaudeAgentClientStatus.FailedToConnect
+            assert client.is_connected() is False
+        finally:
+            stop.set()
+            thread.join(timeout=1)
+
 
 class TestClientThreadEventLoop:
     def test_windows_uses_proactor_loop_without_changing_global_policy(self, monkeypatch):
@@ -459,6 +477,49 @@ class TestConnectWaitsForReadiness:
             stop_worker.set()
             if client._client_thread is not None:
                 client._client_thread.join(timeout=1)
+
+    def test_failed_to_connect_status_is_set_before_event_signal(self):
+        # The worker must call `_set_status(FailedToConnect)` *before*
+        # `_connect_resolved.set()`. `is_connected()`'s status short-circuit
+        # relies on this ordering — if the writes were reversed, callers
+        # waking from `connect()`'s wait could observe the prior status
+        # while the worker thread is briefly still alive, mistakenly
+        # returning True until the status write caught up.
+        client = _make_client()
+        client._update_server_info_async = Mock()
+
+        async def spawn_failure():
+            raise RuntimeError("SDK spawn failed")
+
+        client._get_client = spawn_failure
+
+        call_order = []
+        original_set_status = client._set_status
+        original_event_set = client._connect_resolved.set
+
+        def recording_set_status(status):
+            if status == ClaudeAgentClientStatus.FailedToConnect:
+                call_order.append("status_failed")
+            original_set_status(status)
+
+        def recording_event_set():
+            call_order.append("event_set")
+            original_event_set()
+
+        client._set_status = recording_set_status
+        client._connect_resolved.set = recording_event_set
+
+        client.connect()
+
+        assert "status_failed" in call_order, (
+            f"Expected _set_status(FailedToConnect) to be called, got: {call_order}"
+        )
+        assert "event_set" in call_order, (
+            f"Expected _connect_resolved.set() to be called, got: {call_order}"
+        )
+        assert call_order.index("status_failed") < call_order.index("event_set"), (
+            f"Expected status_failed before event_set, got: {call_order}"
+        )
 
     def test_query_surfaces_server_log_error_when_spawn_fails(self, monkeypatch):
         """End-to-end of the #147 scenario raffaelemancuso hit after PR #148


### PR DESCRIPTION
## Summary

`tests/test_claude_client.py::TestConnectWaitsForReadiness::test_query_surfaces_server_log_error_when_spawn_fails` has been intermittently failing on slow CI runners. The test asserts that after an SDK spawn failure, `query()` returns the actionable "Claude agent is not connected. Check the server log…" message, but CI was sporadically seeing the cryptic "Claude agent is not running" instead. The root cause is a publish-after-start race in `ClaudeCodeClient._start_worker_thread`: when the worker thread crashes on `await self._get_client()`, its exception handler nulls `self._client_thread` and signals `_connect_resolved` *before* the main thread's late `self._client_thread = thread` publish runs — which then resurrects a dead Thread reference whose `is_alive()` reads True for Python's brief cleanup window. `is_connected()` returns True, `query()` slips past `_ensure_connected()`, and `_send_claude_agent_request` hits the dead-thread branch with the misleading error.

## Solution

Use the existing `_status` field to short-circuit `is_connected()` when the worker has resolved as `FailedToConnect`. The worker calls `_set_status(FailedToConnect)` *before* `_connect_resolved.set()`, so any `is_connected()` call ordered after a `connect()` wait sees the failure regardless of which order the publish race resolves in. `_start_worker_thread` resets the status to `Connecting` (under `_connect_lock`) at the start of a retry, so the FailedToConnect state never sticks across attempts.

Reversing publish and start was tried and rejected: it broke `test_connect_in_background_returns_immediately_when_worker_slow`, which joins `_client_thread` for cleanup and hit `RuntimeError: cannot join thread before it is started` on the publish window. The original publish-after-start ordering is a real constraint; the status-field approach sidesteps it entirely.

The load-bearing change is the single conditional in `is_connected()` (`notebook_intelligence/claude.py:386`).

## Testing

- `test_query_surfaces_server_log_error_when_spawn_fails` (the formerly-flaky test) now passes deterministically: **100/100 iterations** locally with the fix, vs intermittent failures on CI without it.
- Two new deterministic unit tests pin the contracts the fix relies on, so a future refactor that reorders status/event writes fails immediately rather than re-introducing the slow-CI flake:
  - `test_returns_false_when_status_is_failed_to_connect` — `is_connected()` returns False when `_status == FailedToConnect` even if `_client_thread.is_alive()` reads True.
  - `test_failed_to_connect_status_is_set_before_event_signal` — worker's exception handler calls `_set_status(FailedToConnect)` *before* `_connect_resolved.set()`.
- Full local sweep: 567 pytest / tsc clean / lint clean / 104 jest.
- Six-agent review (code reuse, code quality, efficiency, distributed-systems / Claude SDK, test architecture, performance) all approved; trimmed the explanatory comment and added the two ordering-pinning tests per the test-architecture reviewer.

## Risks / follow-ups

- **Pre-existing (out of scope):** the worker's exception handler at `notebook_intelligence/claude.py:618` doesn't null `self._client`, so a stale `ClaudeSDKClient` instance carries to the next retry. Flagged by the distributed-systems reviewer as a hygiene gap to address in a separate PR.
- The status field is read across threads without explicit locking. `threading.Event.set/wait` provides happens-before semantics for the post-`connect()` read path; other read paths (e.g., `disconnect()`, `_send_claude_agent_request`'s polling loop) see eventual consistency under the GIL, which matches their existing assumptions.