### PR TITLE
feat(launcher): add tiles for opencode, Pi, and GitHub Copilot CLI

### DIFF
--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -52,7 +52,7 @@ from notebook_intelligence.claude_sessions import (
 )
 import notebook_intelligence.github_copilot as github_copilot
 from notebook_intelligence.built_in_toolsets import built_in_toolsets
-from notebook_intelligence.util import ThreadSafeWebSocketConnector, get_jupyter_root_dir, set_jupyter_root_dir, is_builtin_tool_enabled_in_env, is_provider_enabled_in_env, resolve_claude_cli_path, resolve_opencode_cli_path, resolve_pi_cli_path, resolve_copilot_cli_path
+from notebook_intelligence.util import ThreadSafeWebSocketConnector, get_jupyter_root_dir, set_jupyter_root_dir, is_builtin_tool_enabled_in_env, is_provider_enabled_in_env, resolve_claude_cli_path, resolve_opencode_cli_path, resolve_pi_cli_path, resolve_copilot_cli_path, resolve_codex_cli_path
 from notebook_intelligence.context_factory import RuleContextFactory
 from notebook_intelligence.skillset import SKILL_NAME_REGEX
 
@@ -489,6 +489,7 @@ class GetCapabilitiesHandler(APIHandler):
             "opencode_cli_available": resolve_opencode_cli_path() is not None,
             "pi_cli_available": resolve_pi_cli_path() is not None,
             "github_copilot_cli_available": resolve_copilot_cli_path() is not None,
+            "codex_cli_available": resolve_codex_cli_path() is not None,
             "default_chat_mode": nbi_config.default_chat_mode,
             "chat_feedback_enabled": self.enable_chat_feedback,
             # Single source of truth lives on each domain's base handler so

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -52,7 +52,7 @@ from notebook_intelligence.claude_sessions import (
 )
 import notebook_intelligence.github_copilot as github_copilot
 from notebook_intelligence.built_in_toolsets import built_in_toolsets
-from notebook_intelligence.util import ThreadSafeWebSocketConnector, get_jupyter_root_dir, set_jupyter_root_dir, is_builtin_tool_enabled_in_env, is_provider_enabled_in_env, resolve_claude_cli_path
+from notebook_intelligence.util import ThreadSafeWebSocketConnector, get_jupyter_root_dir, set_jupyter_root_dir, is_builtin_tool_enabled_in_env, is_provider_enabled_in_env, resolve_claude_cli_path, resolve_opencode_cli_path, resolve_pi_cli_path, resolve_copilot_cli_path
 from notebook_intelligence.context_factory import RuleContextFactory
 from notebook_intelligence.skillset import SKILL_NAME_REGEX
 
@@ -482,8 +482,13 @@ class GetCapabilitiesHandler(APIHandler):
                 nbi_config.claude_settings, self.string_overrides
             ),
             "claude_models": ai_service_manager.claude_models,
-            # Drives launcher-tile visibility (issue #183).
+            # Drive launcher-tile visibility (issues #183, #260). Each flag
+            # gates one tile under the "Coding Agent" category. Detection is
+            # PATH-based with NBI_*_CLI_PATH env overrides.
             "claude_cli_available": resolve_claude_cli_path() is not None,
+            "opencode_cli_available": resolve_opencode_cli_path() is not None,
+            "pi_cli_available": resolve_pi_cli_path() is not None,
+            "github_copilot_cli_available": resolve_copilot_cli_path() is not None,
             "default_chat_mode": nbi_config.default_chat_mode,
             "chat_feedback_enabled": self.enable_chat_feedback,
             # Single source of truth lives on each domain's base handler so

--- a/notebook_intelligence/util.py
+++ b/notebook_intelligence/util.py
@@ -61,6 +61,11 @@ def resolve_copilot_cli_path() -> Optional[str]:
     return _resolve_cli_path("copilot", "NBI_GITHUB_COPILOT_CLI_PATH")
 
 
+def resolve_codex_cli_path() -> Optional[str]:
+    """OpenAI Codex CLI. NBI_CODEX_CLI_PATH overrides; else `codex` on PATH."""
+    return _resolve_cli_path("codex", "NBI_CODEX_CLI_PATH")
+
+
 def invalidate_cli_cache(name: Optional[str] = None) -> None:
     """Clear the memoized CLI-path cache. Pass a name to invalidate just one."""
     if name is None:

--- a/notebook_intelligence/util.py
+++ b/notebook_intelligence/util.py
@@ -22,32 +22,51 @@ def get_jupyter_root_dir() -> str:
     return _jupyter_root_dir
 
 
-_UNSET = object()
-_cached_which_claude: object = _UNSET
+_cached_cli_paths: dict[str, Optional[str]] = {}
+
+
+def _resolve_cli_path(name: str, env_var: str) -> Optional[str]:
+    """Resolve an agent-CLI binary path with env override + PATH fallback.
+
+    The env var wins when set; otherwise this is a memoized shutil.which.
+    Capabilities is a hot endpoint and PATH doesn't change at runtime, so
+    every lookup goes through this single cache. Tests should call
+    ``invalidate_cli_cache`` between cases that toggle the env or PATH.
+    """
+    explicit = os.getenv(env_var)
+    if explicit:
+        return explicit
+    if name not in _cached_cli_paths:
+        _cached_cli_paths[name] = shutil.which(name)
+    return _cached_cli_paths[name]
 
 
 def resolve_claude_cli_path() -> Optional[str]:
-    """Resolve the Claude Code CLI binary path.
-
-    NBI_CLAUDE_CLI_PATH wins when set; otherwise fall back to the first
-    `claude` on PATH. Returns None when nothing is found, so callers can
-    decide between raising and proceeding without the CLI.
-
-    The PATH lookup is memoized — capabilities is hot and PATH doesn't
-    change at runtime. Use ``invalidate_claude_cli_cache`` from tests.
-    """
-    explicit = os.getenv("NBI_CLAUDE_CLI_PATH")
-    if explicit:
-        return explicit
-    global _cached_which_claude
-    if _cached_which_claude is _UNSET:
-        _cached_which_claude = shutil.which("claude")
-    return _cached_which_claude  # type: ignore[return-value]
+    """Claude Code CLI. NBI_CLAUDE_CLI_PATH overrides; else `claude` on PATH."""
+    return _resolve_cli_path("claude", "NBI_CLAUDE_CLI_PATH")
 
 
-def invalidate_claude_cli_cache() -> None:
-    global _cached_which_claude
-    _cached_which_claude = _UNSET
+def resolve_opencode_cli_path() -> Optional[str]:
+    """opencode CLI. NBI_OPENCODE_CLI_PATH overrides; else `opencode` on PATH."""
+    return _resolve_cli_path("opencode", "NBI_OPENCODE_CLI_PATH")
+
+
+def resolve_pi_cli_path() -> Optional[str]:
+    """Pi CLI. NBI_PI_CLI_PATH overrides; else `pi` on PATH."""
+    return _resolve_cli_path("pi", "NBI_PI_CLI_PATH")
+
+
+def resolve_copilot_cli_path() -> Optional[str]:
+    """GitHub Copilot CLI. NBI_GITHUB_COPILOT_CLI_PATH overrides; else `copilot` on PATH."""
+    return _resolve_cli_path("copilot", "NBI_GITHUB_COPILOT_CLI_PATH")
+
+
+def invalidate_cli_cache(name: Optional[str] = None) -> None:
+    """Clear the memoized CLI-path cache. Pass a name to invalidate just one."""
+    if name is None:
+        _cached_cli_paths.clear()
+    else:
+        _cached_cli_paths.pop(name, None)
 
 
 def resolve_github_token() -> Optional[str]:

--- a/src/api.ts
+++ b/src/api.ts
@@ -368,6 +368,10 @@ export class NBIConfig {
     return this.capabilities.github_copilot_cli_available === true;
   }
 
+  get isCodexCliAvailable(): boolean {
+    return this.capabilities.codex_cli_available === true;
+  }
+
   get chatFeedbackEnabled(): boolean {
     return this.capabilities.chat_feedback_enabled === true;
   }

--- a/src/api.ts
+++ b/src/api.ts
@@ -356,6 +356,18 @@ export class NBIConfig {
     return this.capabilities.claude_cli_available === true;
   }
 
