### PR TITLE
fix(chat-sidebar): refresh @-mention picker when workspace files change

### DIFF
--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -60,8 +60,10 @@ import {
   VscThumbsupFilled,
   VscThumbsdownFilled,
   VscCloudUpload,
-  VscAttach
+  VscAttach,
+  VscRefresh
 } from './icons';
+import type { Contents } from '@jupyterlab/services';
 
 import {
   extractLLMGeneratedCode,
@@ -454,6 +456,12 @@ const SKIPPED_WORKSPACE_DIRECTORIES = new Set(['__pycache__', 'node_modules']);
 // recovering most of the easy speedup; further parallelism is bounded by
 // the tree's width and the slowest fetch in each batch.
 const WORKSPACE_SCAN_CONCURRENCY = 8;
+// Coalesce window for the Contents-API `fileChanged` storm that fires when
+// the user (or an agent) creates a directory, drops a folder of files, or
+// renames a tree. Without coalescing, one drag-drop of N items would
+// schedule N rescans; with a 300ms window every realistic bulk operation
+// settles into a single rescan.
+const WORKSPACE_FILE_REFRESH_DEBOUNCE_MS = 300;
 
 function countContentLines(content: string): number {
   if (content === '') {
@@ -1325,14 +1333,94 @@ function SidebarComponent(props: any) {
     }
   }, [props]);
 
+  // Latest references for the fileChanged subscription handler to read
+  // without re-binding the effect on every render.
+  const loadWorkspaceFilesRef = useRef(loadWorkspaceFiles);
+  useEffect(() => {
+    loadWorkspaceFilesRef.current = loadWorkspaceFiles;
+  }, [loadWorkspaceFiles]);
+  const showWorkspaceFilePickerRef = useRef(showWorkspaceFilePicker);
+  useEffect(() => {
+    showWorkspaceFilePickerRef.current = showWorkspaceFilePicker;
+  }, [showWorkspaceFilePicker]);
+  // Set when a refresh arrives mid-scan. The in-flight scan's drain loop
+  // honors one more pass at completion, bounding the storm to "at most one
+  // scan running + one queued" instead of cascading cancellations.
+  const pendingRescanRef = useRef(false);
+
+  const runWorkspaceFileScan = useCallback(async () => {
+    if (workspaceFilesLoadingRef.current) {
+      pendingRescanRef.current = true;
+      return;
+    }
+    do {
+      pendingRescanRef.current = false;
+      await loadWorkspaceFilesRef.current();
+    } while (pendingRescanRef.current && showWorkspaceFilePickerRef.current);
+  }, []);
+
+  const runWorkspaceFileScanRef = useRef(runWorkspaceFileScan);
+  useEffect(() => {
+    runWorkspaceFileScanRef.current = runWorkspaceFileScan;
+  }, [runWorkspaceFileScan]);
+
+  // Subscribe to Contents-API changes so a notebook or file created outside
+  // the picker (manually in the file browser, via terminal, or by a Claude
+  // tool that round-trips through the Contents API) shows up without
+  // requiring a full lab reload. The contents manager is a singleton for
+  // the app's lifetime; depending on `[]` avoids `props`-identity churn that
+  // would otherwise reconnect the signal on every parent render and reset
+  // the in-flight debounce timer.
+  const appRef = useRef(props.getApp());
+  useEffect(() => {
+    const contents = appRef.current.serviceManager.contents;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const onFileChanged = (_sender: unknown, change: Contents.IChangedArgs) => {
+      // 'save' fires on every edit-and-save; the picker doesn't care about
+      // content changes, only the file set.
+      if (change.type === 'save') {
+        return;
+      }
+      if (timer !== null) {
+        clearTimeout(timer);
+      }
+      timer = setTimeout(() => {
+        timer = null;
+        if (showWorkspaceFilePickerRef.current) {
+          runWorkspaceFileScanRef.current();
+        } else {
+          // Picker is closed — mark stale so the next open re-scans.
+          setWorkspaceFilesLoaded(false);
+        }
+      }, WORKSPACE_FILE_REFRESH_DEBOUNCE_MS);
+    };
+
+    contents.fileChanged.connect(onFileChanged);
+    return () => {
+      contents.fileChanged.disconnect(onFileChanged);
+      if (timer !== null) {
+        clearTimeout(timer);
+      }
+    };
+  }, []);
+
+  const refreshWorkspaceFiles = useCallback(() => {
+    runWorkspaceFileScanRef.current();
+  }, []);
+
   const handleWorkspaceFilePickerClick = async () => {
     setShowPopover(false);
     setShowModeTools(false);
     const nextState = !showWorkspaceFilePicker;
     setShowWorkspaceFilePicker(nextState);
+    // Sync the ref synchronously so a debounced refresh that fires during
+    // the awaited scan below honors the now-open picker state immediately,
+    // rather than waiting for the post-render useEffect to catch up.
+    showWorkspaceFilePickerRef.current = nextState;
 
     if (nextState && !workspaceFilesLoaded) {
-      await loadWorkspaceFiles();
+      await runWorkspaceFileScan();
     }
   };
 
@@ -3538,9 +3626,45 @@ function SidebarComponent(props: any) {
                 </div>
                 <div style={{ flexGrow: 1 }}></div>
                 <div
+                  className={
+                    'mode-tools-popover-button mode-tools-popover-refresh-button' +
+                    (workspaceFilesLoading ? ' is-loading' : '')
+                  }
+                  title="Refresh file list"
+                  role="button"
+                  tabIndex={0}
+                  aria-label="Refresh workspace file list"
+                  aria-busy={workspaceFilesLoading}
+                  onClick={() => {
+                    if (!workspaceFilesLoading) {
+                      refreshWorkspaceFiles();
+                    }
+                  }}
+                  onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
+                    if (
+                      (event.key === 'Enter' || event.key === ' ') &&
+                      !workspaceFilesLoading
+                    ) {
+                      event.preventDefault();
+                      refreshWorkspaceFiles();
+                    }
+                  }}
+                >
+                  <VscRefresh />
+                </div>
+                <div
                   className="mode-tools-popover-button mode-tools-popover-close-button"
                   title="Close"
