### PR TITLE
feat(mcp): JSON-paste path in Add MCP server dialog

### DIFF
--- a/src/components/claude-mcp-panel.tsx
+++ b/src/components/claude-mcp-panel.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Dialog, showDialog } from '@jupyterlab/apputils';
 import {
   ClaudeMCPScope,
@@ -10,6 +10,11 @@ import {
   NBIAPI
 } from '../api';
 import { FormDialog } from './form-dialog';
+import {
+  configToInput,
+  parseKVLines,
+  parseMcpJsonEntry
+} from './claude-mcp-paste';
 
 const SCOPES: ClaudeMCPScope[] = ['user', 'project', 'local'];
 const TRANSPORTS: ClaudeMCPTransport[] = ['stdio', 'sse', 'http'];
@@ -210,66 +215,102 @@ function ClaudeMCPRow(props: {
   );
 }
 
+type AddDialogMode = 'form' | 'json';
+
+const JSON_PLACEHOLDER = `"server-key": {
+  "command": "uvx",
+  "args": ["server-package@latest"]
+}`;
+
+const FORM_TAB_ID = 'nbi-mcp-add-tab-form';
+const JSON_TAB_ID = 'nbi-mcp-add-tab-json';
+const FORM_PANEL_ID = 'nbi-mcp-add-panel-form';
+const JSON_PANEL_ID = 'nbi-mcp-add-panel-json';
+
 function ClaudeMCPAddDialog(props: {
   onCancel: () => void;
   onSubmit: (input: IClaudeMCPAddInput) => Promise<void>;
 }) {
   const [scope, setScope] = useState<ClaudeMCPScope>('user');
+  const [mode, setMode] = useState<AddDialogMode>('form');
   const [transport, setTransport] = useState<ClaudeMCPTransport>('stdio');
   const [name, setName] = useState('');
   const [commandOrUrl, setCommandOrUrl] = useState('');
   const [argsText, setArgsText] = useState('');
   const [envText, setEnvText] = useState('');
   const [headersText, setHeadersText] = useState('');
+  const [jsonText, setJsonText] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
-  const canSubmit = name.trim() && commandOrUrl.trim() && !submitting;
+  const nameInputRef = useRef<HTMLInputElement>(null);
+  const jsonInputRef = useRef<HTMLTextAreaElement>(null);
+  const formTabRef = useRef<HTMLButtonElement>(null);
+  const jsonTabRef = useRef<HTMLButtonElement>(null);
+  // Skip the first effect run so we don't steal focus from the Scope select
+  // when the dialog mounts; only re-focus when the user actively switches.
+  const hasMountedRef = useRef(false);
+
+  useEffect(() => {
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      return;
+    }
+    if (mode === 'json') {
+      jsonInputRef.current?.focus();
+    } else {
+      nameInputRef.current?.focus();
+    }
+  }, [mode]);
+
+  const canSubmit =
+    mode === 'json'
+      ? jsonText.trim().length > 0 && !submitting
+      : name.trim() && commandOrUrl.trim() && !submitting;
 
   const handleSubmit = async () => {
     if (!canSubmit) {
       return;
     }
-    const argsList = argsText
-      .split('\n')
-      .map(line => line.trim())
-      .filter(Boolean);
-    const parseKVLines = (
-      text: string,
-      separator: string
-    ): Record<string, string> => {
-      const out: Record<string, string> = {};
-      for (const line of text.split('\n')) {
-        const trimmed = line.trim();
-        if (!trimmed) {
-          continue;
-        }
-        const idx = trimmed.indexOf(separator);
-        if (idx > 0) {
-          out[trimmed.slice(0, idx).trim()] = trimmed.slice(idx + 1).trim();
-        }
-      }
-      return out;
-    };
-    const envMap = parseKVLines(envText, '=');
-    const headersMap = parseKVLines(headersText, ':');
     setSubmitError(null);
     setSubmitting(true);
     try {
-      await props.onSubmit({
-        name: name.trim(),
-        scope,
-        transport,
-        commandOrUrl: commandOrUrl.trim(),
-        args: transport === 'stdio' ? argsList : undefined,
-        env: transport === 'stdio' ? envMap : undefined,
-        headers: transport === 'stdio' ? undefined : headersMap
-      });
+      let input: IClaudeMCPAddInput;
+      if (mode === 'json') {
+        const { name: parsedName, config } = parseMcpJsonEntry(jsonText);
+        input = configToInput(parsedName, config, scope);
+      } else {
+        const argsList = argsText
+          .split('\n')
+          .map(line => line.trim())
+          .filter(Boolean);
+        input = {
+          name: name.trim(),
+          scope,
+          transport,
+          commandOrUrl: commandOrUrl.trim(),
+          args: transport === 'stdio' ? argsList : undefined,
+          env: transport === 'stdio' ? parseKVLines(envText, '=') : undefined,
+          headers:
+            transport === 'stdio' ? undefined : parseKVLines(headersText, ':')
+        };
+      }
+      await props.onSubmit(input);
     } catch (e: any) {
       setSubmitError(e?.message ?? String(e));
     } finally {
       setSubmitting(false);
     }
+  };
+
+  const onTabsKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') {
+      return;
+    }
+    event.preventDefault();
+    const next: AddDialogMode = mode === 'form' ? 'json' : 'form';
+    setMode(next);
+    (next === 'form' ? formTabRef : jsonTabRef).current?.focus();
   };
 
   return (
@@ -284,16 +325,6 @@ function ClaudeMCPAddDialog(props: {
       onSubmit={handleSubmit}
     >
       <div className="nbi-form-field">
-        <label>Name</label>
-        <input
-          type="text"
-          value={name}
-          onChange={e => setName(e.target.value)}
-          placeholder="my-server"
-          autoFocus
-        />
-      </div>
-      <div className="nbi-form-field">
         <label>Scope</label>
         <select
           value={scope}
@@ -307,60 +338,136 @@ function ClaudeMCPAddDialog(props: {
         </select>
       </div>
       <div className="nbi-form-field">
-        <label>Transport</label>
-        <select
-          value={transport}
-          onChange={e => setTransport(e.target.value as ClaudeMCPTransport)}
+        <label id="nbi-mcp-add-input-mode-label">Input mode</label>
+        <div
+          className="nbi-segmented-control"
+          role="tablist"
+          aria-labelledby="nbi-mcp-add-input-mode-label"
+          onKeyDown={onTabsKeyDown}
         >
-          {TRANSPORTS.map(t => (
-            <option key={t} value={t}>
-              {t}
-            </option>
-          ))}
-        </select>
+          <button
+            type="button"
+            role="tab"
+            id={FORM_TAB_ID}
+            ref={formTabRef}
+            aria-selected={mode === 'form'}
+            aria-controls={FORM_PANEL_ID}
+            tabIndex={mode === 'form' ? 0 : -1}
+            className={`nbi-segmented-control-option${mode === 'form' ? ' is-active' : ''}`}
+            onClick={() => setMode('form')}
+          >
+            Form
+          </button>
+          <button
+            type="button"
+            role="tab"
+            id={JSON_TAB_ID}
+            ref={jsonTabRef}
+            aria-selected={mode === 'json'}
+            aria-controls={JSON_PANEL_ID}
+            tabIndex={mode === 'json' ? 0 : -1}
+            className={`nbi-segmented-control-option${mode === 'json' ? ' is-active' : ''}`}
+            onClick={() => setMode('json')}
+          >
+            JSON
+          </button>
+        </div>
       </div>
-      <div className="nbi-form-field">
-        <label>{transport === 'stdio' ? 'Command' : 'URL'}</label>
-        <input
-          type="text"
-          value={commandOrUrl}
-          onChange={e => setCommandOrUrl(e.target.value)}
-          placeholder={
-            transport === 'stdio' ? 'npx' : 'https://example.com/mcp'
-          }
-        />
-      </div>
-      {transport === 'stdio' && (
-        <div className="nbi-form-field">
-          <label>Args (one per line)</label>
+      {mode === 'json' ? (
+        <div
+          className="nbi-form-field"
+          role="tabpanel"
+          id={JSON_PANEL_ID}
+          aria-labelledby={JSON_TAB_ID}
+        >
+          <label htmlFor="nbi-mcp-add-json">JSON</label>
           <textarea
-            rows={3}
-            value={argsText}
-            onChange={e => setArgsText(e.target.value)}
-            placeholder={'-y\n@scope/package@latest'}
+            id="nbi-mcp-add-json"
+            ref={jsonInputRef}
+            rows={10}
+            value={jsonText}
+            onChange={e => setJsonText(e.target.value)}
+            placeholder={JSON_PLACEHOLDER}
+            spellCheck={false}
+            autoFocus
           />
         </div>
-      )}
-      {transport === 'stdio' && (
-        <div className="nbi-form-field">
-          <label>Environment (KEY=value, one per line)</label>
-          <textarea
-            rows={3}
-            value={envText}
-            onChange={e => setEnvText(e.target.value)}
-            placeholder="API_KEY=…"
-          />
-        </div>
-      )}
-      {transport !== 'stdio' && (
-        <div className="nbi-form-field">
-          <label>Headers (Name: value, one per line)</label>
-          <textarea
-            rows={3}
-            value={headersText}
-            onChange={e => setHeadersText(e.target.value)}
-            placeholder="Authorization: Bearer …"
-          />
+      ) : (
+        <div
+          role="tabpanel"
+          id={FORM_PANEL_ID}
+          aria-labelledby={FORM_TAB_ID}
+          className="nbi-mcp-add-form-panel"
+        >
+          <div className="nbi-form-field">
+            <label htmlFor="nbi-mcp-add-name">Name</label>
+            <input
+              id="nbi-mcp-add-name"
+              ref={nameInputRef}
+              type="text"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              placeholder="my-server"
+              autoFocus
+            />
+          </div>
+          <div className="nbi-form-field">
+            <label>Transport</label>
+            <select
+              value={transport}
+              onChange={e => setTransport(e.target.value as ClaudeMCPTransport)}
+            >
+              {TRANSPORTS.map(t => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="nbi-form-field">
+            <label>{transport === 'stdio' ? 'Command' : 'URL'}</label>
+            <input
+              type="text"
+              value={commandOrUrl}
+              onChange={e => setCommandOrUrl(e.target.value)}
+              placeholder={
+                transport === 'stdio' ? 'npx' : 'https://example.com/mcp'
+              }
+            />
+          </div>
+          {transport === 'stdio' && (
+            <div className="nbi-form-field">
+              <label>Args (one per line)</label>
+              <textarea
+                rows={3}
+                value={argsText}
+                onChange={e => setArgsText(e.target.value)}
+                placeholder={'-y\n@scope/package@latest'}
+              />
+            </div>
+          )}
+          {transport === 'stdio' && (
+            <div className="nbi-form-field">
+              <label>Environment (KEY=value, one per line)</label>
+              <textarea
+                rows={3}
+                value={envText}
+                onChange={e => setEnvText(e.target.value)}
+                placeholder="API_KEY=…"
+              />
+            </div>
+          )}
+          {transport !== 'stdio' && (
+            <div className="nbi-form-field">
+              <label>Headers (Name: value, one per line)</label>
+              <textarea
+                rows={3}
+                value={headersText}
+                onChange={e => setHeadersText(e.target.value)}
+                placeholder="Authorization: Bearer …"
+              />
+            </div>
+          )}
         </div>
       )}
     </FormDialog>

--- a/src/components/claude-mcp-paste.ts
+++ b/src/components/claude-mcp-paste.ts
@@ -1,0 +1,132 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+import { ClaudeMCPScope, ClaudeMCPTransport, IClaudeMCPAddInput } from '../api';
+
+const VALID_TRANSPORTS: ReadonlyArray<ClaudeMCPTransport> = [
+  'stdio',
+  'sse',
+  'http'
+];
+
+// Accept any of these paste shapes:
+//   "server-key": { ... }                          (bare key + object)
+//   { "server-key": { ... } }                      (wrapped, one entry)
+//   { "mcpServers": { "server-key": { ... } } }    (full mcp.json)
+export function parseMcpJsonEntry(raw: string): {
+  name: string;
+  config: Record<string, any>;
+} {
+  const trimmed = raw.trim().replace(/^,|,$/g, '');
+  if (!trimmed) {
+    throw new Error('JSON is empty.');
+  }
+
+  let parsed: any;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    try {
+      parsed = JSON.parse(`{${trimmed}}`);
+    } catch (e) {
+      throw new Error(`Invalid JSON: ${(e as Error).message}`);
+    }
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('JSON must describe a server entry.');
+  }
+  if (parsed.mcpServers && typeof parsed.mcpServers === 'object') {
+    parsed = parsed.mcpServers;
+  }
+
+  const keys = Object.keys(parsed);
+  if (keys.length === 0) {
+    throw new Error('Expected at least one server entry.');
+  }
+  if (keys.length > 1) {
+    throw new Error('Multiple servers found; paste one entry at a time.');
+  }
+  const name = keys[0];
+  const config = parsed[name];
+  if (!config || typeof config !== 'object' || Array.isArray(config)) {
+    throw new Error(`Server "${name}" config must be an object.`);
+  }
+  return { name, config };
+}
+
+export function configToInput(
+  name: string,
+  config: Record<string, any>,
+  scope: ClaudeMCPScope
+): IClaudeMCPAddInput {
+  const url = typeof config.url === 'string' ? config.url.trim() : '';
+  const command =
+    typeof config.command === 'string' ? config.command.trim() : '';
+  if (!url && !command) {
+    throw new Error('Server config must include "command" or "url".');
+  }
+
+  const explicitTransport =
+    typeof config.transport === 'string' &&
+    (VALID_TRANSPORTS as ReadonlyArray<string>).includes(config.transport)
+      ? (config.transport as ClaudeMCPTransport)
+      : null;
+
+  // If the user pasted an explicit `transport`, it must match the shape of
+  // the rest of the config: `stdio` requires `command`, `sse`/`http` require
+  // `url`. A mismatch is more likely a typo than intent, and silently
+  // downgrading to whatever shape we see is the footgun reviewers flagged.
+  if (explicitTransport === 'stdio' && !command) {
+    throw new Error('transport: "stdio" requires a "command" field.');
+  }
+  if ((explicitTransport === 'http' || explicitTransport === 'sse') && !url) {
+    throw new Error(
+      `transport: "${explicitTransport}" requires a "url" field.`
+    );
+  }
+
+  const transport: ClaudeMCPTransport =
+    explicitTransport ?? (url ? 'http' : 'stdio');
+  const commandOrUrl = transport === 'stdio' ? command : url;
+
+  return {
+    name,
+    scope,
+    transport,
+    commandOrUrl,
+    args:
+      transport === 'stdio' && Array.isArray(config.args)
+        ? config.args.map(String)
+        : undefined,
+    env: transport === 'stdio' ? toStringRecord(config.env) : undefined,
+    headers: transport !== 'stdio' ? toStringRecord(config.headers) : undefined
+  };
+}
+
+export function parseKVLines(
+  text: string,
+  separator: string
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const idx = trimmed.indexOf(separator);
+    if (idx > 0) {
+      out[trimmed.slice(0, idx).trim()] = trimmed.slice(idx + 1).trim();
+    }
+  }
+  return out;
+}
+
+function toStringRecord(obj: any): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (obj && typeof obj === 'object' && !Array.isArray(obj)) {
+    for (const [k, v] of Object.entries(obj)) {
+      out[String(k)] = String(v);
+    }
+  }
+  return out;
+}

--- a/style/base.css
+++ b/style/base.css
@@ -2057,6 +2057,42 @@ svg.access-token-warning {
   box-shadow: 0 0 0 1px var(--jp-brand-color1);
 }
 
+.nbi-segmented-control {
+  display: inline-flex;
+  border: 1px solid var(--jp-border-color1);
+  border-radius: 3px;
+  overflow: hidden;
+  align-self: flex-start;
+}
+
+.nbi-segmented-control-option {
+  background: var(--jp-layout-color1);
+  color: var(--jp-ui-font-color1);
+  border: none;
+  padding: 6px 14px;
+  font-size: var(--jp-ui-font-size1);
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.nbi-segmented-control-option + .nbi-segmented-control-option {
+  border-left: 1px solid var(--jp-border-color1);
+}
+
+.nbi-segmented-control-option:hover {
+  background: var(--jp-layout-color2);
+}
+
+.nbi-segmented-control-option.is-active {
+  background: var(--jp-brand-color1);
+  color: var(--jp-ui-inverse-font-color1, #fff);
+}
+
+.nbi-segmented-control-option:focus-visible {
+  outline: 2px solid var(--jp-brand-color1);
+  outline-offset: -2px;
+}
+
 .nbi-form-field-error {
   font-size: var(--jp-ui-font-size0);
   color: var(--jp-error-color1, #d32f2f);

--- a/tests/ts/claude-mcp-paste.test.ts
+++ b/tests/ts/claude-mcp-paste.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for the JSON-paste branch of the "Add MCP server" dialog. The form
+ * branch is exercised by the existing dialog state machine; this file covers
+ * the parser that turns whatever the user pasted into an IClaudeMCPAddInput.
+ *
+ * Issue #278.
+ */
+import {
+  parseMcpJsonEntry,
+  configToInput
+} from '../../src/components/claude-mcp-paste';
+
+describe('parseMcpJsonEntry', () => {
+  it('accepts a bare "key": {...} pair the user copied out of a config', () => {
+    const raw =
+      '"my-server": { "command": "uvx", "args": ["server-package@latest"] }';
+    const { name, config } = parseMcpJsonEntry(raw);
+    expect(name).toBe('my-server');
+    expect(config.command).toBe('uvx');
+    expect(config.args).toEqual(['server-package@latest']);
+  });
+
+  it('accepts a wrapped { "key": {...} } object', () => {
+    const raw = '{ "my-server": { "command": "uvx" } }';
+    const { name, config } = parseMcpJsonEntry(raw);
+    expect(name).toBe('my-server');
+    expect(config.command).toBe('uvx');
+  });
+
+  it('unwraps a full mcp.json with the mcpServers key', () => {
+    const raw = `{
+      "mcpServers": {
+        "my-server": { "command": "uvx" }
+      }
+    }`;
+    const { name } = parseMcpJsonEntry(raw);
+    expect(name).toBe('my-server');
+  });
+
+  it('strips a stray leading comma (copy-from-larger-config artefact)', () => {
+    const raw = ',"my-server": { "command": "uvx" }';
+    const { name } = parseMcpJsonEntry(raw);
+    expect(name).toBe('my-server');
+  });
+
+  it('strips a stray trailing comma too', () => {
+    const raw = '"my-server": { "command": "uvx" },';
+    const { name } = parseMcpJsonEntry(raw);
+    expect(name).toBe('my-server');
+  });
+
+  it('rejects an mcpServers wrapper with no entries', () => {
+    expect(() => parseMcpJsonEntry('{ "mcpServers": {} }')).toThrow(
+      /at least one server/i
+    );
+  });
+
+  it('rejects an mcpServers wrapper with multiple entries', () => {
+    const raw =
+      '{ "mcpServers": { "a": { "command": "x" }, "b": { "command": "y" } } }';
+    expect(() => parseMcpJsonEntry(raw)).toThrow(/one entry at a time/i);
+  });
+
+  it('rejects empty input', () => {
+    expect(() => parseMcpJsonEntry('')).toThrow(/empty/i);
+    expect(() => parseMcpJsonEntry('   ')).toThrow(/empty/i);
+  });
+
+  it('rejects unparseable JSON', () => {
+    expect(() => parseMcpJsonEntry('not json')).toThrow(/Invalid JSON/i);
+  });
+
+  it('rejects arrays and primitives', () => {
+    expect(() => parseMcpJsonEntry('[1, 2]')).toThrow(/server entry/i);
+    expect(() => parseMcpJsonEntry('"just a string"')).toThrow(/server entry/i);
+  });
+
+  it('rejects multi-server payloads with a guiding message', () => {
+    const raw = '{ "a": { "command": "x" }, "b": { "command": "y" } }';
+    expect(() => parseMcpJsonEntry(raw)).toThrow(/one entry at a time/i);
+  });
+
+  it('rejects an empty object', () => {
+    expect(() => parseMcpJsonEntry('{}')).toThrow(/at least one server/i);
+  });
+
+  it('rejects when the server value is not an object', () => {
+    expect(() => parseMcpJsonEntry('{"my-server": "uvx"}')).toThrow(
+      /must be an object/i
+    );
+  });
+});
+
+describe('configToInput', () => {
+  it('maps a stdio server config into IClaudeMCPAddInput', () => {
+    const input = configToInput(
+      'my-server',
+      {
+        command: 'uvx',
+        args: ['server-package@latest'],
+        env: { TOKEN: 'abc' }
+      },
+      'user'
+    );
+    expect(input).toEqual({
+      name: 'my-server',
+      scope: 'user',
+      transport: 'stdio',
+      commandOrUrl: 'uvx',
+      args: ['server-package@latest'],
+      env: { TOKEN: 'abc' },
+      headers: undefined
+    });
+  });
+
+  it('infers http transport from a url field', () => {
+    const input = configToInput(
+      'remote',
+      {
+        url: 'https://example.com/mcp',
+        headers: { Authorization: 'Bearer x' }
+      },
+      'project'
+    );
+    expect(input.transport).toBe('http');
+    expect(input.commandOrUrl).toBe('https://example.com/mcp');
+    expect(input.headers).toEqual({ Authorization: 'Bearer x' });
+    expect(input.args).toBeUndefined();
+    expect(input.env).toBeUndefined();
+  });
+
+  it('respects an explicit transport: "sse" override on a url server', () => {
+    const input = configToInput(
+      'remote',
+      { url: 'https://example.com/mcp', transport: 'sse' },
+      'user'
+    );
+    expect(input.transport).toBe('sse');
+  });
+
+  it('rejects a config missing both command and url', () => {
+    expect(() =>
+      configToInput('broken', { args: ['x'] } as any, 'user')
+    ).toThrow(/command.*or.*url/i);
+  });
+
+  it('stringifies non-string env / headers values', () => {
+    const input = configToInput(
+      'srv',
+      { command: 'x', env: { PORT: 8080, FLAG: true } },
+      'user'
+    );
+    expect(input.env).toEqual({ PORT: '8080', FLAG: 'true' });
+  });
+
+  it('rejects explicit transport: "http" on a stdio-only config', () => {
+    expect(() =>
+      configToInput('srv', { command: 'uvx', transport: 'http' } as any, 'user')
+    ).toThrow(/url/i);
+  });
+
+  it('rejects explicit transport: "stdio" on a url-only config', () => {
+    expect(() =>
+      configToInput(
+        'srv',
+        { url: 'https://example.com', transport: 'stdio' } as any,
+        'user'
+      )
+    ).toThrow(/command/i);
+  });
+
+  it('ignores an unrecognized transport string and falls back to the shape', () => {
+    const input = configToInput(
+      'srv',
+      { url: 'https://example.com', transport: 'pigeon' } as any,
+      'user'
+    );
+    expect(input.transport).toBe('http');
+  });
+
+  it('drops non-array args silently rather than crashing', () => {
+    const input = configToInput(
+      'srv',
+      { command: 'uvx', args: 'not-an-array' } as any,
+      'user'
+    );
+    expect(input.args).toBeUndefined();
+  });
+
+  it('returns empty env when env is a non-object', () => {
+    const input = configToInput(
+      'srv',
+      { command: 'uvx', env: 'BAD' } as any,
+      'user'
+    );
+    expect(input.env).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary

@mbektas asked for a paste-friendly alternative to the field-by-field form when adding an MCP server. The dialog now has Scope at the top, a Form/JSON tab control below it, and a JSON textarea that parses common copy-paste shapes into the same `IClaudeMCPAddInput` shape the form already emits.

## Solution

**Dialog layout.** Scope is the first field. Below it, a WAI-ARIA `tablist` toggles between Form and JSON. The Form panel is the existing inputs; the JSON panel is a single textarea with a representative placeholder.

**Paste parser** (`src/components/claude-mcp-paste.ts`). Accepts:
- bare `"server-key": { ... }` (the shape that lands when you copy a single entry out of a `.mcp.json`)
- wrapped `{ "server-key": { ... } }`
- full `{ "mcpServers": { "server-key": { ... } } }`
- stray leading or trailing comma (copy-from-larger-config artefact)

Multi-server payloads, empty objects, non-object server values, and unparseable input are rejected with guiding error messages. `configToInput` translates a parsed entry into `IClaudeMCPAddInput`, inferring `transport` from the shape, but honors an explicit `transport` field when present and rejects mismatches (stdio with no command; sse/http with no url) rather than silently downgrading. Six-agent review flagged the silent-downgrade as a real footgun.

**Helpers** moved to a sibling module (`claude-mcp-paste.ts`) so the unit tests don't drag the React tree in to exercise pure data functions.

**A11y.** The Form/JSON control uses `role="tablist"` (not `radiogroup`, which doesn't fit a UI that swaps the rendered subtree). Arrow-Left / Arrow-Right move between tabs with roving `tabindex`. A `useEffect` focuses the right input when the user actively switches modes but skips the first run so it doesn't steal focus from the Scope select on initial mount.

## Testing

`pytest tests/ --ignore=tests/test_claude_client.py -q` (709 passed). `jlpm tsc --noEmit`, `jlpm lint:check`, `jlpm jest` all green; new jest suite `claude-mcp-paste.test.ts` is 23 cases covering each paste shape, the empty / multi-server / non-object / array / primitive rejections, the explicit-transport-mismatch rejections (the footgun fix), and `IClaudeMCPAddInput` mapping (stringification of env values, http inference, sse override, unrecognized transport falls back to shape).

Manual: opened the dialog locally, confirmed Scope sits at the top, tab semantics work with keyboard, paste of the issue's example JSON populates correctly.

## Risks / follow-ups

- The parser doesn't strip `//` comments. A future enhancement could pre-strip JSON-with-comments via a small regex pass, but the standard error message ("Invalid JSON: ...") is informative enough for now.
- The Form panel state is preserved when the user toggles to JSON and back. That's intentional: a user who mis-types JSON and wants to switch to Form to debug shouldn't lose their work.
- Skipped: a React Testing Library test for the dialog's mode-toggle wiring. The 23 unit tests pin the data layer; the UI wiring is a one-liner that I verified manually. Worth adding if regressions appear.

Closes #278