### PR TITLE
feat(copilot): dynamically discover available Copilot chat models

### DIFF
--- a/notebook_intelligence/github_copilot.py
+++ b/notebook_intelligence/github_copilot.py
@@ -49,6 +49,21 @@ github_auth = {
     "token_expires_at": dt.datetime.now()
 }
 
+# Populated from https://api.githubcopilot.com/models once the user has a
+# valid Copilot bearer token. Each entry is a normalized dict:
+# {"id": str, "name": str, "context_window": int}. Empty until the first
+# successful fetch; the LLM provider falls back to its hardcoded list in
+# that case so the settings UI is never blank. Mutated in place by
+# `fetch_copilot_models` so module-level `from ... import` references
+# stay current.
+copilot_models_cache: list[dict] = []
+
+# Conservative floor when the Copilot API omits limits for a model. Picked
+# to match the smallest token cap any Copilot-served model has historically
+# carried, so the token-budget meter (extension.py: `remaining_token_budget`)
+# doesn't zero out and strip all additional context.
+_COPILOT_DEFAULT_CONTEXT_WINDOW = 4096
+
 stop_requested = False
 get_access_code_thread = None
 get_token_thread = None
@@ -313,7 +328,7 @@ def get_token():
             logout()
             wait_for_tokens()
             return
-        
+
         if resp.status_code != 200:
             log.error(f"Failed to get token from GitHub Copilot: {resp_json}")
             return
@@ -328,14 +343,117 @@ def get_token():
         github_auth["verification_uri"] = None
         github_auth["user_code"] = None
         github_auth["status"] = LoginStatus.LOGGED_IN
-        emit_github_login_status_change()
 
         endpoints = resp_json.get('endpoints', {})
         API_ENDPOINT = endpoints.get('api', API_ENDPOINT)
         PROXY_ENDPOINT = endpoints.get('proxy', PROXY_ENDPOINT)
         TOKEN_REFRESH_INTERVAL = resp_json.get('refresh_in', TOKEN_REFRESH_INTERVAL)
+
+        # Populate the chat-model catalogue before announcing LOGGED_IN so
+        # the frontend's capabilities refetch (triggered by the status
+        # change) picks up the dynamic list in the same round trip.
+        # Best-effort: failure logs and falls back to the provider's
+        # hardcoded list so the settings UI is never blank.
+        fetch_copilot_models()
+
+        emit_github_login_status_change()
     except Exception as e:
         log.error(f"Failed to get token from GitHub Copilot: {e}")
