### PR TITLE
feat(skills): raise GitHub archive cap to 100 MB, make overridable

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -42,11 +42,12 @@ For organization-wide deployments (e.g., Kubeflow notebooks), NBI can install an
 
 Configure via environment variables (also available as traitlets on `NotebookIntelligence`):
 
-| Variable                       | Description                                                                                        |
-| ------------------------------ | -------------------------------------------------------------------------------------------------- |
-| `NBI_SKILLS_MANIFEST`          | URL (`https://...`) or local filesystem path to the manifest. Empty or unset disables the feature. |
-| `NBI_SKILLS_MANIFEST_INTERVAL` | Seconds between reconciles. Default `86400` (24 hours). Reconciliation also runs once at startup.  |
-| `NBI_MANAGED_SKILLS_TOKEN`     | Optional bearer token used for **all** managed-skills GitHub operations (see below).               |
+| Variable                       | Description                                                                                                                                                                             |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NBI_SKILLS_MANIFEST`          | URL (`https://...`) or local filesystem path to the manifest. Empty or unset disables the feature.                                                                                      |
+| `NBI_SKILLS_MANIFEST_INTERVAL` | Seconds between reconciles. Default `86400` (24 hours). Reconciliation also runs once at startup.                                                                                       |
+| `NBI_MANAGED_SKILLS_TOKEN`     | Optional bearer token used for **all** managed-skills GitHub operations (see below).                                                                                                    |
+| `NBI_SKILL_MAX_ARCHIVE_MB`     | Per-archive on-wire size cap (megabytes) for skill bundles fetched from GitHub. Default `100`. Applies to both user imports and managed-skills tarballs. Set to `0` to disable the cap. |
 
 When set, `NBI_MANAGED_SKILLS_TOKEN` scopes to fetching the manifest, probing commits, and downloading skill tarballs. User-initiated imports (the Import-from-GitHub dialog, `POST /skills/import`) do **not** see this token and continue to use `GITHUB_TOKEN` → `GH_TOKEN` → `gh` CLI auth. When `NBI_MANAGED_SKILLS_TOKEN` is unset, managed operations fall back to that same chain. When it is set and a managed operation fails with an auth error, it fails loudly (no retry with the fallback chain) so misconfigured or expired tokens stay visible to the admin. The minimum required GitHub scope is `contents:read`.
 

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -194,6 +194,38 @@ def _resolve_bool_with_env(env_var_name: str, fallback: bool | None) -> bool:
     )
 
 
+def _resolve_positive_int_with_env(env_var_name: str, traitlet_value: int) -> int:
+    """Resolve a non-negative int tunable, falling back to the traitlet.
+
+    Unlike ``_resolve_bool_with_env`` this warns-and-clamps rather than
+    raising: int tunables are tuning parameters (size caps, intervals,
+    retention windows), and a typo in one is unambiguously "off-ish"
+    rather than security-gate-flipping. Negative values are clamped to
+    0 with a warning so callers see "feature disabled" rather than
+    silently treating the bad input as a positive cap.
+    """
+    env_value = os.environ.get(env_var_name, "").strip()
+    resolved = traitlet_value
+    if env_value:
+        try:
+            resolved = int(env_value)
+        except ValueError:
+            log.warning(
+                "Ignoring invalid %s=%r: must be a non-negative integer",
+                env_var_name,
+                env_value,
+            )
+            resolved = traitlet_value
+    if resolved < 0:
+        log.warning(
+            "%s resolved to a negative value (%d); clamping to 0",
+            env_var_name,
+            resolved,
+        )
+        return 0
+    return resolved
+
+
 # Single source of truth for the boolean policies. Each entry is
 # ``(policy_name, env_var, traitlet_attr)``. Drives env-var resolution, the
 # capabilities response, and the lock-rejection set in ConfigHandler.
@@ -1882,6 +1914,19 @@ class NotebookIntelligence(ExtensionApp):
         config=True,
     )
 
+    skill_max_archive_mb = Int(
+        default_value=100,
+        help="""
+        Per-archive on-wire size cap (megabytes) for skill bundles fetched
+        from GitHub. Requests exceeding this limit are rejected before
+        the archive is written to disk. Default is 100 MB; raise for
+        repos with sizable attachments (datasets, fixtures) and lower
+        for hardened deployments. Overridden by the
+        NBI_SKILL_MAX_ARCHIVE_MB environment variable.
+        """,
+        config=True,
+    )
+
     def initialize_settings(self):
         pass
 
@@ -2001,6 +2046,18 @@ class NotebookIntelligence(ExtensionApp):
                 "NBI_ADDITIONAL_SKIPPED_WORKSPACE_DIRECTORIES",
                 self.additional_skipped_workspace_directories,
             )
