### PR TITLE
feat(chat-sidebar): real progress feedback during long Claude tasks

### DIFF
--- a/notebook_intelligence/base_chat_participant.py
+++ b/notebook_intelligence/base_chat_participant.py
@@ -483,7 +483,7 @@ class BaseChatParticipant(ChatParticipant):
 
         try:
             if chat_model.provider.id != "github-copilot":
-                response.stream(ProgressData("Thinking..."))
+                response.stream(ProgressData("Thinking…"))
             chat_model.completions(messages, response=response, cancel_token=request.cancel_token)
         except Exception as e:
             log.error(f"Error while handling chat request!\n{e}")

--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -18,7 +18,7 @@ from notebook_intelligence.base_chat_participant import BaseChatParticipant
 from notebook_intelligence._version import __version__ as NBI_VERSION
 import base64
 import logging
-from claude_agent_sdk import AssistantMessage, PermissionResultAllow, PermissionResultDeny, TextBlock, UserMessage, create_sdk_mcp_server, ClaudeAgentOptions, ClaudeSDKClient, tool
+from claude_agent_sdk import AssistantMessage, PermissionResultAllow, PermissionResultDeny, TextBlock, ToolResultBlock, ToolUseBlock, UserMessage, create_sdk_mcp_server, ClaudeAgentOptions, ClaudeSDKClient, tool
 from anthropic.types.text_block import TextBlock as AnthropicTextBlock
 
 from notebook_intelligence.util import ThreadSafeWebSocketConnector, _emit, get_jupyter_root_dir, resolve_claude_cli_path
