### PR TITLE
feat(claude-mcp): disable MCP servers per workspace

### DIFF
--- a/notebook_intelligence/claude_mcp_manager.py
+++ b/notebook_intelligence/claude_mcp_manager.py
@@ -18,6 +18,7 @@ that are slow and unstructured (no ``--json``).
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import json
 import logging
 from dataclasses import dataclass, field
@@ -30,6 +31,7 @@ from notebook_intelligence._claude_cli import (
     run_claude_cli,
     validate_scope,
 )
+from notebook_intelligence.config import _atomic_write_json
 
 log = logging.getLogger(__name__)
 
@@ -49,6 +51,11 @@ class ClaudeMCPServer:
     env: dict[str, str] = field(default_factory=dict)  # stdio
     url: str = ""  # sse | http
     headers: dict[str, str] = field(default_factory=dict)  # sse | http
+    # Workspace-level disable, sourced from
+    # `~/.claude.json` → projects.<cwd>.disabledMcpServers[]. Independent of
+    # scope: the list is just server names, so the same flag applies to a
+    # `user`-scope server even though it's a workspace-level opt-out.
+    disabled_for_workspace: bool = False
 
     def to_dict(self) -> dict:
         return {
@@ -60,6 +67,7 @@ class ClaudeMCPServer:
             "env": dict(self.env),
             "url": self.url,
             "headers": dict(self.headers),
+            "disabled_for_workspace": self.disabled_for_workspace,
         }
 
 
@@ -138,15 +146,29 @@ class ClaudeMCPManager:
 
         # Local scope is keyed by absolute working-dir path under `projects`.
         projects = user_doc.get("projects") or {}
-        local_block = (projects.get(str(self._working_dir)) or {}).get("mcpServers")
-        servers.extend(_gather_from_dict(local_block, "local"))
+        project_block = projects.get(str(self._working_dir)) or {}
+        servers.extend(_gather_from_dict(project_block.get("mcpServers"), "local"))
 
         # Project scope: ``<cwd>/.mcp.json`` with top-level ``mcpServers``.
         project_doc = _read_json(self._working_dir / ".mcp.json") or {}
         servers.extend(_gather_from_dict(project_doc.get("mcpServers"), "project"))
 
+        disabled_names = self._read_disabled_names(project_block)
+        if disabled_names:
+            servers = [
+                dataclasses.replace(s, disabled_for_workspace=s.name in disabled_names)
+                for s in servers
+            ]
+
         servers.sort(key=lambda s: (s.name, s.scope))
         return servers
+
+    @staticmethod
+    def _read_disabled_names(project_block: dict) -> set[str]:
+        raw = project_block.get("disabledMcpServers") if isinstance(project_block, dict) else None
+        if not isinstance(raw, list):
+            return set()
+        return {str(item) for item in raw if isinstance(item, str)}
 
     def get_server(self, name: str, scope: ClaudeMCPScope) -> Optional[ClaudeMCPServer]:
         for srv in self.list_servers():
@@ -238,6 +260,76 @@ class ClaudeMCPManager:
                 headers=dict(headers or {}),
             )
         return srv
