### PR TITLE
fix(notebook-tools): keep cell tools targeting the right notebook when the user switches tabs

### DIFF
--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -16,6 +16,7 @@ import { UUID } from '@lumino/coreutils';
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api.js';
 
 import { NBIAPI, GitHubCopilotLoginStatus } from './api';
+import { injectTaskTargetNotebook } from './task-target-notebook';
 import {
   BackendMessageType,
   BuiltinToolsetType,
@@ -1110,6 +1111,11 @@ function SidebarComponent(props: any) {
   // walk can't land stale results on a reopened picker.
   const workspaceFilesLoadingRef = useRef(false);
   const workspaceScanGenerationRef = useRef(0);
+  // Path of the notebook that was active when the current agent task
+  // started. Threaded into every notebook-cell RunUICommand so tools keep
+  // targeting the right notebook after the user switches tabs mid-task
+  // (issue #252). Cleared / reset on every new chat submission.
+  const taskTargetNotebookPathRef = useRef<string | null>(null);
   const [isDragOver, setIsDragOver] = useState(false);
   const [isUploadingFiles, setIsUploadingFiles] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -2231,6 +2237,15 @@ function SidebarComponent(props: any) {
     setCopilotRequestInProgress(true);
 
     const activeDocInfo: IActiveDocumentInfo = props.getActiveDocumentInfo();
+    // Snapshot the active notebook so cell-targeting tools the agent fires
+    // later in this run keep hitting the right notebook even after the
+    // user switches tabs (issue #252). Non-notebook contexts clear the
+    // ref so a stale path from a previous run doesn't bleed through.
+    taskTargetNotebookPathRef.current = activeDocInfo?.filePath?.endsWith(
+      '.ipynb'
+    )
+      ? activeDocInfo.filePath
+      : null;
     const extractedPrompt = submitPrompt;
     const contents: IChatMessageContent[] = [];
     const app = props.getApp();
@@ -2410,11 +2425,16 @@ function SidebarComponent(props: any) {
             });
           } else if (response.type === BackendMessageType.RunUICommand) {
             const messageId = response.id;
+            const patchedArgs = injectTaskTargetNotebook(
+              response.data.commandId,
+              response.data.args,
+              taskTargetNotebookPathRef.current
+            );
             let result = 'void';
             try {
               result = await app.commands.execute(
                 response.data.commandId,
-                response.data.args
+                patchedArgs
               );
             } catch (error) {
               result = `Error executing command: ${error}`;
@@ -2734,6 +2754,15 @@ function SidebarComponent(props: any) {
         );
       };
       emitProgress(true);
+      // Snapshot the notebook the agent should target for this externally-
+      // triggered request (e.g., notebook-toolbar generation). The
+      // `RunUICommand` handler below uses this for the same tab-switch
+      // resilience covered by the main submit flow (issue #252).
+      const externalActiveDocInfo = props.getActiveDocumentInfo();
+      taskTargetNotebookPathRef.current =
+        externalActiveDocInfo?.filePath?.endsWith('.ipynb')
+          ? externalActiveDocInfo.filePath
+          : null;
       const hideInChat = !!request.hideInChat;
       const newList = hideInChat
         ? chatMessages
@@ -2823,11 +2852,16 @@ function SidebarComponent(props: any) {
             emitProgress(false);
           } else if (response.type === BackendMessageType.RunUICommand) {
             const runUiMessageId = response.id;
+            const patchedArgs = injectTaskTargetNotebook(
+              response.data.commandId,
+              response.data.args,
+              taskTargetNotebookPathRef.current
+            );
             let result = 'void';
             try {
               result = await props
                 .getApp()
-                .commands.execute(response.data.commandId, response.data.args);
+                .commands.execute(response.data.commandId, patchedArgs);
             } catch (error) {
               result = `Error executing command: ${error}`;
             }

--- a/src/command-ids.ts
+++ b/src/command-ids.ts
@@ -1,0 +1,59 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+// Centralized command-id constants for the JupyterLab plugin. Hoisted out
+// of `src/index.ts` so non-JL modules (and Jest tests) can import them
+// without pulling the JupyterLab packages into their dependency graph.
+
+export namespace CommandIDs {
+  export const chatuserInput = 'notebook-intelligence:chat-user-input';
+  export const insertAtCursor = 'notebook-intelligence:insert-at-cursor';
+  export const addCodeAsNewCell = 'notebook-intelligence:add-code-as-new-cell';
+  export const createNewFile = 'notebook-intelligence:create-new-file';
+  export const createNewNotebookFromPython =
+    'notebook-intelligence:create-new-notebook-from-py';
+  export const renameNotebook = 'notebook-intelligence:rename-notebook';
+  export const addCodeCellToNotebook =
+    'notebook-intelligence:add-code-cell-to-notebook';
+  export const addMarkdownCellToNotebook =
+    'notebook-intelligence:add-markdown-cell-to-notebook';
+  export const editorGenerateCode =
+    'notebook-intelligence:editor-generate-code';
+  export const editorExplainThisCode =
+    'notebook-intelligence:editor-explain-this-code';
+  export const editorFixThisCode = 'notebook-intelligence:editor-fix-this-code';
+  export const editorExplainThisOutput =
+    'notebook-intelligence:editor-explain-this-output';
+  export const editorTroubleshootThisOutput =
+    'notebook-intelligence:editor-troubleshoot-this-output';
+  export const editorAskAboutThisOutput =
+    'notebook-intelligence:editor-ask-about-this-output';
+  export const openGitHubCopilotLoginDialog =
+    'notebook-intelligence:open-github-copilot-login-dialog';
+  export const openConfigurationDialog =
+    'notebook-intelligence:open-configuration-dialog';
+  export const addMarkdownCellToActiveNotebook =
+    'notebook-intelligence:add-markdown-cell-to-active-notebook';
+  export const addCodeCellToActiveNotebook =
+    'notebook-intelligence:add-code-cell-to-active-notebook';
+  export const deleteCellAtIndex = 'notebook-intelligence:delete-cell-at-index';
+  export const insertCellAtIndex = 'notebook-intelligence:insert-cell-at-index';
+  export const getCellTypeAndSource =
+    'notebook-intelligence:get-cell-type-and-source';
+  export const setCellTypeAndSource =
+    'notebook-intelligence:set-cell-type-and-source';
+  export const getNumberOfCells = 'notebook-intelligence:get-number-of-cells';
+  export const getCellOutput = 'notebook-intelligence:get-cell-output';
+  export const runCellAtIndex = 'notebook-intelligence:run-cell-at-index';
+  export const getCurrentFileContent =
+    'notebook-intelligence:get-current-file-content';
+  export const setCurrentFileContent =
+    'notebook-intelligence:set-current-file-content';
+  export const openMCPConfigEditor =
+    'notebook-intelligence:open-mcp-config-editor';
+  export const showFormInputDialog =
+    'notebook-intelligence:show-form-input-dialog';
+  export const runCommandInTerminal =
+    'notebook-intelligence:run-command-in-terminal';
+  export const openClaudeCodeLauncher =
+    'notebook-intelligence:open-claude-code-launcher';
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ import {
   IInlineCompletionProvider
 } from '@jupyterlab/completer';
 
-import { NotebookPanel } from '@jupyterlab/notebook';
+import { NotebookActions, NotebookPanel } from '@jupyterlab/notebook';
 import { CodeEditor } from '@jupyterlab/codeeditor';
 import { FileEditorWidget } from '@jupyterlab/fileeditor';
 
@@ -107,6 +107,8 @@ import { createRoot, Root } from 'react-dom/client';
 import { SettingsPanel } from './components/settings-panel';
 import { ITerminalConnection } from '@jupyterlab/services/lib/terminal/terminal';
 import { NotebookGenerationToolbarExtension } from './notebook-generation-toolbar';
+
+import { CommandIDs } from './command-ids';
 
 const addInlinePromptEffect = StateEffect.define<{
   pos: number;
@@ -276,60 +278,6 @@ function getLineEndOffset(editor: CodeEditor.IEditor, offset: number): number {
     line: position.line,
     column: editor.getLine(position.line).length
   });
-}
-
-namespace CommandIDs {
-  export const chatuserInput = 'notebook-intelligence:chat-user-input';
-  export const insertAtCursor = 'notebook-intelligence:insert-at-cursor';
-  export const addCodeAsNewCell = 'notebook-intelligence:add-code-as-new-cell';
-  export const createNewFile = 'notebook-intelligence:create-new-file';
-  export const createNewNotebookFromPython =
-    'notebook-intelligence:create-new-notebook-from-py';
-  export const renameNotebook = 'notebook-intelligence:rename-notebook';
-  export const addCodeCellToNotebook =
-    'notebook-intelligence:add-code-cell-to-notebook';
-  export const addMarkdownCellToNotebook =
-    'notebook-intelligence:add-markdown-cell-to-notebook';
-  export const editorGenerateCode =
-    'notebook-intelligence:editor-generate-code';
-  export const editorExplainThisCode =
-    'notebook-intelligence:editor-explain-this-code';
-  export const editorFixThisCode = 'notebook-intelligence:editor-fix-this-code';
-  export const editorExplainThisOutput =
-    'notebook-intelligence:editor-explain-this-output';
-  export const editorTroubleshootThisOutput =
-    'notebook-intelligence:editor-troubleshoot-this-output';
-  export const editorAskAboutThisOutput =
-    'notebook-intelligence:editor-ask-about-this-output';
-  export const openGitHubCopilotLoginDialog =
-    'notebook-intelligence:open-github-copilot-login-dialog';
-  export const openConfigurationDialog =
-    'notebook-intelligence:open-configuration-dialog';
-  export const addMarkdownCellToActiveNotebook =
-    'notebook-intelligence:add-markdown-cell-to-active-notebook';
-  export const addCodeCellToActiveNotebook =
-    'notebook-intelligence:add-code-cell-to-active-notebook';
-  export const deleteCellAtIndex = 'notebook-intelligence:delete-cell-at-index';
-  export const insertCellAtIndex = 'notebook-intelligence:insert-cell-at-index';
-  export const getCellTypeAndSource =
-    'notebook-intelligence:get-cell-type-and-source';
-  export const setCellTypeAndSource =
-    'notebook-intelligence:set-cell-type-and-source';
-  export const getNumberOfCells = 'notebook-intelligence:get-number-of-cells';
-  export const getCellOutput = 'notebook-intelligence:get-cell-output';
-  export const runCellAtIndex = 'notebook-intelligence:run-cell-at-index';
-  export const getCurrentFileContent =
-    'notebook-intelligence:get-current-file-content';
-  export const setCurrentFileContent =
-    'notebook-intelligence:set-current-file-content';
-  export const openMCPConfigEditor =
-    'notebook-intelligence:open-mcp-config-editor';
-  export const showFormInputDialog =
-    'notebook-intelligence:show-form-input-dialog';
-  export const runCommandInTerminal =
-    'notebook-intelligence:run-command-in-terminal';
-  export const openClaudeCodeLauncher =
-    'notebook-intelligence:open-claude-code-launcher';
 }
 
 const DOCUMENT_WATCH_INTERVAL = 1000;
@@ -1388,12 +1336,10 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
       cellType: 'code' | 'markdown',
       source: string
     ): boolean => {
-      const currentWidget = app.shell.currentWidget;
-      const notebookOpen =
-        currentWidget instanceof NotebookPanel &&
-        currentWidget.sessionContext.path === filePath &&
-        currentWidget.model;
-      if (!notebookOpen) {
+      const widget = docManager.findWidget(filePath);
+      const notebook =
+        widget instanceof NotebookPanel && widget.model ? widget : null;
+      if (!notebook) {
         app.commands.execute('apputils:notify', {
           message: `Failed to access the notebook: ${filePath}`,
           type: 'error',
@@ -1402,7 +1348,7 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
         return false;
       }
 
-      const model = currentWidget.model.sharedModel;
+      const model = notebook.model.sharedModel;
 
       const newCellIndex = isNewEmptyNotebook(model)
         ? 0
@@ -1436,20 +1382,47 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
       }
     });
 
-    const ensureANotebookIsActive = (): boolean => {
-      const currentWidget = app.shell.currentWidget;
-      const notebookOpen =
-        currentWidget instanceof NotebookPanel && currentWidget.model;
-      if (!notebookOpen) {
+    // Resolve the notebook a cell-targeting command should operate on.
+    //
+    // When the chat sidebar dispatches a RunUICommand on behalf of the
+    // agent it injects `notebookPath` — the notebook that was active at
+    // chat-request time. We look that one up via the doc manager so the
+    // command keeps targeting the right notebook even after the user
+    // switches tabs mid-task. If a `notebookPath` was supplied but no
+    // longer resolves (target tab was closed, or the notebook was
+    // renamed), we *do not* silently fall through to `currentWidget` —
+    // that would let the agent mutate a different notebook than it
+    // believed it was operating on. Surface the error and bail.
+    //
+    // For manually-invoked commands (palette, menu, toolbar) there's no
+    // `notebookPath`; the current widget is the intended target and the
+    // fallback applies.
+    const resolveTargetNotebook = (
+      args: { notebookPath?: string } | null | undefined
+    ): NotebookPanel | null => {
+      const requestedPath = args?.notebookPath;
+      if (requestedPath) {
+        const widget = docManager.findWidget(requestedPath);
+        if (widget instanceof NotebookPanel && widget.model) {
+          return widget;
+        }
         app.commands.execute('apputils:notify', {
-          message: 'Failed to find active notebook',
+          message: `Failed to find notebook: ${requestedPath}`,
           type: 'error',
           options: { autoClose: true }
         });
-        return false;
+        return null;
       }
-
-      return true;
+      const currentWidget = app.shell.currentWidget;
+      if (currentWidget instanceof NotebookPanel && currentWidget.model) {
+        return currentWidget;
+      }
+      app.commands.execute('apputils:notify', {
+        message: 'Failed to find active notebook',
+        type: 'error',
+        options: { autoClose: true }
+      });
+      return null;
     };
 
     const ensureAFileEditorIsActive = (): boolean => {
@@ -1469,11 +1442,10 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
 
     app.commands.addCommand(CommandIDs.addMarkdownCellToActiveNotebook, {
       execute: args => {
-        if (!ensureANotebookIsActive()) {
+        const np = resolveTargetNotebook(args);
+        if (!np) {
           return false;
         }
-
-        const np = app.shell.currentWidget as NotebookPanel;
         const model = np.model.sharedModel;
 
         const newCellIndex = isNewEmptyNotebook(model)
@@ -1491,11 +1463,10 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
 
     app.commands.addCommand(CommandIDs.addCodeCellToActiveNotebook, {
       execute: args => {
-        if (!ensureANotebookIsActive()) {
+        const np = resolveTargetNotebook(args);
+        if (!np) {
           return false;
         }
-
-        const np = app.shell.currentWidget as NotebookPanel;
         const model = np.model.sharedModel;
 
         const newCellIndex = isNewEmptyNotebook(model)
@@ -1513,11 +1484,10 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
 
     app.commands.addCommand(CommandIDs.getCellTypeAndSource, {
       execute: args => {
-        if (!ensureANotebookIsActive()) {
+        const np = resolveTargetNotebook(args);
+        if (!np) {
           return false;
         }
-
-        const np = app.shell.currentWidget as NotebookPanel;
         const model = np.model.sharedModel;
 
         return {
@@ -1529,11 +1499,10 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
 
     app.commands.addCommand(CommandIDs.setCellTypeAndSource, {
       execute: args => {
-        if (!ensureANotebookIsActive()) {
+        const np = resolveTargetNotebook(args);
+        if (!np) {
           return false;
         }
-
-        const np = app.shell.currentWidget as NotebookPanel;
         const model = np.model.sharedModel;
 
         const cellIndex = args.cellIndex as number;
@@ -1553,11 +1522,10 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
 
     app.commands.addCommand(CommandIDs.getNumberOfCells, {
       execute: args => {
-        if (!ensureANotebookIsActive()) {
+        const np = resolveTargetNotebook(args);
+        if (!np) {
           return false;
         }
-
-        const np = app.shell.currentWidget as NotebookPanel;
         const model = np.model.sharedModel;
 
         return model.cells.length;
@@ -1566,11 +1534,10 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
 
     app.commands.addCommand(CommandIDs.getCellOutput, {
       execute: args => {
-        if (!ensureANotebookIsActive()) {
+        const np = resolveTargetNotebook(args);
+        if (!np) {
           return false;
         }
-
-        const np = app.shell.currentWidget as NotebookPanel;
         const cellIndex = args.cellIndex as number;
 
         const cell = np.content.widgets[cellIndex];
@@ -1587,11 +1554,10 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
 
     app.commands.addCommand(CommandIDs.insertCellAtIndex, {
       execute: args => {
-        if (!ensureANotebookIsActive()) {
+        const np = resolveTargetNotebook(args);
+        if (!np) {
           return false;
         }
-
-        const np = app.shell.currentWidget as NotebookPanel;
         const model = np.model.sharedModel;
         const cellIndex = args.cellIndex as number;
         const cellType = args.cellType as 'code' | 'markdown';
@@ -1608,11 +1574,10 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
 
     app.commands.addCommand(CommandIDs.deleteCellAtIndex, {
       execute: args => {
-        if (!ensureANotebookIsActive()) {
+        const np = resolveTargetNotebook(args);
+        if (!np) {
           return false;
         }
-
-        const np = app.shell.currentWidget as NotebookPanel;
         const model = np.model.sharedModel;
         const cellIndex = args.cellIndex as number;
 
@@ -1624,14 +1589,18 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
 
     app.commands.addCommand(CommandIDs.runCellAtIndex, {
       execute: async args => {
-        if (!ensureANotebookIsActive()) {
+        const np = resolveTargetNotebook(args);
+        if (!np) {
           return false;
         }
+        np.content.activeCellIndex = args.cellIndex as number;
 
-        const currentWidget = app.shell.currentWidget as NotebookPanel;
-        currentWidget.content.activeCellIndex = args.cellIndex as number;
-
-        await app.commands.execute('notebook:run-cell');
+        // Drive the cell run via NotebookActions directly rather than the
+        // app-level `notebook:run-cell` command. The command operates on the
+        // currently-focused notebook; calling NotebookActions.run with our
+        // resolved target avoids stealing focus from whichever tab the user
+        // is on while the agent is running.
+        await NotebookActions.run(np.content, np.sessionContext);
       }
     });
 

--- a/src/task-target-notebook.ts
+++ b/src/task-target-notebook.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+import { CommandIDs } from './command-ids';
+
+// Cell-targeting commands accept an optional `notebookPath` to bypass
+// `app.shell.currentWidget`. When the agent runs a task and the user
+// switches tabs mid-run, the previously-active notebook is no longer the
+// focused widget; the chat sidebar injects the captured task-target path
+// into args for these command IDs so cell ops resolve against the right
+// notebook (issue #252). Built from `CommandIDs` so a rename on either
+// side is caught at compile time.
+export const NOTEBOOK_TARGETED_COMMAND_IDS: ReadonlySet<string> = new Set([
+  CommandIDs.addMarkdownCellToActiveNotebook,
+  CommandIDs.addCodeCellToActiveNotebook,
+  CommandIDs.getCellTypeAndSource,
+  CommandIDs.setCellTypeAndSource,
+  CommandIDs.getNumberOfCells,
+  CommandIDs.getCellOutput,
+  CommandIDs.insertCellAtIndex,
+  CommandIDs.deleteCellAtIndex,
+  CommandIDs.runCellAtIndex
+]);
+
+export function injectTaskTargetNotebook(
+  commandId: string,
+  args: Record<string, unknown> | undefined,
+  taskTargetPath: string | null
+): Record<string, unknown> | undefined {
+  if (
+    !taskTargetPath ||
+    !NOTEBOOK_TARGETED_COMMAND_IDS.has(commandId) ||
+    (args && args.notebookPath)
+  ) {
+    return args;
+  }
+  return { ...(args ?? {}), notebookPath: taskTargetPath };
+}

--- a/tests/ts/task-target-notebook.test.ts
+++ b/tests/ts/task-target-notebook.test.ts
@@ -1,0 +1,99 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+import { CommandIDs } from '../../src/command-ids';
+import {
+  NOTEBOOK_TARGETED_COMMAND_IDS,
+  injectTaskTargetNotebook
+} from '../../src/task-target-notebook';
+
+const RUN_CELL = CommandIDs.runCellAtIndex;
+const NON_NOTEBOOK = CommandIDs.runCommandInTerminal;
+
+describe('injectTaskTargetNotebook', () => {
+  it('injects notebookPath when command is notebook-targeted and path is set', () => {
+    const result = injectTaskTargetNotebook(
+      RUN_CELL,
+      { cellIndex: 3 },
+      'project/foo.ipynb'
+    );
+    expect(result).toEqual({
+      cellIndex: 3,
+      notebookPath: 'project/foo.ipynb'
+    });
+  });
+
+  it('returns args unchanged when no task-target path is set', () => {
+    const args = { cellIndex: 1 };
+    const result = injectTaskTargetNotebook(RUN_CELL, args, null);
+    // Same reference: no unnecessary clone when nothing to inject.
+    expect(result).toBe(args);
+  });
+
+  it('returns args unchanged when command is not notebook-targeted', () => {
+    const args = { command: 'ls' };
+    const result = injectTaskTargetNotebook(
+      NON_NOTEBOOK,
+      args,
+      'project/foo.ipynb'
+    );
+    expect(result).toBe(args);
+  });
+
+  it('preserves caller-supplied notebookPath rather than overriding it', () => {
+    // If the backend explicitly passes a notebook path the frontend
+    // should defer to it. Otherwise tools that genuinely want to target
+    // a non-active notebook can't.
+    const args = { cellIndex: 0, notebookPath: 'other/bar.ipynb' };
+    const result = injectTaskTargetNotebook(
+      RUN_CELL,
+      args,
+      'project/foo.ipynb'
+    );
+    expect(result).toBe(args);
+    expect((result as { notebookPath: string }).notebookPath).toBe(
+      'other/bar.ipynb'
+    );
+  });
+
+  it('handles undefined args by returning a fresh object with the path', () => {
+    const result = injectTaskTargetNotebook(
+      RUN_CELL,
+      undefined,
+      'project/foo.ipynb'
+    );
+    expect(result).toEqual({ notebookPath: 'project/foo.ipynb' });
+  });
+
+  it('does not mutate the input args', () => {
+    const args = { cellIndex: 7 };
+    injectTaskTargetNotebook(RUN_CELL, args, 'project/foo.ipynb');
+    expect(args).toEqual({ cellIndex: 7 });
+  });
+});
+
+describe('NOTEBOOK_TARGETED_COMMAND_IDS', () => {
+  it('covers every cell-targeting RunUICommand in the backend toolset', () => {
+    // The set is the single source of truth on the frontend for "this
+    // command needs notebookPath injection". Each entry below has a
+    // corresponding `await response.run_ui_command(...)` call in
+    // notebook_intelligence/built_in_toolsets.py or claude.py — if a new
+    // cell-targeting tool lands without an entry here, the agent's calls
+    // will regress to currentWidget-based resolution and fail when the
+    // user switches tabs (issue #252).
+    expect(NOTEBOOK_TARGETED_COMMAND_IDS.has(CommandIDs.runCellAtIndex)).toBe(
+      true
+    );
+    expect(
+      NOTEBOOK_TARGETED_COMMAND_IDS.has(CommandIDs.addCodeCellToActiveNotebook)
+    ).toBe(true);
+    expect(
+      NOTEBOOK_TARGETED_COMMAND_IDS.has(CommandIDs.setCellTypeAndSource)
+    ).toBe(true);
+    // Negative spot check — a non-notebook command must not be in the set
+    // so we don't inject notebookPath where the command would treat it as
+    // a stray arg.
+    expect(
+      NOTEBOOK_TARGETED_COMMAND_IDS.has(CommandIDs.runCommandInTerminal)
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Notebook-cell tools (run-cell, set-cell, get-cell, insert-cell, delete-cell, etc.) failed with **"Failed to find active notebook"** when the user clicked away from the notebook while an agent task was still running. Every cell-targeting JL command resolved its target by reading \`app.shell.currentWidget\` synchronously at execute time — switching tabs broke the resolution and the rest of the agent's task. File and terminal operations were unaffected because they don't depend on a specific notebook being focused.

## Solution

Thread the target notebook through the WebSocket dispatch layer instead of relying on focus:

- **Capture at submit time.** \`src/chat-sidebar.tsx\` snapshots \`activeDocumentInfo.filePath\` into \`taskTargetNotebookPathRef\` when a chat request is submitted. Both submit paths (main flow + the external \`promptRequestHandler\` used by toolbar generation and "explain this code") capture the path.
- **Inject at dispatch.** Both \`RunUICommand\` WebSocket handlers pass incoming args through \`injectTaskTargetNotebook\` before executing. For known notebook-cell command IDs, the helper appends \`notebookPath\` to args when the backend didn't already supply one.
- **Resolve at execute time.** \`src/index.ts\` introduces \`resolveTargetNotebook(args)\`. When \`args.notebookPath\` is supplied we look it up via \`docManager.findWidget()\` and operate on that \`NotebookPanel\` regardless of which tab is focused. If the path was supplied but no longer resolves (target tab closed, notebook renamed) we surface the error rather than falling through to \`currentWidget\` — the agent would otherwise silently mutate the wrong notebook. Manual command invocations (palette, menu, toolbar) carry no \`notebookPath\` and keep the \`currentWidget\` fallback they relied on before.
- **\`runCellAtIndex\` runs without stealing focus.** It now calls \`NotebookActions.run(np.content, np.sessionContext)\` directly. The JL \`notebook:run-cell\` command operates on the focused notebook; the primitive accepts the target widget. The agent's cell runs on the right notebook without pulling the user away from whatever tab they're on.
- **Drift-proofing.** \`CommandIDs\` hoisted to its own \`src/command-ids.ts\` (no JL deps). The new injection set references those constants by symbol, so a rename in \`CommandIDs\` won't silently break the injection. Side benefit: the new helper is now Jest-testable without dragging JupyterLab through the module graph.

## Testing

- \`tests/ts/task-target-notebook.test.ts\` — 7 unit tests pinning the inject helper: notebook-targeted commands get \`notebookPath\` appended, non-notebook commands and caller-supplied paths are left alone, empty / undefined args don't crash, no mutation. Plus a contract test that asserts membership of \`NOTEBOOK_TARGETED_COMMAND_IDS\` is anchored to \`CommandIDs\`.
- 513 pytest / tsc clean / lint clean / 111 jest (104 existing + 7 new), all green.
- Manual: started an agent task in notebook A, switched to notebook B mid-run, watched cell edits, runs, and inserts continue to land on A without pulling focus back. Repeated with a terminal tab and a file editor. Verified the fallback still works for menu-triggered commands by invoking the cell-runner directly via the palette.

## Risks / follow-ups

- **Per-\`messageId\` scoping** of the task-target ref is the right shape for concurrent agent requests, but the current single-ref design is fine given the \`copilotRequestInProgress\` gate on the main submit path. The external \`promptRequestHandler\` path doesn't share that gate; if real overlap is ever observed, switch to a \`Map<messageId, path>\` keyed on the same id both the main and external paths already track.
- **Rename mid-task.** If the user renames the snapshotted notebook while the task is running, \`docManager.findWidget(oldPath)\` returns undefined and the resolver surfaces the error (correctly). Snapshotting a \`NotebookPanel\` reference (or a weakref + its current \`context.path\` getter) would survive renames; deferring as a follow-up.
- **Backend tool surface unchanged.** Tools in \`built_in_toolsets.py\` / \`claude.py\` keep their path-agnostic signatures. If a future tool needs to address a specific non-active notebook, it can pass \`notebookPath\` explicitly in \`run_ui_command\` args; the inject helper preserves caller-supplied paths.

Closes #252.