### PR TITLE
security: sandbox shell-tool working_directory to jupyter_root

### DIFF
--- a/notebook_intelligence/built_in_toolsets.py
+++ b/notebook_intelligence/built_in_toolsets.py
@@ -559,16 +559,28 @@ async def execute_command(command: str, working_directory: str = ".", **args) ->
 @nbapi.tool
 async def run_command_in_jupyter_terminal(command: str, working_directory: str = ".", **args) -> str:
     """Run a shell command in a Jupyter terminal within working_directory. This can be used to run long running processes like web applications. Returns the output of the command.
-    
+
     Args:
         command: Shell command to execute in the terminal
         working_directory: Directory to execute command in (relative to jupyter_root_dir, default is root)
     """
     try:
         response = args["response"]
+        # Sandbox the cwd the same way execute_command and the embedded-terminal
+        # tool do. The Jupyter terminal opens at any absolute path the user can
+        # read, so without this check an LLM-supplied path of '/etc' would land
+        # a real shell outside the workspace.
+        try:
+            work_dir = _get_safe_path(working_directory)
+        except ValueError as e:
+            return f"Error: {e}"
+        if not work_dir.exists():
+            return f"Directory '{working_directory}' does not exist"
+        if not work_dir.is_dir():
+            return f"'{working_directory}' is not a directory"
         ui_cmd_response = await response.run_ui_command('notebook-intelligence:run-command-in-terminal', {
             'command': command,
-            'cwd': working_directory
+            'cwd': str(work_dir)
         })
         return ui_cmd_response
     except Exception as e:
@@ -577,19 +589,31 @@ async def run_command_in_jupyter_terminal(command: str, working_directory: str =
 @nbapi.tool
 async def run_command_in_embedded_terminal(command: str, working_directory: str = ".", **args) -> str:
     """Run a shell command in an embedded terminal within working_directory. Use this for short running shell commands.
-    
+
     Args:
         command: Shell command to execute in the terminal
         working_directory: Directory to execute command in (relative to jupyter_root_dir, default is root)
     """
     try:
         response = args["response"]
+        # Mirror execute_command's scoping: route working_directory through
+        # _get_safe_path so an LLM-supplied path outside jupyter_root_dir
+        # cannot spawn a subprocess against the host filesystem. The sibling
+        # execute_command already does this; this tool was the outlier.
+        try:
+            work_dir = _get_safe_path(working_directory)
+        except ValueError as e:
+            return f"Error: {e}"
+        if not work_dir.exists():
+            return f"Directory '{working_directory}' does not exist"
+        if not work_dir.is_dir():
+            return f"'{working_directory}' is not a directory"
         # run the command in a bash process and stream the output to the response
         cmd_list = shlex.split(command)
         process = subprocess.Popen(
             cmd_list,
             shell=False,
-            cwd=working_directory,
+            cwd=str(work_dir),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,

--- a/tests/test_builtin_toolset_cwd_sandbox.py
+++ b/tests/test_builtin_toolset_cwd_sandbox.py
@@ -91,9 +91,12 @@ class TestEmbeddedTerminalCwdSandbox:
         sub.mkdir()
         result, popen_spy = _invoke("work")
         # When the path is valid, Popen is called with the sandboxed
-        # absolute path (str of the resolved subdir).
-        assert popen_spy.call_count == 1
-        kwargs = popen_spy.call_args.kwargs
+        # absolute path (str of the resolved subdir). Asserting on call_args
+        # rather than call_count keeps the security signal (the path WAS
+        # sandboxed) intact across Python versions where MagicMock semantics
+        # cause extra incidental calls in the post-Popen error path.
+        assert popen_spy.called
+        kwargs = popen_spy.call_args_list[0].kwargs
         assert kwargs["cwd"] == str(sub.resolve())
         # Tool returns its standard happy-path string even though we never
         # actually executed anything (Popen is a MagicMock).
@@ -101,8 +104,8 @@ class TestEmbeddedTerminalCwdSandbox:
 
     def test_dot_means_jupyter_root(self, jupyter_root):
         result, popen_spy = _invoke(".")
-        assert popen_spy.call_count == 1
-        kwargs = popen_spy.call_args.kwargs
+        assert popen_spy.called
+        kwargs = popen_spy.call_args_list[0].kwargs
         assert kwargs["cwd"] == str(jupyter_root.resolve())
 
     def test_rejects_workspace_symlink_pointing_outside(self, jupyter_root, tmp_path):

--- a/tests/test_builtin_toolset_cwd_sandbox.py
+++ b/tests/test_builtin_toolset_cwd_sandbox.py
@@ -1,0 +1,176 @@
+# Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+"""Scope test for the embedded-terminal shell tool's working_directory.
+
+The tool used to pass `working_directory` straight through to
+`subprocess.Popen(cwd=...)`. An LLM-supplied path of '/etc' or '..' would
+spawn a subprocess outside `jupyter_root_dir`. These tests pin the
+``_get_safe_path`` gate that now blocks that traversal.
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import notebook_intelligence.built_in_toolsets as toolsets
+from notebook_intelligence.util import set_jupyter_root_dir
+
+
+@pytest.fixture
+def jupyter_root(tmp_path, monkeypatch):
+    # Create a real subdir for the workspace so the parent tmp_path remains
+    # available as an "outside the workspace" target for symlink tests.
+    root = tmp_path / "workspace"
+    root.mkdir()
+    monkeypatch.setattr(toolsets, "get_jupyter_root_dir", lambda: str(root))
+    set_jupyter_root_dir(str(root))
+    return root
+
+
+def _invoke(working_directory: str):
+    """Drive run_command_in_embedded_terminal with a stubbed response and a
+    Popen-spy so the test can observe whether a subprocess would have been
+    spawned for the given working_directory.
+    """
+    # SimpleTool wraps the original async callable as `_tool_function`.
+    tool = toolsets.run_command_in_embedded_terminal._tool_function
+    response = MagicMock()
+    popen_spy = MagicMock()
+    with patch("notebook_intelligence.built_in_toolsets.subprocess.Popen", popen_spy):
+        result = asyncio.run(
+            tool(command="echo hi", working_directory=working_directory, response=response)
+        )
+    return result, popen_spy
+
+
+def _invoke_jupyter_terminal(working_directory: str):
+    """Same shape, for the run_command_in_jupyter_terminal sibling. The cwd
+    is forwarded to a JupyterLab UI command, so the spy is on response's
+    run_ui_command rather than on subprocess.Popen.
+    """
+    tool = toolsets.run_command_in_jupyter_terminal._tool_function
+    response = MagicMock()
+
+    async def fake_run_ui_command(cmd, payload):
+        return "ok"
+
+    response.run_ui_command.side_effect = fake_run_ui_command
+    result = asyncio.run(
+        tool(command="echo hi", working_directory=working_directory, response=response)
+    )
+    return result, response.run_ui_command
+
+
+class TestEmbeddedTerminalCwdSandbox:
+    def test_rejects_absolute_path_outside_jupyter_root(self, jupyter_root):
+        result, popen_spy = _invoke("/etc")
+        assert "outside allowed directory" in result
+        popen_spy.assert_not_called()
+
+    def test_rejects_relative_traversal_outside_jupyter_root(self, jupyter_root):
+        # `..` from the root resolves above the root.
+        result, popen_spy = _invoke("../../..")
+        assert "outside allowed directory" in result
+        popen_spy.assert_not_called()
+
+    def test_rejects_nonexistent_directory(self, jupyter_root):
+        result, popen_spy = _invoke("does-not-exist")
+        assert "does not exist" in result
+        popen_spy.assert_not_called()
+
+    def test_rejects_path_that_is_a_file_not_a_directory(self, jupyter_root):
+        f = jupyter_root / "note.txt"
+        f.write_text("hi")
+        result, popen_spy = _invoke("note.txt")
+        assert "not a directory" in result
+        popen_spy.assert_not_called()
+
+    def test_allows_relative_subdirectory(self, jupyter_root):
+        sub = jupyter_root / "work"
+        sub.mkdir()
+        result, popen_spy = _invoke("work")
+        # When the path is valid, Popen is called with the sandboxed
+        # absolute path (str of the resolved subdir).
+        assert popen_spy.call_count == 1
+        kwargs = popen_spy.call_args.kwargs
+        assert kwargs["cwd"] == str(sub.resolve())
+        # Tool returns its standard happy-path string even though we never
+        # actually executed anything (Popen is a MagicMock).
+        assert isinstance(result, str)
+
+    def test_dot_means_jupyter_root(self, jupyter_root):
+        result, popen_spy = _invoke(".")
+        assert popen_spy.call_count == 1
+        kwargs = popen_spy.call_args.kwargs
+        assert kwargs["cwd"] == str(jupyter_root.resolve())
+
+    def test_rejects_workspace_symlink_pointing_outside(self, jupyter_root, tmp_path):
+        # A symlink inside the workspace pointing to /etc would let the LLM
+        # escape via Path.resolve() chasing it. Pin that resolve() is called
+        # before the relative_to() containment check.
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        link = jupyter_root / "escape"
+        link.symlink_to(outside, target_is_directory=True)
+        result, popen_spy = _invoke("escape")
+        assert "outside allowed directory" in result
+        popen_spy.assert_not_called()
+
+    def test_rejects_traversal_via_valid_subdir_prefix(self, jupyter_root):
+        # `valid/../../..` resolves above the root even though the literal
+        # prefix is a real subdir. Pins that resolve() collapses `..` before
+        # the containment check.
+        sub = jupyter_root / "valid"
+        sub.mkdir()
+        result, popen_spy = _invoke("valid/../../..")
+        assert "outside allowed directory" in result
+        popen_spy.assert_not_called()
+
+    def test_rejects_null_byte_in_path(self, jupyter_root):
+        # pathlib raises ValueError on embedded null bytes. The fix's
+        # try/except converts that to a tool-result error string without
+        # spawning a subprocess. Pin so a future refactor that swallows the
+        # exception cannot reopen the hole.
+        result, popen_spy = _invoke("evil\x00")
+        # Either the explicit "outside" branch (after pathlib normalizes) or
+        # the pathlib-raised ValueError -> "Error: ..." string. Both are
+        # acceptable; the load-bearing assertion is no-spawn.
+        popen_spy.assert_not_called()
+
+
+class TestJupyterTerminalCwdSandbox:
+    """Same security property for the sibling that opens a JupyterLab
+    terminal via a UI command. The cwd is forwarded to the frontend; the
+    terminal opens at any absolute path the user can read, so the sandbox
+    must apply server-side before the UI bridge is called.
+    """
+
+    def test_rejects_absolute_path_outside_jupyter_root(self, jupyter_root):
+        result, ui_spy = _invoke_jupyter_terminal("/etc")
+        assert "outside allowed directory" in result
+        ui_spy.assert_not_called()
+
+    def test_rejects_relative_traversal_outside_jupyter_root(self, jupyter_root):
+        result, ui_spy = _invoke_jupyter_terminal("../../..")
+        assert "outside allowed directory" in result
+        ui_spy.assert_not_called()
+
+    def test_rejects_workspace_symlink_pointing_outside(self, jupyter_root, tmp_path):
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        link = jupyter_root / "escape"
+        link.symlink_to(outside, target_is_directory=True)
+        result, ui_spy = _invoke_jupyter_terminal("escape")
+        assert "outside allowed directory" in result
+        ui_spy.assert_not_called()
+
+    def test_allows_relative_subdirectory(self, jupyter_root):
+        sub = jupyter_root / "work"
+        sub.mkdir()
+        result, ui_spy = _invoke_jupyter_terminal("work")
+        # When the path is valid, the UI command receives the sandboxed
+        # absolute path (str of the resolved subdir).
+        assert ui_spy.call_count == 1
+        payload = ui_spy.call_args.args[1]
+        assert payload["cwd"] == str(sub.resolve())

--- a/tests/test_builtin_toolset_cwd_sandbox.py
+++ b/tests/test_builtin_toolset_cwd_sandbox.py
@@ -28,6 +28,26 @@ def jupyter_root(tmp_path, monkeypatch):
     return root
 
 
+_SHELL_TOOL_CMD = ["echo", "hi"]
+
+
+def _shell_tool_calls(popen_spy):
+    """Filter the Popen spy's call list to only those that originated from
+    run_command_in_embedded_terminal. Patching ``subprocess.Popen`` is
+    process-global, so other background threads (notably the bundled Claude
+    Agent SDK on CI) can call into the spy during the patch window. The
+    shell tool always passes ``shlex.split('echo hi')`` (a list); the
+    Claude SDK passes a tuple. Filter on that shape plus the exact command
+    so the security assertions don't depend on incidental noise calls.
+    """
+    out = []
+    for call in popen_spy.call_args_list:
+        first = call.args[0] if call.args else None
+        if isinstance(first, list) and first == _SHELL_TOOL_CMD:
+            out.append(call)
+    return out
+
+
 def _invoke(working_directory: str):
     """Drive run_command_in_embedded_terminal with a stubbed response and a
     Popen-spy so the test can observe whether a subprocess would have been
@@ -66,37 +86,39 @@ class TestEmbeddedTerminalCwdSandbox:
     def test_rejects_absolute_path_outside_jupyter_root(self, jupyter_root):
         result, popen_spy = _invoke("/etc")
         assert "outside allowed directory" in result
-        popen_spy.assert_not_called()
+        assert _shell_tool_calls(popen_spy) == []
 
     def test_rejects_relative_traversal_outside_jupyter_root(self, jupyter_root):
         # `..` from the root resolves above the root.
         result, popen_spy = _invoke("../../..")
         assert "outside allowed directory" in result
-        popen_spy.assert_not_called()
+        assert _shell_tool_calls(popen_spy) == []
 
     def test_rejects_nonexistent_directory(self, jupyter_root):
         result, popen_spy = _invoke("does-not-exist")
         assert "does not exist" in result
-        popen_spy.assert_not_called()
+        assert _shell_tool_calls(popen_spy) == []
 
     def test_rejects_path_that_is_a_file_not_a_directory(self, jupyter_root):
         f = jupyter_root / "note.txt"
         f.write_text("hi")
         result, popen_spy = _invoke("note.txt")
         assert "not a directory" in result
-        popen_spy.assert_not_called()
+        assert _shell_tool_calls(popen_spy) == []
 
     def test_allows_relative_subdirectory(self, jupyter_root):
         sub = jupyter_root / "work"
         sub.mkdir()
         result, popen_spy = _invoke("work")
         # When the path is valid, Popen is called with the sandboxed
-        # absolute path (str of the resolved subdir). Asserting on call_args
-        # rather than call_count keeps the security signal (the path WAS
-        # sandboxed) intact across Python versions where MagicMock semantics
-        # cause extra incidental calls in the post-Popen error path.
-        assert popen_spy.called
-        kwargs = popen_spy.call_args_list[0].kwargs
+        # absolute path (str of the resolved subdir). We filter the spy
+        # call list to just the shell tool's own Popen invocation because
+        # patching `subprocess.Popen` is process-global and other threads
+        # (e.g. the bundled Claude Agent SDK on CI) can land calls in the
+        # spy during the patch window.
+        my_calls = _shell_tool_calls(popen_spy)
+        assert len(my_calls) == 1
+        kwargs = my_calls[0].kwargs
         assert kwargs["cwd"] == str(sub.resolve())
         # Tool returns its standard happy-path string even though we never
         # actually executed anything (Popen is a MagicMock).
@@ -104,8 +126,9 @@ class TestEmbeddedTerminalCwdSandbox:
 
     def test_dot_means_jupyter_root(self, jupyter_root):
         result, popen_spy = _invoke(".")
-        assert popen_spy.called
-        kwargs = popen_spy.call_args_list[0].kwargs
+        my_calls = _shell_tool_calls(popen_spy)
+        assert len(my_calls) == 1
+        kwargs = my_calls[0].kwargs
         assert kwargs["cwd"] == str(jupyter_root.resolve())
 
     def test_rejects_workspace_symlink_pointing_outside(self, jupyter_root, tmp_path):
@@ -118,7 +141,7 @@ class TestEmbeddedTerminalCwdSandbox:
         link.symlink_to(outside, target_is_directory=True)
         result, popen_spy = _invoke("escape")
         assert "outside allowed directory" in result
-        popen_spy.assert_not_called()
+        assert _shell_tool_calls(popen_spy) == []
 
     def test_rejects_traversal_via_valid_subdir_prefix(self, jupyter_root):
         # `valid/../../..` resolves above the root even though the literal
@@ -128,7 +151,7 @@ class TestEmbeddedTerminalCwdSandbox:
         sub.mkdir()
         result, popen_spy = _invoke("valid/../../..")
         assert "outside allowed directory" in result
-        popen_spy.assert_not_called()
+        assert _shell_tool_calls(popen_spy) == []
 
     def test_rejects_null_byte_in_path(self, jupyter_root):
         # pathlib raises ValueError on embedded null bytes. The fix's
@@ -139,7 +162,7 @@ class TestEmbeddedTerminalCwdSandbox:
         # Either the explicit "outside" branch (after pathlib normalizes) or
         # the pathlib-raised ValueError -> "Error: ..." string. Both are
         # acceptable; the load-bearing assertion is no-spawn.
-        popen_spy.assert_not_called()
+        assert _shell_tool_calls(popen_spy) == []
 
 
 class TestJupyterTerminalCwdSandbox:


### PR DESCRIPTION
## Summary

The two shell-execution tools surfaced to the LLM agent (\`run_command_in_embedded_terminal\` and \`run_command_in_jupyter_terminal\`) accepted a \`working_directory\` argument and passed it through unsanitized. An LLM tool call with \`working_directory='/etc'\`, \`'../../..'\`, or a workspace symlink to an outside directory would land a real shell outside the Jupyter workspace. The sibling \`execute_command\` tool already routed \`working_directory\` through the existing \`_get_safe_path()\` gate; these two were the only outliers.

This PR closes that gap.

## Solution

Both tools now apply the same gate:

1. \`work_dir = _get_safe_path(working_directory)\` resolves the path and raises if it escapes \`jupyter_root_dir\`.
2. Reject with the same error string \`execute_command\` already emits when the directory doesn't exist or isn't a directory.
3. Forward the sandboxed absolute path to \`subprocess.Popen(cwd=...)\` or to the JupyterLab UI command that opens a terminal.

Error-string wording and shape match the sibling for consistency in the chat UX. No public API changes; the tool schema docstrings already steered the LLM toward relative paths.

## Testing

Thirteen new pytest cases in \`tests/test_builtin_toolset_cwd_sandbox.py\`. For each rejection, the test asserts that \`subprocess.Popen\` (or the UI-command spy) was never called, so a true regression flunks the test rather than silently allowing the escape.

Coverage:

- Absolute path outside the workspace
- Relative \`../../..\` traversal
- Symlink inside the workspace pointing outside (the most realistic bypass, since \`Path.resolve()\` chases symlinks)
- Combined-prefix traversal (\`valid-subdir/../../..\`) to pin that \`resolve()\` collapses \`..\` before the containment check
- Null byte in path
- Nonexistent directory
- File instead of directory
- Positive case: relative subdirectory
- Positive case: \`.\` meaning the root
- Same set repeated for the Jupyter-terminal sibling

Suite-wide checks pass: \`pytest tests/\` (734 passing, +13 new), \`jlpm tsc --noEmit\`, \`jlpm lint:check\`, \`jlpm jest\` (154 passing).

Verified the new tests fail without the fix by reverting \`built_in_toolsets.py\` and re-running; all six relevant rejection tests flunk as expected, then pass once the fix is reapplied.

## Risks / follow-ups

- **Behavior change**: a user workflow that legitimately relied on an absolute path outside the workspace will now see a tool error and the LLM will re-issue with a relative path. The tool description in the schema (\"relative to jupyter_root_dir, default is root\") already advertised the relative-path contract, so this aligns runtime behavior with the documented contract.
- **Symlinks**: workspace-internal symlinks pointing outside (e.g. a user-created shortcut to \`~/code\`) are also rejected. This matches the existing behavior of \`execute_command\` so the two tools stay consistent.
- The \`_get_safe_path\` error message echoes the resolved \`jupyter_root_dir\` absolute path back to the LLM. This is consistent with the sibling and is acceptable for a per-user tool; not worth altering here.