+
+
+def fetch_copilot_models() -> list[dict]:
+    """Fetch the chat-model catalogue from https://api.githubcopilot.com/models.
+
+    Filters to chat models with `model_picker_enabled = true` (the same
+    surface GitHub's official clients expose in their model picker), and
+    normalizes each entry to {"id": str, "name": str, "context_window": int}.
+    Stores the result in ``copilot_models_cache`` (mutated in place) so the
+    LLM provider's `chat_models` property reflects the live list on the
+    next access. Returns the new list; returns the existing cache unchanged
+    on error so a transient outage doesn't blank the dropdown.
+    """
+    token = github_auth.get("token")
+    if not token:
+        return list(copilot_models_cache)
+    try:
+        resp = requests.get(
+            f"{API_ENDPOINT}/models",
+            headers={
+                "authorization": f"Bearer {token}",
+                "editor-version": EDITOR_VERSION,
+                "editor-plugin-version": EDITOR_PLUGIN_VERSION,
+                "user-agent": USER_AGENT,
+                # vscode-chat anchors the response to the same model set
+                # GitHub's official picker shows. Changing this string would
+                # bias the catalogue toward a different surface (inline,
+                # JetBrains, etc.); leave it unless that's the intent.
+                "copilot-integration-id": "vscode-chat",
+            },
+            timeout=10,
+        )
+    except Exception as e:
+        log.warning(f"Failed to fetch Copilot models: {e}")
+        return list(copilot_models_cache)
+
+    if resp.status_code != 200:
+        log.warning(f"Copilot models endpoint returned {resp.status_code}: {resp.text[:200]}")
+        return list(copilot_models_cache)
+
+    try:
+        payload = resp.json()
+    except ValueError as e:
+        log.warning(f"Copilot models response was not JSON: {e}")
+        return list(copilot_models_cache)
+
+    raw_models = payload.get("data", []) if isinstance(payload, dict) else []
+    normalized: list[dict] = []
+    seen_ids: set[str] = set()
+    for entry in raw_models:
+        if not isinstance(entry, dict):
+            continue
+        if not entry.get("model_picker_enabled"):
+            continue
+        caps = entry.get("capabilities", {}) or {}
+        if caps.get("type") != "chat":
+            continue
+        model_id = entry.get("id")
+        if not isinstance(model_id, str) or not model_id or model_id in seen_ids:
+            continue
+        seen_ids.add(model_id)
+        name = entry.get("name") or model_id
+        limits = caps.get("limits", {}) or {}
+        context_window = (
+            limits.get("max_context_window_tokens")
+            or limits.get("max_prompt_tokens")
+            or _COPILOT_DEFAULT_CONTEXT_WINDOW
+        )
+        try:
+            context_window = int(context_window)
+        except (TypeError, ValueError):
+            context_window = _COPILOT_DEFAULT_CONTEXT_WINDOW
+        if context_window <= 0:
+            context_window = _COPILOT_DEFAULT_CONTEXT_WINDOW
+        normalized.append({
+            "id": model_id,
+            "name": str(name),
+            "context_window": context_window,
+        })
+
+    # Preserve the existing cache when the API returns an empty (but
+    # well-formed) response. Replacing a known-good list with [] would
+    # silently flip the provider back to its hardcoded fallback.
+    if not normalized and copilot_models_cache:
+        log.warning("Copilot models endpoint returned no entries; keeping previous cache.")
+        return list(copilot_models_cache)
+
+    copilot_models_cache.clear()
+    copilot_models_cache.extend(normalized)
+    return list(copilot_models_cache)
+
+
+def invalidate_copilot_models_cache() -> None:
+    """Clear the memoized Copilot chat-model list. Mostly used by tests."""
+    copilot_models_cache.clear()
 
 def get_token_thread_func():
     global github_auth, get_token_thread, last_token_fetch_time

--- a/notebook_intelligence/llm_providers/github_copilot_llm_provider.py
+++ b/notebook_intelligence/llm_providers/github_copilot_llm_provider.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import requests
 from notebook_intelligence.api import ChatModel, EmbeddingModel, InlineCompletionModel, LLMProvider, CancelToken, ChatResponse, CompletionContext
+from notebook_intelligence import github_copilot as gh_copilot
 from notebook_intelligence.github_copilot import generate_copilot_headers, completions, inline_completions
 import logging
 
@@ -60,24 +61,40 @@ class GitHubCopilotInlineCompletionModel(InlineCompletionModel):
         return inline_completions(self._model_id, prefix, suffix, language, filename, context, cancel_token)
 
 class GitHubCopilotLLMProvider(LLMProvider):
+    # Used until the dynamic catalogue from https://api.githubcopilot.com/models
+    # is populated. Lets pre-login users see a non-empty dropdown and
+    # protects against API outages.
+    _FALLBACK_CHAT_MODELS: list[tuple[str, str, int]] = [
+        ("gpt-5-mini", "GPT-5 mini", 128000),
+        ("gpt-4.1", "GPT-4.1", 128000),
+        ("gpt-4o", "GPT-4o", 128000),
+        ("gpt-5", "GPT-5", 128000),
+        ("gpt-5.3-codex", "GPT-5.3-Codex", 128000),
+        ("claude-haiku-4.5", "Claude Haiku 4.5", 144000),
+        ("claude-sonnet-4.6", "Claude Sonnet 4.6", 144000),
+        ("claude-sonnet-4.5", "Claude Sonnet 4.5", 144000),
+        ("claude-sonnet-4", "Claude Sonnet 4", 80000),
+        ("claude-opus-4.6", "Claude Opus 4.6", 144000),
+        ("gemini-3.1-pro", "Gemini 3.1 Pro", 128000),
+        ("gemini-2.5-pro", "Gemini 2.5 Pro", 128000),
+    ]
+
     def __init__(self):
