### PR TITLE
fix(chat-sidebar): close workspace file picker on Escape from search input

### DIFF
--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -3972,7 +3972,14 @@ function SidebarComponent(props: any) {
                   value={workspaceFileSearch}
                   onChange={event => setWorkspaceFileSearch(event.target.value)}
                   onKeyDown={(event: KeyboardEvent<HTMLInputElement>) => {
-                    event.stopPropagation();
+                    // Let Escape bubble to the popover's Escape handler so
+                    // the dialog closes even when focus is in the search
+                    // input (issue #262). Other keys still stop here so the
+                    // chat sidebar's keyboard shortcuts don't fire while
+                    // the user is typing a filter.
+                    if (event.key !== 'Escape') {
+                      event.stopPropagation();
+                    }
                   }}
                 />
                 {workspaceFilesError && (


### PR DESCRIPTION
## Summary

The \"Add files as context\" dialog (opened from the `@` button in the chat sidebar) ignored the Escape key once the user clicked into the search field. The wrapper popover already handled Escape, but the search input's keydown listener called `stopPropagation()` for *every* key to keep the chat sidebar's keyboard shortcuts from firing while typing a filter. Escape was getting eaten as collateral, so the only way to dismiss the dialog was clicking the close icon.

## Solution

In `src/chat-sidebar.tsx`, gate the input's `stopPropagation()` on `event.key !== 'Escape'`. Escape bubbles to the popover's existing handler at line 3907; everything else is still swallowed so the sidebar shortcuts don't fire during a search.

## Testing

`jlpm tsc --noEmit && jlpm lint:check && jlpm jest` green. Manual: opened the picker, focused the search field, pressed Escape, dialog closes.

No new automated test. `SidebarComponent` isn't mounted by any existing jest test (it pulls in JupyterLab services, `NBIAPI`, and the workspace file fetch); standing up a harness for a 7-line keydown-delegation fix would be a multi-hour scaffold. A Playwright e2e would be the right home if regression coverage becomes interesting later.

## Risks / follow-ups

Audited the two sibling popovers (`src/components/claude-session-picker.tsx` and `src/components/notebook-generation-popover.tsx`) for the same pattern. Neither has the bug: the session picker has no input to swallow keys, and the notebook-generation popover's textarea handler only intercepts Enter.

Fixes #262