### PR TITLE
feat(plugins): show marketplace details and add an Update button

### DIFF
--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -1102,6 +1102,16 @@ class PluginsMarketplacePluginsHandler(PluginsBaseHandler):
         self.finish(json.dumps({"plugins": plugins}))
 
 
+class PluginsMarketplaceUpdateHandler(PluginsBaseHandler):
+    @tornado.web.authenticated
+    async def post(self, name):
+        try:
+            await self.manager.update_marketplace(name=name)
+            self.finish(json.dumps({"success": True}))
+        except (FileNotFoundError, PermissionError, TimeoutError, ValueError) as e:
+            self._error(e)
+
+
 class SkillsBaseHandler(PolicyGatedHandler):
     """Shared helpers for skills endpoints."""
 
@@ -2702,6 +2712,14 @@ class NotebookIntelligence(ExtensionApp):
         route_pattern_plugins_marketplace_detail = url_path_join(
             base_url, "notebook-intelligence", "plugins", "marketplace", r"([^/]+)"
         )
+        route_pattern_plugins_marketplace_update = url_path_join(
+            base_url,
+            "notebook-intelligence",
+            "plugins",
+            "marketplace",
+            r"([^/]+)",
+            "update",
+        )
         GetCapabilitiesHandler.disabled_tools = self.disabled_tools
         GetCapabilitiesHandler.allow_enabling_tools_with_env = self.allow_enabling_tools_with_env
         GetCapabilitiesHandler.disabled_providers = self.disabled_providers
@@ -2808,6 +2826,10 @@ class NotebookIntelligence(ExtensionApp):
             (
                 route_pattern_plugins_marketplace_plugins,
                 PluginsMarketplacePluginsHandler,
+            ),
+            (
+                route_pattern_plugins_marketplace_update,
+                PluginsMarketplaceUpdateHandler,
             ),
             (route_pattern_plugins_marketplace_detail, PluginsMarketplaceDetailHandler),
             (route_pattern_plugins_marketplace, PluginsMarketplaceListHandler),

--- a/notebook_intelligence/plugin_manager.py
+++ b/notebook_intelligence/plugin_manager.py
@@ -13,6 +13,7 @@ NBI shells out for both reads and writes:
   - `claude plugin disable <plugin> [-s scope]`
   - `claude plugin marketplace add <source> [--scope <scope>]`
   - `claude plugin marketplace remove <name>`
+  - `claude plugin marketplace update [<name>]`
 
 The CLI's JSON-output schema is not formally documented; the manager
 forwards parsed objects to the frontend mostly untouched so newer Claude
@@ -165,12 +166,51 @@ class PluginManager:
 
     async def list_marketplaces(self) -> list[dict[str, Any]]:
         out = await self._run_cli(["plugin", "marketplace", "list", "--json"])
-        return self._parse_json_array(out, "plugin marketplace list")
+        marketplaces = self._parse_json_array(out, "plugin marketplace list")
+        # Enrich each entry with description, version, and plugin list
+        # pulled from the cached marketplace.json. Older clients ignore
+        # the extra keys; the panel uses them to render a richer row. A
+        # missing or malformed manifest logs and skips so one bad entry
+        # cannot break the whole list endpoint. OSError covers
+        # FileNotFoundError, PermissionError, IsADirectoryError; the
+        # ValueError branch covers our own JSON-shape complaints and the
+        # raw UnicodeDecodeError that read_text can raise.
+        for entry in marketplaces:
+            name = entry.get("name")
+            if not isinstance(name, str):
+                continue
+            try:
+                details = self._read_marketplace_details(name)
+            except (OSError, ValueError, UnicodeDecodeError):
+                continue
+            for key, value in details.items():
+                # Prefer a future CLI value when present AND truthy: an
+                # empty-string description from the CLI must not shadow
+                # a useful description from the manifest.
+                if not entry.get(key):
+                    entry[key] = value
+        return marketplaces
 
     async def list_marketplace_plugins(
         self, marketplace: str
     ) -> list[dict[str, Any]]:
         marketplace_name = _validate_marketplace_name(marketplace)
+        doc = self._read_marketplace_manifest(marketplace_name)
+        plugins = doc.get("plugins")
+        if not isinstance(plugins, list):
+            return []
+        return [p for p in plugins if isinstance(p, dict)]
+
+    # Upper bound on marketplace.json size. The realistic shape is a few
+    # KB even for big marketplaces, so a 1 MiB cap covers every legitimate
+    # use while bounding the memory cost of a hostile or corrupt manifest
+    # the next list_marketplaces call would otherwise slurp whole.
+    _MARKETPLACE_MANIFEST_MAX_BYTES: int = 1 * 1024 * 1024
+
+    def _read_marketplace_manifest(self, marketplace_name: str) -> dict[str, Any]:
+        """Read the cached marketplace.json. Raises FileNotFoundError /
+        ValueError on missing or malformed input.
+        """
         manifest = (
             _claude_plugins_root()
             / "marketplaces"
@@ -179,14 +219,64 @@ class PluginManager:
             / "marketplace.json"
         )
         try:
-            out = manifest.read_text(encoding="utf-8")
+            size = manifest.stat().st_size
         except FileNotFoundError as exc:
             raise FileNotFoundError(
                 f"Marketplace manifest not found for {marketplace_name!r}"
             ) from exc