-        self._chat_models = [
-            GitHubCopilotChatModel(self, "gpt-5-mini", "GPT-5 mini", 128000, True),
-            GitHubCopilotChatModel(self, "gpt-4.1", "GPT-4.1", 128000, True),
-            GitHubCopilotChatModel(self, "gpt-4o", "GPT-4o", 128000, True),
-            GitHubCopilotChatModel(self, "gpt-5", "GPT-5", 128000, True),
-            GitHubCopilotChatModel(self, "gpt-5.3-codex", "GPT-5.3-Codex", 128000, True),
-            GitHubCopilotChatModel(self, "claude-haiku-4.5", "Claude Haiku 4.5", 144000, True),
-            GitHubCopilotChatModel(self, "claude-sonnet-4.6", "Claude Sonnet 4.6", 144000, True),
-            GitHubCopilotChatModel(self, "claude-sonnet-4.5", "Claude Sonnet 4.5", 144000, True),
-            GitHubCopilotChatModel(self, "claude-sonnet-4", "Claude Sonnet 4", 80000, True),
-            GitHubCopilotChatModel(self, "claude-opus-4.6", "Claude Opus 4.6", 144000, True),
-            GitHubCopilotChatModel(self, "gemini-3.1-pro", "Gemini 3.1 Pro", 128000, True),
-            GitHubCopilotChatModel(self, "gemini-2.5-pro", "Gemini 2.5 Pro", 128000, True),
-        ]
         self._inline_completion_model_gpt41 = GitHubCopilotInlineCompletionModel(self, "gpt-41-copilot", "GPT-4.1 Copilot")
         self._inline_completion_model_gpt4o = GitHubCopilotInlineCompletionModel(self, "gpt-4o-copilot", "GPT-4o Copilot")
         self._inline_completion_model_codex = GitHubCopilotInlineCompletionModel(self, "copilot-codex", "Copilot Codex")
+
+    def _build_chat_models(self) -> list[ChatModel]:
+        cached = gh_copilot.copilot_models_cache
+        if cached:
+            return [
+                GitHubCopilotChatModel(self, entry["id"], entry["name"], entry["context_window"], True)
+                for entry in cached
+            ]
+        return [
+            GitHubCopilotChatModel(self, model_id, model_name, ctx, True)
+            for (model_id, model_name, ctx) in self._FALLBACK_CHAT_MODELS
+        ]
 
     @property
     def id(self) -> str:
@@ -89,7 +106,9 @@ class GitHubCopilotLLMProvider(LLMProvider):
 
     @property
     def chat_models(self) -> list[ChatModel]:
-        return self._chat_models
+        # Rebuilt per call so the dropdown reflects the current
+        # copilot_models_cache without explicit invalidation paths.
+        return self._build_chat_models()
     
     @property
     def inline_completion_models(self) -> list[InlineCompletionModel]:

--- a/src/api.ts
+++ b/src/api.ts
@@ -502,7 +502,13 @@ export class NBIAPI {
       } else if (
         msg.type === BackendMessageType.GitHubCopilotLoginStatusChange
       ) {
-        this.updateGitHubLoginStatus().then(() => {
+        // The Copilot chat-model catalogue is fetched lazily once the bearer
+        // token is minted (issue #258), so the model dropdown depends on a
+        // capabilities refresh in addition to the login-status update.
+        Promise.all([
+          this.updateGitHubLoginStatus(),
+          this.fetchCapabilities()
+        ]).then(() => {
           this.githubLoginStatusChanged.emit();
         });
       } else if (msg.type === BackendMessageType.SkillsReloaded) {

--- a/tests/test_github_copilot_llm_provider.py
+++ b/tests/test_github_copilot_llm_provider.py
@@ -1,4 +1,16 @@
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from notebook_intelligence import github_copilot as gh_copilot
 from notebook_intelligence.llm_providers.github_copilot_llm_provider import GitHubCopilotLLMProvider
+
+
+@pytest.fixture(autouse=True)
+def _reset_models_cache():
+    gh_copilot.invalidate_copilot_models_cache()
+    yield
+    gh_copilot.invalidate_copilot_models_cache()
 
 
 def test_chat_models_include_recent_github_copilot_models():
@@ -13,3 +25,142 @@ def test_chat_models_include_recent_github_copilot_models():
     assert models["gemini-3.1-pro"].name == "Gemini 3.1 Pro"
 
     assert all(model.supports_tools for model in models.values())
+
+
+def test_chat_models_use_dynamic_cache_when_populated():
+    gh_copilot.copilot_models_cache.extend([
+        {"id": "future-model-1", "name": "Future 1", "context_window": 200000},
+        {"id": "future-model-2", "name": "Future 2", "context_window": 4096},
+    ])
+
+    provider = GitHubCopilotLLMProvider()
+    ids = [m.id for m in provider.chat_models]
+
+    assert ids == ["future-model-1", "future-model-2"]
+    by_id = {m.id: m for m in provider.chat_models}
+    assert by_id["future-model-1"].context_window == 200000
+    assert by_id["future-model-2"].name == "Future 2"
+
+
+def test_fetch_copilot_models_returns_empty_without_token():
+    gh_copilot.github_auth["token"] = None
+    assert gh_copilot.fetch_copilot_models() == []
+
+
+def test_fetch_copilot_models_floors_zero_context_window_to_default():
+    gh_copilot.github_auth["token"] = "fake-bearer-token"
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {
+        "data": [
+            {
+                "id": "no-limits-model",
+                "name": "No Limits",
+                "model_picker_enabled": True,
+                "capabilities": {"type": "chat"},
+            }
+        ]
+    }
+    with patch("notebook_intelligence.github_copilot.requests.get", return_value=response):
+        result = gh_copilot.fetch_copilot_models()
+
+    assert result == [{
+        "id": "no-limits-model",
+        "name": "No Limits",
+        "context_window": 4096,
+    }]
+
+
+def test_fetch_copilot_models_preserves_cache_on_empty_response():
+    gh_copilot.github_auth["token"] = "fake-bearer-token"
+    gh_copilot.copilot_models_cache.append({
+        "id": "previously-cached",
+        "name": "Cached",
+        "context_window": 100000,
+    })
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {"data": []}
+
+    with patch("notebook_intelligence.github_copilot.requests.get", return_value=response):
+        result = gh_copilot.fetch_copilot_models()
+
+    assert [m["id"] for m in result] == ["previously-cached"]
+    assert [m["id"] for m in gh_copilot.copilot_models_cache] == ["previously-cached"]
+
+
+def test_fetch_copilot_models_preserves_cache_on_http_failure():
+    gh_copilot.github_auth["token"] = "fake-bearer-token"
+    gh_copilot.copilot_models_cache.append({
+        "id": "previously-cached",
+        "name": "Cached",
+        "context_window": 100000,
+    })
+    response = MagicMock(status_code=503, text="upstream down")
+
+    with patch("notebook_intelligence.github_copilot.requests.get", return_value=response):
+        result = gh_copilot.fetch_copilot_models()
+
+    assert [m["id"] for m in result] == ["previously-cached"]
+    assert [m["id"] for m in gh_copilot.copilot_models_cache] == ["previously-cached"]
+
+
+def test_fetch_copilot_models_filters_to_picker_enabled_chat_models():
+    gh_copilot.github_auth["token"] = "fake-bearer-token"
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {
+        "data": [
+            {
+                "id": "gpt-foo",
+                "name": "GPT Foo",
+                "model_picker_enabled": True,
+                "capabilities": {
+                    "type": "chat",
+                    "limits": {"max_context_window_tokens": 64000},
+                },
+            },
+            {
+                "id": "gpt-foo-internal",
+                "name": "GPT Foo Internal",
+                "model_picker_enabled": False,
+                "capabilities": {"type": "chat"},
+            },
+            {
+                "id": "text-embed",
+                "model_picker_enabled": True,
+                "capabilities": {"type": "embedding"},
+            },
+            {
+                "id": "gpt-foo",  # duplicate id is dropped
+                "name": "GPT Foo Dup",
+                "model_picker_enabled": True,
+                "capabilities": {"type": "chat"},
+            },
+            {
+                "id": "claude-bar",
+                "model_picker_enabled": True,
+                "capabilities": {
+                    "type": "chat",
+                    "limits": {"max_prompt_tokens": 128000},
+                },
+            },
+        ]
+    }
+
+    with patch("notebook_intelligence.github_copilot.requests.get", return_value=response):
+        result = gh_copilot.fetch_copilot_models()
+
+    assert [m["id"] for m in result] == ["gpt-foo", "claude-bar"]
+    assert result[0]["context_window"] == 64000
+    assert result[1]["context_window"] == 128000
+    # Falls back to id when name is missing.
+    assert result[1]["name"] == "claude-bar"
+
+
+def test_fetch_copilot_models_swallows_http_failure():
+    gh_copilot.github_auth["token"] = "fake-bearer-token"
+    response = MagicMock(status_code=500, text="oops")
+
+    with patch("notebook_intelligence.github_copilot.requests.get", return_value=response):
+        assert gh_copilot.fetch_copilot_models() == []


### PR DESCRIPTION
## Summary

The GitHub Copilot model dropdown was a hardcoded list that went stale every time GitHub added or retired models. This PR makes the catalogue dynamic: NBI calls `https://api.githubcopilot.com/models` with the existing Copilot bearer token on every token refresh (~25 min cadence) and caches the result. The provider's `chat_models` property rebuilds from the cache on each access, falling back to a known-safe hardcoded list when the cache is empty so the settings UI is never blank.

## Solution

**Backend.** New `fetch_copilot_models()` in `notebook_intelligence/github_copilot.py`. Called from `get_token()` after the bearer token is minted and before the `LOGGED_IN` status emit, so the frontend's capabilities refetch picks up the new list on the same round trip. Cache (`copilot_models_cache: list[dict]`) is mutated in place so module-level imports stay live.

Filter: `model_picker_enabled === true` and `capabilities.type === "chat"`, the same intersection GitHub's official picker uses. Deduped by id. `context_window` reads `max_context_window_tokens` then `max_prompt_tokens` then a 4096 floor. Headers include `copilot-integration-id: vscode-chat` (commented) to anchor the response to the chat surface.

**Provider.** `GitHubCopilotLLMProvider._build_chat_models()` returns cache entries when populated, fallback list otherwise. `chat_models` rebuilds per call so the dropdown reflects the live cache without explicit invalidation.

**Frontend.** `GitHubCopilotLoginStatusChange` now triggers `fetchCapabilities()` alongside the login-status refresh so the dropdown updates as soon as the token is available.

## Robustness fixes from the six-agent review

- **`context_window` floor.** A model with no `limits` block previously yielded 0, which `extension.py:1834`'s `0.8 * token_limit` short-circuits, silently stripping all additional context. Now floors to 4096.
- **Preserve cache on errors.** A well-formed-but-empty response (`data: []`), HTTP error, network error, or JSON-decode failure now keeps the prior cache instead of replacing it with []. A transient outage no longer flips the picker back to the hardcoded fallback.
- **In-place cache mutation.** `clear() + extend()` matches the existing `fetch_claude_models` pattern so any future `from ... import copilot_models_cache` reference stays current.
- **Public `invalidate_copilot_models_cache()`** mirroring `invalidate_cli_cache` for tests.
- Dropped the dead `register_copilot_models_changed_callback` API per YAGNI.

## Testing

`pytest tests/ --ignore=tests/test_claude_client.py -q` (706 passed). `jlpm tsc --noEmit`, `jlpm lint:check`, `jlpm jest` all green. 5 new pytest cases covering: cache-vs-fallback selection, no-token early-return, filtering by `model_picker_enabled` + `type === "chat"` + dedup, the 4096 floor for missing-`limits` entries, empty-response preservation, and HTTP-failure preservation.

Manual end-to-end requires a live Copilot login, which the local dev environment doesn't have plumbed in for this branch. The fetch / filter / cache contract is covered by the new unit tests; the integration surface (login → bearer token → /models → cache → capabilities → dropdown) is straightforward wiring.

## Risks / follow-ups

- **Org-disabled models.** The current filter doesn't read `policy.state`; if a model has `model_picker_enabled === true` but the user's org has disabled it, it will appear in the dropdown and fail at call time. Worth a follow-up filter once we have a confirmed sighting.
- **Frontend message order.** `updateGitHubLoginStatus()` and `fetchCapabilities()` run in parallel on the login-status event. They write disjoint state today, so safe; if a future listener branches on "logged in?" while consuming the new model list, sequential ordering would tighten the invariant.

Closes #258