### PR TITLE
fix(claude): render tool-result check on the right of the label

### DIFF
--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -690,7 +690,7 @@ class ClaudeCodeClient():
                                                     # ToolUseBlock is anomalous (cross-
                                                     # query stragglers, sub-agent
                                                     # results routed through a parent
-                                                    # tool_use_id). A bare "✓ Tool"
+                                                    # tool_use_id). A bare "Tool ✓"
                                                     # without context is more
                                                     # confusing than silence, so we
                                                     # only surface results we can
@@ -701,7 +701,7 @@ class ClaudeCodeClient():
                                                     if label is None:
                                                         continue
                                                     icon = "✗" if block.is_error else "✓"
-                                                    response.stream(ProgressData(f"{icon} {label}"))
+                                                    response.stream(ProgressData(f"{label} {icon}"))
                                     else:
                                         pass
                         except Exception as e:


### PR DESCRIPTION
## Summary

Tool-result progress lines had the ✓/✗ glyph on the leading edge of the label, so when a tool completed the entire string shifted horizontally by two characters: "Adding markdown cell…" → "✓ Adding markdown cell". @mbektas  flagged this as visually jumpy.

## Solution

Render the glyph in the trailing position instead. In-progress format ("Adding markdown cell…") stays exactly where it was; on completion the trailing "…" is replaced by " ✓" (or " ✗" on error), so the label stays in the same column it occupied while the tool was in flight.

One-line behavior change in `notebook_intelligence/claude.py` plus an explanatory comment.

## Testing

`pytest tests/ --ignore=tests/test_claude_client.py -q` (709 passed), `pytest tests/test_claude_client.py -q` (57 passed), `jlpm tsc --noEmit`, `jlpm lint:check`, `jlpm jest` (131 passed) all green.

No tests assert on the literal glyph-position string. The change is purely visual; mocking a streaming tool-result event in unit tests would be more scaffold than the change merits.

## Risks / follow-ups

No other production callsites render a tool-result glyph in the leading position (verified via grep on `ProgressData`, `"✓"`, `"✗"`). Frontend renders the streamed string verbatim with no special handling for the glyph location, so no frontend change is needed.

Fixes #274