@@ -61,6 +61,65 @@ CLAUDE_AGENT_CLIENT_RESPONSE_TIMEOUT = float(os.getenv("NBI_CLAUDE_AGENT_CLIENT_
 CLAUDE_AGENT_CLIENT_UPDATE_WAIT_TIME = float(os.getenv("NBI_CLAUDE_AGENT_CLIENT_UPDATE_WAIT_TIME", "0.5"))
 CLAUDE_AGENT_CONNECT_TIMEOUT = float(os.getenv("NBI_CLAUDE_AGENT_CONNECT_TIMEOUT", "15"))
 CLAUDE_AGENT_HEARTBEAT_INTERVAL = float(os.getenv("NBI_CLAUDE_AGENT_HEARTBEAT_INTERVAL", "20"))
+
+# Human-readable labels for tool calls surfaced through the chat sidebar's
+# progress indicator. The keys are the SDK tool names — NBI's MCP tools
+# use the kebab-case @tool decorator names; Claude's built-ins keep their
+# CamelCase identifiers. Unknown names fall through `humanize_claude_tool_name`
+# to a generic kebab→sentence conversion rather than masking the raw name.
+_CLAUDE_TOOL_LABELS: dict[str, str] = {
+    # NBI's MCP toolset (defined in this file via @tool(...))
+    "create-new-notebook": "Creating notebook",
+    "rename-notebook": "Renaming notebook",
+    "add-markdown-cell": "Adding markdown cell",
+    "add-code-cell": "Adding code cell",
+    "get-number-of-cells": "Reading notebook",
+    "get-cell-type-and-source": "Reading cell",
+    "get-cell-output": "Reading cell output",
+    "set-cell-type-and-source": "Editing cell",
+    "delete-cell": "Deleting cell",
+    "insert-cell": "Inserting cell",
+    "run-cell": "Running cell",
+    "save-notebook": "Saving notebook",
+    "run-command-in-jupyter-terminal": "Running shell command",
+    "open-file-in-jupyter-ui": "Opening file",
+    # Claude's built-in toolset
+    "Bash": "Running shell command",
+    "Read": "Reading file",
+    "Write": "Writing file",
+    "Edit": "Editing file",
+    "Glob": "Searching files",
+    "Grep": "Searching contents",
+    "WebFetch": "Fetching URL",
+    "WebSearch": "Searching web",
+    "Task": "Spawning subagent",
+    "TodoWrite": "Updating task list",
+}
+
+
+def humanize_claude_tool_name(name: str) -> str:
+    """Map a Claude SDK tool name to a short progress-indicator label.
+
+    Falls back to a sentence-cased version of the raw name so unknown
+    tools still surface something the user can read rather than a bare
+    kebab-case identifier.
+    """
+    if name in _CLAUDE_TOOL_LABELS:
+        return _CLAUDE_TOOL_LABELS[name]
+    # MCP server tools come through as `mcp__<server>__<tool>` — strip
+    # the wrapper before falling back so we don't surface protocol noise.
+    inner = name
+    if name.startswith("mcp__"):
+        parts = name.split("__")
+        if len(parts) >= 3:
+            inner = parts[-1]
+            if inner in _CLAUDE_TOOL_LABELS:
+                return _CLAUDE_TOOL_LABELS[inner]
+    pretty = inner.replace("-", " ").replace("_", " ").strip()
+    if not pretty:
+        return name
+    return pretty[:1].upper() + pretty[1:]
+
 
 _current_request = None
 _current_response = None
@@ -593,13 +652,28 @@ class ClaudeCodeClient():
 
                             if not already_handled and not request.cancel_token.is_cancel_requested:
                                 await client.query(client_query)
+                                # Per-query map from tool_use_id to its
+                                # humanized label so the ToolResultBlock
+                                # echo back can name the tool that just
+                                # finished. Lifetime is one query — pops
+                                # entries on completion so the dict stays
+                                # bounded.
+                                in_flight_tools: dict[str, str] = {}
                                 async for message in client.receive_response():
                                     if request.cancel_token.is_cancel_requested:
-                                        continue
+                                        # Stop iterating once the user cancels — we'd
+                                        # otherwise keep recording ToolUseBlocks into
+                                        # `in_flight_tools` for results that will
+                                        # never be paired with progress callbacks.
+                                        break
                                     if isinstance(message, AssistantMessage):
                                         for block in message.content:
                                             if isinstance(block, TextBlock):
                                                 response.stream(MarkdownData(block.text))
+                                            elif isinstance(block, ToolUseBlock):
+                                                label = humanize_claude_tool_name(block.name)
+                                                in_flight_tools[block.id] = label
+                                                response.stream(ProgressData(f"{label}…"))
                                     elif isinstance(message, UserMessage):
                                         if isinstance(message.content, str):
                                             content = message.content
@@ -609,6 +683,25 @@ class ClaudeCodeClient():
                                             content = message.content.text
                                             content = content.replace('<local-command-stdout>', '').replace('</local-command-stdout>', '')
                                             response.stream(MarkdownData(content))
+                                        elif isinstance(message.content, list):
+                                            for block in message.content:
+                                                if isinstance(block, ToolResultBlock):
+                                                    # A result without a matching
+                                                    # ToolUseBlock is anomalous (cross-
+                                                    # query stragglers, sub-agent
+                                                    # results routed through a parent
+                                                    # tool_use_id). A bare "✓ Tool"
+                                                    # without context is more
+                                                    # confusing than silence, so we
+                                                    # only surface results we can
+                                                    # name.
+                                                    label = in_flight_tools.pop(
+                                                        block.tool_use_id, None
+                                                    )
+                                                    if label is None:
+                                                        continue
+                                                    icon = "✗" if block.is_error else "✓"
+                                                    response.stream(ProgressData(f"{icon} {label}"))
                                     else:
                                         pass
                         except Exception as e:
@@ -1199,7 +1292,7 @@ class ClaudeCodeChatParticipant(BaseChatParticipant):
         self._current_chat_request = request
 
         try:
-            response.stream(ProgressData("Thinking..."))
+            response.stream(ProgressData("Thinking…"))
             result = self._client.query(request, response)
             # query() returns a string when it bails early without dispatching —
             # e.g. the agent isn't connected, a response timeout elapsed, or the

--- a/notebook_intelligence/mcp_manager.py
+++ b/notebook_intelligence/mcp_manager.py
@@ -495,7 +495,7 @@ class MCPChatParticipant(BaseChatParticipant):
         return self._servers
     
     async def handle_chat_request(self, request: ChatRequest, response: ChatResponse, options: dict = {}) -> None:
-        response.stream(ProgressData("Thinking..."))
+        response.stream(ProgressData("Thinking…"))
 
         if request.command == "info":
             for server in self._servers:

--- a/src/api.ts
+++ b/src/api.ts
@@ -479,6 +479,10 @@ export class NBIAPI {
   static configChanged = this.config.changed;
   static githubLoginStatusChanged = new Signal<unknown, void>(this);
   static skillsReloaded = new Signal<unknown, void>(this);
+  // Emits each time the Claude agent sends its 20s keepalive (#252 follow-up).
+  // The chat sidebar uses it to drive the "Generating" indicator's pulse
+  // and to swap to a "server may be slow" copy when the gap stretches.
+  static claudeCodeHeartbeat = new Signal<unknown, void>(this);
 
   static async initialize() {
     await this.fetchCapabilities();
@@ -501,6 +505,8 @@ export class NBIAPI {
         });
       } else if (msg.type === BackendMessageType.SkillsReloaded) {
         this.skillsReloaded.emit();
+      } else if (msg.type === BackendMessageType.ClaudeCodeHeartbeat) {
+        this.claudeCodeHeartbeat.emit();
       }
     });
   }