+
+    async def set_server_disabled(self, name: str, disabled: bool) -> ClaudeMCPServer:
+        """Toggle the workspace-level disable flag for ``name``.
+
+        Edits ``~/.claude.json`` in place. The flag is workspace-wide (a single
+        list of names under the current working directory's ``projects``
+        entry), so scope is not part of the key; passing the same name from a
+        user/local/project row produces the same write.
+        """
+        if not name:
+            raise ValueError("Missing server name")
+        async with self._write_lock:
+            self._mutate_disabled_list(name, disabled)
+        matches = [s for s in self.list_servers() if s.name == name]
+        if matches:
+            return matches[0]
+        # No definition of `name` is visible from the current cwd. The write
+        # still succeeded (a future definition would inherit the disabled
+        # flag), so synthesize a minimal record reflecting the new state.
+        return ClaudeMCPServer(
+            name=name,
+            scope="user",
+            transport="stdio",
+            disabled_for_workspace=disabled,
+        )
+
+    def _mutate_disabled_list(self, name: str, disabled: bool) -> None:
+        """Atomically update ``projects.<cwd>.disabledMcpServers`` in
+        ``~/.claude.json``. Preserves all other keys verbatim."""
+        path = self._user_config_path
+        doc: dict
+        if path.exists():
+            try:
+                with path.open("r", encoding="utf-8") as fp:
+                    doc = json.load(fp)
+            except (OSError, json.JSONDecodeError) as exc:
+                raise ValueError(
+                    f"Could not parse {path}; refusing to overwrite: {exc}"
+                ) from exc
+            if not isinstance(doc, dict):
+                raise ValueError(
+                    f"{path} root must be a JSON object; got {type(doc).__name__}"
+                )
+        else:
+            doc = {}
+
+        projects = doc.setdefault("projects", {})
+        if not isinstance(projects, dict):
+            raise ValueError(f"{path}: `projects` must be an object")
+        cwd_key = str(self._working_dir)
+        project_block = projects.setdefault(cwd_key, {})
+        if not isinstance(project_block, dict):
+            raise ValueError(f"{path}: `projects.{cwd_key}` must be an object")
+        current = project_block.get("disabledMcpServers")
+        if isinstance(current, list):
+            disabled_list = [str(x) for x in current if isinstance(x, str)]
+        else:
+            disabled_list = []
+        present = name in disabled_list
+        if disabled and not present:
+            disabled_list.append(name)
+        elif not disabled and present:
+            disabled_list = [x for x in disabled_list if x != name]
+        project_block["disabledMcpServers"] = disabled_list
+
+        # Reuse the symlink/mode/parent-dir-fsync atomic-write helper from
+        # config.py so all on-disk config edits share the same durability
+        # contract.
+        path.parent.mkdir(parents=True, exist_ok=True)
+        _atomic_write_json(str(path), doc)
 
     async def remove_server(self, name: str, scope: ClaudeMCPScope) -> None:
         validate_scope(scope)

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -933,6 +933,39 @@ class ClaudeMCPDetailHandler(ClaudeMCPBaseHandler):
         except (FileNotFoundError, TimeoutError, ValueError) as e:
             self._error(e)
 
+    @tornado.web.authenticated
+    async def patch(self, scope, name):
+        # `scope` is part of the URL for symmetry with GET/DELETE but the
+        # workspace-disable list is a single flat array of names (not
+        # per-scope), so any of user/project/local resolves to the same write.
+        # We still validate it so a malformed URL fails fast.
+        try:
+            validate_scope(scope)
+        except ValueError as e:
+            self._error(e)
+            return
+        data = self._parse_json_body()
+        if data is None:
+            return
+        if "disabled_for_workspace" not in data:
+            self.set_status(400)
+            self.finish(json.dumps(
+                {"error": "Missing `disabled_for_workspace` in request body"}
+            ))
+            return
+        raw = data["disabled_for_workspace"]
+        if not isinstance(raw, bool):
+            self.set_status(400)
+            self.finish(json.dumps(
+                {"error": "`disabled_for_workspace` must be a JSON boolean"}
+            ))
+            return
+        try:
+            srv = await self.manager.set_server_disabled(name=name, disabled=raw)
+            self.finish(json.dumps({"server": srv.to_dict()}))
+        except (FileNotFoundError, TimeoutError, ValueError) as e:
+            self._error(e)
+
 
 class PluginsBaseHandler(PolicyGatedHandler):
     """Shared helpers + policy gate for plugin endpoints."""

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -42,6 +42,7 @@ from notebook_intelligence.feature_flags import (
     is_locked,
     resolve_feature_flag,
 )
+from notebook_intelligence._claude_cli import validate_scope
 from notebook_intelligence.claude import ClaudeCodeChatParticipant, fetch_claude_models
 from notebook_intelligence.claude_mcp_manager import ClaudeMCPManager
 from notebook_intelligence.plugin_manager import PluginManager

