### PR TITLE
fix(claude): mention zero-based indexing in cell-tool descriptions

### DIFF
--- a/notebook_intelligence/built_in_toolsets.py
+++ b/notebook_intelligence/built_in_toolsets.py
@@ -72,7 +72,7 @@ async def get_number_of_cells(**args) -> str:
 @nbapi.auto_approve
 @nbapi.tool
 async def get_cell_type_and_source(cell_index: int, **args) -> str:
-    """Get cell type and source for the cell at index for the active notebook.
+    """Get cell type and source for the cell at zero-based index for the active notebook.
 
     Args:
         cell_index: Zero based cell index
@@ -86,7 +86,7 @@ async def get_cell_type_and_source(cell_index: int, **args) -> str:
 @nbapi.auto_approve
 @nbapi.tool
 async def get_cell_output(cell_index: int, **args) -> str:
-    """Get cell output for the cell at index for the active notebook.
+    """Get cell output for the cell at zero-based index for the active notebook.
 
     Args:
         cell_index: Zero based cell index
@@ -99,7 +99,7 @@ async def get_cell_output(cell_index: int, **args) -> str:
 @nbapi.auto_approve
 @nbapi.tool
 async def set_cell_type_and_source(cell_index: int, cell_type: str, source: str, **args) -> str:
-    """Set cell type and source for the cell at index for the active notebook.
+    """Set cell type and source for the cell at zero-based index for the active notebook.
 
     Args:
         cell_index: Zero based cell index
@@ -114,7 +114,7 @@ async def set_cell_type_and_source(cell_index: int, cell_type: str, source: str,
 @nbapi.auto_approve
 @nbapi.tool
 async def delete_cell(cell_index: int, **args) -> str:
-    """Delete the cell at index for the active notebook.
+    """Delete the cell at zero-based index for the active notebook.
 
     Args:
         cell_index: Zero based cell index
@@ -128,7 +128,7 @@ async def delete_cell(cell_index: int, **args) -> str:
 @nbapi.auto_approve
 @nbapi.tool
 async def insert_cell(cell_index: int, cell_type: str, source: str, **args) -> str:
-    """Insert cell with type and source at index for the active notebook.
+    """Insert cell with type and source at zero-based index for the active notebook.
 
     Args:
         cell_index: Zero based cell index
@@ -143,7 +143,7 @@ async def insert_cell(cell_index: int, cell_type: str, source: str, **args) -> s
 @nbapi.auto_approve
 @nbapi.tool
 async def run_cell(cell_index: int, **args) -> str:
-    """Run the cell at index for the active notebook.
+    """Run the cell at zero-based index for the active notebook.
 
     Args:
         cell_index: Zero based cell index

--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -979,7 +979,7 @@ async def get_number_of_cells(args) -> str:
 
     return tool_text_response(ui_cmd_response)
 
-@tool("get-cell-type-and-source", "Gets the type and source of the cell at index.", {"cell_index": int})
+@tool("get-cell-type-and-source", "Gets the type and source of the cell at zero-based index.", {"cell_index": int})
 async def get_cell_type_and_source(args) -> str:
     """Get cell type and source for the cell at index for the active notebook.
 
@@ -992,7 +992,7 @@ async def get_cell_type_and_source(args) -> str:
     return tool_text_response(ui_cmd_response)
 
 
-@tool("get-cell-output", "Gets the output of the cell at index.", {"cell_index": int})
+@tool("get-cell-output", "Gets the output of the cell at zero-based index.", {"cell_index": int})
 async def get_cell_output(args) -> str:
     """Get cell output for the cell at index for the active notebook.
 
@@ -1004,7 +1004,7 @@ async def get_cell_output(args) -> str:
 
     return tool_text_response(ui_cmd_response)
 
-@tool("set-cell-type-and-source", "Sets the type and source of the cell at index.", {"cell_index": int, "cell_type": str, "source": str})
+@tool("set-cell-type-and-source", "Sets the type and source of the cell at zero-based index.", {"cell_index": int, "cell_type": str, "source": str})
 async def set_cell_type_and_source(args) -> str:
     """Set cell type and source for the cell at index for the active notebook.
 
@@ -1018,7 +1018,7 @@ async def set_cell_type_and_source(args) -> str:
 
     return tool_text_response(ui_cmd_response)
 
-@tool("delete-cell", "Deletes the cell at index.", {"cell_index": int})
+@tool("delete-cell", "Deletes the cell at zero-based index.", {"cell_index": int})
 async def delete_cell(args) -> str:
     """Delete the cell at index for the active notebook.
 
@@ -1031,7 +1031,7 @@ async def delete_cell(args) -> str:
 
     return tool_text_response(f"Deleted the cell at index: {args['cell_index']}")
 
-@tool("insert-cell", "Inserts a cell with type and source at index.", {"cell_index": int, "cell_type": str, "source": str})
+@tool("insert-cell", "Inserts a cell with type and source at zero-based index.", {"cell_index": int, "cell_type": str, "source": str})
 async def insert_cell(args) -> str:
     """Insert cell with type and source at index for the active notebook.
 
@@ -1045,7 +1045,7 @@ async def insert_cell(args) -> str:
 
     return tool_text_response(ui_cmd_response)
 
-@tool("run-cell", "Runs the cell at index.", {"cell_index": int})
+@tool("run-cell", "Runs the cell at zero-based index.", {"cell_index": int})
 async def run_cell(args) -> str:
     """Run the cell at index for the active notebook.
 


### PR DESCRIPTION
## Summary

Claude (and likely other LLMs in Copilot/Anthropic-API mode) was calling NBI's notebook cell-index tools with 1-based indices despite the Python docstrings saying zero-based. The result: off-by-one cell edits, inserts, runs, etc. The issue author empirically verified that surfacing the "zero-based" wording in the model-facing tool description fixes the behavior.

## Solution

Updated the @tool description string in `notebook_intelligence/claude.py` for the six cell-index tools (`get-cell-type-and-source`, `get-cell-output`, `set-cell-type-and-source`, `delete-cell`, `insert-cell`, `run-cell`) from "the cell at index" to "the cell at zero-based index." Mirror change in `notebook_intelligence/built_in_toolsets.py` for the parallel Copilot/Anthropic-API path (first-line of the docstring, which `@nbapi.tool` propagates to the model-visible schema).

## Testing

Manual: existing `tests/test_claude_tool_humanizer.py` covers tool-name humanization, not the description strings, so it doesn't need an update. The fix's correctness is an empirical property (does the model pick the right index?) that can't be unit-tested without a live Claude session. Mehmet confirmed the behavior under test before filing.

`pytest tests/ --ignore=tests/test_claude_client.py` (699 passed), `jlpm tsc --noEmit`, `jlpm lint:check`, `jlpm jest` (131 passed) all green.

## Risks / follow-ups

Two follow-ups noted in the review pass but intentionally out of scope:

- **Per-parameter `Annotated[int, "..."]` schemas.** The `claude_agent_sdk` supports unwrapping `Annotated` types to emit field-level JSON-schema descriptions. That'd be a stronger anchor than the tool-level prose. Worth doing across all numeric/typed params, not just `cell_index`; better as a separate refactor.
- **`run_cell`'s `args['cell_index'] is not None else 0` fallback.** A one-off defensive guard from before this fix. May be dead code now or may still be masking a different SDK quirk. Left alone to avoid expanding scope.

Fixes #261