### PR TITLE
feat(chat-sidebar): hover preview for image context thumbnails

### DIFF
--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -3724,11 +3724,19 @@ function SidebarComponent(props: any) {
                     <div>
                       {file.isImage && file.imageDataUrl ? (
                         <>
-                          <img
-                            src={file.imageDataUrl}
-                            className="context-pill-thumbnail"
-                            alt={file.path}
-                          />
+                          <span className="context-pill-thumbnail-wrap">
+                            <img
+                              src={file.imageDataUrl}
+                              className="context-pill-thumbnail"
+                              alt={file.path}
+                            />
+                            <img
+                              src={file.imageDataUrl}
+                              className="context-pill-thumbnail-preview"
+                              alt=""
+                              aria-hidden="true"
+                            />
+                          </span>
                           {file.path}
                         </>
                       ) : file.source === 'upload' ? (

--- a/style/base.css
+++ b/style/base.css
@@ -57,13 +57,40 @@
   border-style: dashed;
 }
 
+.context-pill-thumbnail-wrap {
+  position: relative;
+  display: inline-block;
+  vertical-align: middle;
+  line-height: 0;
+}
+
 .context-pill-thumbnail {
   max-height: 36px;
   max-width: 54px;
   object-fit: contain;
   border-radius: 2px;
-  vertical-align: middle;
   margin-right: 4px;
+}
+
+.context-pill-thumbnail-preview {
+  display: none;
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 0;
+  max-width: 320px;
+  max-height: 320px;
+  object-fit: contain;
+  border-radius: 6px;
+  background: var(--jp-layout-color1);
+  padding: 4px;
+  box-shadow: 0 6px 20px rgb(0 0 0 / 25%);
+  z-index: 100;
+  pointer-events: none;
+}
+
+.context-pill-thumbnail-wrap:hover .context-pill-thumbnail-preview,
+.context-pill-thumbnail-wrap:focus-within .context-pill-thumbnail-preview {
+  display: block;
 }
 
 .user-input-context.uploading-indicator {
@@ -171,6 +198,13 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* Image pills need overflow: visible so the hover preview can escape
+   the truncation clip. Their visible content is the filename plus a
+   small thumbnail, so dropping the ellipsis here is fine. */
+.user-input-context.image-file > div:first-child {
+  overflow: visible;
 }
 
 .user-input-context.off {


### PR DESCRIPTION
## Summary

The 36×54 thumbnail in an `@`-context pill is too small to identify which image is which when several share filenames or when the user has just dropped a batch in. Hovering the thumbnail now pops a larger preview (up to 320×320, fit-contain) above the pill.

## Solution

Pure CSS hover preview. A second `<img>` (aria-hidden, same data URL as the small thumbnail) lives inside a new `position: relative` wrapper around the thumbnail and is toggled via `:hover` / `:focus-within` on that wrapper. No React state, no listener, no hot-path cost.

The pill row's `overflow: hidden` is relaxed to `visible` for the `.image-file` variant so the absolutely-positioned preview can escape upward. Image pills carry short filenames in practice, so dropping the ellipsis truncation there is the right trade.

## Testing

`jlpm tsc --noEmit && jlpm lint:check && jlpm jest` green. Manual: dropped a PNG into the chat composer, hovered the thumbnail in the pill, verified the larger version pops above. Used keyboard tab/focus on the wrap to confirm `:focus-within` triggers it too.

No new automated test. Verifying a CSS hover state requires mounting `SidebarComponent` (JupyterLab services, `NBIAPI`, the upload pipeline) which is a multi-hour harness for a styling change.

## Risks / follow-ups

- Cursor moving from the thumbnail into the preview region exits the wrapper's bbox and dismisses the preview (the preview is positioned outside the wrap's content rect). For an MVP this is fine — the preview is a peek, not a destination. A future enhancement could add a small invisible "bridge" element or move to JS-managed positioning.
- Preview always positions above (`bottom: calc(100% + 6px)`). Pills near the top of the viewport could overflow upward; in practice they sit at the bottom of the chat composer so this is rare.

Closes #259