### PR TITLE
fix(launcher): use sparkle icon for Coding Agent header

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1347,7 +1347,7 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
     app.commands.addCommand(CommandIDs.openClaudeCodeLauncher, {
       label: 'Claude Code',
       caption: 'Resume or start a Claude Code session',
-      icon: claudeIcon,
+      icon: sparkleIcon,
       // The launcher tile opens a Jupyter terminal that runs the
       // `claude` CLI directly — it doesn't depend on NBI being in
       // Claude Code chat mode (which gates the chat-sidebar SDK

--- a/src/index.ts
+++ b/src/index.ts
@@ -1347,7 +1347,7 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
     app.commands.addCommand(CommandIDs.openClaudeCodeLauncher, {
       label: 'Claude Code',
       caption: 'Resume or start a Claude Code session',
-      icon: sparkleIcon,
+      icon: claudeIcon,
       // The launcher tile opens a Jupyter terminal that runs the
       // `claude` CLI directly — it doesn't depend on NBI being in
       // Claude Code chat mode (which gates the chat-sidebar SDK

--- a/style/base.css
+++ b/style/base.css
@@ -2827,10 +2827,9 @@ svg.access-token-warning {
   z-index: 100;
 }
 
-/* Coding Agent launcher tile: Anthropic orange icon.
+/* Coding Agent launcher tiles.
    Placed last to satisfy no-descending-specificity lint rule. */
-.jp-LauncherCard[data-category='Coding Agent'] .jp-LauncherCard-icon svg,
-.jp-Launcher-sectionHeader svg[data-icon='notebook-intelligence:claude-icon'] {
+.jp-LauncherCard[data-category='Coding Agent'] .jp-LauncherCard-icon svg {
   color: #d97757;
 }
 


### PR DESCRIPTION
## Summary
- use NBI's existing sparkle icon for the Claude Code launcher command, which is the first item in the Coding Agent launcher section
- remove the stale section-header CSS selector that targeted the Claude icon

JupyterLab derives a launcher section header icon from the first item in that section, so this makes the Coding Agent header use the NBI sparkle icon instead of the Claude icon. The Claude-specific extension icon path is still kept for Claude inline-model mode.

Fixes #275.

## Validation
- `.venv/bin/jlpm stylelint:check` - passed
- `.venv/bin/jlpm test --runInBand` - 10 suites / 131 tests passed
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/jlpm lint:check` - passed
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/jlpm build:lib` - passed
- `git diff --check` - passed
- `git diff | gitleaks stdin --no-banner --redact` - no leaks found

Not run: browser screenshot; this change is limited to the launcher command icon used by the section header.