-        return self._parse_json_array(
-            out, f"plugin marketplace {marketplace_name} manifest"
-        )
+        if size > self._MARKETPLACE_MANIFEST_MAX_BYTES:
+            raise ValueError(
+                f"marketplace.json for {marketplace_name!r} exceeds the "
+                f"{self._MARKETPLACE_MANIFEST_MAX_BYTES}-byte cap "
+                f"({size} bytes)"
+            )
+        try:
+            text = manifest.read_text(encoding="utf-8")
+        except FileNotFoundError as exc:
+            raise FileNotFoundError(
+                f"Marketplace manifest not found for {marketplace_name!r}"
+            ) from exc
+        try:
+            doc = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"Could not parse marketplace.json for {marketplace_name!r}: {exc}"
+            ) from exc
+        if not isinstance(doc, dict):
+            raise ValueError(
+                f"marketplace.json for {marketplace_name!r} is not a JSON object"
+            )
+        return doc
+
+    def _read_marketplace_details(self, marketplace_name: str) -> dict[str, Any]:
+        """Return ``description``, ``version``, ``plugin_count``, and
+        ``plugin_names`` for the named marketplace.
+
+        Reads the cached ``.claude-plugin/marketplace.json`` written by
+        ``claude plugin marketplace add``. Both top-level and
+        ``metadata.*`` fields are recognized: the documented schema puts
+        ``description``/``version`` at top level but the same keys are
+        accepted under ``metadata`` for backward compatibility, per the
+        Claude Code marketplace docs.
+        """
+        doc = self._read_marketplace_manifest(marketplace_name)
+        metadata = doc.get("metadata") if isinstance(doc.get("metadata"), dict) else {}
+        description = doc.get("description") or metadata.get("description") or ""
+        version = doc.get("version") or metadata.get("version") or ""
+        plugins_raw = doc.get("plugins")
+        plugin_names: list[str] = []
+        if isinstance(plugins_raw, list):
+            for plugin in plugins_raw:
+                if isinstance(plugin, dict):
+                    name = plugin.get("name")
+                    if isinstance(name, str) and name:
+                        plugin_names.append(name)
+        return {
+            "description": str(description) if description else "",
+            "version": str(version) if version else "",
+            "plugin_count": len(plugin_names),
+            "plugin_names": plugin_names,
+        }
 
     # --- writes (CLI shell-outs) ---------------------------------------
 
@@ -288,6 +378,35 @@ class PluginManager:
         reject_flag_smuggling("name", name)
         async with self._write_lock:
             await self._run_cli(["plugin", "marketplace", "remove", name])
+
+    async def update_marketplace(self, *, name: str) -> None:
+        """Run ``claude plugin marketplace update <name>``.
+
+        Refreshes the local cache of the marketplace manifest from its
+        source (git pull, HTTPS refetch, local-path recopy). The CLI
+        does not return JSON for this command; success is signaled by
+        exit code zero. Times out under the same network budget as
+        ``add_marketplace`` because the underlying ``git`` call has the
+        same potential to stall.
+        """
+        marketplace_name = _validate_marketplace_name(name)
+        # Marketplace `update` re-fetches from the original source; if it
+        # was a GitHub URL the same auth chain that worked for `add`
+        # needs to apply here too. The CLI persists the source from the
+        # initial add, so we cannot inspect it without re-reading the
+        # cached config, but injecting the token unconditionally is
+        # harmless for non-GitHub sources (the CLI just ignores it) and
+        # the env never lands in argv.
+        token = resolve_github_token()
+        env_overrides: Optional[dict[str, str]] = (
+            {"GITHUB_TOKEN": token, "GH_TOKEN": token} if token else None
+        )
+        async with self._write_lock:
+            await self._run_cli(
+                ["plugin", "marketplace", "update", marketplace_name],
+                timeout=CLI_TIMEOUT_MARKETPLACE_ADD_SECONDS,
+                env_overrides=env_overrides,
+            )
 
     # --- internals -----------------------------------------------------
 

--- a/notebook_intelligence/plugin_manager.py
+++ b/notebook_intelligence/plugin_manager.py
@@ -175,6 +175,12 @@ class PluginManager:
         # FileNotFoundError, PermissionError, IsADirectoryError; the
         # ValueError branch covers our own JSON-shape complaints and the
         # raw UnicodeDecodeError that read_text can raise.
+        # `plugin_count` and `plugin_names` are coupled: if the CLI
+        # surfaces either, the row must show the CLI's view of both,
+        # otherwise the count and the visible name list could disagree
+        # (e.g. "42 plugins: alpha, beta" because count came from CLI
+        # and names came from the manifest).
+        _coupled_keys = ("plugin_count", "plugin_names")
         for entry in marketplaces:
             name = entry.get("name")
             if not isinstance(name, str):
@@ -183,10 +189,21 @@ class PluginManager:
                 details = self._read_marketplace_details(name)
             except (OSError, ValueError, UnicodeDecodeError):
                 continue
+            cli_supplied_plugin_meta = any(
+                key in entry and entry.get(key) is not None
+                for key in _coupled_keys
+            )
             for key, value in details.items():
-                # Prefer a future CLI value when present AND truthy: an
-                # empty-string description from the CLI must not shadow
-                # a useful description from the manifest.
+                if key in _coupled_keys:
+                    # Only overlay when CLI provided neither half.
+                    if cli_supplied_plugin_meta:
+                        continue
+                    entry[key] = value
+                    continue
+                # Other enrichment keys: prefer a future CLI value when
+                # present AND truthy. An empty-string description from
+                # the CLI must not shadow a useful description from the
+                # manifest.
                 if not entry.get(key):
                     entry[key] = value
         return marketplaces
@@ -210,7 +227,18 @@ class PluginManager:
     def _read_marketplace_manifest(self, marketplace_name: str) -> dict[str, Any]:
         """Read the cached marketplace.json. Raises FileNotFoundError /
         ValueError on missing or malformed input.
+
+        Validate the name against the same path-traversal / NUL / flag
+        checks that gate ``list_marketplace_plugins``. The CLI sanitizes
+        its own output today, but consistency keeps the manifest-read
+        layer self-defending instead of relying on every caller to gate
+        upstream.
         """
