### PR TITLE
a11y(chat-sidebar): promote header icon-divs to keyboard-reachable buttons

### DIFF
--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -3565,8 +3565,8 @@ function SidebarComponent(props: any) {
               type="button"
               className="user-input-footer-button"
               onClick={() => setShowClaudeSessionPicker(true)}
-              title="Resume previous Claude session"
               aria-label="Resume previous Claude session"
+              title="Resume a Claude session you started earlier in this workspace"
             >
               <VscHistory />
             </button>
@@ -3576,8 +3576,8 @@ function SidebarComponent(props: any) {
           type="button"
           className="user-input-footer-button"
           onClick={() => handleSettingsButtonClick()}
-          title="Open Notebook Intelligence settings"
           aria-label="Open Notebook Intelligence settings"
+          title="Configure providers, API keys, MCP servers, and skills"
         >
           <VscSettingsGear />
         </button>

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -3552,31 +3552,35 @@ function SidebarComponent(props: any) {
         <div className="sidebar-title">Notebook Intelligence</div>
         {NBIAPI.config.isInClaudeCodeMode && (
           <>
-            <div
+            <button
+              type="button"
               className="user-input-footer-button"
               onClick={() => startNewChatSession()}
               title="Start a new chat session (restarts the Claude client)"
               aria-label="Start a new chat session"
             >
               <VscAdd />
-            </div>
-            <div
+            </button>
+            <button
+              type="button"
               className="user-input-footer-button"
               onClick={() => setShowClaudeSessionPicker(true)}
               title="Resume previous Claude session"
+              aria-label="Resume previous Claude session"
             >
               <VscHistory />
-            </div>
+            </button>
           </>
         )}
-        <div
+        <button
+          type="button"
           className="user-input-footer-button"
           onClick={() => handleSettingsButtonClick()}
           title="Open Notebook Intelligence settings"
           aria-label="Open Notebook Intelligence settings"
         >
           <VscSettingsGear />
-        </div>
+        </button>
       </div>
       <div className="nbi-status-banner-live" aria-live="polite">
         {skillsReloadedVisible && (
@@ -3871,7 +3875,8 @@ function SidebarComponent(props: any) {
                 </div>
               )}
               {chatMode !== 'ask' && !NBIAPI.config.isInClaudeCodeMode && (
-                <div
+                <button
+                  type="button"
                   className={`user-input-footer-button tools-button ${unsafeToolSelected ? 'tools-button-warning' : selectedToolCount > 0 ? 'tools-button-active' : ''}`}
                   onClick={() => handleChatToolsButtonClick()}
                   title={
@@ -3879,10 +3884,15 @@ function SidebarComponent(props: any) {
                       ? `Tool selection can cause irreversible changes! Review each tool execution carefully.\n${toolSelectionTitle}`
                       : toolSelectionTitle
                   }
+                  aria-label={
+                    unsafeToolSelected
+                      ? 'Configure tools (warning: irreversible tools selected)'
+                      : 'Configure tools'
+                  }
                 >
                   <VscTools />
                   {selectedToolCount > 0 && <>{selectedToolCount}</>}
-                </div>
+                </button>
               )}
               {NBIAPI.config.isInClaudeCodeMode && (
                 <span

--- a/style/base.css
+++ b/style/base.css
@@ -277,21 +277,24 @@
 }
 
 /* Reset native chrome on the footer buttons that now render as <button>
-   so they line up visually with the older <div onClick> variants. */
+   so they line up visually with the older <div onClick> variants.
+   `line-height: 1` keeps the tools-button badge from drifting a pixel
+   relative to the icon when rendered inside a button vs a div. */
 button.user-input-footer-button {
   background: none;
   border: none;
   font: inherit;
+  line-height: 1;
   display: inline-flex;
   align-items: center;
   justify-content: center;
 }
 
 /* Visible focus ring for keyboard users. :focus-visible keeps it from
-   firing on a plain click. The 2px outline + 1px offset mirrors how
-   JupyterLab's own toolbar buttons signal focus. */
+   firing on a plain click. Matches the brand-color focus indicator
+   the other NBI buttons use elsewhere in this stylesheet. */
 .user-input-footer-button:focus-visible {
-  outline: 2px solid var(--jp-brand-color1, #2196f3);
+  outline: 2px solid var(--jp-brand-color1);
   outline-offset: 1px;
   border-radius: 3px;
   color: var(--jp-ui-font-color1);

--- a/style/base.css
+++ b/style/base.css
@@ -287,6 +287,16 @@ button.user-input-footer-button {
   justify-content: center;
 }
 
+/* Visible focus ring for keyboard users. :focus-visible keeps it from
+   firing on a plain click. The 2px outline + 1px offset mirrors how
+   JupyterLab's own toolbar buttons signal focus. */
+.user-input-footer-button:focus-visible {
+  outline: 2px solid var(--jp-brand-color1, #2196f3);
+  outline-offset: 1px;
+  border-radius: 3px;
+  color: var(--jp-ui-font-color1);
+}
+
 /* The slash-button (mentions and commands) renders text rather than an
    svg, so size and center the glyph instead of relying on the svg rule. */
 .user-input-footer-slash-button {

--- a/ui-tests/tests/chat-sidebar.spec.ts
+++ b/ui-tests/tests/chat-sidebar.spec.ts
@@ -35,14 +35,30 @@ test.describe('chat sidebar layout', () => {
     await expect(slash).toHaveText('/');
   });
 
-  test('sidebar-header gear icon carries a title', async ({ page }) => {
-    // The gear used to ship without a title attribute while its neighbours
-    // had one; users hovering the icon got no affordance. Pin the title.
+  test('sidebar-header gear is a focusable, labelled button', async ({
+    page
+  }) => {
+    // Regression guard for D155 / D156: the gear used to be a <div onClick>
+    // so keyboard users could not reach it. Pin that it is now a real
+    // <button> with an aria-label, that Tab focus lands on it, and that
+    // pressing Enter dispatches its click handler (the settings dialog
+    // opens as the observable side effect).
     await openChatSidebar(page);
     const gear = page
-      .locator('.sidebar-header [title="Open Notebook Intelligence settings"]')
+      .locator(
+        '.sidebar-header button[aria-label="Open Notebook Intelligence settings"]'
+      )
       .first();
     await expect(gear).toBeVisible();
+    await gear.focus();
+    await expect(gear).toBeFocused();
+    await page.keyboard.press('Enter');
+    // The settings command opens an NBI settings widget in the main area.
+    // Asserting the panel's wrapper appears proves Enter dispatched the
+    // button's onClick handler.
+    await expect(page.locator('.nbi-settings-panel').first()).toBeVisible({
+      timeout: 5000
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

The new-chat, resume-session, settings, and agent-mode tools icons in the chat sidebar were `<div onClick>` nodes with no tabIndex or keyboard handler. Keyboard-only users could not reach them at all, and screen readers announced them as generic group nodes. The resume-session and tools-button were additionally missing aria-labels, so they announced as empty even when navigation reached them.

## Solution

Promote the four icons to `<button type='button'>` so they pick up native Enter/Space activation, the browser focus ring, and 'button' role announcement. Differentiate the title (longer descriptive hint) from the aria-label (short name) so NVDA/JAWS do not announce the same string twice. Add a `:focus-visible` outline in `style/base.css` using `--jp-brand-color1`, matching the seven existing focus-ring rules already in the stylesheet. The `button.user-input-footer-button` reset keeps the converted elements visually identical to the previous divs, with `line-height: 1` added so the tools-button badge stays aligned.

## Testing

- `jlpm tsc --noEmit` clean. `jlpm lint:check` clean. `jlpm jest` 181 passed.
- Galata regression: `ui-tests/tests/chat-sidebar.spec.ts` now tabs to the gear, presses Enter, and asserts the settings panel appears.
- Manual Playwright walk: tab focus lands on each header icon, the brand-color focus ring is visible in light and dark themes, Enter activates the click handler.

## Risks / follow-ups

- Two cleaner refactors remain for separate PRs: a `jsx-a11y` ESLint rule to ban new `<div onClick>` (five other offenders survive elsewhere in `src/`), and a richer adoption of `@jupyterlab/ui-components` `ToolbarButton`. Both were deferred to keep this diff narrowly scoped.
- No tracked GitHub issue; the audit identifiers (D155, D156) are internal.