### PR TITLE
security: add runtime kill switch for the managed-skills reconciler

### DIFF
--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -395,9 +395,28 @@ Force-off does three things at once:
 
 - Hides the **Skills** tab in the Settings panel.
 - Returns HTTP 403 from every `/notebook-intelligence/skills/*` route, so a stale frontend or a direct API caller can't read or write skills.
-- Suppresses the [managed-skills reconciler](#managed-claude-skills-token) — the manifest is treated as empty, no `SkillReconciler` is constructed, and no scheduled reconcile runs. Org-curated skills still on disk are not touched, but new manifests aren't pulled. **Takes effect on JupyterLab server restart.** Live config-reload won't stop a reconciler that's already running.
+- Suppresses the [managed-skills reconciler](#managed-claude-skills-token) — the manifest is treated as empty, no `SkillReconciler` is constructed, and no scheduled reconcile runs. Org-curated skills still on disk are not touched, but new manifests aren't pulled. **Takes effect on JupyterLab server restart.** For incident-response without a restart, see the kill switch below.
 
-Use this when an org wants to disable user-authored Claude skills entirely.
+#### Stopping a running reconciler without a server restart
+
+If the manifest URL or the managed-skills token is compromised and you need to stop the in-flight reconciler immediately, two non-restart paths are now available:
+
+1. **HTTP kill switch:** `POST /notebook-intelligence/skills/reconciler/stop`. Authenticated (Jupyter session token). Stops the background reconciler and returns `{"stopped": true, "was_running": <bool>}`. Idempotent; safe to script across pods.
+
+   ```bash
+   curl -X POST -H "Authorization: token $JUPYTER_TOKEN" \
+        https://hub.example.com/user/<name>/notebook-intelligence/skills/reconciler/stop
+   ```
+
+2. **Env-var flip:** the reconciler re-reads `NBI_SKILLS_MANAGEMENT_POLICY` at the start of each cycle and self-stops if it reads `force-off`. If your platform supports in-place pod env updates (rare), this fires the kill switch on the next reconcile boundary (default 24h). For most deployments the HTTP route is the faster option.
+
+Either mechanism only stops the background thread; existing skill bundles on disk remain. Use `claude` or filesystem tooling to remove them if needed.
+
+> **No live restart.** Once stopped, the reconciler stays stopped for the life of the JupyterLab process. There is no `/start` companion endpoint; bouncing the server is the only path to re-enable reconciliation in the same pod. This is intentional: a kill switch that another script can flip back on isn't a kill switch.
+>
+> **Per-user trust.** The endpoint is authenticated with the user's Jupyter session token, not an admin claim. In hub deployments where the JupyterLab pod owner is not the policy admin (typical for JupyterHub), a tenant can stop their own pod's reconciler. The reconciler is per-pod, so this only affects that user's managed-skills delivery. For deployments that need to prevent self-stop, leave `skills_management_policy` at `user-choice` and rely on the manifest-fetch token's scope as the auth boundary instead.
+
+Use this section's full-disable when an org wants to disable user-authored Claude skills entirely.
 
 > **Blast radius.** Force-off only kills the _management UI_ — skill bundles already on disk under `~/.claude/skills/` or a project's `.claude/skills/` keep being discovered by Claude Code itself because Claude's skill loader doesn't consult NBI's policy. To stop existing skills from loading, remove them on disk before flipping the policy.
 
@@ -550,6 +569,7 @@ All routes live under `/notebook-intelligence/`. All require Jupyter authenticat
 | `/notebook-intelligence/skills/import/preview`              | POST            | Preview a GitHub-hosted skill before installing.                                                                     |
 | `/notebook-intelligence/skills/import`                      | POST            | Install a GitHub-hosted skill (user-initiated).                                                                      |
 | `/notebook-intelligence/skills/reconcile`                   | POST            | Run the managed-skills reconciler. Returns 409 if `NBI_SKILLS_MANIFEST` is unset.                                    |
+| `/notebook-intelligence/skills/reconciler/stop`             | POST            | Incident-response kill switch. Stops the background reconciler without a server restart. Idempotent.                 |
 | `/notebook-intelligence/skills/<scope>/<name>`              | GET/PUT/DELETE  | Skill detail; managed skills are read-only.                                                                          |
 | `/notebook-intelligence/skills/<scope>/<name>/rename`       | POST            | Rename a skill (denied for managed skills).                                                                          |
 | `/notebook-intelligence/skills/<scope>/<name>/files`        | GET/POST/DELETE | Skill bundle file ops.                                                                                               |

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -1257,6 +1257,28 @@ class SkillsReconcileHandler(SkillsBaseHandler):
         self.finish(json.dumps(result.to_dict()))
 
 
+class SkillsReconcilerStopHandler(APIHandler):
+    """Incident-response kill switch for the managed-skills reconciler.
+
+    Not gated by ``SkillsBaseHandler.policy_enabled_attr`` because the
+    intended use is "stop the background loop regardless of current policy
+    state" — e.g. when a compromised manifest URL or leaked managed token
+    needs to be neutralized before the pod can be restarted.
+    """
+
+    @tornado.web.authenticated
+    async def post(self):
+        reconciler = ai_service_manager.get_skill_reconciler()
+        if reconciler is None:
+            # Already not running. Idempotent: don't 404 / 409 the caller
+            # since the desired end state matches.
+            self.finish(json.dumps({"stopped": True, "was_running": False}))
+            return
+        was_running = reconciler.is_running()
+        reconciler.stop()
+        self.finish(json.dumps({"stopped": True, "was_running": was_running}))
+
+
 class SkillRenameHandler(SkillsBaseHandler):
     @tornado.web.authenticated
     def post(self, scope, name):
@@ -2575,6 +2597,9 @@ class NotebookIntelligence(ExtensionApp):
         route_pattern_skills_import_preview = url_path_join(base_url, "notebook-intelligence", "skills", "import", "preview")
         route_pattern_skills_import = url_path_join(base_url, "notebook-intelligence", "skills", "import")
         route_pattern_skills_reconcile = url_path_join(base_url, "notebook-intelligence", "skills", "reconcile")
+        route_pattern_skills_reconciler_stop = url_path_join(
+            base_url, "notebook-intelligence", "skills", "reconciler", "stop"
+        )
         route_pattern_skill_detail = url_path_join(base_url, "notebook-intelligence", "skills", r"(user|project)", skill_name)
         route_pattern_skill_rename = url_path_join(base_url, "notebook-intelligence", "skills", r"(user|project)", skill_name, "rename")
         route_pattern_skill_bundle_file = url_path_join(base_url, "notebook-intelligence", "skills", r"(user|project)", skill_name, "files")
@@ -2673,6 +2698,10 @@ class NotebookIntelligence(ExtensionApp):
             (route_pattern_skills_import_preview, SkillsImportPreviewHandler),
             (route_pattern_skills_import, SkillsImportHandler),
             (route_pattern_skills_reconcile, SkillsReconcileHandler),
+            # Deliberately not gated by SkillsBaseHandler — the kill switch
+            # must remain reachable while skills_management_policy=force-off
+            # is the active state. See the handler docstring.
+            (route_pattern_skills_reconciler_stop, SkillsReconcilerStopHandler),
             (route_pattern_skill_bundle_file_rename, SkillBundleFileRenameHandler),
             (route_pattern_skill_bundle_file, SkillBundleFileHandler),
             (route_pattern_skill_rename, SkillRenameHandler),

--- a/notebook_intelligence/skill_reconciler.py
+++ b/notebook_intelligence/skill_reconciler.py
@@ -10,6 +10,7 @@ See `skill_manifest.py` for the manifest schema.
 from __future__ import annotations
 
 import logging
+import os
 import re
 import threading
 from dataclasses import dataclass, field
@@ -129,11 +130,31 @@ class SkillReconciler:
             thread.join(timeout=timeout)
         self._thread = None
 
+    def is_running(self) -> bool:
+        thread = self._thread
+        return thread is not None and thread.is_alive()
+
     # -- internals ----------------------------------------------------------
+
+    @staticmethod
+    def _policy_force_off() -> bool:
+        """Re-read NBI_SKILLS_MANAGEMENT_POLICY at runtime so the reconciler
+        can honor an env-var flip without a server restart. Used as the
+        per-cycle kill switch so admins who can update pod env in place have
+        a working stop signal beyond the explicit HTTP endpoint."""
+        return os.environ.get("NBI_SKILLS_MANAGEMENT_POLICY", "").strip().lower() == "force-off"
 
     def _run_loop(self) -> None:
         # First pass runs immediately, then we sleep between reconciles.
         while not self._stop.is_set():
+            if self._policy_force_off():
+                log.info(
+                    "NBI_SKILLS_MANAGEMENT_POLICY is force-off; stopping the "
+                    "managed-skills reconciler. Existing skills on disk are "
+                    "not touched."
+                )
+                self._stop.set()
+                return
             try:
                 self.reconcile()
             except Exception:  # noqa: BLE001 — thread must survive any error

--- a/tests/test_skill_reconciler.py
+++ b/tests/test_skill_reconciler.py
@@ -392,3 +392,121 @@ class TestBackgroundThread:
         reconciler = SkillReconciler(manager, manifest, interval_seconds=60)
         reconciler.stop()
         reconciler.stop()
+
+    def test_is_running_reflects_thread_state(self, manager, tmp_path):
+        manifest = _write_manifest(tmp_path, "")
+        reconciler = SkillReconciler(manager, manifest, interval_seconds=60)
+        assert reconciler.is_running() is False
+        reconciler.start()
+        try:
+            # The thread starts in the constructor's stop-check window; allow
+            # a brief beat for it to actually enter _run_loop.
+            deadline = time.monotonic() + 1.0
+            while not reconciler.is_running() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert reconciler.is_running() is True
+        finally:
+            reconciler.stop()
+        assert reconciler.is_running() is False
+
+
+class TestPolicyForceOffStop:
+    """The reconciler self-stops when NBI_SKILLS_MANAGEMENT_POLICY flips to
+    force-off at runtime, so an admin who can update pod env in place has a
+    working kill switch without restarting the server (companion to the
+    HTTP stop endpoint).
+    """
+
+    def test_force_off_at_start_stops_immediately(self, manager, tmp_path, monkeypatch):
+        manifest = _write_manifest(tmp_path, "")
+        reconciler = SkillReconciler(manager, manifest, interval_seconds=60)
+        call_count = {"n": 0}
+        orig_reconcile = reconciler.reconcile
+
+        def tracking_reconcile():
+            call_count["n"] += 1
+            return orig_reconcile()
+
+        reconciler.reconcile = tracking_reconcile  # type: ignore[assignment]
+        monkeypatch.setenv("NBI_SKILLS_MANAGEMENT_POLICY", "force-off")
+        reconciler._interval_seconds = 0.05
+        reconciler.start()
+        try:
+            deadline = time.monotonic() + 2.0
+            while reconciler.is_running() and time.monotonic() < deadline:
+                time.sleep(0.05)
+        finally:
+            reconciler.stop()
+        # The loop checks the env BEFORE the reconcile call, so no pass
+        # should have run.
+        assert call_count["n"] == 0
+        assert reconciler.is_running() is False
+
+    def test_force_off_mid_loop_stops_before_next_pass(self, manager, tmp_path, monkeypatch):
+        manifest = _write_manifest(tmp_path, "")
+        reconciler = SkillReconciler(manager, manifest, interval_seconds=60)
+        call_count = {"n": 0}
+        orig_reconcile = reconciler.reconcile
+
+        def tracking_reconcile():
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                # Flip the policy after the first pass; the next iteration
+                # of the loop should see force-off and stop.
+                monkeypatch.setenv("NBI_SKILLS_MANAGEMENT_POLICY", "force-off")
+            return orig_reconcile()
+
+        reconciler.reconcile = tracking_reconcile  # type: ignore[assignment]
+        reconciler._interval_seconds = 0.05
+        reconciler.start()
+        try:
+            deadline = time.monotonic() + 2.0
+            while reconciler.is_running() and time.monotonic() < deadline:
+                time.sleep(0.05)
+        finally:
+            reconciler.stop()
+        # Exactly one reconcile pass should have run before the kill switch
+        # took effect on the next iteration.
+        assert call_count["n"] == 1
+        assert reconciler.is_running() is False
+
+    def test_user_choice_keeps_running(self, manager, tmp_path, monkeypatch):
+        manifest = _write_manifest(tmp_path, "")
+        reconciler = SkillReconciler(manager, manifest, interval_seconds=60)
+        call_count = {"n": 0}
+        orig_reconcile = reconciler.reconcile
+
+        def tracking_reconcile():
+            call_count["n"] += 1
+            return orig_reconcile()
+
+        reconciler.reconcile = tracking_reconcile  # type: ignore[assignment]
+        # Explicitly user-choice (default state, but pin it in case test
+        # ordering inherits force-off from a sibling test).
+        monkeypatch.setenv("NBI_SKILLS_MANAGEMENT_POLICY", "user-choice")
+        reconciler._interval_seconds = 0.05
+        reconciler.start()
+        try:
+            deadline = time.monotonic() + 2.0
+            while call_count["n"] < 2 and time.monotonic() < deadline:
+                time.sleep(0.05)
+        finally:
+            reconciler.stop()
+        # The loop ran at least twice and was not killed by env state.
+        assert call_count["n"] >= 2
+
+    def test_policy_check_is_case_insensitive_and_trimmed(self, monkeypatch):
+        # Pin the exact env-parsing contract so a future refactor that
+        # tightens the match doesn't silently make admin-style "Force-Off"
+        # values stop firing the kill switch.
+        for env_value, expected in [
+            ("force-off", True),
+            ("Force-Off", True),
+            ("  force-off ", True),
+            ("FORCE-OFF", True),
+            ("user-choice", False),
+            ("", False),
+            ("force_off", False),  # underscore is a typo, not a match
+        ]:
+            monkeypatch.setenv("NBI_SKILLS_MANAGEMENT_POLICY", env_value)
+            assert SkillReconciler._policy_force_off() is expected, env_value

--- a/tests/test_skills_handlers.py
+++ b/tests/test_skills_handlers.py
@@ -16,6 +16,7 @@ from notebook_intelligence.extension import (
     SkillsImportPreviewHandler,
     SkillsListHandler,
     SkillsReconcileHandler,
+    SkillsReconcilerStopHandler,
 )
 from notebook_intelligence.skill_reconciler import ReconcileResult
 from notebook_intelligence.skill_manager import SkillManager
@@ -591,6 +592,53 @@ class TestSkillsReconcileHandler:
             "unchanged": 3,
             "errors": ["boom"],
         }
+
+
+class TestSkillsReconcilerStopHandler:
+    """Incident-response kill switch endpoint. Stops the background
+    reconciler at runtime without a server restart. Not gated by the
+    skills_management policy (the intended use is to stop the loop
+    regardless of current policy state)."""
+
+    def test_returns_was_running_false_when_reconciler_absent(self, skill_manager):
+        ext_module.ai_service_manager.get_skill_reconciler.return_value = None
+        handler = _make_handler(SkillsReconcilerStopHandler)
+        asyncio.run(SkillsReconcilerStopHandler.post(handler))
+        body = _parse_response(handler)
+        assert body == {"stopped": True, "was_running": False}
+        handler.set_status.assert_not_called()
+
+    def test_stops_running_reconciler(self, skill_manager):
+        reconciler = MagicMock()
+        reconciler.is_running.return_value = True
+        ext_module.ai_service_manager.get_skill_reconciler.return_value = reconciler
+        handler = _make_handler(SkillsReconcilerStopHandler)
+        asyncio.run(SkillsReconcilerStopHandler.post(handler))
+        reconciler.stop.assert_called_once()
+        body = _parse_response(handler)
+        assert body == {"stopped": True, "was_running": True}
+
+    def test_idempotent_when_already_stopped(self, skill_manager):
+        # Second POST after a stop should report was_running=False without
+        # erroring, so admins can blindly retry the kill switch from a
+        # script.
+        reconciler = MagicMock()
+        reconciler.is_running.return_value = False
+        ext_module.ai_service_manager.get_skill_reconciler.return_value = reconciler
+        handler = _make_handler(SkillsReconcilerStopHandler)
+        asyncio.run(SkillsReconcilerStopHandler.post(handler))
+        reconciler.stop.assert_called_once()
+        body = _parse_response(handler)
+        assert body == {"stopped": True, "was_running": False}
+
+    def test_not_subject_to_skills_management_policy_gate(self, skill_manager):
+        # Pin the deliberate inversion: when an admin force-offs the Skills
+        # policy, the rest of /skills/* returns 403, but the stop endpoint
+        # must still work — otherwise the kill switch is unreachable in
+        # the exact state it exists to support. Verified by inspecting the
+        # MRO; a future refactor that adds SkillsBaseHandler to the bases
+        # would re-introduce the deadlock.
+        assert SkillsBaseHandler not in SkillsReconcilerStopHandler.__mro__
 
 
 # Per-family policy-gate coverage lives in `tests/test_policy_gate.py`,


### PR DESCRIPTION
## Summary

The admin guide currently documents that setting \`skills_management_policy = force-off\` (or \`NBI_SKILLS_MANAGEMENT_POLICY=force-off\`) will \"suppress the managed-skills reconciler,\" but also concedes the suppression \"takes effect on JupyterLab server restart\" and that a live config-reload won't stop a reconciler that's already running. For an incident-response kill switch (compromised manifest URL, leaked managed-skills token), needing a server restart is too slow.

This PR adds two non-restart paths to stop the reconciler.

## Solution

**1. HTTP kill switch.** New endpoint \`POST /notebook-intelligence/skills/reconciler/stop\`. Authenticated with the standard Jupyter session token. Returns \`{\"stopped\": true, \"was_running\": <bool>}\` so callers know whether the call actually interrupted work. Idempotent: a second POST after the reconciler is already stopped returns the same success shape, so admins can script the call across pods without special-casing already-stopped pods.

The endpoint is **deliberately not gated by the Skills management policy**. Inheriting from \`SkillsBaseHandler\` would mean the policy gate returns 403 in the exact \`force-off\` state where the kill switch is supposed to fire. A test pins this contract structurally (\`SkillsBaseHandler\` not in the MRO) so a future refactor can't silently re-introduce the deadlock.

**2. Per-cycle env-var recheck.** The reconciler's background loop now reads \`NBI_SKILLS_MANAGEMENT_POLICY\` at the top of each iteration via a new \`_policy_force_off()\` helper. If force-off is observed, the loop self-stops and logs. Latency is bounded by the cycle interval (default 24h), so this is the slow path for deployments that don't or can't call the HTTP endpoint. Adds one env-var read per cycle; zero ongoing cost.

A new \`SkillReconciler.is_running()\` helper supports the new endpoint's \`was_running\` payload field. \`AIServiceManager.handle_stop_request\` continues to call \`reconciler.stop()\` at shutdown; double-stop is safe and the early self-stop leaves \`_thread\` non-null so the shutdown join is harmless.

## Testing

Eight new pytest cases across two files:

- \`TestPolicyForceOffStop\`: force-off at start prevents any reconcile pass; force-off mid-loop stops before the next pass; user-choice leaves the loop running; case-insensitive policy parsing including the \`force_off\`-vs-\`force-off\` underscore-vs-dash typo guard.
- \`TestBackgroundThread::test_is_running_reflects_thread_state\`: \`is_running()\` returns False before start, True during run, False after stop.
- \`TestSkillsReconcilerStopHandler\`: idempotent in both running and stopped states, returns the correct \`was_running\` value, and a structural MRO assertion pinning the deliberate gate-bypass.

\`pytest tests/\` (730 passing), \`jlpm tsc --noEmit\`, \`jlpm lint:check\`, \`jlpm jest\` (154 passing). All four green.

Six-agent review applied: added the MRO contract test, added the no-live-restart and per-tenant trust notes to the admin guide, added a clarifying comment at the route-registration site.

## Risks / follow-ups

- **No live restart of the reconciler.** Once stopped, only a server bounce re-enables it in the same pod. Intentional: a kill switch another script could flip back on isn't a kill switch. Documented as a sharp edge.
- **Per-tenant trust posture.** The endpoint authenticates with the user's Jupyter session token, not an admin claim. In hub deployments where the pod owner is not the policy admin, a tenant can stop their own pod's reconciler. The reconciler is per-pod, so this only affects that user's managed-skills delivery. Documented.
- **Capabilities surfacing.** The Skills panel does not currently show a \"reconciler stopped\" status indicator. Worth a follow-up so users can verify the kill switch worked from the UI, but not load-bearing for this PR.