+  get isOpenCodeCliAvailable(): boolean {
+    return this.capabilities.opencode_cli_available === true;
+  }
+
+  get isPiCliAvailable(): boolean {
+    return this.capabilities.pi_cli_available === true;
+  }
+
+  get isGitHubCopilotCliAvailable(): boolean {
+    return this.capabilities.github_copilot_cli_available === true;
+  }
+
   get chatFeedbackEnabled(): boolean {
     return this.capabilities.chat_feedback_enabled === true;
   }

--- a/src/command-ids.ts
+++ b/src/command-ids.ts
@@ -61,4 +61,5 @@ export namespace CommandIDs {
   export const openPiLauncher = 'notebook-intelligence:open-pi-launcher';
   export const openGitHubCopilotCliLauncher =
     'notebook-intelligence:open-github-copilot-cli-launcher';
+  export const openCodexLauncher = 'notebook-intelligence:open-codex-launcher';
 }

--- a/src/command-ids.ts
+++ b/src/command-ids.ts
@@ -56,4 +56,9 @@ export namespace CommandIDs {
     'notebook-intelligence:run-command-in-terminal';
   export const openClaudeCodeLauncher =
     'notebook-intelligence:open-claude-code-launcher';
+  export const openOpenCodeLauncher =
+    'notebook-intelligence:open-opencode-launcher';
+  export const openPiLauncher = 'notebook-intelligence:open-pi-launcher';
+  export const openGitHubCopilotCliLauncher =
+    'notebook-intelligence:open-github-copilot-cli-launcher';
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ import { Menu, Panel, Widget } from '@lumino/widgets';
 import { CommandRegistry } from '@lumino/commands';
 import { IStatusBar } from '@jupyterlab/statusbar';
 import { ILauncher } from '@jupyterlab/launcher';
+import { IDisposable } from '@lumino/disposable';
 import React from 'react';
 import { ReactWidget } from '@jupyterlab/apputils';
 import { LauncherPicker } from './components/launcher-picker';
@@ -1315,13 +1316,40 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
       }
     });
 
-    if (launcher) {
-      launcher.add({
-        command: CommandIDs.openClaudeCodeLauncher,
-        category: 'Coding Agent',
-        rank: -1
-      });
-    }
+    // Add or dispose a launcher entry based on a live availability check.
+    // The launcher renders every item in its model regardless of the
+    // backing command's `isVisible`, so gating tile visibility requires
+    // adding only when available and disposing when not. Re-evaluates on
+    // every NBIAPI.configChanged so a late capabilities load (or a
+    // future hot-reload of the CLI on PATH) takes effect without a
+    // browser refresh.
+    const syncLauncherEntry = (
+      commandId: string,
+      itemOptions: Omit<ILauncher.IItemOptions, 'command'>,
+      isAvailable: () => boolean
+    ) => {
+      if (!launcher) {
+        return;
+      }
+      let entry: IDisposable | null = null;
+      const sync = () => {
+        const available = isAvailable();
+        if (available && !entry) {
+          entry = launcher.add({ command: commandId, ...itemOptions });
+        } else if (!available && entry) {
+          entry.dispose();
+          entry = null;
+        }
+      };
+      sync();
+      NBIAPI.configChanged.connect(sync);
+    };
+
+    syncLauncherEntry(
+      CommandIDs.openClaudeCodeLauncher,
+      { category: 'Coding Agent', rank: -1 },
+      () => NBIAPI.config.isClaudeCliAvailable
+    );
 
     // Additional coding-agent CLIs (issue #260). First-phase scope: detect
     // the binary on PATH (backend exposes `<agent>_cli_available`), show a
@@ -1344,12 +1372,11 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
           launchCliInTerminal(config.cliCommand, defaultBrowser?.model.path);
         }
       });
-      if (launcher) {
-        launcher.add({
-          command: config.commandId,
-          category: 'Coding Agent'
-        });
-      }
+      syncLauncherEntry(
+        config.commandId,
+        { category: 'Coding Agent' },
+        config.isAvailable
+      );
       NBIAPI.configChanged.connect(() => {
         app.commands.notifyCommandChanged(config.commandId);
       });
