### PR TITLE
security: enforce 0o600 on the encrypted GitHub token file

### DIFF
--- a/notebook_intelligence/config.py
+++ b/notebook_intelligence/config.py
@@ -232,7 +232,7 @@ class NBIConfig:
         self.set('active_rules', active_rules)
 
 
-def _atomic_write_json(target: str, payload: dict) -> None:
+def _atomic_write_json(target: str, payload: dict, *, mode: Optional[int] = None) -> None:
     """Crash-safe replacement for ``open(target, 'w') + json.dump``.
 
     Plain truncating writes leave the destination empty (or partial)
@@ -245,10 +245,16 @@ def _atomic_write_json(target: str, payload: dict) -> None:
     to a shared config file expects ``save()`` to update the link's
     target, not replace the link itself. Resolve via ``realpath`` first.
 
-    Mode-preserving: ``mkstemp`` returns a 0o600 file; if the existing
-    config has different permissions (e.g. 0o644 for a shared install),
-    re-apply them after the swap so the user's chmod isn't silently
-    undone.
+    Mode handling:
+      - ``mode`` argument set: the file is written with exactly that mode,
+        regardless of any existing mode. Callers that handle secrets (the
+        encrypted GitHub token at ``~/.jupyter/nbi/user-data.json``) pass
+        ``0o600`` so the file is never world-readable, even if a prior
+        umask-default write or a manual chmod widened the perms.
+      - ``mode=None`` (default): ``mkstemp`` returns a 0o600 file; if the
+        existing target has different permissions (e.g. 0o644 for a
+        shared install), re-apply them after the swap so the user's
+        chmod isn't silently undone.
 
     Durability: ``fsync`` the tempfile, then ``fsync`` the target's
     parent directory on POSIX so the rename itself survives a crash.
@@ -270,9 +276,14 @@ def _atomic_write_json(target: str, payload: dict) -> None:
             json.dump(payload, fh, indent=2)
             fh.flush()
             os.fsync(fh.fileno())
-        if existing_mode is not None:
+        # Decide what mode the post-rename file should carry:
+        #   - explicit mode overrides everything (secrets case)
+        #   - else preserve existing target mode (shared-install case)
+        #   - else leave mkstemp's 0o600
+        effective_mode = mode if mode is not None else existing_mode
+        if effective_mode is not None:
             try:
-                os.chmod(tmp_path, existing_mode)
+                os.chmod(tmp_path, effective_mode)
             except OSError:
                 # Some filesystems (FAT, certain network mounts) reject chmod;
                 # the swap itself is still safe, just lose the mode bits.

--- a/notebook_intelligence/github_copilot.py
+++ b/notebook_intelligence/github_copilot.py
@@ -127,6 +127,19 @@ def read_stored_github_access_token() -> str:
 
     return None
 
+def _save_user_data(user_data: dict) -> None:
+    """Single write path for ``~/.jupyter/nbi/user-data.json``.
+
+    The file is a secret (encrypted GitHub Copilot token). Force 0o600 on
+    every write so the file is never group/world-readable, even if a
+    prior write under a permissive umask or a manual chmod widened the
+    perms. Routing both write sites through this helper keeps the mode
+    contract in one place; a future third writer can't accidentally drop
+    it.
+    """
+    _atomic_write_json(user_data_file, user_data, mode=0o600)
+
+
 def write_github_access_token(access_token: str) -> bool:
     try:
         encrypted_access_token = encrypt_with_password(access_token_password, access_token.encode())
@@ -142,12 +155,7 @@ def write_github_access_token(access_token: str) -> bool:
         user_data.update({
             'github_access_token': base64_access_token
         })
-        # The encrypted token is a secret. Force 0o600 on every write so
-        # the file is never group/world-readable, even if a prior write
-        # under a permissive umask or a manual chmod widened the perms.
-        # The atomic helper rewrites via a sibling tempfile + rename, so
-        # the mode is applied to a fresh inode each time.
-        _atomic_write_json(user_data_file, user_data, mode=0o600)
+        _save_user_data(user_data)
         return True
     except Exception as e:
         log.error(f"Failed to write GitHub access token: {e}")
@@ -164,7 +172,7 @@ def delete_stored_github_access_token() -> bool:
             user_data = json.load(file)
         user_data.pop('github_access_token', None)
 
-        _atomic_write_json(user_data_file, user_data, mode=0o600)
+        _save_user_data(user_data)
         return True
     except Exception as e:
         log.error(f"Failed to delete GitHub access token: {e}")

--- a/notebook_intelligence/github_copilot.py
+++ b/notebook_intelligence/github_copilot.py
@@ -13,6 +13,7 @@ import sseclient
 import datetime as dt
 import logging
 from notebook_intelligence.api import BackendMessageType, CancelToken, ChatResponse, CompletionContext, MarkdownData
+from notebook_intelligence.config import _atomic_write_json
 from notebook_intelligence.util import decrypt_with_password, encrypt_with_password, ThreadSafeWebSocketConnector
 
 from ._version import __version__ as NBI_VERSION
@@ -141,8 +142,12 @@ def write_github_access_token(access_token: str) -> bool:
         user_data.update({
             'github_access_token': base64_access_token
         })
-        with open(user_data_file, 'w') as file:
-            json.dump(user_data, file, indent=4)
+        # The encrypted token is a secret. Force 0o600 on every write so
+        # the file is never group/world-readable, even if a prior write
+        # under a permissive umask or a manual chmod widened the perms.
+        # The atomic helper rewrites via a sibling tempfile + rename, so
+        # the mode is applied to a fresh inode each time.
+        _atomic_write_json(user_data_file, user_data, mode=0o600)
         return True
     except Exception as e:
         log.error(f"Failed to write GitHub access token: {e}")
@@ -159,8 +164,7 @@ def delete_stored_github_access_token() -> bool:
             user_data = json.load(file)
         user_data.pop('github_access_token', None)
 
-        with open(user_data_file, 'w') as file:
-            json.dump(user_data, file, indent=4)
+        _atomic_write_json(user_data_file, user_data, mode=0o600)
         return True
     except Exception as e:
         log.error(f"Failed to delete GitHub access token: {e}")

--- a/tests/test_config_atomic_save.py
+++ b/tests/test_config_atomic_save.py
@@ -102,3 +102,38 @@ class TestAtomicWriteJson:
 
         # Mode bits preserved across the atomic swap.
         assert (target.stat().st_mode & 0o777) == 0o640
+
+    def test_explicit_mode_overrides_existing(self, tmp_path):
+        # The secrets case (e.g. ~/.jupyter/nbi/user-data.json): even if
+        # the existing file was somehow widened to 0o644 by a prior
+        # umask-default write, an explicit mode=0o600 must tighten it.
+        import os as _os
+        target = tmp_path / "user-data.json"
+        target.write_text(json.dumps({"old": True}))
+        _os.chmod(target, 0o644)
+
+        _atomic_write_json(str(target), {"new": True}, mode=0o600)
+
+        assert (target.stat().st_mode & 0o777) == 0o600
+
+    def test_explicit_mode_on_first_create(self, tmp_path):
+        # No existing file. Explicit mode still applies, so the secret
+        # file starts at 0o600 from the very first write.
+        target = tmp_path / "user-data.json"
+        assert not target.exists()
+
+        _atomic_write_json(str(target), {"secret": "x"}, mode=0o600)
+
+        assert (target.stat().st_mode & 0o777) == 0o600
+
+    def test_default_mode_preserves_existing(self, tmp_path):
+        # Regression: passing no mode keeps the pre-fix behavior so
+        # existing callers don't see their file mode tightened.
+        import os as _os
+        target = tmp_path / "config.json"
+        target.write_text(json.dumps({"old": True}))
+        _os.chmod(target, 0o644)
+
+        _atomic_write_json(str(target), {"new": True})  # no mode arg
+
+        assert (target.stat().st_mode & 0o777) == 0o644

--- a/tests/test_github_copilot_user_data_mode.py
+++ b/tests/test_github_copilot_user_data_mode.py
@@ -1,0 +1,72 @@
+# Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+"""Pin the file-mode contract on `~/.jupyter/nbi/user-data.json`.
+
+The file holds the encrypted GitHub Copilot access token. A default
+umask write produces 0o644, which on shared-home topologies (NFS,
+classroom labs) lets other users read the ciphertext and brute-force
+the default password. The fix forces 0o600 on every write so the file
+is never group/world-readable, regardless of prior state.
+"""
+
+import json
+import os
+import stat
+
+import pytest
+
+from notebook_intelligence import github_copilot
+
+
+@pytest.fixture
+def temp_user_data(tmp_path, monkeypatch):
+    """Redirect the module-level `user_data_file` to a tmp_path location
+    so the test never touches the real ~/.jupyter/nbi/."""
+    target = tmp_path / "user-data.json"
+    monkeypatch.setattr(github_copilot, "user_data_file", str(target))
+    return target
+
+
+def _mode(path):
+    return stat.S_IMODE(os.stat(path).st_mode)
+
+
+class TestUserDataFileMode:
+    def test_first_write_is_0o600(self, temp_user_data):
+        assert not temp_user_data.exists()
+        github_copilot.write_github_access_token("ghp_test_token")
+        assert temp_user_data.exists()
+        # File is owner-RW only; no group/world bits at all.
+        assert _mode(temp_user_data) == 0o600
+
+    def test_rewrite_tightens_loose_mode(self, temp_user_data):
+        # Simulate a prior write under default umask that left the file
+        # world-readable. The next write must tighten it back to 0o600
+        # rather than preserve the loose mode.
+        temp_user_data.write_text(json.dumps({}))
+        os.chmod(temp_user_data, 0o644)
+
+        github_copilot.write_github_access_token("ghp_test_token")
+
+        assert _mode(temp_user_data) == 0o600
+
+    def test_delete_preserves_0o600(self, temp_user_data):
+        # `delete_stored_github_access_token` rewrites the file with the
+        # token field removed. The file mode must stay tight even
+        # through deletes.
+        github_copilot.write_github_access_token("ghp_test_token")
+        # Loosen explicitly to verify the delete-write tightens again.
+        os.chmod(temp_user_data, 0o644)
+
+        github_copilot.delete_stored_github_access_token()
+
+        assert _mode(temp_user_data) == 0o600
+
+    def test_write_persists_token_payload(self, temp_user_data):
+        # Sanity: the mode-tightening fix must not regress the actual
+        # token write. The encrypted token must still be present and
+        # decryptable on the next read.
+        github_copilot.write_github_access_token("ghp_test_token")
+
+        recovered = github_copilot.read_stored_github_access_token()
+        assert recovered == "ghp_test_token"


### PR DESCRIPTION
## Summary

\`~/.jupyter/nbi/user-data.json\` holds the encrypted GitHub Copilot access token. The previous write path used \`open(user_data_file, 'w')\` under the default umask, which on most systems produces \`0o644\` and leaves the ciphertext group/world-readable. On a shared-home topology (NFS, classroom labs) any other user can read the file and brute-force the default password.

## Solution

Both write sites (\`write_github_access_token\` and \`delete_stored_github_access_token\`) now go through \`_atomic_write_json\` with \`mode=0o600\` forced. The helper grew an optional \`mode\` kwarg that, when set, applies regardless of any existing file mode. Default behavior (preserve existing mode) is unchanged for other callers, so the config-file path stays backward-compatible.

The mode is enforced on **every** write, not only on first-create. A prior umask-default write or a manual \`chmod\` that widened the perms is tightened back to \`0o600\` on the next save.

## Testing

Four new pytest cases in \`tests/test_github_copilot_user_data_mode.py\` (first-write, loose-mode-tightened-on-rewrite, mode-preserved-through-delete, read-back roundtrip) plus three new cases in \`tests/test_config_atomic_save.py\` covering the new \`mode\` kwarg (override, first-create, no-mode-arg backward compat). Confirmed regression detection by reverting \`github_copilot.py\` to upstream/main and re-running: 3 of 4 user-data tests fail.

\`pytest tests/\` (739 passing, +7 new), \`jlpm tsc --noEmit\`, \`jlpm lint:check\`, \`jlpm jest\` (154 passing). All four green.

## Risks / follow-ups

- The atomic-write helper takes a fresh inode each rewrite, so symlinks pointed at the file get followed. Behavior preserved from the existing helper.
- The encryption-password and per-user-salt findings are separate items addressed in companion PRs; this one is only the file-mode hardening.