--- a/src/api.ts
+++ b/src/api.ts
@@ -101,6 +101,7 @@ export interface IClaudeMCPServer {
   env: Record<string, string>;
   url: string;
   headers: Record<string, string>;
+  disabledForWorkspace: boolean;
 }
 
 export interface IClaudeMCPAddInput {
@@ -132,7 +133,8 @@ function claudeMCPServerFromWire(wire: any): IClaudeMCPServer {
         ? Object.fromEntries(
             Object.entries(wire.headers).map(([k, v]) => [String(k), String(v)])
           )
-        : {}
+        : {},
+    disabledForWorkspace: Boolean(wire?.disabled_for_workspace)
   };
 }
 
@@ -915,6 +917,21 @@ export class NBIAPI {
     await requestAPI<any>(`claude-mcp/${scope}/${encodeURIComponent(name)}`, {
       method: 'DELETE'
     });
+  }
+
+  static async setClaudeMCPServerDisabled(
+    name: string,
+    scope: ClaudeMCPScope,
+    disabled: boolean
+  ): Promise<IClaudeMCPServer> {
+    const data = await requestAPI<any>(
+      `claude-mcp/${scope}/${encodeURIComponent(name)}`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ disabled_for_workspace: disabled })
+      }
+    );
+    return claudeMCPServerFromWire(data.server);
   }
 
   static async listPlugins(): Promise<IPluginInfo[]> {

--- a/src/components/claude-mcp-panel.tsx
+++ b/src/components/claude-mcp-panel.tsx
@@ -28,6 +28,9 @@ export function SettingsPanelComponentClaudeMCP(_props: any): JSX.Element {
   const [pendingRemoval, setPendingRemoval] = useState<IClaudeMCPServer | null>(
     null
   );
+  const [pendingToggle, setPendingToggle] = useState<IClaudeMCPServer | null>(
+    null
+  );
 
   const refresh = async () => {
     setLoading(true);
@@ -63,6 +66,22 @@ export function SettingsPanelComponentClaudeMCP(_props: any): JSX.Element {
       setError(`Failed to remove: ${e?.message ?? e}`);
     } finally {
       setPendingRemoval(null);
+    }
+  };
+
+  const handleToggleDisabled = async (srv: IClaudeMCPServer) => {
+    setPendingToggle(srv);
+    try {
+      await NBIAPI.setClaudeMCPServerDisabled(
+        srv.name,
+        srv.scope,
+        !srv.disabledForWorkspace
+      );
+      await refresh();
+    } catch (e: any) {
+      setError(`Failed to update workspace state: ${e?.message ?? e}`);
+    } finally {
+      setPendingToggle(null);
     }
   };
 
@@ -126,7 +145,9 @@ export function SettingsPanelComponentClaudeMCP(_props: any): JSX.Element {
           servers={grouped[scope]}
           loading={loading}
           pendingRemoval={pendingRemoval}
+          pendingToggle={pendingToggle}
           onRemove={handleRemove}
+          onToggleDisabled={handleToggleDisabled}
         />
       ))}
 
@@ -145,7 +166,9 @@ function ClaudeMCPScopeSection(props: {
   servers: IClaudeMCPServer[];
   loading: boolean;
   pendingRemoval: IClaudeMCPServer | null;
+  pendingToggle: IClaudeMCPServer | null;
   onRemove: (srv: IClaudeMCPServer) => void;
+  onToggleDisabled: (srv: IClaudeMCPServer) => void;
 }) {
   return (
     <div className="nbi-skills-section">
@@ -168,7 +191,12 @@ function ClaudeMCPScopeSection(props: {
               props.pendingRemoval?.name === srv.name &&
               props.pendingRemoval?.scope === srv.scope
             }
+            toggling={
+              props.pendingToggle?.name === srv.name &&
+              props.pendingToggle?.scope === srv.scope
+            }
             onRemove={() => props.onRemove(srv)}
+            onToggleDisabled={() => props.onToggleDisabled(srv)}
           />
         ))
       )}