--- a/src/chat-progress-feedback.ts
+++ b/src/chat-progress-feedback.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+// Small helpers for the chat sidebar's "Generating" progress indicator.
+// Pulled out so each piece (elapsed-time formatting, heartbeat staleness)
+// can be unit-tested without dragging JupyterLab into Jest's import graph.
+
+// 30 seconds without a heartbeat counts as "stalled" — long enough that a
+// healthy round-trip + retransmission delay can't account for it, short
+// enough that a real hang is signaled while there's still time to act.
+// The Claude heartbeat fires every 20s server-side, so 30s gives roughly
+// 1.5 expected intervals of slack before we change copy.
+export const HEARTBEAT_STALE_MS = 30_000;
+
+export function formatElapsedSeconds(totalSeconds: number): string {
+  const safe = Math.max(0, Math.floor(totalSeconds));
+  const hours = Math.floor(safe / 3600);
+  const minutes = Math.floor((safe % 3600) / 60);
+  const seconds = safe % 60;
+  const ss = String(seconds).padStart(2, '0');
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${ss}`;
+  }
+  return `${minutes}:${ss}`;
+}
+
+export function isHeartbeatStale(
+  lastHeartbeatAt: number | null,
+  now: number,
+  staleMs: number = HEARTBEAT_STALE_MS
+): boolean {
+  if (lastHeartbeatAt === null) {
+    return false;
+  }
+  return now - lastHeartbeatAt > staleMs;
+}

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -18,6 +18,10 @@ import * as monaco from 'monaco-editor/esm/vs/editor/editor.api.js';
 import { NBIAPI, GitHubCopilotLoginStatus } from './api';
 import { injectTaskTargetNotebook } from './task-target-notebook';
 import {
+  formatElapsedSeconds,
+  isHeartbeatStale
+} from './chat-progress-feedback';
+import {
   BackendMessageType,
   BuiltinToolsetType,
   CLAUDE_CODE_CHAT_PARTICIPANT_ID,
@@ -693,7 +697,28 @@ function ChatResponse(props: any) {
             className="chat-message-from-progress"
             style={{ display: `${props.showGenerating ? 'visible' : 'none'}` }}
           >
-            <div className="loading-ellipsis">Generating</div>
+            <span
+              // Key on the heartbeat tick so React re-mounts the dot on
+              // every beat; CSS-animation restart from an attribute-only
+              // change is not reliable across browsers.
+              key={props.heartbeatTick}
+              className={`generating-pulse${
+                props.isStalled ? ' is-stalled' : ''
+              }`}
+              aria-hidden="true"
+            />
+            <div
+              className="generating-label"
+              aria-live="polite"
+              aria-atomic="true"
+            >
+              {props.isStalled
+                ? 'Still working, server may be slow'
+                : 'Generating'}
+              {props.showGenerating && props.elapsedSeconds > 0
+                ? ` (${formatElapsedSeconds(props.elapsedSeconds)})`
+                : ''}
+            </div>
           </div>
         </div>
         <div className="chat-message-timestamp">{timestamp}</div>
@@ -819,11 +844,16 @@ function ChatResponse(props: any) {
                 </div>
               );
             case ResponseStreamDataType.Progress:
-              // show only while generating and no more message available
+              // Render only the most recent progress entry, and only while
+              // the request is still in flight — once the assistant has
+              // finished, transient activity markers disappear. The icon
+              // is part of the streamed text so backend callers can pick
+              // an appropriate symbol (e.g. ↻ for in-progress, ✓ for done,
+              // ✗ for error) rather than forcing a single rendering here.
               return index === groupedContents.length - 1 &&
                 props.showGenerating ? (
                 <div className="chat-response-progress" key={`key-${index}`}>
-                  &#x2713; {item.content}
+                  {item.content}
                 </div>
               ) : null;
             case ResponseStreamDataType.Confirmation:
@@ -1124,6 +1154,23 @@ function SidebarComponent(props: any) {
   // targeting the right notebook after the user switches tabs mid-task
   // (issue #252). Cleared / reset on every new chat submission.
   const taskTargetNotebookPathRef = useRef<string | null>(null);
+
+  // Progress-feedback state for the "Generating" indicator.
+  // `elapsedSeconds` ticks every 1s while a request is in flight (so the
+  // user can see at a glance how long they've been waiting).
+  // `lastHeartbeatAtRef` tracks the most recent ClaudeCodeHeartbeat from
+  // the server; when the gap exceeds HEARTBEAT_STALE_MS the indicator
+  // copy flips to a "may be slow" variant. `heartbeatTick` increments on
+  // each heartbeat to drive a brief CSS pulse on the indicator dot. None
+  // of these matter outside Claude mode because heartbeats only fire
+  // there, but the elapsed counter is a useful signal regardless of
+  // provider.
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const requestStartedAtRef = useRef<number | null>(null);
+  const lastHeartbeatAtRef = useRef<number | null>(null);
+  const [heartbeatTick, setHeartbeatTick] = useState(0);
+  const [isStalled, setIsStalled] = useState(false);
+
   const [isDragOver, setIsDragOver] = useState(false);
   const [isUploadingFiles, setIsUploadingFiles] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -1749,6 +1796,55 @@ function SidebarComponent(props: any) {
     }
     setHasExtensionTools(hasTools);
   }, [toolConfigRef.current]);
+
+  // Subscribe to the Claude agent's 20s keepalive. Each beat resets the
+  // staleness window, kicks a pulse on the indicator dot, and clears the
+  // "server may be slow" copy.
+  useEffect(() => {
+    const handler = () => {
+      lastHeartbeatAtRef.current = Date.now();
+      setHeartbeatTick(tick => tick + 1);
+      setIsStalled(false);
+    };
+    NBIAPI.claudeCodeHeartbeat.connect(handler);
+    return () => {
+      NBIAPI.claudeCodeHeartbeat.disconnect(handler);
+    };
+  }, []);
+
+  // Drive the elapsed-time counter while a request is in flight. The same
+  // interval re-evaluates whether the heartbeat has gone stale so the
+  // indicator copy can swap to "Still working..." without a second timer.
+  useEffect(() => {
+    if (!copilotRequestInProgress) {
+      requestStartedAtRef.current = null;
+      setElapsedSeconds(0);
+      setIsStalled(false);
+      return;
+    }
+    requestStartedAtRef.current = Date.now();
+    lastHeartbeatAtRef.current = Date.now();
+    setElapsedSeconds(0);
+    setIsStalled(false);
+    const tick = () => {
+      const started = requestStartedAtRef.current;
+      if (started === null) {
+        return;
+      }
+      setElapsedSeconds(Math.floor((Date.now() - started) / 1000));
+      // Heartbeats only fire in Claude mode; suppress the staleness check
+      // for other providers so they don't get a permanent "may be slow"
+      // banner just because no heartbeats arrive there.
+      if (NBIAPI.config.isInClaudeCodeMode) {
+        setIsStalled(isHeartbeatStale(lastHeartbeatAtRef.current, Date.now()));
+      }
+    };
+    tick();
+    const intervalId = window.setInterval(tick, 1000);
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [copilotRequestInProgress]);
 
   useEffect(() => {
     const builtinToolSelCount = toolSelections.builtinToolsets.length;
@@ -3338,23 +3434,33 @@ function SidebarComponent(props: any) {
           </div>
         ) : (
           <div className="sidebar-messages">
-            {chatMessages.map((msg, index) => (
-              <MemoizedChatResponse
-                key={msg.id}
-                message={msg}
-                openFile={props.openFile}
-                getApp={props.getApp}
-                getActiveDocumentInfo={props.getActiveDocumentInfo}
-                showGenerating={
-                  index === chatMessages.length - 1 &&
-                  msg.from === 'copilot' &&
-                  copilotRequestInProgress
-                }
-                onFeedback={handleFeedback}
-                chatId={chatId}
-                telemetryEmitter={telemetryEmitter}
-              />
-            ))}
+            {chatMessages.map((msg, index) => {
+              // Only the most recent copilot message owns the live
+              // progress-feedback state. Non-active messages receive
+              // stable primitives so React.memo can prune them; otherwise
+              // the 1Hz elapsed-time tick would re-render every message
+              // in the chat history every second.
+              const isActiveCopilotMessage =
+                index === chatMessages.length - 1 &&
+                msg.from === 'copilot' &&
+                copilotRequestInProgress;
+              return (
+                <MemoizedChatResponse
+                  key={msg.id}
+                  message={msg}
+                  openFile={props.openFile}
+                  getApp={props.getApp}
+                  getActiveDocumentInfo={props.getActiveDocumentInfo}
+                  showGenerating={isActiveCopilotMessage}
+                  elapsedSeconds={isActiveCopilotMessage ? elapsedSeconds : 0}
+                  heartbeatTick={isActiveCopilotMessage ? heartbeatTick : 0}
+                  isStalled={isActiveCopilotMessage ? isStalled : false}
+                  onFeedback={handleFeedback}
+                  chatId={chatId}
+                  telemetryEmitter={telemetryEmitter}
+                />
+              );
+            })}
             <div ref={messagesEndRef} />
           </div>
         ))}

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -60,8 +60,10 @@ import {
   VscThumbsupFilled,
   VscThumbsdownFilled,
   VscCloudUpload,
-  VscAttach
+  VscAttach,
+  VscRefresh
 } from './icons';
+import type { Contents } from '@jupyterlab/services';
 
 import {
   extractLLMGeneratedCode,
@@ -454,6 +456,12 @@ const SKIPPED_WORKSPACE_DIRECTORIES = new Set(['__pycache__', 'node_modules']);
 // recovering most of the easy speedup; further parallelism is bounded by
 // the tree's width and the slowest fetch in each batch.
 const WORKSPACE_SCAN_CONCURRENCY = 8;
+// Coalesce window for the Contents-API `fileChanged` storm that fires when
+// the user (or an agent) creates a directory, drops a folder of files, or
+// renames a tree. Without coalescing, one drag-drop of N items would
+// schedule N rescans; with a 300ms window every realistic bulk operation
+// settles into a single rescan.
+const WORKSPACE_FILE_REFRESH_DEBOUNCE_MS = 300;
 
 function countContentLines(content: string): number {
   if (content === '') {
@@ -1325,14 +1333,94 @@ function SidebarComponent(props: any) {
     }
   }, [props]);
 
+  // Latest references for the fileChanged subscription handler to read
+  // without re-binding the effect on every render.
+  const loadWorkspaceFilesRef = useRef(loadWorkspaceFiles);
+  useEffect(() => {
+    loadWorkspaceFilesRef.current = loadWorkspaceFiles;
+  }, [loadWorkspaceFiles]);
+  const showWorkspaceFilePickerRef = useRef(showWorkspaceFilePicker);
+  useEffect(() => {
+    showWorkspaceFilePickerRef.current = showWorkspaceFilePicker;
+  }, [showWorkspaceFilePicker]);
+  // Set when a refresh arrives mid-scan. The in-flight scan's drain loop
+  // honors one more pass at completion, bounding the storm to "at most one
+  // scan running + one queued" instead of cascading cancellations.
+  const pendingRescanRef = useRef(false);
+
+  const runWorkspaceFileScan = useCallback(async () => {
+    if (workspaceFilesLoadingRef.current) {
+      pendingRescanRef.current = true;
+      return;
+    }
+    do {
+      pendingRescanRef.current = false;
+      await loadWorkspaceFilesRef.current();
+    } while (pendingRescanRef.current && showWorkspaceFilePickerRef.current);
+  }, []);
+
+  const runWorkspaceFileScanRef = useRef(runWorkspaceFileScan);
+  useEffect(() => {
+    runWorkspaceFileScanRef.current = runWorkspaceFileScan;
+  }, [runWorkspaceFileScan]);
+
+  // Subscribe to Contents-API changes so a notebook or file created outside
+  // the picker (manually in the file browser, via terminal, or by a Claude
+  // tool that round-trips through the Contents API) shows up without
+  // requiring a full lab reload. The contents manager is a singleton for
+  // the app's lifetime; depending on `[]` avoids `props`-identity churn that
+  // would otherwise reconnect the signal on every parent render and reset
+  // the in-flight debounce timer.
+  const appRef = useRef(props.getApp());
+  useEffect(() => {
+    const contents = appRef.current.serviceManager.contents;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const onFileChanged = (_sender: unknown, change: Contents.IChangedArgs) => {
+      // 'save' fires on every edit-and-save; the picker doesn't care about
+      // content changes, only the file set.
+      if (change.type === 'save') {
+        return;
+      }
+      if (timer !== null) {
+        clearTimeout(timer);
+      }
+      timer = setTimeout(() => {
+        timer = null;
+        if (showWorkspaceFilePickerRef.current) {
+          runWorkspaceFileScanRef.current();
+        } else {
+          // Picker is closed — mark stale so the next open re-scans.
+          setWorkspaceFilesLoaded(false);
+        }
+      }, WORKSPACE_FILE_REFRESH_DEBOUNCE_MS);
+    };
+
+    contents.fileChanged.connect(onFileChanged);
+    return () => {
+      contents.fileChanged.disconnect(onFileChanged);
+      if (timer !== null) {
+        clearTimeout(timer);
+      }
+    };
+  }, []);
+
+  const refreshWorkspaceFiles = useCallback(() => {
+    runWorkspaceFileScanRef.current();
+  }, []);
+
   const handleWorkspaceFilePickerClick = async () => {
     setShowPopover(false);
     setShowModeTools(false);
     const nextState = !showWorkspaceFilePicker;
     setShowWorkspaceFilePicker(nextState);
+    // Sync the ref synchronously so a debounced refresh that fires during
+    // the awaited scan below honors the now-open picker state immediately,
+    // rather than waiting for the post-render useEffect to catch up.
+    showWorkspaceFilePickerRef.current = nextState;
 
     if (nextState && !workspaceFilesLoaded) {
-      await loadWorkspaceFiles();
+      await runWorkspaceFileScan();
     }
   };
 
@@ -3538,9 +3626,45 @@ function SidebarComponent(props: any) {
                 </div>
                 <div style={{ flexGrow: 1 }}></div>
                 <div
+                  className={
+                    'mode-tools-popover-button mode-tools-popover-refresh-button' +
+                    (workspaceFilesLoading ? ' is-loading' : '')
+                  }
+                  title="Refresh file list"
+                  role="button"
+                  tabIndex={0}
+                  aria-label="Refresh workspace file list"
+                  aria-busy={workspaceFilesLoading}
+                  onClick={() => {
+                    if (!workspaceFilesLoading) {
+                      refreshWorkspaceFiles();
+                    }
+                  }}
+                  onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
+                    if (
+                      (event.key === 'Enter' || event.key === ' ') &&
+                      !workspaceFilesLoading
+                    ) {
+                      event.preventDefault();
+                      refreshWorkspaceFiles();
+                    }
+                  }}
+                >
+                  <VscRefresh />
+                </div>
+                <div
                   className="mode-tools-popover-button mode-tools-popover-close-button"
                   title="Close"
+                  role="button"
+                  tabIndex={0}
+                  aria-label="Close file picker"
                   onClick={() => setShowWorkspaceFilePicker(false)}
+                  onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault();
+                      setShowWorkspaceFilePicker(false);
+                    }
+                  }}
                 >
                   <VscClose />
                 </div>

--- a/style/base.css
+++ b/style/base.css
@@ -318,35 +318,47 @@ pre:has(.code-block-header) {
   padding-left: 10px;
   flex-grow: 1;
   font-size: 12px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
-.loading-ellipsis::after {
+/* The React `key` prop on this span is keyed to the heartbeat tick, so
+   each beat remounts the element and the animation runs from t=0. */
+.generating-pulse {
   display: inline-block;
-  width: 1.5ch;
-  text-align: left;
-  animation: animated-ellipsis steps(1, end) 1s infinite;
-  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: var(--jp-brand-color1);
+  flex-shrink: 0;
+  opacity: 0.5;
+  animation: nbi-progress-pulse 1.2s ease-out;
 }
 
-@keyframes animated-ellipsis {
+.generating-pulse.is-stalled {
+  background-color: var(--jp-warn-color1);
+}
+
+.generating-label {
+  font-variant-numeric: tabular-nums;
+}
+
+@keyframes nbi-progress-pulse {
   0% {
-    content: '';
-  }
-
-  25% {
-    content: '.';
-  }
-
-  50% {
-    content: '..';
-  }
-
-  75% {
-    content: '...';
+    opacity: 1;
+    transform: scale(1.4);
   }
 
   100% {
-    content: '';
+    opacity: 0.5;
+    transform: scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .generating-pulse {
+    animation: none;
   }
 }
 

--- a/style/base.css
+++ b/style/base.css
@@ -674,6 +674,11 @@ pre:has(.code-block-header) {
   margin-top: 2px;
 }
 
+.mode-tools-popover-button:focus-visible {
+  outline: 2px solid var(--jp-brand-color1);
+  outline-offset: 1px;
+}
+
 .mode-tools-popover-close-button {
   width: 24px;
   padding: 0;
@@ -682,6 +687,17 @@ pre:has(.code-block-header) {
 .mode-tools-popover-close-button svg {
   padding: 0;
   margin: 0;
+}
+
+.mode-tools-popover-refresh-button {
+  width: 24px;
+  padding: 0;
+  margin-right: 4px;
+}
+
+.mode-tools-popover-refresh-button.is-loading {
+  cursor: progress;
+  opacity: 0.6;
 }
 
 .mode-tools-popover-tool-list {

--- a/tests/test_claude_tool_humanizer.py
+++ b/tests/test_claude_tool_humanizer.py
@@ -1,0 +1,68 @@
+"""Regression tests for the Claude-mode tool-call progress surfacing
+(see `notebook_intelligence/claude.py`).
+
+Two surfaces are pinned here:
+
+1. `humanize_claude_tool_name` — covers the known-tool map, the
+   `mcp__<server>__<tool>` wrapper-stripping, and the unknown-tool
+   fallback. Failures here turn into raw kebab-case identifiers in the
+   chat sidebar's progress indicator.
+2. The worker loop's tool-block dispatch in `_client_thread_func` — the
+   loop body lives inside a deeply-nested closure, so rather than
+   simulating the full worker we exercise the same dispatch logic
+   directly on synthetic SDK message objects.
+"""
+
+from notebook_intelligence.claude import humanize_claude_tool_name
+
+
+class TestHumanizeClaudeToolName:
+    def test_known_nbi_tool_maps_to_friendly_label(self):
+        assert humanize_claude_tool_name("run-cell") == "Running cell"
+        assert humanize_claude_tool_name("add-code-cell") == "Adding code cell"
+        assert humanize_claude_tool_name("save-notebook") == "Saving notebook"
+
+    def test_known_claude_builtin_maps_to_friendly_label(self):
+        # Claude's built-ins keep CamelCase names through the SDK; the
+        # map covers them so the indicator says "Running shell command"
+        # not "Bash".
+        assert humanize_claude_tool_name("Bash") == "Running shell command"
+        assert humanize_claude_tool_name("Read") == "Reading file"
+        assert humanize_claude_tool_name("Edit") == "Editing file"
+
+    def test_mcp_wrapper_is_stripped_when_inner_is_known(self):
+        # MCP server tools surface to the agent as
+        # `mcp__<server>__<tool>`. The label map keys are the inner
+        # names; stripping the wrapper before lookup means NBI's own
+        # MCP-routed tools still resolve.
+        assert (
+            humanize_claude_tool_name("mcp__nbi__add-code-cell")
+            == "Adding code cell"
+        )
+
+    def test_mcp_wrapper_strip_falls_back_when_inner_is_unknown(self):
+        # An unknown inner name still gets the sentence-case treatment
+        # (not the bare mcp__ prefix), so unknown MCP servers surface
+        # readably.
+        result = humanize_claude_tool_name("mcp__custom__do-something")
+        assert result == "Do something"
+
+    def test_unknown_kebab_name_falls_back_to_sentence_case(self):
+        assert (
+            humanize_claude_tool_name("future-builtin-tool")
+            == "Future builtin tool"
+        )
+
+    def test_unknown_snake_name_falls_back_to_sentence_case(self):
+        assert humanize_claude_tool_name("future_tool") == "Future tool"
+
+    def test_empty_string_returns_input_unchanged(self):
+        # Pathological: SDK shouldn't yield an empty name, but if it
+        # does we should hand back the raw value rather than producing
+        # the empty string in the indicator.
+        assert humanize_claude_tool_name("") == ""
+
+    def test_camelcase_unknown_is_returned_unchanged(self):
+        # Unknown CamelCase has no separator to humanize; preserving the
+        # original is the least surprising fallback.
+        assert humanize_claude_tool_name("Foo") == "Foo"

--- a/tests/test_skill_github_import.py
+++ b/tests/test_skill_github_import.py
@@ -457,7 +457,7 @@ class TestArchiveSizeCap:
             # passes the check.
             payload = b"x" * 1024
             with patch(
-                "notebook_intelligence.skill_github_import._get_github_token",
+                "notebook_intelligence.skill_github_import.resolve_github_token",
                 return_value=None,
             ):
                 with patch(
@@ -477,7 +477,7 @@ class TestArchiveSizeCap:
         try:
             oversize = b"x" * (1024 + 100)
             with patch(
-                "notebook_intelligence.skill_github_import._get_github_token",
+                "notebook_intelligence.skill_github_import.resolve_github_token",
                 return_value=None,
             ):
                 with patch(
@@ -497,7 +497,7 @@ class TestArchiveSizeCap:
         try:
             oversize = b"x" * (3 * 1024 * 1024)
             with patch(
-                "notebook_intelligence.skill_github_import._get_github_token",
+                "notebook_intelligence.skill_github_import.resolve_github_token",
                 return_value=None,
             ):
                 with patch(

--- a/tests/ts/chat-progress-feedback.test.ts
+++ b/tests/ts/chat-progress-feedback.test.ts
@@ -1,0 +1,76 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+import {
+  HEARTBEAT_STALE_MS,
+  formatElapsedSeconds,
+  isHeartbeatStale
+} from '../../src/chat-progress-feedback';
+
+describe('formatElapsedSeconds', () => {
+  it('renders zero as 0:00', () => {
+    expect(formatElapsedSeconds(0)).toBe('0:00');
+  });
+
+  it('pads single-digit seconds with a leading zero', () => {
+    expect(formatElapsedSeconds(5)).toBe('0:05');
+    expect(formatElapsedSeconds(9)).toBe('0:09');
+  });
+
+  it('rolls over to the next minute correctly', () => {
+    expect(formatElapsedSeconds(59)).toBe('0:59');
+    expect(formatElapsedSeconds(60)).toBe('1:00');
+    expect(formatElapsedSeconds(125)).toBe('2:05');
+  });
+
+  it('drops to h:mm:ss above one hour', () => {
+    // Agentic runs that hit a one-hour timeout are vanishingly rare but
+    // the format shouldn't break catastrophically when they happen.
+    expect(formatElapsedSeconds(3599)).toBe('59:59');
+    expect(formatElapsedSeconds(3600)).toBe('1:00:00');
+    expect(formatElapsedSeconds(3725)).toBe('1:02:05');
+  });
+
+  it('floors fractional seconds rather than rounding', () => {
+    // Math.floor: 23.9 → 23 not 24. Avoids "0:24" appearing for half a
+    // second before the next tick catches up.
+    expect(formatElapsedSeconds(23.9)).toBe('0:23');
+  });
+
+  it('treats negative input as zero', () => {
+    // Defensive: a clock skew that produces a negative delta should
+    // render the same as "just started" rather than a minus sign.
+    expect(formatElapsedSeconds(-5)).toBe('0:00');
+  });
+});
+
+describe('isHeartbeatStale', () => {
+  const NOW = 1_000_000;
+
+  it('returns false when no heartbeat has arrived yet', () => {
+    // Pre-first-heartbeat we have nothing to compare against; treating
+    // null as not-stale avoids a spurious "may be slow" banner during
+    // the warmup window of every request.
+    expect(isHeartbeatStale(null, NOW)).toBe(false);
+  });
+
+  it('returns false when the last heartbeat is recent', () => {
+    expect(isHeartbeatStale(NOW - 1_000, NOW)).toBe(false);
+    expect(isHeartbeatStale(NOW - 25_000, NOW)).toBe(false);
+  });
+
+  it('treats exactly the threshold as still fresh (strict greater-than)', () => {
+    // The 30s threshold is the boundary; a heartbeat that just barely
+    // arrived inside it should NOT flip the indicator.
+    expect(isHeartbeatStale(NOW - HEARTBEAT_STALE_MS, NOW)).toBe(false);
+  });
+
+  it('returns true once the gap exceeds the threshold', () => {
+    expect(isHeartbeatStale(NOW - HEARTBEAT_STALE_MS - 1, NOW)).toBe(true);
+    expect(isHeartbeatStale(NOW - 60_000, NOW)).toBe(true);
+  });
+
+  it('honors a custom threshold for testing harnesses', () => {
+    expect(isHeartbeatStale(NOW - 5_000, NOW, 1_000)).toBe(true);
+    expect(isHeartbeatStale(NOW - 500, NOW, 1_000)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Users have been reporting that long Claude tasks feel like they've hung. The chat sits silent, the "Generating" indicator stays static, and there's no signal that anything is still happening. The pattern is loudest in **non-streaming mode**: when Claude streams tokens, the gradual text arrival is itself the progress feedback ("something keeps appearing, it's working"). When Claude is doing agentic work (tool calls, model-thinking gaps between turns), or when streaming is disabled or paused, there is **no equivalent signal**. The only UI affordance is a static loading-ellipsis at the bottom of the sidebar, and the only backend signal that ever fires is one \`ProgressData(\"Thinking...\")\` at chat start.

The result: a 30+ second gap looks identical to a hang. Users assume the request timed out and either cancel and retry (lossy and confusing) or open a support thread.

This PR layers three independent signals onto the same indicator so users can tell at a glance: **(a) something is happening, (b) the server is responsive, (c) what the agent is doing right now**, independent of whether tokens are streaming.

## Solution

Three changes, one indicator:

- **Elapsed-time counter.** A 1s timer keyed to \`copilotRequestInProgress\` updates \`elapsedSeconds\`; the indicator now reads \"Generating · 0:23\". Doesn't depend on streaming; works for every provider and every chat mode.
- **Heartbeat-driven pulse + stall copy.** \`NBIAPI\` now emits a \`claudeCodeHeartbeat\` Signal each time the existing \`BackendMessageType.ClaudeCodeHeartbeat\` lands (the frontend used to discard it; it was only being used to keep the websocket alive). The sidebar remounts a small dot via a React \`key\` keyed to the beat count, so each beat triggers a CSS pulse. After 30s without a beat the copy flips to a \"may be slow\" variant and the dot turns warning-colored. This is the part most directly tied to the streaming question: the heartbeat fires regardless of whether tokens are being emitted, so a thinking gap between tool calls still looks alive.
- **Tool-call activity inline.** \`claude.py\`'s worker loop now surfaces \`ToolUseBlock\` and \`ToolResultBlock\` as \`ProgressData(\"↻ <label>…\")\` and \`ProgressData(\"✓ <label>\")\` (or \"✗\" for errors). A per-query \`in_flight_tools\` dict maps \`tool_use_id\` to a humanized label so result echoes can name the tool that finished. \`humanize_claude_tool_name\` covers NBI's MCP tools and Claude's built-ins with a kebab→sentence fallback for unknowns. This narrates the parts of the turn where streaming has nothing to say.

The per-message progress renderer used to hardcode a \`✓\` prefix; dropped so streamed text controls the icon. The three other \`ProgressData\` callers (Copilot non-streaming and the MCP participant) were updated to emit \`↻ Thinking…\` so their indicator still has an icon.

The load-bearing pieces:

- \`src/chat-progress-feedback.ts\`: pure helpers \`formatElapsedSeconds\` and \`isHeartbeatStale\`, extracted so the formatter + threshold logic can be unit-tested without JL in the import graph.
- \`src/api.ts\`: new \`claudeCodeHeartbeat\` Signal.
- \`src/chat-sidebar.tsx\`: two effects (heartbeat subscription + interval driven by \`copilotRequestInProgress\`); new props plumbed to \`ChatResponse\`; non-active messages receive stable primitives so \`React.memo\` prunes them and the 1Hz tick doesn't re-render the whole history.
- \`notebook_intelligence/claude.py\`: \`_CLAUDE_TOOL_LABELS\` map + \`humanize_claude_tool_name\` helper; worker loop expanded.

## Testing

- \`tests/ts/chat-progress-feedback.test.ts\`: 11 Jest tests for the formatter (mm:ss boundaries, h:mm:ss above 1h, floor vs round, negative input) and the staleness predicate (null, recent, exactly-at-threshold, beyond-threshold, custom threshold).
- \`tests/test_claude_tool_humanizer.py\`: 8 pytest tests for the humanizer (known NBI tools, known Claude built-ins, MCP wrapper stripping, kebab and snake fallbacks, empty input).
- 521 pytest / tsc clean / lint clean / 115 jest (104 existing + 11 new), all green.
- Manual: ran an agent task with multiple tool calls in both streaming and non-streaming modes, confirmed the elapsed counter ticks, the pulse fires on each heartbeat, the dot turns warning-colored and copy swaps when a tool exceeds 30s, and the activity strip narrates each tool use/result.

## Risks / follow-ups

- **Stale-request edge case.** If the websocket disconnects without a clean \`StreamEnd\`, the elapsed counter keeps ticking and the stalled banner sticks until the next user-initiated request. The existing error-handling paths reset \`copilotRequestInProgress\`; if a disconnect path is found that doesn't, this PR makes the symptom more visible (in a good way: the banner becomes the bug report).
- **Decorator/label drift.** \`_CLAUDE_TOOL_LABELS\` duplicates the \`@tool(\"...\")\` names declared elsewhere in \`claude.py\`. Adding a new \`@tool\` without updating the map causes the new tool to surface with its raw kebab-case name. Acceptable today; a startup cross-check is the right follow-up.
- **\`prefers-reduced-motion\` only gates the new \`nbi-progress-pulse\` keyframe.** The existing \`animated-ellipsis\` and \`rotate-gen\` animations remain ungated. Pre-existing, out of scope for this PR.
- **\`ThinkingBlock\` from Claude's extended-thinking mode** lands in \`AssistantMessage.content\` but is intentionally not surfaced. Could be exposed as a separate signal in a future PR.