### PR TITLE
feat(copilot): add newer GitHub Copilot chat models

### DIFF
--- a/notebook_intelligence/llm_providers/github_copilot_llm_provider.py
+++ b/notebook_intelligence/llm_providers/github_copilot_llm_provider.py
@@ -66,8 +66,13 @@ class GitHubCopilotLLMProvider(LLMProvider):
             GitHubCopilotChatModel(self, "gpt-4.1", "GPT-4.1", 128000, True),
             GitHubCopilotChatModel(self, "gpt-4o", "GPT-4o", 128000, True),
             GitHubCopilotChatModel(self, "gpt-5", "GPT-5", 128000, True),
+            GitHubCopilotChatModel(self, "gpt-5.3-codex", "GPT-5.3-Codex", 128000, True),
+            GitHubCopilotChatModel(self, "claude-haiku-4.5", "Claude Haiku 4.5", 144000, True),
+            GitHubCopilotChatModel(self, "claude-sonnet-4.6", "Claude Sonnet 4.6", 144000, True),
             GitHubCopilotChatModel(self, "claude-sonnet-4.5", "Claude Sonnet 4.5", 144000, True),
             GitHubCopilotChatModel(self, "claude-sonnet-4", "Claude Sonnet 4", 80000, True),
+            GitHubCopilotChatModel(self, "claude-opus-4.6", "Claude Opus 4.6", 144000, True),
+            GitHubCopilotChatModel(self, "gemini-3.1-pro", "Gemini 3.1 Pro", 128000, True),
             GitHubCopilotChatModel(self, "gemini-2.5-pro", "Gemini 2.5 Pro", 128000, True),
         ]
         self._inline_completion_model_gpt41 = GitHubCopilotInlineCompletionModel(self, "gpt-41-copilot", "GPT-4.1 Copilot")

--- a/tests/test_github_copilot_llm_provider.py
+++ b/tests/test_github_copilot_llm_provider.py
@@ -1,0 +1,15 @@
+from notebook_intelligence.llm_providers.github_copilot_llm_provider import GitHubCopilotLLMProvider
+
+
+def test_chat_models_include_recent_github_copilot_models():
+    provider = GitHubCopilotLLMProvider()
+
+    models = {model.id: model for model in provider.chat_models}
+
+    assert models["gpt-5.3-codex"].name == "GPT-5.3-Codex"
+    assert models["claude-haiku-4.5"].name == "Claude Haiku 4.5"
+    assert models["claude-sonnet-4.6"].name == "Claude Sonnet 4.6"
+    assert models["claude-opus-4.6"].name == "Claude Opus 4.6"
+    assert models["gemini-3.1-pro"].name == "Gemini 3.1 Pro"
+
+    assert all(model.supports_tools for model in models.values())


### PR DESCRIPTION
## Summary
- add the latest GitHub Copilot chat models requested in #141 to the provider list
- cover the new model IDs/names with a focused regression test

## Testing
- `.venv/bin/python -m py_compile notebook_intelligence/llm_providers/github_copilot_llm_provider.py tests/test_github_copilot_llm_provider.py`
- `.venv/bin/pytest -q tests/test_github_copilot_llm_provider.py`

Closes #141