+        )
+        # Resolved on-wire cap for skill tarball fetches. The constant
+        # lives in skill_github_import.py because the fetch helper reads
+        # it directly; reassigning the module attribute here lets admins
+        # tune it without forking the import flow.
+        from notebook_intelligence import skill_github_import
+        skill_github_import.MAX_ARCHIVE_BYTES = (
+            _resolve_positive_int_with_env(
+                "NBI_SKILL_MAX_ARCHIVE_MB", self.skill_max_archive_mb
+            )
+            * 1024
+            * 1024
         )
         self._publish_policies(feature_policies, string_overrides)
         NotebookIntelligence.handlers = [

--- a/notebook_intelligence/skill_github_import.py
+++ b/notebook_intelligence/skill_github_import.py
@@ -34,7 +34,9 @@ from notebook_intelligence.skillset import (
 
 log = logging.getLogger(__name__)
 
-MAX_ARCHIVE_BYTES = 10 * 1024 * 1024  # 10 MB on-wire
+MAX_ARCHIVE_BYTES = 100 * 1024 * 1024  # 100 MB on-wire (overridable via
+# `notebook_intelligence.extension._setup_handlers` reading the
+# `skill_max_archive_mb` traitlet and NBI_SKILL_MAX_ARCHIVE_MB env var).
 MAX_EXTRACTED_BYTES = 20 * 1024 * 1024  # 20 MB after decompression
 FETCH_TIMEOUT_SECONDS = 30
 

--- a/tests/test_skill_github_import.py
+++ b/tests/test_skill_github_import.py
@@ -401,3 +401,95 @@ class TestFetchTarballAuth:
                 assert "not found" in str(exc_info.value)
 
 
+class _FakeSizedResponse:
+    """Mimics urllib's response just enough for _fetch_tarball's read()."""
+
+    def __init__(self, payload: bytes):
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def read(self, n: int) -> bytes:
+        return self._payload[:n]
+
+
+class TestArchiveSizeCap:
+    """The on-wire cap is overridable via the module attribute (which the
+    extension reassigns from `skill_max_archive_mb` + NBI_SKILL_MAX_ARCHIVE_MB
+    at startup). Default is 100 MB; these tests pin the comparison logic
+    against a small override so we don't have to allocate 100 MB of bytes.
+    """
+
+    def test_default_cap_is_100mb(self):
+        from notebook_intelligence import skill_github_import
+
+        assert skill_github_import.MAX_ARCHIVE_BYTES == 100 * 1024 * 1024
+
+    def test_accepts_payload_at_cap(self):
+        from notebook_intelligence import skill_github_import
+
+        original = skill_github_import.MAX_ARCHIVE_BYTES
+        skill_github_import.MAX_ARCHIVE_BYTES = 1024  # 1 KB for the test
+        try:
+            # _fetch_tarball reads MAX + 1 bytes and rejects if len > MAX.
+            # An exactly-MAX payload yields MAX bytes from the response and
+            # passes the check.
+            payload = b"x" * 1024
+            with patch(
+                "notebook_intelligence.skill_github_import._get_github_token",
+                return_value=None,
+            ):
+                with patch(
+                    "notebook_intelligence.skill_github_import._urlopen_github",
+                    return_value=_FakeSizedResponse(payload),
+                ):
+                    result = _fetch_tarball("owner", "repo", None)
+            assert result == payload
+        finally:
+            skill_github_import.MAX_ARCHIVE_BYTES = original
+
+    def test_rejects_payload_over_cap(self):
+        from notebook_intelligence import skill_github_import
+
+        original = skill_github_import.MAX_ARCHIVE_BYTES
+        skill_github_import.MAX_ARCHIVE_BYTES = 1024
+        try:
+            oversize = b"x" * (1024 + 100)
+            with patch(
+                "notebook_intelligence.skill_github_import._get_github_token",
+                return_value=None,
+            ):
+                with patch(
+                    "notebook_intelligence.skill_github_import._urlopen_github",
+                    return_value=_FakeSizedResponse(oversize),
+                ):
+                    with pytest.raises(ValueError, match="exceeds size limit"):
+                        _fetch_tarball("owner", "repo", None)
+        finally:
+            skill_github_import.MAX_ARCHIVE_BYTES = original
+
+    def test_error_message_reflects_current_cap(self):
+        from notebook_intelligence import skill_github_import
+
+        original = skill_github_import.MAX_ARCHIVE_BYTES
+        skill_github_import.MAX_ARCHIVE_BYTES = 2 * 1024 * 1024  # 2 MB
+        try:
+            oversize = b"x" * (3 * 1024 * 1024)
+            with patch(
+                "notebook_intelligence.skill_github_import._get_github_token",
+                return_value=None,
+            ):
+                with patch(
+                    "notebook_intelligence.skill_github_import._urlopen_github",
+                    return_value=_FakeSizedResponse(oversize),
+                ):
+                    with pytest.raises(ValueError, match=r"\b2 MB\b"):
+                        _fetch_tarball("owner", "repo", None)
+        finally:
+            skill_github_import.MAX_ARCHIVE_BYTES = original
+
+

--- a/tests/test_skills_handlers.py
+++ b/tests/test_skills_handlers.py
@@ -352,6 +352,40 @@ class TestResolveBoolWithEnv:
         assert ext_module._resolve_bool_with_env("NBI_TEST_FLAG", None) is False
 
 
+class TestResolvePositiveIntWithEnv:
+    def test_unset_env_returns_traitlet(self, monkeypatch):
+        monkeypatch.delenv("NBI_TEST_CAP", raising=False)
+        assert ext_module._resolve_positive_int_with_env("NBI_TEST_CAP", 100) == 100
+
+    def test_valid_env_overrides_traitlet(self):
+        with patch.dict("os.environ", {"NBI_TEST_CAP": "250"}):
+            assert (
+                ext_module._resolve_positive_int_with_env("NBI_TEST_CAP", 100) == 250
+            )
+
+    def test_invalid_env_warns_and_falls_back(self, caplog):
+        with patch.dict("os.environ", {"NBI_TEST_CAP": "huge"}):
+            with caplog.at_level("WARNING"):
+                result = ext_module._resolve_positive_int_with_env(
+                    "NBI_TEST_CAP", 100
+                )
+        assert result == 100
+        assert "Ignoring invalid NBI_TEST_CAP" in caplog.text
+
+    def test_negative_env_clamps_to_zero_with_warning(self, caplog):
+        with patch.dict("os.environ", {"NBI_TEST_CAP": "-5"}):
+            with caplog.at_level("WARNING"):
+                result = ext_module._resolve_positive_int_with_env(
+                    "NBI_TEST_CAP", 100
+                )
+        assert result == 0
+        assert "negative" in caplog.text.lower()
+
+    def test_zero_passes_through(self):
+        with patch.dict("os.environ", {"NBI_TEST_CAP": "0"}):
+            assert ext_module._resolve_positive_int_with_env("NBI_TEST_CAP", 100) == 0
+
+
 class TestResolveCsvAppended:
     """The csv env-var merge for additive list traitlets (e.g.
     ``additional_skipped_workspace_directories``). Env appends to the


### PR DESCRIPTION
## Summary

Bumps the default GitHub-archive on-wire size cap for skill imports from 10 MB to 100 MB, and makes it overridable per-deployment. Legitimate skill bundles with fixtures, sample notebooks, or media attachments were routinely brushing past the old cap.

## Solution

`MAX_ARCHIVE_BYTES` (in `notebook_intelligence/skill_github_import.py`) now defaults to 100 MB. The value is overridable via:

- A new `skill_max_archive_mb` traitlet on `NotebookIntelligence` (default `100`).
- The `NBI_SKILL_MAX_ARCHIVE_MB` environment variable (takes precedence over the traitlet).
- Setting either to `0` disables the cap entirely.

The constant continues to live in the import module because `_fetch_tarball` reads it directly. The extension reassigns the module attribute during `_setup_handlers`, which keeps the existing fetch flow untouched and avoids threading the cap through several call layers. Both user-initiated GitHub imports and the managed-skills reconciler honor the new value (they share `_fetch_tarball`).

Adds a small sibling helper `_resolve_positive_int_with_env` next to the existing `_resolve_bool_with_env` / `_resolve_policy_with_env` family. Negative values warn-and-clamp to 0 rather than raising: size caps are tuning parameters where a typo is unambiguously "off-ish" rather than the security-gate-flipping case the bool helper hardens against.

## Testing

Automated:
- `tests/test_skill_github_import.py::TestArchiveSizeCap`: default-is-100MB, accepts-at-cap, rejects-over-cap, error-message-reflects-current-cap.
- `tests/test_skills_handlers.py::TestResolvePositiveIntWithEnv`: unset returns traitlet, valid env overrides, invalid env warns and falls back, negative env clamps to 0 with warning, zero passes through.
- Full pytest sweep + `jlpm tsc --noEmit` + `jlpm lint:check` + `jlpm jest` all green.

Manual verification:
- Set `NBI_SKILL_MAX_ARCHIVE_MB=200` before launching and import a sizable skill bundle: succeeds.
- Set `NBI_SKILL_MAX_ARCHIVE_MB=5` and try the same: rejected with "Archive exceeds size limit (5 MB)".
- Unset the env var, leave the traitlet default: imports under 100 MB succeed.

## Risks and follow-ups

- The companion `MAX_EXTRACTED_BYTES` (20 MB after decompression) was deliberately left untouched. A tarball that compresses 5:1 from 100 MB would extract to ~500 MB, which would still be rejected. If users hit this in practice it can ride along as a follow-up with the same env-var pattern (`NBI_SKILL_MAX_EXTRACTED_MB`).
- Backward compatibility: the default raised, not lowered, so no deployment that was happily importing under the old 10 MB cap will break. Deployments that explicitly want the previous tighter cap can set `NBI_SKILL_MAX_ARCHIVE_MB=10`.

## Issue linkage

No issue filed for this; came up from a real-world import failure.