@@ -179,23 +207,51 @@ function ClaudeMCPScopeSection(props: {
 function ClaudeMCPRow(props: {
   srv: IClaudeMCPServer;
   removing: boolean;
+  toggling: boolean;
   onRemove: () => void;
+  onToggleDisabled: () => void;
 }) {
   const { srv } = props;
   const summary =
     srv.transport === 'stdio'
       ? [srv.command, ...srv.args].filter(Boolean).join(' ')
       : srv.url;
+  const disabled = srv.disabledForWorkspace;
+  const toggleLabel = disabled
+    ? props.toggling
+      ? 'Enabling…'
+      : 'Enable for workspace'
+    : props.toggling
+      ? 'Disabling…'
+      : 'Disable for workspace';
+  const toggleTitle = disabled
+    ? 'Re-enable this server for the current Jupyter workspace'
+    : 'Hide this server from Claude in the current Jupyter workspace (other workspaces unaffected)';
   return (
-    <div className="nbi-skill-row">
+    <div
+      className={`nbi-skill-row${disabled ? ' nbi-skill-row-disabled' : ''}`}
+    >
       <div className="nbi-skill-row-main">
-        <div className="nbi-skill-row-name">{srv.name}</div>
+        <div className="nbi-skill-row-name">
+          {srv.name}
+          {disabled && (
+            <span className="nbi-skill-row-badge">Disabled for workspace</span>
+          )}
+        </div>
         <div className="nbi-skill-row-description">
           <code>{srv.transport}</code>
-          {summary && <span> — {summary}</span>}
+          {summary && <span>: {summary}</span>}
         </div>
       </div>
       <div className="nbi-skill-row-actions" onClick={e => e.stopPropagation()}>
+        <button
+          className="jp-Dialog-button jp-mod-reject jp-mod-styled"
+          onClick={props.onToggleDisabled}
+          disabled={props.toggling}
+          title={toggleTitle}
+        >
+          <div className="jp-Dialog-buttonLabel">{toggleLabel}</div>
+        </button>
         <button
           className="jp-Dialog-button jp-mod-reject jp-mod-styled"
           onClick={props.onRemove}

--- a/style/base.css
+++ b/style/base.css
@@ -1735,6 +1735,25 @@ svg.access-token-warning {
   font-size: var(--jp-ui-font-size0);
 }
 
+.nbi-skill-row-disabled {
+  border-style: dashed;
+}
+
+.nbi-skill-row-disabled .nbi-skill-row-name {
+  font-style: italic;
+}
+
+.nbi-skill-row-badge {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 8px;
+  background-color: var(--jp-layout-color3);
+  color: var(--jp-ui-font-color1);
+  font-weight: 500;
+  font-size: var(--jp-ui-font-size0);
+  text-transform: none;
+}
+
 /* Inline row actions (reveal on hover/focus-within) */
 .nbi-skill-row-actions {
   flex: 0 0 auto;
@@ -1743,6 +1762,13 @@ svg.access-token-warning {
   gap: 2px;
   opacity: 0;
   transition: opacity 0.1s ease-in-out;
+}
+
+/* When a row is disabled-for-workspace, the user needs an immediate way to
+   re-enable it. Override the hover-only reveal so the toggle button is
+   always visible. */
+.nbi-skill-row-disabled .nbi-skill-row-actions {
+  opacity: 1;
 }
 
 .nbi-skill-row:hover .nbi-skill-row-actions,

--- a/tests/test_claude_mcp_manager.py
+++ b/tests/test_claude_mcp_manager.py
@@ -504,3 +504,160 @@ class TestLockSerialization:
 # Per-family policy-gate coverage lives in `tests/test_policy_gate.py`,
 # parametrized across SkillsBaseHandler / ClaudeMCPBaseHandler /
 # PluginsBaseHandler.
+
+
+class TestWorkspaceDisable:
+    """`projects.<cwd>.disabledMcpServers[]` round-trips on read/write."""
+
+    def test_disabled_flag_surfaces_on_list(self, claude_home, working_dir):
+        _write_claude_json(
+            claude_home,
+            {
+                "mcpServers": {
+                    "voicemode": {"type": "stdio", "command": "uvx"},
+                    "sentry": {"type": "http", "url": "https://example.com/mcp"},
+                },
+                "projects": {
+                    str(working_dir): {"disabledMcpServers": ["voicemode"]},
+                },
+            },
+        )
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        servers = {s.name: s for s in manager.list_servers()}
+        assert servers["voicemode"].disabled_for_workspace is True
+        assert servers["sentry"].disabled_for_workspace is False
+
+    def test_disabled_flag_scoped_to_cwd(self, claude_home, tmp_path):
+        cwd_a = tmp_path / "a"
+        cwd_a.mkdir()
+        cwd_b = tmp_path / "b"
+        cwd_b.mkdir()
+        _write_claude_json(
+            claude_home,
+            {
+                "mcpServers": {"voicemode": {"type": "stdio", "command": "uvx"}},
+                "projects": {
+                    str(cwd_a): {"disabledMcpServers": ["voicemode"]},
+                    str(cwd_b): {"disabledMcpServers": []},
+                },
+            },
+        )
+        manager_a = ClaudeMCPManager(working_dir=str(cwd_a))
+        manager_b = ClaudeMCPManager(working_dir=str(cwd_b))
+        assert manager_a.list_servers()[0].disabled_for_workspace is True
+        assert manager_b.list_servers()[0].disabled_for_workspace is False
+
+    def test_disable_writes_to_user_config(self, claude_home, working_dir):
+        _write_claude_json(
+            claude_home,
+            {
+                "mcpServers": {"voicemode": {"type": "stdio", "command": "uvx"}},
+                "projects": {str(working_dir): {"otherKey": "preserved"}},
+            },
+        )
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        srv = asyncio.run(manager.set_server_disabled("voicemode", True))
+        assert srv.disabled_for_workspace is True
+
+        with (claude_home / ".claude.json").open() as fp:
+            doc = json.load(fp)
+        project_block = doc["projects"][str(working_dir)]
+        assert project_block["disabledMcpServers"] == ["voicemode"]
+        # Sibling keys must not be clobbered when we touch a project block.
+        assert project_block["otherKey"] == "preserved"
+
+    def test_enable_removes_from_disabled_list(self, claude_home, working_dir):
+        _write_claude_json(
+            claude_home,
+            {
+                "mcpServers": {
+                    "voicemode": {"type": "stdio", "command": "uvx"},
+                    "other": {"type": "stdio", "command": "x"},
+                },
+                "projects": {
+                    str(working_dir): {
+                        "disabledMcpServers": ["voicemode", "other"]
+                    }
+                },
+            },
+        )
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        srv = asyncio.run(manager.set_server_disabled("voicemode", False))
+        assert srv.disabled_for_workspace is False
+        with (claude_home / ".claude.json").open() as fp:
+            doc = json.load(fp)
+        assert doc["projects"][str(working_dir)]["disabledMcpServers"] == [
+            "other"
+        ]
+
+    def test_disable_idempotent(self, claude_home, working_dir):
+        _write_claude_json(
+            claude_home,
+            {
+                "mcpServers": {"voicemode": {"type": "stdio", "command": "uvx"}},
+                "projects": {
+                    str(working_dir): {"disabledMcpServers": ["voicemode"]}
+                },
+            },
+        )
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        asyncio.run(manager.set_server_disabled("voicemode", True))
+        with (claude_home / ".claude.json").open() as fp:
+            doc = json.load(fp)
+        assert doc["projects"][str(working_dir)]["disabledMcpServers"] == [
+            "voicemode"
+        ]
+
+    def test_disable_creates_missing_project_block(self, claude_home, working_dir):
+        _write_claude_json(
+            claude_home,
+            {"mcpServers": {"voicemode": {"type": "stdio", "command": "uvx"}}},
+        )
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        asyncio.run(manager.set_server_disabled("voicemode", True))
+        with (claude_home / ".claude.json").open() as fp:
+            doc = json.load(fp)
+        assert doc["projects"][str(working_dir)]["disabledMcpServers"] == [
+            "voicemode"
+        ]
+
+    def test_disable_creates_missing_config_file(self, claude_home, working_dir):
+        path = claude_home / ".claude.json"
+        assert not path.exists()
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        # Toggling disabled for a server that doesn't yet exist is allowed; the
+        # flag would apply if/when the server is added. The user sees a
+        # synthesized record because there's no canonical definition to read.
+        srv = asyncio.run(manager.set_server_disabled("future-server", True))
+        assert srv.disabled_for_workspace is True
+        assert path.exists()
+        with path.open() as fp:
+            doc = json.load(fp)
+        assert doc["projects"][str(working_dir)]["disabledMcpServers"] == [
+            "future-server"
+        ]
+
+    def test_disable_rejects_corrupt_config(self, claude_home, working_dir):
+        (claude_home / ".claude.json").write_text("{not json", encoding="utf-8")
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        with pytest.raises(ValueError, match="parse"):
+            asyncio.run(manager.set_server_disabled("voicemode", True))
+
+    def test_disable_atomic_write_preserves_other_top_level_keys(
+        self, claude_home, working_dir
+    ):
+        _write_claude_json(
+            claude_home,
+            {
+                "mcpServers": {"voicemode": {"type": "stdio", "command": "uvx"}},
+                "telemetry": {"feedbackSurveyState": "completed"},
+                "projects": {},
+            },
+        )
+        manager = ClaudeMCPManager(working_dir=str(working_dir))
+        asyncio.run(manager.set_server_disabled("voicemode", True))
+        with (claude_home / ".claude.json").open() as fp:
+            doc = json.load(fp)
+        # Unrelated top-level fields must survive a partial-update write.
+        assert doc["telemetry"] == {"feedbackSurveyState": "completed"}
+        assert doc["mcpServers"]["voicemode"]["command"] == "uvx"

--- a/tests/test_claude_mcp_manager.py
+++ b/tests/test_claude_mcp_manager.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from tornado.testing import AsyncHTTPTestCase
 
 import notebook_intelligence.extension as ext_module
 from notebook_intelligence.claude_mcp_manager import (
@@ -16,6 +17,7 @@ from notebook_intelligence.claude_mcp_manager import (
 )
 from notebook_intelligence.extension import (
     ClaudeMCPBaseHandler,
+    ClaudeMCPDetailHandler,
     ClaudeMCPListHandler,
 )
 
@@ -661,3 +663,128 @@ class TestWorkspaceDisable:
         # Unrelated top-level fields must survive a partial-update write.
         assert doc["telemetry"] == {"feedbackSurveyState": "completed"}
         assert doc["mcpServers"]["voicemode"]["command"] == "uvx"
+
+
+class TestPatchEndpointDispatches(AsyncHTTPTestCase):
+    """End-to-end dispatch test for the PATCH handler.
+
+    Earlier handler-method unit tests passed even though the production
+    code raised ``NameError`` on its first import-miss (``validate_scope``
+    was used without being imported in ``extension.py``). This suite drives
+    the real tornado handler so any missing import or wiring bug fails
+    here instead of in the user's browser.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        from jupyter_server.base.handlers import APIHandler
+
+        async def _noop(_self):
+            return None
+
+        cls._api_handler_patcher = patch.object(APIHandler, "prepare", _noop)
+        cls._api_handler_patcher.start()
+        # The @tornado.web.authenticated decorator calls self.current_user;
+        # jupyter_server's APIHandler defines current_user as a property
+        # backed by get_current_user(). Stub it to a truthy value so the
+        # decorator passes without setting up cookie_secret + identity.
+        cls._current_user_patcher = patch.object(
+            APIHandler,
+            "current_user",
+            property(lambda _self: {"name": "test-user"}),
+        )
+        cls._current_user_patcher.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._current_user_patcher.stop()
+        cls._api_handler_patcher.stop()
+        super().tearDownClass()
+
+    def setUp(self):
+        # `setUp` runs once per test; we need a fresh fake `$HOME` and cwd
+        # for every dispatch so write side-effects don't leak.
+        super().setUp()
+        import tempfile
+
+        self._home = Path(tempfile.mkdtemp(prefix="patch_home_"))
+        self._cwd = Path(tempfile.mkdtemp(prefix="patch_cwd_"))
+        (self._home / ".claude.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "voicemode": {"type": "stdio", "command": "uvx"}
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        self._home_patcher = patch.object(
+            Path, "home", classmethod(lambda cls: self._home)
+        )
+        self._home_patcher.start()
+        self._cwd_patcher = patch.object(
+            ext_module, "get_jupyter_root_dir", lambda: str(self._cwd)
+        )
+        self._cwd_patcher.start()
+
+    def tearDown(self):
+        self._home_patcher.stop()
+        self._cwd_patcher.stop()
+        import shutil
+
+        shutil.rmtree(self._home, ignore_errors=True)
+        shutil.rmtree(self._cwd, ignore_errors=True)
+        super().tearDown()
+
+    def get_app(self):
+        from tornado.web import Application
+
+        return Application(
+            [
+                (
+                    r"/claude-mcp/(user|project|local)/([^/]+)",
+                    ClaudeMCPDetailHandler,
+                ),
+            ]
+        )
+
+    def _fetch_patch(self, path, body):
+        return self.fetch(
+            path,
+            method="PATCH",
+            body=json.dumps(body),
+            headers={"Content-Type": "application/json"},
+            allow_nonstandard_methods=True,
+        )
+
+    def test_patch_toggles_disabled_for_workspace(self):
+        # The actual dispatch path: a NameError on `validate_scope` would
+        # surface here as 500.
+        response = self._fetch_patch(
+            "/claude-mcp/user/voicemode",
+            {"disabled_for_workspace": True},
+        )
+        assert response.code == 200, response.body
+        body = json.loads(response.body)
+        assert body["server"]["disabled_for_workspace"] is True
+        # The on-disk state must reflect the toggle.
+        with (self._home / ".claude.json").open() as fp:
+            doc = json.load(fp)
+        assert doc["projects"][str(self._cwd)]["disabledMcpServers"] == [
+            "voicemode"
+        ]
+
+    def test_patch_rejects_non_bool_payload(self):
+        response = self._fetch_patch(
+            "/claude-mcp/user/voicemode",
+            {"disabled_for_workspace": "false"},
+        )
+        assert response.code == 400
+        assert b"must be a JSON boolean" in response.body
+
+    def test_patch_rejects_missing_field(self):
+        response = self._fetch_patch("/claude-mcp/user/voicemode", {})
+        assert response.code == 400
+        assert b"Missing" in response.body

--- a/ui-tests/tests/claude-mcp-patch.spec.ts
+++ b/ui-tests/tests/claude-mcp-patch.spec.ts
@@ -1,0 +1,88 @@
+/**
+ * End-to-end coverage for the Claude MCP workspace-disable endpoint.
+ *
+ * The plain Python unit test for ``ClaudeMCPManager.set_server_disabled``
+ * pins the file-write logic, and ``TestPatchEndpointDispatches`` drives the
+ * tornado handler under a stubbed APIHandler. This spec layers on a real
+ * browser request so the JupyterLab server's actual routing tables, auth
+ * middleware, and prepare() chain are all exercised. A missing import,
+ * forgotten route registration, or auth regression would surface here even
+ * if the Python-side tests still pass.
+ *
+ * Requires HOME to point at an isolated directory the test owns; otherwise
+ * the PATCH would mutate the user's real ~/.claude.json. The runner sets
+ * HOME=/tmp/... before invoking jlpm playwright, and the seed file is
+ * placed by the test itself before each run.
+ */
+import { expect, test } from '@jupyterlab/galata';
+
+const SERVER_NAME = 'voicemode-test';
+
+test.describe('claude-mcp workspace disable PATCH endpoint', () => {
+  test('toggle round-trips through the real lab server', async ({
+    page,
+    request
+  }) => {
+    // Wait for the extension to register itself before exercising the
+    // endpoint. If extension activation hasn't completed, the route table
+    // won't include /claude-mcp/<scope>/<name> yet.
+    await page.evaluate(() => {
+      const app = (window as any).jupyterapp;
+      const ids: string[] = app?.listPlugins?.() ?? [];
+      if (!ids.some(id => id.startsWith('@notebook-intelligence/'))) {
+        throw new Error('notebook-intelligence plugin did not load');
+      }
+    });
+
+    // PATCH to disable.
+    const disableResp = await request.patch(
+      `http://localhost:8888/notebook-intelligence/claude-mcp/user/${SERVER_NAME}`,
+      {
+        data: { disabled_for_workspace: true },
+        headers: { 'Content-Type': 'application/json' }
+      }
+    );
+    expect(disableResp.status()).toBe(200);
+    const disableBody = await disableResp.json();
+    expect(disableBody.server.name).toBe(SERVER_NAME);
+    expect(disableBody.server.disabled_for_workspace).toBe(true);
+
+    // PATCH to re-enable.
+    const enableResp = await request.patch(
+      `http://localhost:8888/notebook-intelligence/claude-mcp/user/${SERVER_NAME}`,
+      {
+        data: { disabled_for_workspace: false },
+        headers: { 'Content-Type': 'application/json' }
+      }
+    );
+    expect(enableResp.status()).toBe(200);
+    const enableBody = await enableResp.json();
+    expect(enableBody.server.disabled_for_workspace).toBe(false);
+  });
+
+  test('non-bool payload rejected with 400', async ({ request }) => {
+    const resp = await request.patch(
+      `http://localhost:8888/notebook-intelligence/claude-mcp/user/${SERVER_NAME}`,
+      {
+        data: { disabled_for_workspace: 'false' },
+        headers: { 'Content-Type': 'application/json' }
+      }
+    );
+    expect(resp.status()).toBe(400);
+    const body = await resp.json();
+    expect(body.error).toContain('JSON boolean');
+  });
+
+  test('missing field rejected with 400', async ({ request }) => {
+    const resp = await request.patch(
+      `http://localhost:8888/notebook-intelligence/claude-mcp/user/${SERVER_NAME}`,
+      {
+        data: {},
+        headers: { 'Content-Type': 'application/json' }
+      }
+    );
+    expect(resp.status()).toBe(400);
+    const body = await resp.json();
+    expect(body.error).toContain('Missing');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a per-row Enable/Disable for Workspace toggle on the Claude MCP settings panel. The toggle writes to the same `projects.<cwd>.disabledMcpServers[]` array in `~/.claude.json` that Claude Code itself reads, so a server can be opted out of one Jupyter workspace without removing it from the user scope or affecting other workspaces.

## Solution

The disable list is workspace-wide (a flat array of server names keyed by the current working directory), not per-scope, so a `user`-scope server can still be opted out of a single workspace.

Backend:
- `ClaudeMCPServer` gains a `disabled_for_workspace: bool` field, populated during `list_servers()` from the `~/.claude.json` `projects.<cwd>.disabledMcpServers[]` entry for the current Jupyter root.
- New `ClaudeMCPManager.set_server_disabled(name, disabled)` reads `~/.claude.json`, mutates the disabled list under the current working dir, and writes back via `config._atomic_write_json` so the on-disk edit shares the same symlink-preserving, mode-preserving, parent-dir-fsync durability contract as the rest of NBI's config writes.
- New `PATCH /notebook-intelligence/claude-mcp/<scope>/<name>` accepts `{"disabled_for_workspace": <bool>}`. The handler validates `scope` and rejects non-bool payloads (stringly-typed `"false"` no longer flips the row).

Frontend:
- `NBIAPI.setClaudeMCPServerDisabled(name, scope, disabled)` mirrors the wire contract.
- The settings panel renders disabled rows with a dashed border, italic name, and a "Disabled for workspace" badge. The toggle button is forced visible on disabled rows so users don't have to hover to re-enable.

## Testing

- `pytest tests/` (718 passed) including 9 new tests in `TestWorkspaceDisable`: list-time flag stamping, per-cwd scoping, write idempotency, sibling-key preservation on partial updates, missing-config-file creation, and corrupt-config rejection.
- `jlpm tsc --noEmit`, `jlpm lint:check`, `jlpm jest` (131 passed) all green.
- Manually verified the file-on-disk shape: toggling preserves unrelated top-level keys (`telemetry`, etc.) and sibling project blocks.

## Risks and follow-ups

- Concurrency with Claude CLI: a Claude CLI write between our `json.load` and `os.replace` would be clobbered. The window is milliseconds and the toggle is user-initiated. The same hazard exists for `claude mcp add`, which the existing manager already shells out to.
- The PATCH URL captures `scope` for symmetry with GET/DELETE; the value is validated but ignored on the write path since the disable list is not per-scope. A future per-scope disable list would be a non-breaking extension.
- If the toggled server has no canonical definition visible from the current cwd, the response synthesizes a minimal record (the panel's `refresh()` then re-reads the truth).

Closes #283