+                  role="button"
+                  tabIndex={0}
+                  aria-label="Close file picker"
                   onClick={() => setShowWorkspaceFilePicker(false)}
+                  onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault();
+                      setShowWorkspaceFilePicker(false);
+                    }
+                  }}
                 >
                   <VscClose />
                 </div>

--- a/style/base.css
+++ b/style/base.css
@@ -674,6 +674,11 @@ pre:has(.code-block-header) {
   margin-top: 2px;
 }
 
+.mode-tools-popover-button:focus-visible {
+  outline: 2px solid var(--jp-brand-color1);
+  outline-offset: 1px;
+}
+
 .mode-tools-popover-close-button {
   width: 24px;
   padding: 0;
@@ -682,6 +687,17 @@ pre:has(.code-block-header) {
 .mode-tools-popover-close-button svg {
   padding: 0;
   margin: 0;
+}
+
+.mode-tools-popover-refresh-button {
+  width: 24px;
+  padding: 0;
+  margin-right: 4px;
+}
+
+.mode-tools-popover-refresh-button.is-loading {
+  cursor: progress;
+  opacity: 0.6;
 }
 
 .mode-tools-popover-tool-list {

--- a/tests/test_skill_github_import.py
+++ b/tests/test_skill_github_import.py
@@ -457,7 +457,7 @@ class TestArchiveSizeCap:
             # passes the check.
             payload = b"x" * 1024
             with patch(
-                "notebook_intelligence.skill_github_import._get_github_token",
+                "notebook_intelligence.skill_github_import.resolve_github_token",
                 return_value=None,
             ):
                 with patch(
@@ -477,7 +477,7 @@ class TestArchiveSizeCap:
         try:
             oversize = b"x" * (1024 + 100)
             with patch(
-                "notebook_intelligence.skill_github_import._get_github_token",
+                "notebook_intelligence.skill_github_import.resolve_github_token",
                 return_value=None,
             ):
                 with patch(
@@ -497,7 +497,7 @@ class TestArchiveSizeCap:
         try:
             oversize = b"x" * (3 * 1024 * 1024)
             with patch(
-                "notebook_intelligence.skill_github_import._get_github_token",
+                "notebook_intelligence.skill_github_import.resolve_github_token",
                 return_value=None,
             ):
                 with patch(


### PR DESCRIPTION
## Summary

The chat-sidebar \`@\`-mention workspace file picker scanned once on first open and cached the result for the lifetime of the chat sidebar — \`workspaceFilesLoaded\` was set true after the initial scan and never reset, with no \`ContentsManager.fileChanged\` subscription and no manual refresh affordance. Users creating a notebook in the file browser, running \`touch foo.py\` in a terminal, or letting Claude generate files would not see them in the picker until a full lab reload.

## Solution

Subscribe to \`ContentsManager.fileChanged\`. When the picker is open the new file shows up after a 300ms debounce; when it's closed the cache is marked stale so the next open re-scans. A manual refresh icon button (\`VscRefresh\`) is added to the picker header as the escape hatch for the limitation below.

Three load-bearing decisions, all flagged by reviewers and addressed before push:

- **300ms debounce.** Coalesces the signal storm that fires when a folder is dropped or an agent creates many files. Tighter (100ms) misfires during real bursts on slower hardware; looser (1s) feels laggy on single creates.
- **In-flight gate, not force-cancel.** A first draft force-canceled the previous scan on every signal. Worst-case (open picker, agent creating files at 2/s, scans taking ~1s) that produced a never-completing scan storm. The new \`runWorkspaceFileScan\` sets a \`pendingRescanRef\` flag while a scan is in flight and the running scan drains the flag at completion. Bounds the worst case to "at most one scan running + one queued."
- **Stable subscription deps.** First draft used \`[props]\`. \`ReactWidget\` rebuilds \`props\` on every Lumino update, so the effect was reconnecting the signal on every parent render and clearing the in-flight debounce timer mid-coalesce — defeating the point. The contents manager is a singleton; captured once via \`appRef\`, deps now \`[]\`.

Plus two small a11y fixes the reviewer flagged in the same surface:

- The picker's close button was a bare \`<div onClick>\` — added \`role=\"button\"\`, \`tabIndex=0\`, \`aria-label\`, and an Enter/Space keyboard handler so it matches the new refresh button.
- Added \`:focus-visible\` on \`.mode-tools-popover-button\` so keyboard users can see focus on either button.

## Testing

- 513 pytest / tsc clean / lint clean / 104 jest, all green.
- No new automated tests. The testable surface is the one-line \`change.type !== 'save'\` predicate; the React-component behavior (signal subscription, debounce, gate, in-flight drain) lacks component-test infrastructure in the codebase. Six-agent review confirmed this was the right call given the existing test patterns.
- Manual verification: created files via the JupyterLab file browser, ran \`touch\` in a JupyterLab terminal, and had a Claude agent generate a notebook. Picker auto-refreshes in cases 1 and 2; case 3 refreshes on manual button (see Risks).

## Risks / follow-ups

- **Server-side disk writes don't fire \`fileChanged\`** (flagged by the JupyterLab-extension reviewer). Some NBI agent tools in \`notebook_intelligence/built_in_toolsets.py\` write to disk directly via \`open()\` rather than the Contents API. Those changes don't propagate through \`fileChanged\` to any client. The manual refresh button is the mitigation today; routing those writes through the Contents API would close the gap and is a worthwhile follow-up.
- **Incremental list update instead of full rescan** — flagged by the performance reviewer as a refactor opportunity. With the 300ms debounce + in-flight gate the rescan cost is now bounded, so this is deferred.
- **Real \`<button>\` vs \`<div role=button>\`** — flagged by the a11y reviewer. All four popover buttons in this header use the same \`<div role=button>\` pattern. Migrating the whole family to real \`<button>\` is its own PR; this one fixes the consistency by bringing the close button up to the same a11y bar as the new refresh button.