@@ -1382,10 +1409,18 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
       isAvailable: () => NBIAPI.config.isGitHubCopilotCliAvailable
     });
 
-    // Refresh the Claude Code launcher tile's enabled/visible state when the
-    // user toggles Claude Code mode or installs the CLI. Without this, the
-    // tile keeps its initial-load decision until full reload. The other
-    // agent-CLI tiles are wired the same way inside registerAgentCliLauncher.
+    registerAgentCliLauncher({
+      commandId: CommandIDs.openCodexLauncher,
+      label: 'Codex',
+      caption: 'Start an OpenAI Codex CLI session in a Jupyter terminal',
+      icon: terminalIcon,
+      cliCommand: 'codex',
+      isAvailable: () => NBIAPI.config.isCodexCliAvailable
+    });
+
+    // Refresh the Claude Code command's palette-visibility state when the
+    // user installs/uninstalls the CLI. The launcher tile is already gated
+    // via syncLauncherEntry; this is for the command palette only.
     NBIAPI.configChanged.connect(() => {
       app.commands.notifyCommandChanged(CommandIDs.openClaudeCodeLauncher);
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ import { FileBrowserModel, IDefaultFileBrowser } from '@jupyterlab/filebrowser';
 
 import { ContentsManager, KernelSpecManager } from '@jupyterlab/services';
 
-import { LabIcon } from '@jupyterlab/ui-components';
+import { LabIcon, terminalIcon } from '@jupyterlab/ui-components';
 
 import { Menu, Panel, Widget } from '@lumino/widgets';
 import { CommandRegistry } from '@lumino/commands';
@@ -1232,7 +1232,7 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
 
     // Waits for bash's first prompt before sending, avoiding the race condition
     // where the command is sent before the shell has started.
-    const launchClaudeInTerminal = async (
+    const launchCliInTerminal = async (
       command: string,
       cwd?: string
     ): Promise<void> => {
@@ -1288,7 +1288,7 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
                 const cmd = session.cwd
                   ? `cd ${session.cwd} && claude --resume ${session.session_id}`
                   : `claude --resume ${session.session_id}`;
-                launchClaudeInTerminal(cmd);
+                launchCliInTerminal(cmd);
               }
             });
           }
@@ -1310,7 +1310,7 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
           // New Session: open the terminal at whatever subdirectory the file
           // browser is currently viewing, mirroring how Jupyter's own
           // terminal launcher behaves (issue #182).
-          launchClaudeInTerminal('claude', defaultBrowser?.model.path);
+          launchCliInTerminal('claude', defaultBrowser?.model.path);
         }
       }
     });
@@ -1323,9 +1323,69 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
       });
     }
 
-    // Refresh the launcher tile's enabled/visible state when the user
-    // toggles Claude Code mode or installs the CLI. Without this, the
-    // tile keeps its initial-load decision until full reload.
+    // Additional coding-agent CLIs (issue #260). First-phase scope: detect
+    // the binary on PATH (backend exposes `<agent>_cli_available`), show a
+    // tile when present, click opens a terminal in the file-browser's
+    // current directory and types the CLI command. No session picker.
+    const registerAgentCliLauncher = (config: {
+      commandId: string;
+      label: string;
+      caption: string;
+      icon: LabIcon;
+      cliCommand: string;
+      isAvailable: () => boolean;
+    }) => {
+      app.commands.addCommand(config.commandId, {
+        label: config.label,
+        caption: config.caption,
+        icon: config.icon,
+        isVisible: () => config.isAvailable(),
+        execute: () => {
+          launchCliInTerminal(config.cliCommand, defaultBrowser?.model.path);
+        }
+      });
+      if (launcher) {
+        launcher.add({
+          command: config.commandId,
+          category: 'Coding Agent'
+        });
+      }
+      NBIAPI.configChanged.connect(() => {
+        app.commands.notifyCommandChanged(config.commandId);
+      });
+    };
+
+    registerAgentCliLauncher({
+      commandId: CommandIDs.openOpenCodeLauncher,
+      label: 'opencode',
+      caption: 'Start an opencode session in a Jupyter terminal',
+      icon: terminalIcon,
+      cliCommand: 'opencode',
+      isAvailable: () => NBIAPI.config.isOpenCodeCliAvailable
+    });
+
+    registerAgentCliLauncher({
+      commandId: CommandIDs.openPiLauncher,
+      label: 'Pi',
+      caption: 'Start a Pi session in a Jupyter terminal',
+      icon: terminalIcon,
+      cliCommand: 'pi',
+      isAvailable: () => NBIAPI.config.isPiCliAvailable
+    });
+
+    registerAgentCliLauncher({
+      commandId: CommandIDs.openGitHubCopilotCliLauncher,
+      label: 'GitHub Copilot CLI',
+      caption: 'Start a GitHub Copilot CLI session in a Jupyter terminal',
+      icon: githubCopilotIcon,
+      cliCommand: 'copilot',
+      isAvailable: () => NBIAPI.config.isGitHubCopilotCliAvailable
+    });
+
+    // Refresh the Claude Code launcher tile's enabled/visible state when the
+    // user toggles Claude Code mode or installs the CLI. Without this, the
+    // tile keeps its initial-load decision until full reload. The other
+    // agent-CLI tiles are wired the same way inside registerAgentCliLauncher.
     NBIAPI.configChanged.connect(() => {
       app.commands.notifyCommandChanged(CommandIDs.openClaudeCodeLauncher);
     });