+        # Raises ValueError on path-traversal / NUL / leading-dash /
+        # path-separator names. The enrichment caller in
+        # `list_marketplaces` catches ValueError and skips, so a single
+        # bad CLI-returned name still doesn't break the list.
+        marketplace_name = _validate_marketplace_name(marketplace_name)
         manifest = (
             _claude_plugins_root()
             / "marketplaces"

--- a/src/api.ts
+++ b/src/api.ts
@@ -90,6 +90,10 @@ export interface IPluginMarketplaceInfo {
   name?: string;
   source?: string;
   scope?: PluginScope | string;
+  description?: string;
+  version?: string;
+  plugin_count?: number;
+  plugin_names?: string[];
   [key: string]: unknown;
 }
 
@@ -1023,6 +1027,16 @@ export class NBIAPI {
     await requestAPI<any>(`plugins/marketplace/${encodeURIComponent(name)}`, {
       method: 'DELETE'
     });
+  }
+
+  static async updatePluginMarketplace(name: string): Promise<void> {
+    await requestAPI<any>(
+      `plugins/marketplace/${encodeURIComponent(name)}/update`,
+      {
+        method: 'POST',
+        body: '{}'
+      }
+    );
   }
 
   static async reconcileManagedSkills(): Promise<IReconcileResult> {

--- a/src/components/plugins-panel.tsx
+++ b/src/components/plugins-panel.tsx
@@ -22,6 +22,25 @@ function marketplaceName(marketplace: IPluginMarketplaceInfo): string {
   return String(marketplace.name ?? '').trim();
 }
 
+// Plugin-name list trimmed with ellipsis. Caller decides the visible cap;
+// the helper just stitches a comma-separated string and appends the
+// "+N more" tail when the cap is hit, so the row width stays bounded
+// even for marketplaces with hundreds of plugins.
+export function summarizePluginNames(
+  names: readonly string[] | undefined,
+  visible: number
+): string {
+  if (!names || names.length === 0) {
+    return '';
+  }
+  if (names.length <= visible) {
+    return names.join(', ');
+  }
+  const head = names.slice(0, visible).join(', ');
+  const remaining = names.length - visible;
+  return `${head}, +${remaining} more`;
+}
+
 function pluginName(plugin: IPluginInfo): string {
   return String(plugin.name ?? plugin.id ?? '').trim();
 }
@@ -151,6 +170,22 @@ export function SettingsPanelComponentPlugins(_props: any): JSX.Element {
     }
   };
 
+  const handleUpdateMarketplace = async (m: IPluginMarketplaceInfo) => {
+    const name = String(m.name ?? '');
+    if (!name) {
+      return;
+    }
+    setBusyMarketplace(name);
+    try {
+      await NBIAPI.updatePluginMarketplace(name);
+      await refresh();
+    } catch (e: any) {
+      setError(`Failed to update marketplace: ${e?.message ?? e}`);
+    } finally {
+      setBusyMarketplace(null);
+    }
+  };
+
   const grouped: Record<PluginScope, IPluginInfo[]> = {
     user: [],
     project: [],
@@ -216,6 +251,7 @@ export function SettingsPanelComponentPlugins(_props: any): JSX.Element {
               info={m}
               busy={busyMarketplace === String(m.name ?? '')}
               onRemove={() => handleRemoveMarketplace(m)}
+              onUpdate={() => handleUpdateMarketplace(m)}
             />
           ))
         )}
@@ -347,25 +383,83 @@ function PluginRow(props: {
   );
 }
 
