### PR TITLE
feat(terminal): drag-drop file attach with @-mention / raw modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Most settings panel toggles can be locked by org administrators. Two shapes:
 | `NBI_SKILLS_MANAGEMENT_POLICY`             | The Skills tab (force-off hides it and 403s the API; also disables the managed-skills reconciler)                            |
 | `NBI_CLAUDE_MCP_MANAGEMENT_POLICY`         | The Claude-mode MCP Servers tab (force-off hides it and 403s `/claude-mcp/*`; independent of the non-Claude MCP Servers tab) |
 | `NBI_CLAUDE_PLUGINS_MANAGEMENT_POLICY`     | The Claude-mode Plugins tab (force-off hides it and 403s `/plugins/*`)                                                       |
+| `NBI_TERMINAL_DRAG_DROP_POLICY`            | Terminal drag-drop file attach feature                                                                                       |
 
 The first three also have matching traitlets on `NotebookIntelligence` (`explain_error_policy`, `output_followup_policy`, `output_toolbar_policy`); add the others as needed in the same shape:
 
@@ -192,6 +193,15 @@ Per-user preferences (default on for the cell-output features) live in `config.j
 | `ANTHROPIC_BASE_URL`                   | Claude → Base URL                                                            |
 
 Provider IDs: `github-copilot`, `openai-compatible`, `litellm-compatible`, `ollama`, `none`. The `*_MODEL_ID` value is whatever the chosen provider exposes (e.g. `gpt-4o`, `llama3:latest`). Claude model IDs are the literal IDs from the Anthropic API (e.g. `claude-opus-4-7`, `claude-sonnet-4-6`); empty string = "Default (recommended)"; `NBI_CLAUDE_INLINE_COMPLETION_MODEL` also accepts `none` (no inline completion in Claude mode) or `inherit` (use the General-tab Auto-complete model).
+
+**Upload tunables** govern the shared upload endpoint used by both chat-sidebar file attachments and terminal drag-drop:
+
+| Env var                      | Default | Behavior                                                                                                                                                          |
+| ---------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NBI_UPLOAD_MAX_MB`          | `50`    | Per-file size cap in megabytes. Requests over the cap return HTTP 413. Set to `0` to disable the cap entirely.                                                    |
+| `NBI_UPLOAD_RETENTION_HOURS` | `24`    | How long staged uploads survive in the temp directory before the next upload sweeps them. Set to `0` to keep only the atexit purge (uploads survive the session). |
+
+The same values are also configurable via the `upload_max_mb` and `upload_retention_hours` traitlets on `NotebookIntelligence`.
 
 ### Remembering GitHub Copilot login
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -21,7 +21,9 @@ module.exports = {
   // The tests don't depend on real tokenization, so stub it out.
   moduleNameMapper: {
     '^tiktoken$': '<rootDir>/tests/ts/__mocks__/tiktoken.ts',
-    '\\.svg$': '<rootDir>/tests/ts/__mocks__/svg.ts'
+    '\\.svg$': '<rootDir>/tests/ts/__mocks__/svg.ts',
+    '^@jupyterlab/apputils$':
+      '<rootDir>/tests/ts/__mocks__/jupyterlab-apputils.ts'
   },
   clearMocks: true
 };

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -1869,10 +1869,31 @@ class WebsocketCopilotHandler(websocket.WebSocketHandler):
                 is_image = context.get("isImage", False)
                 file_path = context["filePath"]
                 if not is_upload:
-                    file_path = path.join(NotebookIntelligence.root_dir, file_path)
+                    # Workspace-relative paths arrive verbatim from the
+                    # frontend (file browser drag, @-mention picker, ...).
+                    # path.join silently passes through absolute paths and
+                    # doesn't normalize ``..`` traversal, so sandbox the
+                    # resolved path against root_dir before reading.
+                    joined = path.join(NotebookIntelligence.root_dir, file_path)
+                    resolved = os.path.realpath(joined)
+                    workspace_root = os.path.realpath(NotebookIntelligence.root_dir)
+                    try:
+                        in_workspace = (
+                            os.path.commonpath([resolved, workspace_root])
+                            == workspace_root
+                        )
+                    except ValueError:
+                        in_workspace = False
+                    if not in_workspace:
+                        log.warning(
+                            "Rejecting out-of-workspace context path: %r",
+                            context["filePath"],
+                        )
+                        continue
+                    file_path = resolved
                 context_filename = path.basename(file_path)
 
-                if is_image and is_upload:
+                if is_image:
                     if is_claude_code_mode:
                         # Claude Code CLI takes text only; pass file path so agent can read the image
                         chat_history.append({

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -10,6 +10,7 @@ import datetime as dt
 import os
 import shutil
 import tempfile
+import time
 from typing import Union
 import uuid
 import threading
@@ -299,6 +300,11 @@ FEATURE_POLICY_SPEC = (
         "NBI_CLAUDE_PLUGINS_MANAGEMENT_POLICY",
         "claude_plugins_management_policy",
     ),
+    (
+        "terminal_drag_drop",
+        "NBI_TERMINAL_DRAG_DROP_POLICY",
+        "terminal_drag_drop_policy",
+    ),
 )
 FEATURE_POLICY_NAMES = tuple(name for name, _, _ in FEATURE_POLICY_SPEC)
 
@@ -342,11 +348,14 @@ def _build_feature_policies_response(policies: dict, nbi_config) -> dict:
         "claude_setting_source_user": "user" in sources,
         "claude_setting_source_project": "project" in sources,
         "store_github_access_token": bool(nbi_config.store_github_access_token),
-        # Admin-only gate; user has no toggle, so user_value is always True.
-        # The policy resolver still applies force-off / force-on correctly.
+        # Admin-only gates; user has no toggle, so user_value is always
+        # True. The policy resolver still applies force-off / force-on
+        # correctly so admins can flip them. The frontend keys off
+        # `locked && !enabled` to know when to hide the feature.
         "skills_management": True,
         "claude_mcp_management": True,
         "claude_plugins_management": True,
+        "terminal_drag_drop": True,
     }
 
     response = {}
@@ -1289,6 +1298,12 @@ class SkillBundleFileRenameHandler(SkillsBaseHandler):
 
 
 _upload_dir: str | None = None
+_DEFAULT_UPLOAD_MAX_MB = 50
+_DEFAULT_UPLOAD_RETENTION_HOURS = 24
+_SWEEP_INTERVAL_SECONDS = 60
+_sweep_lock = threading.Lock()
+_last_sweep_at: float = 0.0
+
 
 def _get_upload_dir() -> str:
     """Return a temp directory for uploaded files, creating it on first call."""
@@ -1298,12 +1313,53 @@ def _get_upload_dir() -> str:
         atexit.register(lambda d=_upload_dir: shutil.rmtree(d, ignore_errors=True))
     return _upload_dir
 
+
+def _sweep_upload_dir(retention_hours: int) -> None:
+    """Best-effort removal of upload subdirs past the retention window.
+
+    Runs lazily after each successful upload, rate-limited to one sweep per
+    ``_SWEEP_INTERVAL_SECONDS`` so a burst of parallel uploads doesn't pay
+    the full ``listdir + stat`` cost on every request.
+    ``retention_hours <= 0`` keeps the atexit-only purge path by skipping
+    the sweep entirely.
+    """
+    if retention_hours <= 0:
+        return
+    global _last_sweep_at
+    now = time.time()
+    with _sweep_lock:
+        if now - _last_sweep_at < _SWEEP_INTERVAL_SECONDS:
+            return
+        _last_sweep_at = now
+    root = _get_upload_dir()
+    cutoff = now - retention_hours * 3600
+    try:
+        entries = os.listdir(root)
+    except OSError:
+        return
+    for entry in entries:
+        candidate = path.join(root, entry)
+        try:
+            stat_result = os.stat(candidate)
+        except OSError:
+            # Includes FileNotFoundError when a concurrent sweep beats us.
+            continue
+        if not os.path.isdir(candidate):
+            continue
+        if stat_result.st_mtime >= cutoff:
+            continue
+        shutil.rmtree(candidate, ignore_errors=True)
+
+
 class FileUploadHandler(APIHandler):
     """Accepts a file upload and stores it in a temp directory.
 
     Returns the absolute server-side path so the frontend can reference it
     in chat context and Claude Code can read it natively.
     """
+
+    upload_max_mb: int = _DEFAULT_UPLOAD_MAX_MB
+    upload_retention_hours: int = _DEFAULT_UPLOAD_RETENTION_HOURS
 
     @tornado.web.authenticated
     def post(self):
@@ -1314,6 +1370,19 @@ class FileUploadHandler(APIHandler):
             return
 
         upload = fileinfo[0]
+        body = upload["body"]
+
+        # Reject oversize uploads before writing to disk so a giant payload
+        # can't briefly fill the staging dir. 0 disables the cap.
+        if self.upload_max_mb > 0:
+            max_bytes = self.upload_max_mb * 1024 * 1024
+            if len(body) > max_bytes:
+                self.set_status(413)
+                self.finish(json.dumps({
+                    "error": f"File exceeds {self.upload_max_mb} MB upload limit"
+                }))
+                return
+
         original_name = upload.get("filename", "upload")
         # Sanitise filename: keep only the basename to prevent path traversal.
         safe_name = path.basename(original_name)
@@ -1326,7 +1395,9 @@ class FileUploadHandler(APIHandler):
         dest_path = path.join(dest_dir, safe_name)
 
         with open(dest_path, "wb") as fh:
-            fh.write(upload["body"])
+            fh.write(body)
+
+        _sweep_upload_dir(self.upload_retention_hours)
 
         self.finish(json.dumps({
             "serverPath": dest_path,
@@ -2228,6 +2299,45 @@ class NotebookIntelligence(ExtensionApp):
         config=True,
     )
 
+    terminal_drag_drop_policy = TraitletEnum(
+        list(VALID_POLICIES),
+        default_value=POLICY_USER_CHOICE,
+        help="""
+        Org-wide policy for the terminal drag-drop file-attach feature.
+        "user-choice" (default) and "force-on" both enable the listener.
+        "force-off" suppresses the listener so files dragged onto a
+        terminal fall through to the browser's default behavior; useful
+        for hardened deployments that don't want files staged through
+        the upload endpoint. Overridden by the
+        NBI_TERMINAL_DRAG_DROP_POLICY env var.
+        """,
+        config=True,
+    )
+
+    upload_max_mb = Int(
+        default_value=_DEFAULT_UPLOAD_MAX_MB,
+        help="""
+        Per-file size cap (megabytes) for the chat-sidebar and terminal
+        drag-drop upload endpoint. Requests exceeding this limit get a
+        413. Set to 0 to disable the cap entirely. Overridden by the
+        NBI_UPLOAD_MAX_MB env var.
+        """,
+        config=True,
+    )
+
+    upload_retention_hours = Int(
+        default_value=_DEFAULT_UPLOAD_RETENTION_HOURS,
+        help="""
+        How long staged uploads survive before they're swept on the next
+        upload. Files still referenced by a long-running Claude session
+        past this window will be unreachable, so tune higher for long
+        sessions. Set to 0 to disable the lazy sweep and keep only the
+        atexit purge. Overridden by the NBI_UPLOAD_RETENTION_HOURS env
+        var.
+        """,
+        config=True,
+    )
+
     allow_github_plugin_import = Bool(
         default_value=True,
         help="""
@@ -2459,6 +2569,12 @@ class NotebookIntelligence(ExtensionApp):
             )
             * 1024
             * 1024
+        )
+        FileUploadHandler.upload_max_mb = _resolve_positive_int_with_env(
+            "NBI_UPLOAD_MAX_MB", self.upload_max_mb
+        )
+        FileUploadHandler.upload_retention_hours = _resolve_positive_int_with_env(
+            "NBI_UPLOAD_RETENTION_HOURS", self.upload_retention_hours
         )
         self._publish_policies(feature_policies, string_overrides)
         NotebookIntelligence.handlers = [

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
         "@jupyterlab/notebook": "^4.0.0",
         "@jupyterlab/services": "^7.0.0",
         "@jupyterlab/settingregistry": "^4.0.0",
+        "@jupyterlab/terminal": "^4.0.0",
         "monaco-editor": "0.21.3",
         "react-icons": "~5.6.0",
         "react-markdown": "^9.0.1",

--- a/src/api.ts
+++ b/src/api.ts
@@ -237,7 +237,8 @@ export type FeaturePolicyName =
   | 'store_github_access_token'
   | 'skills_management'
   | 'claude_mcp_management'
-  | 'claude_plugins_management';
+  | 'claude_plugins_management'
+  | 'terminal_drag_drop';
 
 export type IFeaturePolicies = Record<
   FeaturePolicyName,
@@ -408,7 +409,8 @@ export class NBIConfig {
       'store_github_access_token',
       'skills_management',
       'claude_mcp_management',
-      'claude_plugins_management'
+      'claude_plugins_management',
+      'terminal_drag_drop'
     ];
     // Admin-only management gates (no per-user toggle) default *open* when
     // missing — a new frontend hitting an older backend without these

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -10,7 +10,7 @@ import React, {
   useState,
   memo
 } from 'react';
-import { ReactWidget } from '@jupyterlab/apputils';
+import { Notification, ReactWidget } from '@jupyterlab/apputils';
 import { UUID } from '@lumino/coreutils';
 
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api.js';
@@ -1749,19 +1749,16 @@ function SidebarComponent(props: any) {
   // Attach a list of workspace-relative paths (from JL file browser
   // drag) as chat context. Images are attached as image context (with a
   // base64 dataURL thumbnail) so the model can see them; text and
-  // notebook files are attached as content context. De-dupes against
-  // the currently selected set.
+  // notebook files are attached as content context.
   const attachWorkspacePaths = async (paths: string[]) => {
-    const alreadySelected = new Set(selectedContextFiles.map(f => f.path));
-    const unique = paths.filter(p => !alreadySelected.has(p));
-    if (unique.length === 0) {
+    if (paths.length === 0) {
       return;
     }
     const contentsManager = props.getApp().serviceManager.contents;
     const additions: ISelectedContextFile[] = [];
     const errors: string[] = [];
     await Promise.all(
-      unique.map(async path => {
+      paths.map(async path => {
         try {
           const model: any = await contentsManager.get(path, { content: true });
           const mimetype: string = model.mimetype || '';
@@ -1796,14 +1793,28 @@ function SidebarComponent(props: any) {
       })
     );
     if (additions.length > 0) {
-      setSelectedContextFiles(previous =>
-        [...previous, ...additions].sort((lhs, rhs) =>
+      // De-dupe inside the functional updater so it reads the freshest
+      // state. A stale closure on `selectedContextFiles` here would let
+      // the same path land twice when the user drops it a second time.
+      setSelectedContextFiles(previous => {
+        const existing = new Set(previous.map(f => f.path));
+        const fresh = additions.filter(a => !existing.has(a.path));
+        if (fresh.length === 0) {
+          return previous;
+        }
+        return [...previous, ...fresh].sort((lhs, rhs) =>
           lhs.path.localeCompare(rhs.path)
-        )
-      );
+        );
+      });
+      // Move keyboard focus into the prompt so the user can immediately
+      // describe what they want done with the attached files.
+      promptInputRef.current?.focus();
     }
     if (errors.length > 0) {
-      addSystemNotice(`Could not attach: ${errors.join('; ')}.`);
+      // Match the terminal-drag error path (Notification toast) instead
+      // of slipping a chat-message-notice into the transcript, which
+      // can scroll out of view.
+      Notification.warning(`Could not attach: ${errors.join('; ')}`);
     }
   };
 

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -1747,7 +1747,10 @@ function SidebarComponent(props: any) {
   }, []);
 
   // Attach a list of workspace-relative paths (from JL file browser
-  // drag) as chat context. De-dupes against the currently selected set.
+  // drag) as chat context. Images are attached as image context (with a
+  // base64 dataURL thumbnail) so the model can see them; text and
+  // notebook files are attached as content context. De-dupes against
+  // the currently selected set.
   const attachWorkspacePaths = async (paths: string[]) => {
     const alreadySelected = new Set(selectedContextFiles.map(f => f.path));
     const unique = paths.filter(p => !alreadySelected.has(p));
@@ -1761,6 +1764,22 @@ function SidebarComponent(props: any) {
       unique.map(async path => {
         try {
           const model: any = await contentsManager.get(path, { content: true });
+          const mimetype: string = model.mimetype || '';
+          // Image branch: file is already on the server, so build a
+          // data URL from the base64 content for the thumbnail and let
+          // the backend resolve the workspace path. No upload needed.
+          if (model.format === 'base64' && mimetype.startsWith('image/')) {
+            additions.push({
+              content: '',
+              lineCount: 0,
+              path,
+              type: 'file',
+              isImage: true,
+              imageDataUrl: `data:${mimetype};base64,${model.content}`,
+              mimeType: mimetype
+            });
+            return;
+          }
           const content = serializeWorkspaceFileContent(model);
           if (content.trim() === '') {
             throw new Error(`'${path}' has no content to attach.`);

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -1078,6 +1078,7 @@ function SidebarComponent(props: any) {
     useState(0);
   const promptInputRef = useRef<HTMLTextAreaElement>(null);
   const autocompleteRef = useRef<HTMLDivElement>(null);
+  const sidebarRootRef = useRef<HTMLDivElement>(null);
   const atButtonRef = useRef<HTMLAnchorElement>(null);
   const [promptHistory, setPromptHistory] = useState<string[]>([]);
   // position on prompt history stack
@@ -1633,6 +1634,159 @@ function SidebarComponent(props: any) {
   useEffect(() => {
     cleanupRemovedToolsFromToolSelections();
   }, [mcpServerEnabledState]);
+
+  // JupyterLab file-browser drag uses Lumino's lm-* CustomEvents (mime
+  // 'application/x-jupyter-icontents' carrying workspace-relative paths),
+  // not native HTML5 drag. We listen at the document level with capture
+  // phase + a containment check so intermediate widgets that
+  // stopPropagation in target phase can't swallow the event.
+  useEffect(() => {
+    const FILE_BROWSER_MIME = 'application/x-jupyter-icontents';
+
+    const isInsideSidebar = (event: Event): boolean => {
+      const root = sidebarRootRef.current;
+      if (!root) {
+        return false;
+      }
+      const target = event.target;
+      return target instanceof Node && root.contains(target);
+    };
+
+    const hasPaths = (event: Event): boolean => {
+      const mimeData = (
+        event as unknown as {
+          mimeData?: { hasData?: (key: string) => boolean };
+        }
+      ).mimeData;
+      return mimeData?.hasData?.(FILE_BROWSER_MIME) === true;
+    };
+
+    const dragEnter = (event: Event) => {
+      if (
+        !NBIAPI.getChatEnabled() ||
+        !hasPaths(event) ||
+        !isInsideSidebar(event)
+      ) {
+        return;
+      }
+      setIsDragOver(true);
+      event.preventDefault();
+      event.stopPropagation();
+    };
+
+    const dragOver = (event: Event) => {
+      if (
+        !NBIAPI.getChatEnabled() ||
+        !hasPaths(event) ||
+        !isInsideSidebar(event)
+      ) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      // Mirror the source's proposedAction. The JL file browser starts
+      // its Drag with supportedActions: 'move'; setting dropAction to a
+      // value outside that set falls through validateAction to 'none'
+      // and Lumino skips lm-drop on pointerup.
+      const drag = event as unknown as {
+        proposedAction?: string;
+        dropAction: string;
+      };
+      drag.dropAction = drag.proposedAction || 'move';
+    };
+
+    const dragLeave = (event: Event) => {
+      if (!NBIAPI.getChatEnabled() || !isInsideSidebar(event)) {
+        return;
+      }
+      // Only clear the overlay when the drag genuinely leaves the
+      // sidebar; ignore leaves that cross internal child boundaries.
+      const related = (event as unknown as { relatedTarget?: Node | null })
+        .relatedTarget;
+      if (related && sidebarRootRef.current?.contains(related)) {
+        return;
+      }
+      setIsDragOver(false);
+    };
+
+    const drop = (event: Event) => {
+      if (
+        !NBIAPI.getChatEnabled() ||
+        !hasPaths(event) ||
+        !isInsideSidebar(event)
+      ) {
+        return;
+      }
+      const dragEvent = event as unknown as {
+        mimeData: { getData: (key: string) => unknown };
+        proposedAction?: string;
+        dropAction: string;
+      };
+      const raw = dragEvent.mimeData.getData(FILE_BROWSER_MIME);
+      if (!Array.isArray(raw) || raw.length === 0) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      dragEvent.dropAction = dragEvent.proposedAction || 'move';
+      setIsDragOver(false);
+      const paths = raw.filter((p): p is string => typeof p === 'string');
+      void attachWorkspacePaths(paths);
+    };
+
+    document.addEventListener('lm-dragenter', dragEnter, true);
+    document.addEventListener('lm-dragover', dragOver, true);
+    document.addEventListener('lm-dragleave', dragLeave, true);
+    document.addEventListener('lm-drop', drop, true);
+    return () => {
+      document.removeEventListener('lm-dragenter', dragEnter, true);
+      document.removeEventListener('lm-dragover', dragOver, true);
+      document.removeEventListener('lm-dragleave', dragLeave, true);
+      document.removeEventListener('lm-drop', drop, true);
+    };
+  }, []);
+
+  // Attach a list of workspace-relative paths (from JL file browser
+  // drag) as chat context. De-dupes against the currently selected set.
+  const attachWorkspacePaths = async (paths: string[]) => {
+    const alreadySelected = new Set(selectedContextFiles.map(f => f.path));
+    const unique = paths.filter(p => !alreadySelected.has(p));
+    if (unique.length === 0) {
+      return;
+    }
+    const contentsManager = props.getApp().serviceManager.contents;
+    const additions: ISelectedContextFile[] = [];
+    const errors: string[] = [];
+    await Promise.all(
+      unique.map(async path => {
+        try {
+          const model: any = await contentsManager.get(path, { content: true });
+          const content = serializeWorkspaceFileContent(model);
+          if (content.trim() === '') {
+            throw new Error(`'${path}' has no content to attach.`);
+          }
+          additions.push({
+            content,
+            lineCount: countContentLines(content),
+            path,
+            type: model.type === 'notebook' ? 'notebook' : 'file'
+          });
+        } catch (error: any) {
+          errors.push(error?.message || `Failed to attach '${path}'.`);
+        }
+      })
+    );
+    if (additions.length > 0) {
+      setSelectedContextFiles(previous =>
+        [...previous, ...additions].sort((lhs, rhs) =>
+          lhs.path.localeCompare(rhs.path)
+        )
+      );
+    }
+    if (errors.length > 0) {
+      addSystemNotice(`Could not attach: ${errors.join('; ')}.`);
+    }
+  };
 
   useEffect(() => {
     const handler = () => {
@@ -3156,6 +3310,7 @@ function SidebarComponent(props: any) {
 
   return (
     <div
+      ref={sidebarRootRef}
       className={`sidebar${isDragOver ? ' drag-over' : ''}`}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -1545,6 +1545,10 @@ function SidebarComponent(props: any) {
 
       if (newContextFiles.length > 0) {
         setSelectedContextFiles(prev => [...prev, ...newContextFiles]);
+        // Same reason as the lm-drop path: the gesture that initiated this
+        // (HTML5 drop, file dialog, image paste) often leaves focus outside
+        // the chat composer, so the next Enter goes somewhere unintended.
+        promptInputRef.current?.focus();
       }
     } finally {
       setIsUploadingFiles(false);

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,10 @@ import * as path from 'path';
 import { createRoot, Root } from 'react-dom/client';
 import { SettingsPanel } from './components/settings-panel';
 import { ITerminalConnection } from '@jupyterlab/services/lib/terminal/terminal';
+import { ITerminalTracker } from '@jupyterlab/terminal';
+import { Token } from '@lumino/coreutils';
 import { NotebookGenerationToolbarExtension } from './notebook-generation-toolbar';
+import { attachTerminalDragDrop } from './terminal-drag';
 
 import { CommandIDs } from './command-ids';
 
@@ -791,7 +794,16 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
     ICommandPalette,
     IMainMenu
   ],
-  optional: [ISettingRegistry, IStatusBar, ILauncher],
+  // @jupyterlab/terminal nests its own @lumino/coreutils copy, so its
+  // Token class is structurally identical but nominally distinct from
+  // ours. Cast through the top-level Token type to keep the plugin
+  // declaration well-typed for the other optionals.
+  optional: [
+    ISettingRegistry,
+    IStatusBar,
+    ILauncher,
+    ITerminalTracker as unknown as Token<unknown>
+  ],
   provides: INotebookIntelligence,
   activate: async (
     app: JupyterFrontEnd,
@@ -803,7 +815,8 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
     mainMenu: IMainMenu,
     settingRegistry: ISettingRegistry | null,
     statusBar: IStatusBar | null,
-    launcher: ILauncher | null
+    launcher: ILauncher | null,
+    terminalTracker: ITerminalTracker | null
   ) => {
     console.log(
       'JupyterLab extension @notebook-intelligence/notebook-intelligence is activated!'
@@ -828,6 +841,29 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
     };
 
     await NBIAPI.initialize();
+
+    if (terminalTracker) {
+      attachTerminalDragDrop({
+        tracker: terminalTracker,
+        // dragover fires at ~60Hz, so we read straight off the
+        // capabilities object (cheap property lookup) instead of going
+        // through the `featurePolicies` getter (which rebuilds an
+        // 11-key object every call). Re-evaluated per event so a future
+        // capabilities reload (policy flipped server-side) takes effect
+        // without tearing down listeners.
+        isEnabled: () => {
+          const policy =
+            NBIAPI.config.capabilities?.feature_policies?.terminal_drag_drop;
+          // Default-enabled when the key is absent: an older backend or
+          // a future capability schema bump shouldn't silently disable
+          // the feature.
+          if (!policy) {
+            return true;
+          }
+          return policy.enabled !== false;
+        }
+      });
+    }
 
     let closeOpenPopover: (() => void) | null = null;
     let mcpConfigEditor: MCPConfigEditor | null = null;

--- a/src/shell-utils.ts
+++ b/src/shell-utils.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+/**
+ * POSIX-shell single-quote escape: every embedded single quote is closed,
+ * emitted as an escaped literal, and the quote re-opened. The result is
+ * safe to splice into a shell command without further sanitization.
+ */
+export function shellSingleQuote(value: string): string {
+  return "'" + value.replace(/'/g, "'\\''") + "'";
+}

--- a/src/terminal-drag-format.ts
+++ b/src/terminal-drag-format.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+// Pure helpers extracted from `terminal-drag.ts` so they can be unit
+// tested without JupyterLab / Lumino imports (which pull DOM globals
+// that jsdom doesn't provide, like DragEvent).
+
+import { shellSingleQuote } from './shell-utils';
+
+export type DragMode = 'mention' | 'raw';
+
+/**
+ * Format a list of paths for injection per mode. @-mention prefixes each
+ * path with "@" (Claude Code syntax, no quoting); raw mode shell-escapes
+ * absolute paths for non-Claude shell sessions. Single-space separator
+ * is intentional; the trailing space is appended by the caller.
+ */
+export function formatForMode(paths: string[], mode: DragMode): string {
+  if (mode === 'mention') {
+    return paths.map(p => `@${p}`).join(' ');
+  }
+  return paths.map(shellSingleQuote).join(' ');
+}
+
+export function invertMode(mode: DragMode, shouldInvert: boolean): DragMode {
+  if (!shouldInvert) {
+    return mode;
+  }
+  return mode === 'mention' ? 'raw' : 'mention';
+}

--- a/src/terminal-drag.ts
+++ b/src/terminal-drag.ts
@@ -15,13 +15,8 @@ export { formatForMode, invertMode } from './terminal-drag-format';
 // unify with our top-level ones. Capturing only what we touch keeps the
 // module decoupled from that version skew and unit-testable without a
 // real JupyterLab application context.
-interface ITerminalSessionLike {
-  send(message: { type: string; content: string[] }): void;
-}
-
 interface ITerminalWidgetLike {
   paste(text: string): void;
-  session: ITerminalSessionLike;
 }
 
 interface IDisposedSignalLike {
@@ -241,29 +236,6 @@ function setupTerminal(
     );
   };
 
-  // xterm.js sends a bare CR for both Enter and Shift+Enter, so Claude
-  // Code's prompt input can't distinguish them and submits on either.
-  // Intercept Shift+Enter at the widget level and write the ESC+CR
-  // "meta-enter" byte sequence to the PTY instead; that's the same
-  // pattern macOS Terminal emits for Option+Enter and that Claude
-  // Code's prompt parses as a newline.
-  const handleKeyDown = (event: KeyboardEvent) => {
-    if (
-      event.key !== 'Enter' ||
-      !event.shiftKey ||
-      event.ctrlKey ||
-      event.metaKey ||
-      event.altKey ||
-      event.isComposing
-    ) {
-      return;
-    }
-    event.preventDefault();
-    event.stopImmediatePropagation();
-    widget.content.session.send({ type: 'stdin', content: ['\x1b\r'] });
-  };
-
-  host.addEventListener('keydown', handleKeyDown, true);
   host.addEventListener('dragenter', handleDragEnter, true);
   host.addEventListener('dragover', handleDragOver, true);
   host.addEventListener('dragleave', handleDragLeave, true);
@@ -284,7 +256,6 @@ function setupTerminal(
   widget.toolbar.addItem('nbi-terminal-drag-mode', button);
 
   state.cleanup = () => {
-    host.removeEventListener('keydown', handleKeyDown, true);
     host.removeEventListener('dragenter', handleDragEnter, true);
     host.removeEventListener('dragover', handleDragOver, true);
     host.removeEventListener('dragleave', handleDragLeave, true);

--- a/src/terminal-drag.ts
+++ b/src/terminal-drag.ts
@@ -15,8 +15,13 @@ export { formatForMode, invertMode } from './terminal-drag-format';
 // unify with our top-level ones. Capturing only what we touch keeps the
 // module decoupled from that version skew and unit-testable without a
 // real JupyterLab application context.
+interface ITerminalSessionLike {
+  send(message: { type: string; content: string[] }): void;
+}
+
 interface ITerminalWidgetLike {
   paste(text: string): void;
+  session: ITerminalSessionLike;
 }
 
 interface IDisposedSignalLike {
@@ -236,6 +241,29 @@ function setupTerminal(
     );
   };
 
+  // xterm.js sends a bare CR for both Enter and Shift+Enter, so Claude
+  // Code's prompt input can't distinguish them and submits on either.
+  // Intercept Shift+Enter at the widget level and write the ESC+CR
+  // "meta-enter" byte sequence to the PTY instead; that's the same
+  // pattern macOS Terminal emits for Option+Enter and that Claude
+  // Code's prompt parses as a newline.
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (
+      event.key !== 'Enter' ||
+      !event.shiftKey ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.altKey ||
+      event.isComposing
+    ) {
+      return;
+    }
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    widget.content.session.send({ type: 'stdin', content: ['\x1b\r'] });
+  };
+
+  host.addEventListener('keydown', handleKeyDown, true);
   host.addEventListener('dragenter', handleDragEnter, true);
   host.addEventListener('dragover', handleDragOver, true);
   host.addEventListener('dragleave', handleDragLeave, true);
@@ -256,6 +284,7 @@ function setupTerminal(
   widget.toolbar.addItem('nbi-terminal-drag-mode', button);
 
   state.cleanup = () => {
+    host.removeEventListener('keydown', handleKeyDown, true);
     host.removeEventListener('dragenter', handleDragEnter, true);
     host.removeEventListener('dragover', handleDragOver, true);
     host.removeEventListener('dragleave', handleDragLeave, true);

--- a/src/terminal-drag.ts
+++ b/src/terminal-drag.ts
@@ -160,27 +160,47 @@ function setupTerminal(
     void uploadAndInject(files, shiftHeld, inject);
   };
 
+  // Lumino dispatches lm-* events on the deepest DOM element under the
+  // cursor. Listening on `host` would in theory catch the bubble, but
+  // intermediate widgets (e.g. xterm's viewport) can call
+  // stopPropagation in a target-phase handler before we see it. Listening
+  // at the document level with a containment check is the most reliable
+  // way to observe a drop that's geometrically inside this terminal.
+  const isInsideHost = (event: Event): boolean => {
+    const target = event.target;
+    return target instanceof Node && host.contains(target);
+  };
+
   const handleLuminoDragEnter = (event: Event) => {
-    if (!isEnabled() || !hasFileBrowserPaths(event)) {
+    if (!isEnabled() || !hasFileBrowserPaths(event) || !isInsideHost(event)) {
       return;
     }
     state.dragDepth += 1;
     host.classList.add(DRAG_OVER_CLASS);
     event.preventDefault();
-    event.stopImmediatePropagation();
+    event.stopPropagation();
   };
 
   const handleLuminoDragOver = (event: Event) => {
-    if (!isEnabled() || !hasFileBrowserPaths(event)) {
+    if (!isEnabled() || !hasFileBrowserPaths(event) || !isInsideHost(event)) {
       return;
     }
     event.preventDefault();
-    event.stopImmediatePropagation();
-    (event as unknown as { dropAction: string }).dropAction = 'copy';
+    event.stopPropagation();
+    // Echo the source's proposedAction back as dropAction. The file
+    // browser starts its Drag with supportedActions: 'move', so a
+    // hardcoded 'copy' falls through validateAction to 'none' and
+    // Lumino skips lm-drop on pointerup. Mirroring proposedAction keeps
+    // us inside whatever the source supports.
+    const dragEvent = event as unknown as {
+      proposedAction?: string;
+      dropAction: string;
+    };
+    dragEvent.dropAction = dragEvent.proposedAction || 'move';
   };
 
   const handleLuminoDragLeave = (event: Event) => {
-    if (!isEnabled()) {
+    if (!isEnabled() || !isInsideHost(event)) {
       return;
     }
     state.dragDepth = Math.max(0, state.dragDepth - 1);
@@ -188,16 +208,17 @@ function setupTerminal(
       host.classList.remove(DRAG_OVER_CLASS);
     }
     event.preventDefault();
-    event.stopImmediatePropagation();
+    event.stopPropagation();
   };
 
   const handleLuminoDrop = (event: Event) => {
-    if (!isEnabled() || !hasFileBrowserPaths(event)) {
+    if (!isEnabled() || !hasFileBrowserPaths(event) || !isInsideHost(event)) {
       return;
     }
     const dragEvent = event as unknown as {
       mimeData: { getData: (key: string) => unknown };
       shiftKey: boolean;
+      proposedAction?: string;
       dropAction: string;
     };
     const paths = dragEvent.mimeData.getData(FILE_BROWSER_MIME);
@@ -205,8 +226,8 @@ function setupTerminal(
       return;
     }
     event.preventDefault();
-    event.stopImmediatePropagation();
-    dragEvent.dropAction = 'copy';
+    event.stopPropagation();
+    dragEvent.dropAction = dragEvent.proposedAction || 'move';
     state.dragDepth = 0;
     host.classList.remove(DRAG_OVER_CLASS);
     inject(
@@ -219,10 +240,14 @@ function setupTerminal(
   host.addEventListener('dragover', handleDragOver, true);
   host.addEventListener('dragleave', handleDragLeave, true);
   host.addEventListener('drop', handleDrop, true);
-  host.addEventListener('lm-dragenter', handleLuminoDragEnter);
-  host.addEventListener('lm-dragover', handleLuminoDragOver);
-  host.addEventListener('lm-dragleave', handleLuminoDragLeave);
-  host.addEventListener('lm-drop', handleLuminoDrop);
+  // lm-* listeners go on the document (capture phase) so we observe
+  // them before any intermediate widget can stopPropagation. The
+  // containment check filters to events whose target is inside this
+  // terminal's host node.
+  document.addEventListener('lm-dragenter', handleLuminoDragEnter, true);
+  document.addEventListener('lm-dragover', handleLuminoDragOver, true);
+  document.addEventListener('lm-dragleave', handleLuminoDragLeave, true);
+  document.addEventListener('lm-drop', handleLuminoDrop, true);
 
   const button = new TerminalDragModeButton('mention', () => {
     state.mode = state.mode === 'mention' ? 'raw' : 'mention';
@@ -235,10 +260,10 @@ function setupTerminal(
     host.removeEventListener('dragover', handleDragOver, true);
     host.removeEventListener('dragleave', handleDragLeave, true);
     host.removeEventListener('drop', handleDrop, true);
-    host.removeEventListener('lm-dragenter', handleLuminoDragEnter);
-    host.removeEventListener('lm-dragover', handleLuminoDragOver);
-    host.removeEventListener('lm-dragleave', handleLuminoDragLeave);
-    host.removeEventListener('lm-drop', handleLuminoDrop);
+    document.removeEventListener('lm-dragenter', handleLuminoDragEnter, true);
+    document.removeEventListener('lm-dragover', handleLuminoDragOver, true);
+    document.removeEventListener('lm-dragleave', handleLuminoDragLeave, true);
+    document.removeEventListener('lm-drop', handleLuminoDrop, true);
   };
 
   widget.disposed.connect(() => {

--- a/src/terminal-drag.ts
+++ b/src/terminal-drag.ts
@@ -17,6 +17,7 @@ export { formatForMode, invertMode } from './terminal-drag-format';
 // real JupyterLab application context.
 interface ITerminalWidgetLike {
   paste(text: string): void;
+  activate?(): void;
 }
 
 interface IDisposedSignalLike {
@@ -32,6 +33,8 @@ interface IMainAreaWidgetLike {
   content: ITerminalWidgetLike;
   toolbar: ITerminalToolbarLike;
   disposed: IDisposedSignalLike;
+  isDisposed?: boolean;
+  activate?(): void;
 }
 
 interface ITerminalTrackerLike {
@@ -100,8 +103,18 @@ function setupTerminal(
     if (paths.length === 0) {
       return;
     }
+    // Async upload paths can finish after the terminal is closed; calling
+    // paste on a disposed Lumino Widget throws.
+    if (widget.isDisposed) {
+      return;
+    }
     const effectiveMode = invertMode(state.mode, shiftHeld);
     widget.content.paste(`${formatForMode(paths, effectiveMode)} `);
+    // Activate the outer MainAreaWidget so the terminal also gets raised
+    // if it's a background tab in a split. Otherwise the next keystroke
+    // goes to the file-browser (Enter would "open the selected file") or
+    // to whichever surface held focus before the drag.
+    widget.activate?.();
   };
 
   const handleDragEnter = (event: DragEvent) => {

--- a/src/terminal-drag.ts
+++ b/src/terminal-drag.ts
@@ -1,0 +1,344 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+import { Notification } from '@jupyterlab/apputils';
+import { Widget } from '@lumino/widgets';
+
+import { NBIAPI } from './api';
+import { DragMode, formatForMode, invertMode } from './terminal-drag-format';
+
+export type { DragMode } from './terminal-drag-format';
+export { formatForMode, invertMode } from './terminal-drag-format';
+
+// Structural types over `IMainAreaWidgetLike` and
+// `ITerminalTracker`: @jupyterlab/terminal nests its own copies of
+// @jupyterlab/apputils and @lumino/widgets, so the nominal types don't
+// unify with our top-level ones. Capturing only what we touch keeps the
+// module decoupled from that version skew and unit-testable without a
+// real JupyterLab application context.
+interface ITerminalWidgetLike {
+  paste(text: string): void;
+}
+
+interface IDisposedSignalLike {
+  connect(slot: () => void): void;
+}
+
+interface ITerminalToolbarLike {
+  addItem(name: string, widget: Widget): boolean;
+}
+
+interface IMainAreaWidgetLike {
+  node: HTMLElement;
+  content: ITerminalWidgetLike;
+  toolbar: ITerminalToolbarLike;
+  disposed: IDisposedSignalLike;
+}
+
+interface ITerminalTrackerLike {
+  widgetAdded: {
+    connect(slot: (sender: unknown, widget: IMainAreaWidgetLike) => void): void;
+  };
+  forEach(fn: (widget: IMainAreaWidgetLike) => void): void;
+}
+
+// File-browser drag dispatches a Lumino lm-drop event carrying paths
+// under this MIME (see node_modules/@jupyterlab/filebrowser/lib/listing.js).
+const FILE_BROWSER_MIME = 'application/x-jupyter-icontents';
+
+const DRAG_OVER_CLASS = 'nbi-terminal-drag-over';
+const TOOLBAR_BUTTON_CLASS = 'nbi-terminal-drag-mode-button';
+
+interface ITerminalDragState {
+  mode: DragMode;
+  dragDepth: number;
+  cleanup: () => void;
+}
+
+const widgetState = new WeakMap<IMainAreaWidgetLike, ITerminalDragState>();
+
+export interface ITerminalDragOptions {
+  // Untyped on the public surface because @jupyterlab/terminal nests its
+  // own copy of every Lumino/JL type; coercing inside keeps callers from
+  // needing to know about the duplication.
+  tracker: unknown;
+  /**
+   * Re-evaluated on each event so flipping the admin policy at runtime
+   * (e.g. force-off via env at next reload) takes effect on listeners
+   * that are already wired without needing to tear them down.
+   */
+  isEnabled: () => boolean;
+}
+
+export function attachTerminalDragDrop(options: ITerminalDragOptions): void {
+  const tracker = options.tracker as ITerminalTrackerLike;
+  const { isEnabled } = options;
+
+  const wire = (widget: IMainAreaWidgetLike) => {
+    if (widgetState.has(widget)) {
+      return;
+    }
+    setupTerminal(widget, isEnabled);
+  };
+
+  tracker.forEach(wire);
+  tracker.widgetAdded.connect((_, widget) => wire(widget));
+}
+
+function setupTerminal(
+  widget: IMainAreaWidgetLike,
+  isEnabled: () => boolean
+): void {
+  const host = widget.node;
+
+  const state: ITerminalDragState = {
+    mode: 'mention',
+    dragDepth: 0,
+    cleanup: () => {}
+  };
+
+  const inject = (paths: string[], shiftHeld: boolean) => {
+    if (paths.length === 0) {
+      return;
+    }
+    const effectiveMode = invertMode(state.mode, shiftHeld);
+    widget.content.paste(`${formatForMode(paths, effectiveMode)} `);
+  };
+
+  const handleDragEnter = (event: DragEvent) => {
+    if (!isEnabled() || !event.dataTransfer) {
+      return;
+    }
+    if (!event.dataTransfer.types.includes('Files')) {
+      return;
+    }
+    state.dragDepth += 1;
+    host.classList.add(DRAG_OVER_CLASS);
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  };
+
+  const handleDragOver = (event: DragEvent) => {
+    if (!isEnabled() || !event.dataTransfer) {
+      return;
+    }
+    if (!event.dataTransfer.types.includes('Files')) {
+      return;
+    }
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    event.dataTransfer.dropEffect = 'copy';
+  };
+
+  const handleDragLeave = (event: DragEvent) => {
+    if (!isEnabled()) {
+      return;
+    }
+    state.dragDepth = Math.max(0, state.dragDepth - 1);
+    if (state.dragDepth === 0) {
+      host.classList.remove(DRAG_OVER_CLASS);
+    }
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  };
+
+  const handleDrop = (event: DragEvent) => {
+    if (!isEnabled()) {
+      return;
+    }
+    state.dragDepth = 0;
+    host.classList.remove(DRAG_OVER_CLASS);
+    if (!event.dataTransfer) {
+      return;
+    }
+    const files = Array.from(event.dataTransfer.files);
+    if (files.length === 0) {
+      return;
+    }
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    const shiftHeld = event.shiftKey;
+    void uploadAndInject(files, shiftHeld, inject);
+  };
+
+  const handleLuminoDragEnter = (event: Event) => {
+    if (!isEnabled() || !hasFileBrowserPaths(event)) {
+      return;
+    }
+    state.dragDepth += 1;
+    host.classList.add(DRAG_OVER_CLASS);
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  };
+
+  const handleLuminoDragOver = (event: Event) => {
+    if (!isEnabled() || !hasFileBrowserPaths(event)) {
+      return;
+    }
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    (event as unknown as { dropAction: string }).dropAction = 'copy';
+  };
+
+  const handleLuminoDragLeave = (event: Event) => {
+    if (!isEnabled()) {
+      return;
+    }
+    state.dragDepth = Math.max(0, state.dragDepth - 1);
+    if (state.dragDepth === 0) {
+      host.classList.remove(DRAG_OVER_CLASS);
+    }
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  };
+
+  const handleLuminoDrop = (event: Event) => {
+    if (!isEnabled() || !hasFileBrowserPaths(event)) {
+      return;
+    }
+    const dragEvent = event as unknown as {
+      mimeData: { getData: (key: string) => unknown };
+      shiftKey: boolean;
+      dropAction: string;
+    };
+    const paths = dragEvent.mimeData.getData(FILE_BROWSER_MIME);
+    if (!Array.isArray(paths) || paths.length === 0) {
+      return;
+    }
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    dragEvent.dropAction = 'copy';
+    state.dragDepth = 0;
+    host.classList.remove(DRAG_OVER_CLASS);
+    inject(
+      paths.filter((p): p is string => typeof p === 'string'),
+      dragEvent.shiftKey
+    );
+  };
+
+  host.addEventListener('dragenter', handleDragEnter, true);
+  host.addEventListener('dragover', handleDragOver, true);
+  host.addEventListener('dragleave', handleDragLeave, true);
+  host.addEventListener('drop', handleDrop, true);
+  host.addEventListener('lm-dragenter', handleLuminoDragEnter);
+  host.addEventListener('lm-dragover', handleLuminoDragOver);
+  host.addEventListener('lm-dragleave', handleLuminoDragLeave);
+  host.addEventListener('lm-drop', handleLuminoDrop);
+
+  const button = new TerminalDragModeButton('mention', () => {
+    state.mode = state.mode === 'mention' ? 'raw' : 'mention';
+    button.setMode(state.mode);
+  });
+  widget.toolbar.addItem('nbi-terminal-drag-mode', button);
+
+  state.cleanup = () => {
+    host.removeEventListener('dragenter', handleDragEnter, true);
+    host.removeEventListener('dragover', handleDragOver, true);
+    host.removeEventListener('dragleave', handleDragLeave, true);
+    host.removeEventListener('drop', handleDrop, true);
+    host.removeEventListener('lm-dragenter', handleLuminoDragEnter);
+    host.removeEventListener('lm-dragover', handleLuminoDragOver);
+    host.removeEventListener('lm-dragleave', handleLuminoDragLeave);
+    host.removeEventListener('lm-drop', handleLuminoDrop);
+  };
+
+  widget.disposed.connect(() => {
+    state.cleanup();
+    widgetState.delete(widget);
+  });
+
+  widgetState.set(widget, state);
+}
+
+function hasFileBrowserPaths(event: Event): boolean {
+  const mimeData = (
+    event as unknown as { mimeData?: { hasData?: (key: string) => boolean } }
+  ).mimeData;
+  return mimeData?.hasData?.(FILE_BROWSER_MIME) === true;
+}
+
+async function uploadAndInject(
+  files: File[],
+  shiftHeld: boolean,
+  inject: (paths: string[], shiftHeld: boolean) => void
+): Promise<void> {
+  const results = await Promise.allSettled(
+    files.map(f => NBIAPI.uploadFile(f))
+  );
+  const paths: string[] = [];
+  const failures: { name: string; reason: string }[] = [];
+  results.forEach((result, index) => {
+    const file = files[index];
+    if (result.status === 'fulfilled') {
+      paths.push(result.value.serverPath);
+      return;
+    }
+    failures.push({
+      name: file.name,
+      reason: describeUploadError(result.reason)
+    });
+  });
+  if (failures.length > 0) {
+    // Inline in the toast so the user sees both what failed and why
+    // (e.g. 413 from the size cap). Truncated to 3 entries; rest collapsed
+    // into a "+ N more" footer to fit JL's 140-char notification limit.
+    const head = failures
+      .slice(0, 3)
+      .map(f => `${f.name}: ${f.reason}`)
+      .join('; ');
+    const tail = failures.length > 3 ? ` (+${failures.length - 3} more)` : '';
+    Notification.error(`Terminal drop upload failed for ${head}${tail}`);
+  }
+  inject(paths, shiftHeld);
+}
+
+function describeUploadError(reason: unknown): string {
+  if (reason && typeof reason === 'object') {
+    const r = reason as { message?: unknown; response?: { status?: number } };
+    if (typeof r.message === 'string' && r.message.trim().length > 0) {
+      return r.message;
+    }
+    if (r.response && typeof r.response.status === 'number') {
+      return `HTTP ${r.response.status}`;
+    }
+  }
+  return String(reason);
+}
+
+class TerminalDragModeButton extends Widget {
+  private _button: HTMLButtonElement;
+  private _onToggle: () => void;
+
+  constructor(initialMode: DragMode, onToggle: () => void) {
+    super();
+    this.addClass('jp-Toolbar-item');
+    this.addClass(TOOLBAR_BUTTON_CLASS);
+    this._onToggle = onToggle;
+
+    this._button = document.createElement('button');
+    this._button.type = 'button';
+    this._button.classList.add('jp-ToolbarButtonComponent');
+    this._button.classList.add(`${TOOLBAR_BUTTON_CLASS}-toggle`);
+    this._button.addEventListener('click', () => this._onToggle());
+    this.node.appendChild(this._button);
+
+    this.setMode(initialMode);
+  }
+
+  setMode(mode: DragMode): void {
+    const isMention = mode === 'mention';
+    this._button.textContent = isMention ? '@' : '/';
+    this._button.setAttribute('aria-pressed', isMention ? 'false' : 'true');
+    // aria-label carries the full mode + Shift-modifier explanation;
+    // title is a short hover-tip so screen readers don't double-announce
+    // the same string from both attributes.
+    this._button.setAttribute(
+      'aria-label',
+      isMention
+        ? 'Terminal drop inserts @-mention paths. Click to switch to raw path mode. Hold Shift while dropping to invert for one drop.'
+        : 'Terminal drop inserts raw, shell-escaped absolute paths. Click to switch to @-mention mode. Hold Shift while dropping to invert for one drop.'
+    );
+    this._button.title = isMention
+      ? 'Drop mode: @-mention'
+      : 'Drop mode: raw path';
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,8 @@ import { CodeEditor } from '@jupyterlab/codeeditor';
 import { encoding_for_model } from 'tiktoken';
 import { NotebookPanel } from '@jupyterlab/notebook';
 
+import { shellSingleQuote } from './shell-utils';
+
 const tiktoken_encoding = encoding_for_model('gpt-4o');
 
 export function removeAnsiChars(str: string): string {
@@ -294,14 +296,7 @@ export function applyCodeToSelectionInEditor(
   });
 }
 
-/**
- * POSIX-shell single-quote escape: every embedded single quote is closed,
- * emitted as an escaped literal, and the quote re-opened. The result is
- * safe to splice into a shell command without further sanitization.
- */
-export function shellSingleQuote(value: string): string {
-  return "'" + value.replace(/'/g, "'\\''") + "'";
-}
+export { shellSingleQuote };
 
 /**
  * Build a `claude --resume <id>` command wrapped in `cd <cwd>` so the

--- a/style/base.css
+++ b/style/base.css
@@ -2580,6 +2580,53 @@ svg.access-token-warning {
   white-space: nowrap;
 }
 
+.nbi-terminal-drag-mode-button {
+  display: inline-flex;
+  align-items: center;
+}
+
+.nbi-terminal-drag-mode-button-toggle {
+  min-width: 24px;
+  height: 24px;
+  padding: 0 6px;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  background: transparent;
+  color: var(--jp-ui-font-color1);
+  font-family: var(--jp-ui-font-family);
+  font-size: var(--jp-ui-font-size1);
+  cursor: pointer;
+}
+
+.nbi-terminal-drag-mode-button-toggle:hover {
+  background-color: var(--jp-layout-color2);
+}
+
+.nbi-terminal-drag-mode-button-toggle:focus-visible {
+  outline: 2px solid var(--jp-brand-color1);
+  outline-offset: 1px;
+}
+
+.nbi-terminal-drag-mode-button-toggle[aria-pressed='true'] {
+  border-color: var(--jp-brand-color1);
+  color: var(--jp-brand-color1);
+}
+
+.nbi-terminal-drag-over {
+  position: relative;
+}
+
+.nbi-terminal-drag-over::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border: 2px dashed var(--jp-brand-color1);
+  border-radius: 4px;
+  background-color: color-mix(in srgb, var(--jp-brand-color1) 12%, transparent);
+  z-index: 100;
+}
+
 /* Coding Agent launcher tile: Anthropic orange icon.
    Placed last to satisfy no-descending-specificity lint rule. */
 .jp-LauncherCard[data-category='Coding Agent'] .jp-LauncherCard-icon svg,

--- a/tests/test_file_upload.py
+++ b/tests/test_file_upload.py
@@ -3,17 +3,24 @@
 Covers:
 - Temp directory creation and cleanup
 - FileUploadHandler: successful uploads, missing file, path traversal protection
+- Size cap enforcement (413 on exceed)
+- Retention sweep of stale upload subdirs
 """
 
 import json
 import os
 import shutil
+import time
 from unittest.mock import MagicMock
 
 import pytest
 
 import notebook_intelligence.extension as ext
-from notebook_intelligence.extension import FileUploadHandler, _get_upload_dir
+from notebook_intelligence.extension import (
+    FileUploadHandler,
+    _get_upload_dir,
+    _sweep_upload_dir,
+)
 
 
 @pytest.fixture
@@ -43,6 +50,12 @@ def _make_handler(files=None):
     handler.request.files = files or {}
     handler.set_status = MagicMock()
     handler.finish = MagicMock()
+    # MagicMock(spec=...) does not expose the spec's class attributes; copy
+    # them onto the instance so post() can read its tunables. Tests that
+    # mutate the class attr expect the next call to _make_handler to
+    # observe the new value.
+    handler.upload_max_mb = FileUploadHandler.upload_max_mb
+    handler.upload_retention_hours = FileUploadHandler.upload_retention_hours
     return handler
 
 
@@ -141,3 +154,148 @@ class TestFileUploadHandler:
         assert len(set(paths)) == 3
         for p in paths:
             assert os.path.isfile(p)
+
+
+# ---------------------------------------------------------------------------
+# Size cap
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def upload_max_mb():
+    """Restore the class-level cap after a test mutates it."""
+    original = FileUploadHandler.upload_max_mb
+    yield
+    FileUploadHandler.upload_max_mb = original
+
+
+class TestUploadSizeCap:
+    def test_rejects_oversize_with_413(self, upload_dir, upload_max_mb):
+        FileUploadHandler.upload_max_mb = 1
+        # 1 MB + 1 byte; trips the 1 MB cap.
+        oversize = b"x" * (1 * 1024 * 1024 + 1)
+        handler = _make_handler(files={
+            "file": [{"filename": "big.bin", "body": oversize}]
+        })
+
+        FileUploadHandler.post(handler)
+
+        handler.set_status.assert_called_once_with(413)
+        response = _parse_response(handler)
+        assert "1 MB" in response["error"]
+
+    def test_accepts_when_under_cap(self, upload_dir, upload_max_mb):
+        FileUploadHandler.upload_max_mb = 1
+        body = b"x" * 1024
+        handler = _make_handler(files={
+            "file": [{"filename": "small.bin", "body": body}]
+        })
+
+        FileUploadHandler.post(handler)
+
+        handler.set_status.assert_not_called()
+        assert _parse_response(handler)["filename"] == "small.bin"
+
+    def test_cap_zero_disables_check(self, upload_dir, upload_max_mb):
+        FileUploadHandler.upload_max_mb = 0
+        # Would trip a 1 MB cap; with 0 (disabled) it should succeed.
+        body = b"x" * (5 * 1024 * 1024)
+        handler = _make_handler(files={
+            "file": [{"filename": "big.bin", "body": body}]
+        })
+
+        FileUploadHandler.post(handler)
+
+        handler.set_status.assert_not_called()
+        assert os.path.getsize(_parse_response(handler)["serverPath"]) == len(body)
+
+
+# ---------------------------------------------------------------------------
+# Retention sweep
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def reset_sweep_throttle():
+    """Drop the rate-limit timestamp so each test can trigger a fresh sweep."""
+    ext._last_sweep_at = 0.0
+    yield
+    ext._last_sweep_at = 0.0
+
+
+class TestSweepUploadDir:
+    def test_zero_retention_skips_sweep(self, upload_dir):
+        stale = os.path.join(upload_dir, "stale-bundle")
+        os.makedirs(stale)
+        # Mark as ancient: 100 hours old.
+        old_mtime = time.time() - 100 * 3600
+        os.utime(stale, (old_mtime, old_mtime))
+
+        _sweep_upload_dir(retention_hours=0)
+
+        assert os.path.isdir(stale)
+
+    def test_removes_stale_subdir_preserves_fresh(self, upload_dir):
+        stale = os.path.join(upload_dir, "stale-bundle")
+        fresh = os.path.join(upload_dir, "fresh-bundle")
+        os.makedirs(stale)
+        os.makedirs(fresh)
+        old_mtime = time.time() - 48 * 3600  # 48h ago
+        os.utime(stale, (old_mtime, old_mtime))
+
+        _sweep_upload_dir(retention_hours=24)
+
+        assert not os.path.exists(stale)
+        assert os.path.isdir(fresh)
+
+    def test_handles_missing_root(self, tmp_path):
+        # Point _upload_dir at a path that doesn't exist; sweep must not raise.
+        original = ext._upload_dir
+        ext._upload_dir = str(tmp_path / "nonexistent")
+        try:
+            _sweep_upload_dir(retention_hours=1)  # no-op, no exception
+        finally:
+            ext._upload_dir = original
+
+    def test_ignores_non_directories(self, upload_dir):
+        rogue = os.path.join(upload_dir, "rogue.txt")
+        with open(rogue, "wb") as fh:
+            fh.write(b"data")
+        old_mtime = time.time() - 100 * 3600
+        os.utime(rogue, (old_mtime, old_mtime))
+
+        _sweep_upload_dir(retention_hours=1)
+
+        assert os.path.isfile(rogue)
+
+    def test_sweep_runs_after_successful_upload(self, upload_dir):
+        stale = os.path.join(upload_dir, "stale-bundle")
+        os.makedirs(stale)
+        old_mtime = time.time() - 100 * 3600
+        os.utime(stale, (old_mtime, old_mtime))
+
+        original = FileUploadHandler.upload_retention_hours
+        FileUploadHandler.upload_retention_hours = 24
+        try:
+            handler = _make_handler(files={
+                "file": [{"filename": "new.txt", "body": b"data"}]
+            })
+            FileUploadHandler.post(handler)
+        finally:
+            FileUploadHandler.upload_retention_hours = original
+
+        # The successful upload's own subdir survives; the stale one is gone.
+        assert not os.path.exists(stale)
+        new_path = _parse_response(handler)["serverPath"]
+        assert os.path.isfile(new_path)
+
+    def test_rate_limit_skips_recent_sweep(self, upload_dir):
+        # A sweep within the throttle window must not re-walk the dir.
+        ext._last_sweep_at = time.time()  # Just swept; cooldown active.
+        stale = os.path.join(upload_dir, "stale-bundle")
+        os.makedirs(stale)
+        old_mtime = time.time() - 100 * 3600
+        os.utime(stale, (old_mtime, old_mtime))
+
+        _sweep_upload_dir(retention_hours=24)
+
+        # Throttle suppressed the second sweep; stale subdir is still present.
+        assert os.path.isdir(stale)

--- a/tests/test_image_context.py
+++ b/tests/test_image_context.py
@@ -242,3 +242,98 @@ class TestImageContextInChatHistory:
         image_msg = history[0]
         assert isinstance(image_msg["content"], str)
         assert str(missing) in image_msg["content"]
+
+    def test_workspace_image_drag_reaches_vision_provider(
+        self, _thread, mock_nbi, mock_ai, tmp_path
+    ):
+        # File-browser drag of an image sets isImage=true and isUpload=false
+        # (no temp staging); the backend should still send the multimodal
+        # vision payload so OpenAI-vision providers see the image bytes.
+        mock_nbi.root_dir = str(tmp_path)
+        mock_ai.chat_model = None
+        mock_ai.is_claude_code_mode = False
+
+        image_bytes = b"\x89PNG\r\n\x1a\n" + b"\xfe\xed\xfa\xce" * 8
+        img_file = tmp_path / "diagram.png"
+        img_file.write_bytes(image_bytes)
+
+        ctx = _image_context(img_file)
+        ctx["isUpload"] = False
+        ctx["filePath"] = "diagram.png"  # workspace-relative, as the
+                                         # frontend file-browser handler sends.
+
+        handler = _make_handler()
+        history = _on_message(handler, [ctx])
+
+        image_msg = history[0]
+        assert isinstance(image_msg["content"], list)
+        assert image_msg["content"][1]["type"] == "image_url"
+        b64 = image_msg["content"][1]["image_url"]["url"].split(",", 1)[1]
+        assert base64.b64decode(b64) == image_bytes
+
+    def test_path_traversal_outside_workspace_is_rejected(
+        self, _thread, mock_nbi, mock_ai, tmp_path, caplog
+    ):
+        # A workspace-relative path that escapes via ``..`` must not read
+        # from outside root_dir. Create a sentinel file outside the
+        # workspace and try to attach it.
+        outside = tmp_path.parent / "secret.txt"
+        outside.write_bytes(b"do-not-read")
+
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        mock_nbi.root_dir = str(workspace)
+        mock_ai.chat_model = None
+        mock_ai.is_claude_code_mode = False
+
+        ctx = {
+            "isUpload": False,
+            "isImage": False,
+            "filePath": "../secret.txt",
+            "content": "do-not-read",  # client-provided body is ignored
+                                       # once the path check rejects.
+            "currentCellContents": None,
+            "startLine": 1,
+            "endLine": 1,
+        }
+
+        handler = _make_handler()
+        with caplog.at_level(logging.WARNING):
+            history = _on_message(handler, [ctx])
+
+        # Only the user prompt remains; the traversal context was dropped.
+        assert len(history) == 1
+        assert history[0]["role"] == "user"
+        assert "Rejecting out-of-workspace context path" in caplog.text
+
+    def test_absolute_path_outside_workspace_is_rejected(
+        self, _thread, mock_nbi, mock_ai, tmp_path, caplog
+    ):
+        # path.join silently returns the absolute path when the second
+        # arg is absolute, so a malformed payload could pass an absolute
+        # ``/etc/passwd`` without escaping ``root_dir``. Sandbox catches it.
+        outside = tmp_path.parent / "absolute-secret.txt"
+        outside.write_bytes(b"do-not-read")
+
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        mock_nbi.root_dir = str(workspace)
+        mock_ai.chat_model = None
+        mock_ai.is_claude_code_mode = False
+
+        ctx = {
+            "isUpload": False,
+            "isImage": False,
+            "filePath": str(outside),
+            "content": "do-not-read",
+            "currentCellContents": None,
+            "startLine": 1,
+            "endLine": 1,
+        }
+
+        handler = _make_handler()
+        with caplog.at_level(logging.WARNING):
+            history = _on_message(handler, [ctx])
+
+        assert len(history) == 1
+        assert "Rejecting out-of-workspace context path" in caplog.text

--- a/tests/test_skill_github_import.py
+++ b/tests/test_skill_github_import.py
@@ -457,7 +457,7 @@ class TestArchiveSizeCap:
             # passes the check.
             payload = b"x" * 1024
             with patch(
-                "notebook_intelligence.skill_github_import._get_github_token",
+                "notebook_intelligence.skill_github_import.resolve_github_token",
                 return_value=None,
             ):
                 with patch(
@@ -477,7 +477,7 @@ class TestArchiveSizeCap:
         try:
             oversize = b"x" * (1024 + 100)
             with patch(
-                "notebook_intelligence.skill_github_import._get_github_token",
+                "notebook_intelligence.skill_github_import.resolve_github_token",
                 return_value=None,
             ):
                 with patch(
@@ -497,7 +497,7 @@ class TestArchiveSizeCap:
         try:
             oversize = b"x" * (3 * 1024 * 1024)
             with patch(
-                "notebook_intelligence.skill_github_import._get_github_token",
+                "notebook_intelligence.skill_github_import.resolve_github_token",
                 return_value=None,
             ):
                 with patch(

--- a/tests/ts/__mocks__/jupyterlab-apputils.ts
+++ b/tests/ts/__mocks__/jupyterlab-apputils.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+// Stub for @jupyterlab/apputils. The real package is ESM and pulls in
+// @jupyterlab/ui-components, which jest's CommonJS pipeline can't load.
+// terminal-drag.ts only touches Notification; mock just that surface.
+
+export const Notification = {
+  error: jest.fn(),
+  warning: jest.fn(),
+  info: jest.fn(),
+  success: jest.fn()
+};

--- a/tests/ts/setup.ts
+++ b/tests/ts/setup.ts
@@ -11,3 +11,13 @@ if (typeof globalThis.TextDecoder === 'undefined') {
 if (typeof globalThis.TextEncoder === 'undefined') {
   globalThis.TextEncoder = TextEncoder as typeof globalThis.TextEncoder;
 }
+
+// jsdom doesn't expose DragEvent; @lumino/dragdrop references it at module
+// load. A subclass of MouseEvent keeps the `instanceof` chain one-way: a
+// real DragEvent is also a MouseEvent, but a plain MouseEvent isn't a
+// DragEvent, so tests that use `event instanceof DragEvent` to discriminate
+// drag from click still get the right answer.
+if (typeof (globalThis as { DragEvent?: unknown }).DragEvent === 'undefined') {
+  class DragEventShim extends MouseEvent {}
+  (globalThis as { DragEvent: unknown }).DragEvent = DragEventShim;
+}

--- a/tests/ts/terminal-drag.test.ts
+++ b/tests/ts/terminal-drag.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
 
+import { attachTerminalDragDrop } from '../../src/terminal-drag';
 import { formatForMode, invertMode } from '../../src/terminal-drag-format';
 
 describe('formatForMode', () => {
@@ -41,5 +42,142 @@ describe('invertMode', () => {
   it('flips mention to raw and back when shouldInvert is true', () => {
     expect(invertMode('mention', true)).toBe('raw');
     expect(invertMode('raw', true)).toBe('mention');
+  });
+});
+
+describe('attachTerminalDragDrop lm-drop handler', () => {
+  type ConnectSlot = (sender: unknown, widget: unknown) => void;
+  type DisposedSlot = () => void;
+
+  interface ITestWidgetEnv {
+    mock: any;
+    host: HTMLElement;
+    paste: jest.Mock;
+    activate: jest.Mock;
+    fireDisposed: () => void;
+  }
+
+  function setupTracker(): {
+    tracker: any;
+    fireWidgetAdded: (widget: unknown) => void;
+  } {
+    let widgetAddedSlot: ConnectSlot | null = null;
+    const tracker = {
+      widgetAdded: {
+        connect: (slot: ConnectSlot) => {
+          widgetAddedSlot = slot;
+        }
+      },
+      forEach: (_fn: (widget: unknown) => void) => undefined
+    };
+    return {
+      tracker,
+      fireWidgetAdded: (widget: unknown) => {
+        if (!widgetAddedSlot) {
+          throw new Error('widgetAdded was never wired');
+        }
+        widgetAddedSlot(null, widget);
+      }
+    };
+  }
+
+  function buildWidget(): ITestWidgetEnv {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const paste = jest.fn();
+    const activate = jest.fn();
+    let isDisposed = false;
+    const disposedSlots: DisposedSlot[] = [];
+    const mock = {
+      node: host,
+      content: { paste },
+      toolbar: { addItem: jest.fn().mockReturnValue(true) },
+      disposed: {
+        connect: (slot: DisposedSlot) => {
+          disposedSlots.push(slot);
+        }
+      },
+      activate,
+      get isDisposed() {
+        return isDisposed;
+      }
+    };
+    return {
+      mock,
+      host,
+      paste,
+      activate,
+      fireDisposed: () => {
+        isDisposed = true;
+        disposedSlots.forEach(slot => slot());
+      }
+    };
+  }
+
+  function dispatchLmDrop(target: EventTarget, paths: string[]): void {
+    const event: any = new Event('lm-drop', {
+      bubbles: true,
+      cancelable: true
+    });
+    event.mimeData = {
+      hasData: (key: string) => key === 'application/x-jupyter-icontents',
+      getData: (key: string) =>
+        key === 'application/x-jupyter-icontents' ? paths : null
+    };
+    event.proposedAction = 'move';
+    event.dropAction = 'none';
+    event.shiftKey = false;
+    target.dispatchEvent(event);
+  }
+
+  // Each test must dispose its widget so the document-level lm-* listeners
+  // attached by setupTerminal don't leak across tests in this file.
+  const envs: ITestWidgetEnv[] = [];
+  afterEach(() => {
+    envs.splice(0).forEach(env => {
+      env.fireDisposed();
+      if (env.host.parentNode) {
+        env.host.parentNode.removeChild(env.host);
+      }
+    });
+  });
+
+  function newEnv(): ITestWidgetEnv {
+    const env = buildWidget();
+    envs.push(env);
+    return env;
+  }
+
+  it('activates the widget after pasting so the next Enter goes to xterm, not the file-browser', () => {
+    const env = newEnv();
+    const { tracker, fireWidgetAdded } = setupTracker();
+    attachTerminalDragDrop({ tracker, isEnabled: () => true });
+    fireWidgetAdded(env.mock);
+
+    dispatchLmDrop(env.host, ['/tmp/file.txt']);
+
+    expect(env.paste).toHaveBeenCalledTimes(1);
+    expect(env.paste).toHaveBeenCalledWith('@/tmp/file.txt ');
+    expect(env.activate).toHaveBeenCalledTimes(1);
+    // Activate must run after paste so the terminal owns focus before the
+    // user presses Enter; otherwise the file-browser's "open selected item"
+    // handler eats the first keypress.
+    expect(env.activate.mock.invocationCallOrder[0]).toBeGreaterThan(
+      env.paste.mock.invocationCallOrder[0]
+    );
+  });
+
+  it('handles drops on a descendant of the terminal host, not just the host itself', () => {
+    const env = newEnv();
+    const inner = document.createElement('div');
+    env.host.appendChild(inner);
+    const { tracker, fireWidgetAdded } = setupTracker();
+    attachTerminalDragDrop({ tracker, isEnabled: () => true });
+    fireWidgetAdded(env.mock);
+
+    dispatchLmDrop(inner, ['/tmp/nested.txt']);
+
+    expect(env.paste).toHaveBeenCalledWith('@/tmp/nested.txt ');
+    expect(env.activate).toHaveBeenCalled();
   });
 });

--- a/tests/ts/terminal-drag.test.ts
+++ b/tests/ts/terminal-drag.test.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+import { formatForMode, invertMode } from '../../src/terminal-drag-format';
+
+describe('formatForMode', () => {
+  it('prefixes each path with @ in mention mode', () => {
+    expect(formatForMode(['/tmp/a.txt', '/tmp/b.txt'], 'mention')).toBe(
+      '@/tmp/a.txt @/tmp/b.txt'
+    );
+  });
+
+  it('shell-escapes each path in raw mode', () => {
+    expect(formatForMode(['/tmp/a.txt', '/tmp/with space.txt'], 'raw')).toBe(
+      "'/tmp/a.txt' '/tmp/with space.txt'"
+    );
+  });
+
+  it('returns empty string for empty input in either mode', () => {
+    expect(formatForMode([], 'mention')).toBe('');
+    expect(formatForMode([], 'raw')).toBe('');
+  });
+
+  it('handles a single path in mention mode', () => {
+    expect(formatForMode(['/tmp/only.txt'], 'mention')).toBe('@/tmp/only.txt');
+  });
+
+  it('does not quote the @-prefix in mention mode', () => {
+    // Intentional: Claude Code parses bare @<path> tokens, so wrapping them
+    // in shell quotes would break the parse. Mention mode trusts the path
+    // not to contain shell metacharacters; raw mode is the path that quotes.
+    expect(formatForMode(['/tmp/a b.txt'], 'mention')).toBe('@/tmp/a b.txt');
+  });
+});
+
+describe('invertMode', () => {
+  it('returns the original mode when shouldInvert is false', () => {
+    expect(invertMode('mention', false)).toBe('mention');
+    expect(invertMode('raw', false)).toBe('raw');
+  });
+
+  it('flips mention to raw and back when shouldInvert is true', () => {
+    expect(invertMode('mention', true)).toBe('raw');
+    expect(invertMode('raw', true)).toBe('mention');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1395,7 +1395,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/apputils@npm:^4.3.7":
+"@jupyterlab/apputils@npm:^4.3.7, @jupyterlab/apputils@npm:^4.6.7":
   version: 4.6.7
   resolution: "@jupyterlab/apputils@npm:4.6.7"
   dependencies:
@@ -2533,6 +2533,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/terminal@npm:^4.0.0":
+  version: 4.5.7
+  resolution: "@jupyterlab/terminal@npm:4.5.7"
+  dependencies:
+    "@jupyterlab/apputils": ^4.6.7
+    "@jupyterlab/services": ^7.5.7
+    "@jupyterlab/translation": ^4.5.7
+    "@lumino/coreutils": ^2.2.2
+    "@lumino/domutils": ^2.0.4
+    "@lumino/messaging": ^2.0.4
+    "@lumino/signaling": ^2.1.5
+    "@lumino/widgets": ^2.7.5
+    "@xterm/addon-canvas": ~0.7.0
+    "@xterm/addon-fit": ~0.10.0
+    "@xterm/addon-search": ~0.15.0
+    "@xterm/addon-web-links": ~0.11.0
+    "@xterm/addon-webgl": ~0.18.0
+    "@xterm/xterm": ~5.5.0
+    color: ^5.0.0
+  checksum: 8255dc9c63952a8e206c75ce6ea6f6a5e7d21b07249618de0388ebfc08692105ab5c328a1ca7a078ad4bd4ab50fb4ba3b614a97a81abf9b3210727be08e00924
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/toc@npm:^6.2.5":
   version: 6.2.5
   resolution: "@jupyterlab/toc@npm:6.2.5"
@@ -3307,6 +3330,7 @@ __metadata:
     "@jupyterlab/notebook": ^4.0.0
     "@jupyterlab/services": ^7.0.0
     "@jupyterlab/settingregistry": ^4.0.0
+    "@jupyterlab/terminal": ^4.0.0
     "@testing-library/jest-dom": ^6.4.0
     "@testing-library/react": ^14.2.0
     "@types/jest": ^29.5.12
@@ -4106,6 +4130,58 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xterm/addon-canvas@npm:~0.7.0":
+  version: 0.7.0
+  resolution: "@xterm/addon-canvas@npm:0.7.0"
+  peerDependencies:
+    "@xterm/xterm": ^5.0.0
+  checksum: 28b9965f34e01a9bbcc31651dee2d4a9380aad528039484cce372b856be820705b293c4b5091cee65208c3dfbf6f944f27ecc6c3b794df5a96036cbf6dba0d74
+  languageName: node
+  linkType: hard
+
+"@xterm/addon-fit@npm:~0.10.0":
+  version: 0.10.0
+  resolution: "@xterm/addon-fit@npm:0.10.0"
+  peerDependencies:
+    "@xterm/xterm": ^5.0.0
+  checksum: 8edfad561c0d0316c5883cbe2ce56109f105a2b2bf53b71d5f8c788e656a3205c1093a659dddcf4025a459e4b7ff8e07b6c6a19815c8711deeded560de5f1893
+  languageName: node
+  linkType: hard
+
+"@xterm/addon-search@npm:~0.15.0":
+  version: 0.15.0
+  resolution: "@xterm/addon-search@npm:0.15.0"
+  peerDependencies:
+    "@xterm/xterm": ^5.0.0
+  checksum: d4f77e3637f915e86c9208da70f615f5e6150810943931a4bba8a3422d5c2b791b84d2136de65603dbc4437328f4c584c8faa1f53e71524dd667bee631ca3f1e
+  languageName: node
+  linkType: hard
+
+"@xterm/addon-web-links@npm:~0.11.0":
+  version: 0.11.0
+  resolution: "@xterm/addon-web-links@npm:0.11.0"
+  peerDependencies:
+    "@xterm/xterm": ^5.0.0
+  checksum: c1b36b649b8cddc613213eb9e835daf3106a8be359a19ccacca1f1d9ff883b59d478f166109ee017fa3994d224dcdd82976ad5d5a1221271ab8d3d5684eb141d
+  languageName: node
+  linkType: hard
+
+"@xterm/addon-webgl@npm:~0.18.0":
+  version: 0.18.0
+  resolution: "@xterm/addon-webgl@npm:0.18.0"
+  peerDependencies:
+    "@xterm/xterm": ^5.0.0
+  checksum: 942ecaa4e08423563a795a1a63fa79637e60d4e3aba1b5fa2f426e1d7b19c553e8c8f1cfad1258461f22e05362e791f642dc6aab7e8766e26d4d3876617d8320
+  languageName: node
+  linkType: hard
+
+"@xterm/xterm@npm:~5.5.0":
+  version: 5.5.0
+  resolution: "@xterm/xterm@npm:5.5.0"
+  checksum: 393c1891b95fdd50d05e7a063abdc95a6643d2c45a4231637c23db90511426a95b1b56a5c4c91831121d2710aee9de97cf5e426016c589ca87dea8fff9a41b33
+  languageName: node
+  linkType: hard
+
 "@xtuc/ieee754@npm:^1.2.0":
   version: 1.2.0
   resolution: "@xtuc/ieee754@npm:1.2.0"
@@ -4886,6 +4962,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"color-convert@npm:^3.1.3":
+  version: 3.1.3
+  resolution: "color-convert@npm:3.1.3"
+  dependencies:
+    color-name: ^2.0.0
+  checksum: 5133952b53c76dfb0f1d9d19b21efa1394cc9a9e0ae8556c6ac366bfe8dd806ddd88448eb23a2dc6f671c85b29290ab547052c6e1c9cb165e14c38a933d327f3
+  languageName: node
+  linkType: hard
+
 "color-name@npm:1.1.3":
   version: 1.1.3
   resolution: "color-name@npm:1.1.3"
@@ -4893,10 +4978,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"color-name@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "color-name@npm:2.1.0"
+  checksum: eb014f71d87408e318e95d3f554f188370d354ba8e0ffa4341d0fd19de391bfe2bc96e563d4f6614644d676bc24f475560dffee3fe310c2d6865d007410a9a2b
+  languageName: node
+  linkType: hard
+
 "color-name@npm:~1.1.4":
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: b0445859521eb4021cd0fb0cc1a75cecf67fceecae89b63f62b201cca8d345baf8b952c966862a9d9a2632987d4f6581f0ec8d957dfacece86f0a7919316f610
+  languageName: node
+  linkType: hard
+
+"color-string@npm:^2.1.3":
+  version: 2.1.4
+  resolution: "color-string@npm:2.1.4"
+  dependencies:
+    color-name: ^2.0.0
+  checksum: f9caa29d529c549febeec813fcc0ecb184ff3dee92cec78f1fd3dfe2c4168fc1b74442efc40e34d2d677470967f570234d11086c3b137d6f9958a8fe12587fde
+  languageName: node
+  linkType: hard
+
+"color@npm:^5.0.0":
+  version: 5.0.3
+  resolution: "color@npm:5.0.3"
+  dependencies:
+    color-convert: ^3.1.3
+    color-string: ^2.1.3
+  checksum: 2ad337a520f8d702febc45912d7a27417268ea4c56bdbf8121cdb8dad7309e418a7c78f164d7cb59b68bd9e703b5a3bc046cff80051c30e7561f7e726ca207ac
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Drag a file from your desktop onto a JupyterLab terminal, and the terminal injects `@<path>` (Claude Code's `@`-mention syntax) at the cursor. The browser's security model doesn't expose OS paths to web pages, so the browser uploads the dropped file to a server-side staging directory first; the server returns the absolute path, and the terminal pastes that. Drags from the JupyterLab file browser work too (no upload, the path is already known).

## Solution

The chat sidebar already implements file-drop attachment with the exact server plumbing this feature needs: `NBIAPI.uploadFile(file)` POSTs `multipart/form-data` to `FileUploadHandler`, which writes the file to a per-upload tempdir and returns `{ serverPath, filename }`. This PR adds a small `src/terminal-drag.ts` module that subscribes to `ITerminalTracker.widgetAdded`, attaches capture-phase `dragover`/`drop` (and Lumino `lm-drop`) handlers on each terminal, and injects via `terminal.content.paste(...)` so the PTY treats the text the same as a real paste (preserving bracketed-paste framing that Claude Code relies on for multi-token `@<path>` parses).

Per-terminal toolbar toggle switches the default mode (`@`-mention vs shell-escaped raw path). Holding Shift while dropping inverts mode for one drop.

While the server side is shared with chat uploads, this PR also adds three knobs that benefit both surfaces:

- `NBI_TERMINAL_DRAG_DROP_POLICY` (force-on / force-off / user-choice): standard admin policy triad. `force-off` suppresses the terminal listener so files dragged onto a terminal fall through to the browser's default behavior. Useful for hardened deployments that don't want files staged through the upload endpoint.
- `NBI_UPLOAD_MAX_MB` (default 50): per-file size cap. Requests over the cap return HTTP 413; the frontend surfaces the rejection via a Notification toast so screen-reader users see the same signal as sighted users.
- `NBI_UPLOAD_RETENTION_HOURS` (default 24): lazy retention sweep on the staging directory. Rate-limited to once per 60s so a burst of parallel uploads doesn't pay the `listdir + stat` cost on every request.

Two micro-architecture notes:

- Pure helpers (`formatForMode`, `invertMode`) live in `src/terminal-drag-format.ts` so jest can exercise them without pulling Lumino/DOM imports. The same logic applies to `shellSingleQuote`, which moves from `src/utils.ts` (loads tiktoken at module import) to a tiny `src/shell-utils.ts`; `utils.ts` re-exports for backward compat.
- `isEnabled()` reads the policy off the raw `NBIAPI.config.capabilities.feature_policies.terminal_drag_drop` object rather than the `featurePolicies` getter, because `dragover` fires at ~60 Hz and the getter rebuilds an 11-key object per call.

## Testing

Automated:
- `tests/test_file_upload.py`: size cap 413 path + accepts under cap + 0 disables cap; retention sweep removes stale subdirs while preserving fresh ones, runs after a successful upload, throttles within the 60s window, handles missing root and non-directory entries.
- `tests/ts/terminal-drag.test.ts`: `formatForMode` (mention vs raw, multi-file space-joined, empty input, shell-escape edge cases), `invertMode` (Shift-inversion semantics).
- Full pytest sweep (522 passing), `jlpm tsc --noEmit`, `jlpm lint:check`, `jlpm jest` (111 passing) all green.

Manual verification:
- Drag a file from Finder onto a Claude Code terminal: confirm `@</tmp/...>` is injected.
- Toggle the toolbar button: confirm subsequent drops shell-escape the path.
- Hold Shift while dropping: confirm the per-drop mode flips.
- Drop a file over the 50 MB cap: confirm a Notification toast appears with the filename and reason.
- Set `NBI_TERMINAL_DRAG_DROP_POLICY=force-off`: confirm drops fall through to the browser default.
- Drag a file from the JupyterLab file browser: confirm the relative path is injected without re-upload.

## Risks and follow-ups

- The `ITerminalTracker` token is cast to `Token<unknown>` because `@jupyterlab/terminal@4.5.7` ships its own nested `@lumino/coreutils`, making the nominal Token class distinct from our top-level copy. Runtime is unaffected (Lumino looks up tokens by reference identity against the host JupyterLab's own registry), but the type-system contortion is real. Cleanest follow-up is a `yarn resolutions` block; out of scope for this PR.
- Structural types in `src/terminal-drag.ts` (`IMainAreaWidgetLike`, `ITerminalTrackerLike`, etc.) capture only what the module touches. Same nested-version-skew workaround. Will simplify once the resolutions follow-up lands.
- The size cap runs after Tornado has parsed the multipart body into memory, so the 100 MB default `max_body_size` is still the worst-case ceiling. Streamed uploads with `set_max_body_size` would tighten that further; out of scope here.
- The `terminal_drag_drop` policy currently maps "user-choice" and "force-on" to the same enabled state because there's no user-facing toggle. If a future Settings panel adds one, swap the literal `True` in `_build_feature_policies_response` for the user value and add a `locked_keys` entry in `ConfigHandler`.
- No keyboard fallback for drag-drop. A "Browse files" toolbar button alongside the mode toggle is a natural follow-up.

Closes #248.