### PR DESCRIPTION
## Summary

The Coding Agent launcher category previously had a single tile (Claude Code). This PR adds three more, matching the first-phase scope from the issue: detect the binary on PATH, show a tile when present, click opens a Jupyter terminal in the file-browser's current directory and runs the CLI. No session picker.

## Solution

**Backend.** Refactored `resolve_claude_cli_path` to delegate to a generic `_resolve_cli_path(name, env_var)` backed by a single dict cache. Added `resolve_opencode_cli_path`, `resolve_pi_cli_path`, `resolve_copilot_cli_path` as one-line wrappers, each with an `NBI_<AGENT>_CLI_PATH` env override that mirrors the existing Claude pattern. The capabilities response gains `opencode_cli_available`, `pi_cli_available`, `github_copilot_cli_available` flags.

**Frontend.** New `isOpenCodeCliAvailable`, `isPiCliAvailable`, `isGitHubCopilotCliAvailable` getters on `NBIAPI.config`. A `registerAgentCliLauncher` helper takes `(commandId, label, caption, icon, cliCommand, isAvailable)` and wires the command + tile + `configChanged` refresh in one place. The Claude Code tile keeps its bespoke session-picker UX and isn't routed through the helper (folding it in would balloon the helper's API to handle a single outlier). Renamed `launchClaudeInTerminal` → `launchCliInTerminal` since three new callers needed it.

**Icons.** opencode and Pi reuse JL's `terminalIcon` as a first-phase placeholder, which reads as "this opens a terminal" and matches the actual behavior. GitHub Copilot CLI reuses the existing `githubCopilotIcon`. Brand-specific icons can be a follow-up if licensing allows.

## Testing

`pytest tests/ --ignore=tests/test_claude_client.py -q` (699 passed). `jlpm tsc --noEmit`, `jlpm lint:check`, `jlpm jest` all green. Manual: confirmed the existing Claude tile still works after the helper rename and that the new tiles' visibility tracks the binary presence on PATH.

No new automated tests. The util helpers are direct wrappers around the already-exercised memoized `shutil.which` path, and tile registration is JL framework boilerplate unreachable from jest without a real lab application context.

## Risks / follow-ups

- **Icons.** Generic terminal icon is intentional for first-phase. If the project wants brand icons for opencode / Pi, add them via the same `LabIcon` + `svgstr` pattern used by `claudeIcon` and pass them into the helper.
- **CLI invocation.** GitHub Copilot CLI is detected as the `copilot` binary (the new standalone CLI). If you'd rather support `gh copilot` (the extension form), point `NBI_GITHUB_COPILOT_CLI_PATH` at `gh` and adjust `cliCommand` to `gh copilot`. Worth confirming which surface the project wants to anchor on.
- **Session resume.** Out of scope; the issue scopes this to "Launching a Jupyter Terminal in the active working directory is good enough for the first phase." A follow-up could mirror the Claude Code session-picker UX once those CLIs grow comparable history surfaces.

Closes #260