+// Visible plugin-name cap on the marketplace row. Picked so a typical
+// marketplace (a handful of plugins) fits on one line, with longer lists
+// collapsing to "a, b, c, +N more" so the row width stays bounded.
+const MARKETPLACE_VISIBLE_PLUGINS = 5;
+
 function MarketplaceRow(props: {
   info: IPluginMarketplaceInfo;
   busy: boolean;
   onRemove: () => void;
+  onUpdate: () => void;
 }) {
   const { info } = props;
+  const description =
+    typeof info.description === 'string' ? info.description.trim() : '';
+  const version = typeof info.version === 'string' ? info.version.trim() : '';
+  const pluginNames = Array.isArray(info.plugin_names)
+    ? info.plugin_names.filter((n): n is string => typeof n === 'string')
+    : [];
+  const pluginCount =
+    typeof info.plugin_count === 'number'
+      ? info.plugin_count
+      : pluginNames.length;
+  const pluginSummary = summarizePluginNames(
+    pluginNames,
+    MARKETPLACE_VISIBLE_PLUGINS
+  );
+  // Pluralize for 0/1/N: "no plugins" reads better than "0 plugins" when
+  // the marketplace manifest has not yet been refreshed and we have no
+  // plugin entries.
+  const pluginCountLabel =
+    pluginCount === 0
+      ? 'no plugins'
+      : pluginCount === 1
+        ? '1 plugin'
+        : `${pluginCount} plugins`;
+  // Only render the plugin summary line when the manifest read produced
+  // a count or name list. Without this guard, a marketplace that the
+  // user just added but whose manifest hasn't been cached yet would
+  // render "no plugins" and look broken; here it just renders no line
+  // at all until the next refresh picks up the manifest.
+  const hasPluginManifestData =
+    Array.isArray(info.plugin_names) || typeof info.plugin_count === 'number';
   return (
     <div className="nbi-skill-row">
       <div className="nbi-skill-row-main">
         <div className="nbi-skill-row-name">
           {String(info.name ?? '(unnamed)')}
+          {version && (
+            <span className="nbi-skill-row-version"> v{version}</span>
+          )}
         </div>
+        {description && (
+          <div className="nbi-skill-row-description">{description}</div>
+        )}
         {info.source && (
           <div className="nbi-skill-row-description">
             <code>{String(info.source)}</code>
           </div>
         )}
+        {hasPluginManifestData && (
+          <div className="nbi-skill-row-description nbi-skill-row-plugins">
+            {pluginCountLabel}
+            {pluginSummary && <span>{`: ${pluginSummary}`}</span>}
+          </div>
+        )}
       </div>
       <div className="nbi-skill-row-actions" onClick={e => e.stopPropagation()}>
+        <button
+          className="jp-Dialog-button jp-mod-reject jp-mod-styled"
+          onClick={props.onUpdate}
+          disabled={props.busy}
+          title="Refresh this marketplace from its source"
+        >
+          <div className="jp-Dialog-buttonLabel">
+            {props.busy ? 'Updating…' : 'Update'}
+          </div>
+        </button>
         <button
           className="jp-Dialog-button jp-mod-reject jp-mod-styled"
           onClick={props.onRemove}

--- a/src/components/plugins-panel.tsx
+++ b/src/components/plugins-panel.tsx
@@ -451,7 +451,7 @@ function MarketplaceRow(props: {
       </div>
       <div className="nbi-skill-row-actions" onClick={e => e.stopPropagation()}>
         <button
-          className="jp-Dialog-button jp-mod-reject jp-mod-styled"
+          className="jp-Dialog-button jp-mod-accept jp-mod-styled"
           onClick={props.onUpdate}
           disabled={props.busy}
           title="Refresh this marketplace from its source"

--- a/style/base.css
+++ b/style/base.css
@@ -1742,6 +1742,18 @@ svg.access-token-warning {
   font-size: var(--jp-ui-font-size0);
 }
 
+.nbi-skill-row-version {
+  font-weight: 400;
+  color: var(--jp-ui-font-color2);
+  font-size: var(--jp-ui-font-size0);
+}
+
+.nbi-skill-row-plugins {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .nbi-skill-row-disabled {
   border-style: dashed;
 }

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -130,6 +130,259 @@ class TestPluginManagerReads:
         result = asyncio.run(manager.list_marketplaces())
         assert result == [{"name": "acme", "source": "github:acme/marketplace"}]
 
+    def test_list_marketplaces_enriches_with_manifest_details(
+        self, fake_cli, tmp_path, monkeypatch
+    ):
+        # Pin the enrichment path: when a cached marketplace.json sits
+        # alongside the marketplace entry, the response carries
+        # description, version, plugin_count, and plugin_names so the
+        # frontend can render a rich row without a second HTTP round
+        # trip per marketplace.
+        plugins_root = tmp_path / "plugins"
+        manifest = (
+            plugins_root
+            / "marketplaces"
+            / "acme"
+            / ".claude-plugin"
+            / "marketplace.json"
+        )
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text(
+            json.dumps(
+                {
+                    "name": "acme",
+                    "description": "Acme team plugins",
+                    "version": "1.2.3",
+                    "plugins": [
+                        {"name": "alpha", "source": "./a"},
+                        {"name": "beta", "source": "./b"},
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("CLAUDE_CODE_PLUGIN_CACHE_DIR", str(plugins_root))
+        _stub_subprocess(
+            monkeypatch,
+            captured={},
+            stdout=b'[{"name":"acme","source":"github:acme/marketplace"}]',
+        )
+
+        result = asyncio.run(PluginManager().list_marketplaces())
+
+        assert result == [
+            {
+                "name": "acme",
+                "source": "github:acme/marketplace",
+                "description": "Acme team plugins",
+                "version": "1.2.3",
+                "plugin_count": 2,
+                "plugin_names": ["alpha", "beta"],
+            }
+        ]
+
+    def test_list_marketplaces_reads_metadata_block_as_fallback(
+        self, fake_cli, tmp_path, monkeypatch
+    ):
+        # Claude marketplaces predating the top-level fields keep
+        # description/version under "metadata". Honoring both keeps the
+        # row rich for older marketplaces the user already installed.
+        plugins_root = tmp_path / "plugins"
+        manifest = (
+            plugins_root
+            / "marketplaces"
+            / "old"
+            / ".claude-plugin"
+            / "marketplace.json"
+        )
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text(
+            json.dumps(
+                {
+                    "name": "old",
+                    "metadata": {"description": "Old style", "version": "0.9"},
+                    "plugins": [{"name": "only", "source": "./only"}],
+                }
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("CLAUDE_CODE_PLUGIN_CACHE_DIR", str(plugins_root))
+        _stub_subprocess(
+            monkeypatch,
+            captured={},
+            stdout=b'[{"name":"old","source":"./old"}]',
+        )
+
+        result = asyncio.run(PluginManager().list_marketplaces())
+        assert result[0]["description"] == "Old style"
+        assert result[0]["version"] == "0.9"
+        assert result[0]["plugin_count"] == 1
+        assert result[0]["plugin_names"] == ["only"]
+
+    def test_list_marketplaces_skips_missing_manifest(
+        self, fake_cli, tmp_path, monkeypatch
+    ):
+        # A marketplace just added but not yet cached, or one whose
+        # manifest disappeared, must not break the entire list. The
+        # entry comes back without the enrichment fields.
+        monkeypatch.setenv("CLAUDE_CODE_PLUGIN_CACHE_DIR", str(tmp_path / "noexist"))
+        _stub_subprocess(
+            monkeypatch,
+            captured={},
+            stdout=b'[{"name":"acme","source":"./acme"}]',
+        )
+        result = asyncio.run(PluginManager().list_marketplaces())
+        assert result == [{"name": "acme", "source": "./acme"}]
+
+    @pytest.mark.parametrize(
+        "cli_field,cli_value,manifest_field,manifest_value",
+        [
+            ("description", "from cli", "description", "from manifest"),
+            ("version", "9.9.9", "version", "1.0.0"),
+            ("plugin_count", 42, "plugin_count", 2),
+            (
+                "plugin_names",
+                ["a", "b"],
+                "plugin_names",
+                ["c", "d", "e"],
+            ),
+        ],
+    )
+    def test_list_marketplaces_does_not_override_cli_supplied_fields(
+        self,
+        fake_cli,
+        tmp_path,
+        monkeypatch,
+        cli_field,
+        cli_value,
+        manifest_field,
+        manifest_value,
+    ):
+        # If a future Claude release surfaces any of the enrichment
+        # fields on the list itself, defer to the CLI value instead of
+        # overwriting from the cached manifest. Parametrized across
+        # description/version/plugin_count/plugin_names so a regression
+        # in any single field's override branch is caught.
+        plugins_root = tmp_path / "plugins"
+        manifest = (
+            plugins_root
+            / "marketplaces"
+            / "acme"
+            / ".claude-plugin"
+            / "marketplace.json"
+        )
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text(
+            json.dumps(
+                {
+                    "description": "from manifest",
+                    "version": "1.0.0",
+                    "plugins": [
+                        {"name": "c", "source": "./c"},
+                        {"name": "d", "source": "./d"},
+                        {"name": "e", "source": "./e"},
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("CLAUDE_CODE_PLUGIN_CACHE_DIR", str(plugins_root))
+        cli_entry = {"name": "acme", "source": "./acme", cli_field: cli_value}
+        _stub_subprocess(
+            monkeypatch,
+            captured={},
+            stdout=json.dumps([cli_entry]).encode(),
+        )
+        result = asyncio.run(PluginManager().list_marketplaces())
+        assert result[0][cli_field] == cli_value
+
+    def test_list_marketplaces_overrides_empty_cli_string_with_manifest_value(
+        self, fake_cli, tmp_path, monkeypatch
+    ):
+        # An empty-string CLI value must not shadow a useful manifest
+        # value. The overlay rule is "prefer CLI when truthy", so
+        # description: "" from the CLI falls through to the manifest's
+        # description.
+        plugins_root = tmp_path / "plugins"
+        manifest = (
+            plugins_root
+            / "marketplaces"
+            / "acme"
+            / ".claude-plugin"
+            / "marketplace.json"
+        )
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text(
+            json.dumps({"description": "from manifest", "plugins": []}),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("CLAUDE_CODE_PLUGIN_CACHE_DIR", str(plugins_root))
+        _stub_subprocess(
+            monkeypatch,
+            captured={},
+            stdout=b'[{"name":"acme","source":"./acme","description":""}]',
+        )
+        result = asyncio.run(PluginManager().list_marketplaces())
+        assert result[0]["description"] == "from manifest"
+
+    def test_list_marketplaces_rejects_oversize_manifest(
+        self, fake_cli, tmp_path, monkeypatch
+    ):
+        # A marketplace.json that exceeds the size cap is treated as
+        # missing for enrichment purposes; the entry comes back from
+        # the CLI unenriched. Test would otherwise OOM the server on a
+        # large or hostile manifest.
+        plugins_root = tmp_path / "plugins"
+        manifest = (
+            plugins_root
+            / "marketplaces"
+            / "huge"
+            / ".claude-plugin"
+            / "marketplace.json"
+        )
+        manifest.parent.mkdir(parents=True)
+        # Write 2 MiB of valid-looking JSON so the size check fires
+        # rather than the JSON parser.
+        manifest.write_text(
+            "{" + '"x":"' + "z" * (2 * 1024 * 1024) + '"}',
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("CLAUDE_CODE_PLUGIN_CACHE_DIR", str(plugins_root))
+        _stub_subprocess(
+            monkeypatch,
+            captured={},
+            stdout=b'[{"name":"huge","source":"./huge"}]',
+        )
+        result = asyncio.run(PluginManager().list_marketplaces())
+        assert result == [{"name": "huge", "source": "./huge"}]
+
+    def test_list_marketplaces_skips_unreadable_manifest_dir(
+        self, fake_cli, tmp_path, monkeypatch
+    ):
+        # PermissionError from a stat on the manifest dir must not abort
+        # the list endpoint. The entry comes back from the CLI without
+        # enrichment fields, mirroring the missing-manifest behavior.
+        plugins_root = tmp_path / "plugins"
+
+        from pathlib import Path
+
+        original_stat = Path.stat
+
+        def stat_with_permission_error(self, *args, **kwargs):
+            if "huge" in str(self):
+                raise PermissionError("simulated")
+            return original_stat(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "stat", stat_with_permission_error)
+        monkeypatch.setenv("CLAUDE_CODE_PLUGIN_CACHE_DIR", str(plugins_root))
+        _stub_subprocess(
+            monkeypatch,
+            captured={},
+            stdout=b'[{"name":"huge","source":"./huge"}]',
+        )
+        result = asyncio.run(PluginManager().list_marketplaces())
+        assert result == [{"name": "huge", "source": "./huge"}]
+
     def test_list_marketplace_plugins_reads_cached_manifest(
         self, tmp_path, monkeypatch
     ):
@@ -506,6 +759,54 @@ class TestPluginManagerWrites:
             "remove",
             "acme",
         ]
+
+    def test_update_marketplace_invokes_cli(self, fake_cli, monkeypatch):
+        captured: dict = {}
+        _stub_subprocess(monkeypatch, captured=captured)
+        # No GitHub token available so the env-overrides branch is
+        # skipped; argv carries only the literal command.
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.setattr(
+            "notebook_intelligence.plugin_manager.resolve_github_token",
+            lambda: None,
+        )
+        manager = PluginManager()
+        asyncio.run(manager.update_marketplace(name="acme"))
+        assert captured["argv"][1:] == [
+            "plugin",
+            "marketplace",
+            "update",
+            "acme",
+        ]
+        # Without a token, run_claude_cli passes env=None so the
+        # subprocess inherits the parent environment unchanged.
+        assert captured["kwargs"]["env"] is None
+
+    def test_update_marketplace_injects_github_token_when_available(
+        self, fake_cli, monkeypatch
+    ):
+        # If the user has GITHUB_TOKEN set, the update flow injects it
+        # the same way add_marketplace does, so refreshing a private GHE
+        # marketplace works without process-level env. Token flows via
+        # env (not argv) so it doesn't appear in the redacted DEBUG log.
+        captured: dict = {}
+        _stub_subprocess(monkeypatch, captured=captured)
+        monkeypatch.setattr(
+            "notebook_intelligence.plugin_manager.resolve_github_token",
+            lambda: "ghu_test_token",
+        )
+        manager = PluginManager()
+        asyncio.run(manager.update_marketplace(name="acme"))
+        env = captured["kwargs"]["env"]
+        assert env is not None
+        assert env["GITHUB_TOKEN"] == "ghu_test_token"
+        assert env["GH_TOKEN"] == "ghu_test_token"
+
+    def test_update_marketplace_rejects_path_traversal_name(self):
+        manager = PluginManager()
+        with pytest.raises(ValueError, match="Invalid marketplace name"):
+            asyncio.run(manager.update_marketplace(name="..\\evil"))
 
     def test_cli_failure_raises_with_stderr(self, fake_cli, monkeypatch):
         async def fake_subprocess(*argv, **kwargs):

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -296,6 +296,70 @@ class TestPluginManagerReads:
         result = asyncio.run(PluginManager().list_marketplaces())
         assert result[0][cli_field] == cli_value
 
+    def test_list_marketplaces_couples_plugin_count_and_plugin_names(
+        self, fake_cli, tmp_path, monkeypatch
+    ):
+        # plugin_count and plugin_names must stay in sync. If a future
+        # CLI surfaces only the count, the manifest's names must NOT be
+        # merged in (or the row would render "42 plugins: alpha, beta"
+        # with the two halves disagreeing). The whole pair is treated
+        # atomically: CLI sets both or the manifest sets both.
+        plugins_root = tmp_path / "plugins"
+        manifest = (
+            plugins_root
+            / "marketplaces"
+            / "acme"
+            / ".claude-plugin"
+            / "marketplace.json"
+        )
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text(
+            json.dumps(
+                {
+                    "description": "from manifest",
+                    "plugins": [
+                        {"name": "alpha", "source": "./a"},
+                        {"name": "beta", "source": "./b"},
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("CLAUDE_CODE_PLUGIN_CACHE_DIR", str(plugins_root))
+        # CLI surfaces only the count; names should NOT be backfilled.
+        _stub_subprocess(
+            monkeypatch,
+            captured={},
+            stdout=b'[{"name":"acme","source":"./acme","plugin_count":42}]',
+        )
+        result = asyncio.run(PluginManager().list_marketplaces())
+        assert result[0]["plugin_count"] == 42
+        assert "plugin_names" not in result[0]
+
+    def test_list_marketplaces_rejects_path_traversal_in_cli_name(
+        self, fake_cli, tmp_path, monkeypatch
+    ):
+        # Defense in depth: the CLI shouldn't return a name like
+        # `../evil`, but `_read_marketplace_manifest` now validates
+        # anyway. A bad CLI-returned name causes the enrichment to
+        # skip for that entry (caught at ValueError), leaving the rest
+        # of the list intact.
+        monkeypatch.setenv("CLAUDE_CODE_PLUGIN_CACHE_DIR", str(tmp_path / "plugins"))
+        _stub_subprocess(
+            monkeypatch,
+            captured={},
+            stdout=b'[{"name":"../evil","source":"./e"},{"name":"good","source":"./g"}]',
+        )
+        result = asyncio.run(PluginManager().list_marketplaces())
+        # Both entries come back; neither is enriched (the bad one is
+        # rejected by name validation, the good one has no manifest in
+        # the empty cache dir).
+        assert [m["name"] for m in result] == ["../evil", "good"]
+        # No enrichment keys were synthesized for the path-traversal
+        # entry; the row falls back to the CLI fields only.
+        assert "description" not in result[0]
+        assert "plugin_count" not in result[0]
+
     def test_list_marketplaces_overrides_empty_cli_string_with_manifest_value(
         self, fake_cli, tmp_path, monkeypatch
     ):

--- a/tests/ts/plugins-panel.test.tsx
+++ b/tests/ts/plugins-panel.test.tsx
@@ -3,6 +3,14 @@
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
+jest.mock('@jupyterlab/apputils', () => ({
+  Dialog: {
+    cancelButton: jest.fn(() => ({})),
+    warnButton: jest.fn(() => ({ accept: true }))
+  },
+  showDialog: jest.fn(() => Promise.resolve({ button: { accept: true } }))
+}));
+
 jest.mock('../../src/api', () => ({
   NBIAPI: {
     config: {
@@ -15,12 +23,17 @@ jest.mock('../../src/api', () => ({
     listPlugins: jest.fn(),
     listPluginMarketplaces: jest.fn(),
     listPluginMarketplacePlugins: jest.fn(),
-    installPlugin: jest.fn()
+    installPlugin: jest.fn(),
+    removePluginMarketplace: jest.fn(),
+    updatePluginMarketplace: jest.fn()
   }
 }));
 
 import { NBIAPI } from '../../src/api';
-import { SettingsPanelComponentPlugins } from '../../src/components/plugins-panel';
+import {
+  SettingsPanelComponentPlugins,
+  summarizePluginNames
+} from '../../src/components/plugins-panel';
 
 describe('SettingsPanelComponentPlugins', () => {
   const api = NBIAPI as any;
@@ -138,5 +151,153 @@ describe('SettingsPanelComponentPlugins', () => {
         'user'
       );
     });
+  });
+
+  describe('marketplace row', () => {
+    beforeEach(() => {
+      api.listPluginMarketplaces.mockResolvedValue([
+        {
+          name: 'acme',
+          source: 'github:acme/marketplace',
+          description: 'Acme team plugins',
+          version: '1.2.3',
+          plugin_count: 2,
+          plugin_names: ['alpha', 'beta']
+        }
+      ]);
+      api.updatePluginMarketplace.mockResolvedValue(undefined);
+    });
+
+    it('renders description, version, and plugin summary', async () => {
+      render(<SettingsPanelComponentPlugins />);
+
+      await screen.findByText('acme');
+      expect(screen.getByText('Acme team plugins')).toBeInTheDocument();
+      expect(screen.getByText('v1.2.3')).toBeInTheDocument();
+      // The plugin summary lands inside a div together with the count
+      // label, so search by class to pick up both halves.
+      const pluginSummary = document.querySelector(
+        '.nbi-skill-row-plugins'
+      ) as HTMLElement;
+      expect(pluginSummary.textContent).toContain('2 plugins');
+      expect(pluginSummary.textContent).toContain('alpha, beta');
+    });
+
+    it('trims long plugin lists with a +N more tail', async () => {
+      api.listPluginMarketplaces.mockResolvedValue([
+        {
+          name: 'big',
+          source: './big',
+          plugin_count: 9,
+          plugin_names: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']
+        }
+      ]);
+
+      render(<SettingsPanelComponentPlugins />);
+      await screen.findByText('big');
+      const pluginSummary = document.querySelector(
+        '.nbi-skill-row-plugins'
+      ) as HTMLElement;
+      expect(pluginSummary.textContent).toContain('9 plugins');
+      expect(pluginSummary.textContent).toContain('a, b, c, d, e, +4 more');
+    });
+
+    it('renders "no plugins" when the count is zero', async () => {
+      api.listPluginMarketplaces.mockResolvedValue([
+        { name: 'empty', source: './empty', plugin_count: 0, plugin_names: [] }
+      ]);
+      render(<SettingsPanelComponentPlugins />);
+      await screen.findByText('empty');
+      const pluginSummary = document.querySelector(
+        '.nbi-skill-row-plugins'
+      ) as HTMLElement;
+      expect(pluginSummary.textContent).toBe('no plugins');
+    });
+
+    it('omits the plugin line entirely when manifest data is absent', async () => {
+      // Manifest read failed or just-added marketplace not yet cached:
+      // the backend omits plugin_count + plugin_names. The row must
+      // not render a misleading "no plugins" line in that case.
+      api.listPluginMarketplaces.mockResolvedValue([
+        { name: 'pending', source: './pending' }
+      ]);
+      render(<SettingsPanelComponentPlugins />);
+      await screen.findByText('pending');
+      expect(document.querySelector('.nbi-skill-row-plugins')).toBeNull();
+    });
+
+    it('calls updatePluginMarketplace on click', async () => {
+      render(<SettingsPanelComponentPlugins />);
+
+      await screen.findByText('acme');
+      fireEvent.click(screen.getByRole('button', { name: 'Update' }));
+
+      await waitFor(() => {
+        expect(api.updatePluginMarketplace).toHaveBeenCalledWith('acme');
+      });
+      // After a successful update the panel refreshes its data.
+      expect(api.listPluginMarketplaces.mock.calls.length).toBeGreaterThan(1);
+    });
+
+    it('shows Updating… and disables both row buttons while in flight', async () => {
+      // Hold the update call open with a deferred promise so the test
+      // can observe the busy state. Without this, the resolve happens
+      // before the assertions and the disabled flip is invisible.
+      let resolveUpdate: () => void = () => undefined;
+      api.updatePluginMarketplace.mockImplementationOnce(
+        () =>
+          new Promise<void>(resolve => {
+            resolveUpdate = resolve;
+          })
+      );
+      render(<SettingsPanelComponentPlugins />);
+      await screen.findByText('acme');
+      fireEvent.click(screen.getByRole('button', { name: 'Update' }));
+      const updating = await screen.findByRole('button', {
+        name: 'Updating…'
+      });
+      expect(updating).toBeDisabled();
+      // When the row is busy, Remove's label also flips to "Removing…"
+      // so both buttons disable in tandem. The label flip itself is
+      // worth pinning: a regression that kept the Remove label static
+      // would also pass `disabled`, but the user wouldn't see why both
+      // buttons are inert.
+      expect(screen.getByRole('button', { name: 'Removing…' })).toBeDisabled();
+      resolveUpdate();
+      await waitFor(() => {
+        expect(api.updatePluginMarketplace).toHaveBeenCalled();
+      });
+    });
+
+    it('shows an error when the update fails', async () => {
+      api.updatePluginMarketplace.mockRejectedValueOnce(
+        new Error('network down')
+      );
+      render(<SettingsPanelComponentPlugins />);
+      await screen.findByText('acme');
+      fireEvent.click(screen.getByRole('button', { name: 'Update' }));
+      await screen.findByText(/Failed to update marketplace: network down/);
+    });
+  });
+});
+
+describe('summarizePluginNames', () => {
+  it('returns empty string for undefined / empty', () => {
+    expect(summarizePluginNames(undefined, 5)).toBe('');
+    expect(summarizePluginNames([], 5)).toBe('');
+  });
+
+  it('returns the full list when under the visible cap', () => {
+    expect(summarizePluginNames(['a', 'b'], 5)).toBe('a, b');
+  });
+
+  it('returns the full list when exactly at the visible cap', () => {
+    expect(summarizePluginNames(['a', 'b', 'c'], 3)).toBe('a, b, c');
+  });
+
+  it('truncates and appends +N more when over the cap', () => {
+    expect(summarizePluginNames(['a', 'b', 'c', 'd', 'e'], 3)).toBe(
+      'a, b, c, +2 more'
+    );
   });
 });


### PR DESCRIPTION
## Summary

Plugin marketplace rows on the Plugins tab now show the marketplace's description, version, and a plugin-count + comma-separated name list trimmed with `+N more`. Each row has an Update button that runs `claude plugin marketplace update <name>` and refreshes the panel.

## Solution

**Backend (`notebook_intelligence/plugin_manager.py`)**: `list_marketplaces` enriches each entry with `description`, `version`, `plugin_count`, and `plugin_names` pulled from the cached `~/.claude/plugins/marketplaces/<name>/.claude-plugin/marketplace.json`. Both the documented top-level fields (`description`, `version`) and the legacy `metadata.description` / `metadata.version` shape are read for backward compatibility per the Claude Code marketplace docs. New `update_marketplace(name)` method shells out to `claude plugin marketplace update <name>` with optional GitHub-token injection via env (never argv).

The manifest read is bounded by a 1 MiB size cap to keep a hostile or corrupt marketplace.json from OOMing the server on a list-marketplaces call. The read-failure path swallows `OSError` (including `PermissionError` and `FileNotFoundError`), `ValueError`, and `UnicodeDecodeError` so one bad manifest cannot abort the whole list endpoint. `_read_marketplace_manifest` also validates the marketplace name against the same path-traversal / NUL / leading-dash check used by `list_marketplace_plugins`, so a CLI-returned name like `../evil` is rejected at the manifest-read layer rather than relying on upstream sanitization.

Enrichment overlay rules:

- `description` and `version`: a non-empty CLI value wins; an empty-string CLI value falls through to the manifest, so a future Claude CLI release that surfaces these fields server-side is honored.
- `plugin_count` and `plugin_names`: treated as a coupled pair. If the CLI surfaces either, both come from the CLI; otherwise both come from the manifest. Coupling prevents a row that shows "42 plugins: alpha, beta" because the count came from one source and the names from another.

**Handler (`notebook_intelligence/extension.py`)**: new `PluginsMarketplaceUpdateHandler` at `POST plugins/marketplace/<name>/update`, registered ahead of the catch-all detail route and inheriting `PluginsBaseHandler` so `@tornado.web.authenticated` and the `claude_plugins_management` policy gate both apply.

**Client (`src/api.ts`)**: `IPluginMarketplaceInfo` gains optional `description`, `version`, `plugin_count`, `plugin_names`. New `updatePluginMarketplace(name)` method.

**UI (`src/components/plugins-panel.tsx` + `style/base.css`)**: row renders the name with a `v<version>` pill, the description (when present), the source string (existing), and a plugin summary "N plugins: a, b, c, +D more" via a new exported `summarizePluginNames` helper. Visible cap defaults to 5; the row CSS also has `text-overflow: ellipsis` as a width-based fallback. The plugin line is omitted entirely when the manifest hasn't been cached yet so a just-added marketplace doesn't render a misleading "no plugins." Buttons: Update (`jp-mod-accept`, matching its non-destructive intent) and Remove (`jp-mod-reject`). The busy state disables both buttons in tandem with verb-specific labels ("Updating…", "Removing…").

## Testing

- `tests/test_plugin_manager.py`: pytest cases covering top-level + metadata.* enrichment, override-on-truthy semantics parametrized across description / version / plugin_count / plugin_names, plugin_count/plugin_names coupling (CLI sets one but not both → both still come from CLI), oversize-manifest rejection, unreadable-dir skip, missing-manifest skip, path-traversal rejection in a CLI-returned name, the new update CLI invocation, GitHub-token injection on update, and path-traversal rejection on the update name argument.
- `tests/ts/plugins-panel.test.tsx`: jest cases on the marketplace row (description / version / plugin summary, +N truncation, empty-state copy, manifest-not-loaded omission, update button calls API, error path) plus `summarizePluginNames` semantics, plus the busy-state contract (both row buttons disabled, verb-specific labels) while an update is in flight.
- Full suites: pytest 788 pass, tsc clean, prettier clean, jest clean.

## Risks / follow-ups

- **Behavior change**: the marketplace list response gains four optional fields. Existing clients ignore them; the new client renders the richer row. No backwards-incompatible field renames.
- **Manual UI walk-through deferred**: I couldn't start a local JupyterLab server autonomously (the auto-classifier blocked it). The jest suite covers the row layout, but a real-browser pass against a freshly-added marketplace (Playwright or hand) would catch CSS regressions the unit tests can't see.
- **Token injection on local sources**: `update_marketplace` injects `GITHUB_TOKEN` unconditionally. The token never lands in argv (env only), and the `claude` subprocess only forwards it to `git` when the upstream is GitHub, so non-GitHub sources see an unused env var. Deliberate to avoid re-reading the source from disk on every update; comment in-tree calls this out.
- **No `--scope` on update**: marketplace names are unique within the global Claude plugin cache, so `claude plugin marketplace update <name>` is scope-free by design.

Closes #289.