### PR TITLE
a11y(popovers): keyboard-first workspace, tools, and slash popovers

### DIFF
--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -1127,6 +1127,16 @@ function SidebarComponent(props: any) {
   const autocompleteRef = useRef<HTMLDivElement>(null);
   const sidebarRootRef = useRef<HTMLDivElement>(null);
   const atButtonRef = useRef<HTMLButtonElement>(null);
+  // Refs on the popover wrappers so we can move focus into the dialog
+  // when it opens (replaces the broken autoFocus={true} pattern, which
+  // only works on form controls). Paired with focus-restore refs that
+  // remember which element triggered the open so we can put focus back
+  // on close, regardless of which exit path the user took.
+  const workspaceFilePopoverRef = useRef<HTMLDivElement>(null);
+  const modeToolsPopoverRef = useRef<HTMLDivElement>(null);
+  const workspaceFilePickerOpenerRef = useRef<HTMLElement | null>(null);
+  const modeToolsOpenerRef = useRef<HTMLElement | null>(null);
+  const slashPopoverOpenerRef = useRef<HTMLElement | null>(null);
   const [promptHistory, setPromptHistory] = useState<string[]>([]);
   // position on prompt history stack
   const [promptHistoryIndex, setPromptHistoryIndex] = useState(0);
@@ -1400,6 +1410,59 @@ function SidebarComponent(props: any) {
   useEffect(() => {
     showWorkspaceFilePickerRef.current = showWorkspaceFilePicker;
   }, [showWorkspaceFilePicker]);
+
+  // Focus management for the workspace file picker: move focus into the
+  // popover on open so keyboard users land inside it, then restore focus
+  // to the trigger on close. Restoration runs on the close transition
+  // regardless of which exit path (close button, Escape, outside click)
+  // dismissed the popover.
+  const prevWorkspaceFilePickerRef = useRef(false);
+  useEffect(() => {
+    if (showWorkspaceFilePicker && !prevWorkspaceFilePickerRef.current) {
+      workspaceFilePopoverRef.current?.focus();
+    } else if (!showWorkspaceFilePicker && prevWorkspaceFilePickerRef.current) {
+      const opener = workspaceFilePickerOpenerRef.current;
+      workspaceFilePickerOpenerRef.current = null;
+      if (opener && document.contains(opener)) {
+        opener.focus();
+      }
+    }
+    prevWorkspaceFilePickerRef.current = showWorkspaceFilePicker;
+  }, [showWorkspaceFilePicker]);
+
+  // Same pattern for the mode-tools popover.
+  const prevModeToolsRef = useRef(false);
+  useEffect(() => {
+    if (showModeTools && !prevModeToolsRef.current) {
+      modeToolsPopoverRef.current?.focus();
+    } else if (!showModeTools && prevModeToolsRef.current) {
+      const opener = modeToolsOpenerRef.current;
+      modeToolsOpenerRef.current = null;
+      if (opener && document.contains(opener)) {
+        opener.focus();
+      }
+    }
+    prevModeToolsRef.current = showModeTools;
+  }, [showModeTools]);
+
+  // Slash-popover restoration: only the close transition matters; the
+  // popover lives next to the textarea and the textarea retains focus
+  // while it's open, so there's nothing to focus *into* on open.
+  const prevShowPopoverRef = useRef(false);
+  useEffect(() => {
+    if (!showPopover && prevShowPopoverRef.current) {
+      const opener = slashPopoverOpenerRef.current;
+      slashPopoverOpenerRef.current = null;
+      // The slash popover always lives alongside the prompt textarea;
+      // bias toward returning focus there if the recorded opener is gone.
+      if (opener && document.contains(opener)) {
+        opener.focus();
+      } else if (promptInputRef.current) {
+        promptInputRef.current.focus();
+      }
+    }
+    prevShowPopoverRef.current = showPopover;
+  }, [showPopover]);
   // Set when a refresh arrives mid-scan. The in-flight scan's drain loop
   // honors one more pass at completion, bounding the storm to "at most one
   // scan running + one queued" instead of cascading cancellations.
@@ -1470,6 +1533,12 @@ function SidebarComponent(props: any) {
     setShowPopover(false);
     setShowModeTools(false);
     const nextState = !showWorkspaceFilePicker;
+    // Capture the trigger element before re-render so we can restore
+    // focus to it when the popover closes (D030).
+    if (nextState) {
+      workspaceFilePickerOpenerRef.current =
+        (document.activeElement as HTMLElement | null) ?? null;
+    }
     setShowWorkspaceFilePicker(nextState);
     // Sync the ref synchronously so a debounced refresh that fires during
     // the awaited scan below honors the now-open picker state immediately,
@@ -2464,6 +2533,10 @@ function SidebarComponent(props: any) {
     setPrompt(newPrompt);
     const trimmedPrompt = newPrompt.trimStart();
     if (trimmedPrompt === '@' || trimmedPrompt === '/') {
+      // D030: remember which element opened the popover so focus returns
+      // there on close. For the typing path that's the textarea itself.
+      slashPopoverOpenerRef.current =
+        (document.activeElement as HTMLElement | null) ?? null;
       setShowPopover(true);
       filterPrefixSuggestions(trimmedPrompt);
     } else if (trimmedPrompt.startsWith('@') || trimmedPrompt.startsWith('/')) {
@@ -2539,6 +2612,9 @@ function SidebarComponent(props: any) {
   const handleChatToolsButtonClick = async () => {
     setShowWorkspaceFilePicker(false);
     if (!showModeTools) {
+      // D030: remember the trigger so focus returns there on close.
+      modeToolsOpenerRef.current =
+        (document.activeElement as HTMLElement | null) ?? null;
       NBIAPI.fetchCapabilities().then(() => {
         toolConfigRef.current = NBIAPI.config.toolConfig;
         mcpServerSettingsRef.current = NBIAPI.config.mcpServerSettings;
@@ -3812,7 +3888,16 @@ function SidebarComponent(props: any) {
                 ref={atButtonRef}
                 className="user-input-footer-button user-input-footer-slash-button"
                 onClick={() => {
-                  setShowPopover(prev => !prev);
+                  setShowPopover(prev => {
+                    if (!prev) {
+                      // D030: remember the button so focus returns to it
+                      // on close. Capture before the state flip so we
+                      // record the click target, not whatever the focus
+                      // shift below leaves behind.
+                      slashPopoverOpenerRef.current = atButtonRef.current;
+                    }
+                    return !prev;
+                  });
                   promptInputRef.current?.focus();
                 }}
                 title="Slash commands"
@@ -3924,9 +4009,9 @@ function SidebarComponent(props: any) {
           )}
           {showWorkspaceFilePicker && (
             <div
+              ref={workspaceFilePopoverRef}
               className="workspace-file-popover"
-              tabIndex={1}
-              autoFocus={true}
+              tabIndex={-1}
               onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
                 if (event.key === 'Escape') {
                   event.stopPropagation();
@@ -3943,49 +4028,33 @@ function SidebarComponent(props: any) {
                   Add files as context
                 </div>
                 <div style={{ flexGrow: 1 }}></div>
-                <div
+                <button
+                  type="button"
                   className={
                     'mode-tools-popover-button mode-tools-popover-refresh-button' +
                     (workspaceFilesLoading ? ' is-loading' : '')
                   }
                   title="Refresh file list"
-                  role="button"
-                  tabIndex={0}
                   aria-label="Refresh workspace file list"
                   aria-busy={workspaceFilesLoading}
+                  disabled={workspaceFilesLoading}
                   onClick={() => {
                     if (!workspaceFilesLoading) {
                       refreshWorkspaceFiles();
                     }
                   }}
-                  onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
-                    if (
-                      (event.key === 'Enter' || event.key === ' ') &&
-                      !workspaceFilesLoading
-                    ) {
-                      event.preventDefault();
-                      refreshWorkspaceFiles();
-                    }
-                  }}
                 >
                   <VscRefresh />
-                </div>
-                <div
+                </button>
+                <button
+                  type="button"
                   className="mode-tools-popover-button mode-tools-popover-close-button"
                   title="Close"
-                  role="button"
-                  tabIndex={0}
                   aria-label="Close file picker"
                   onClick={() => setShowWorkspaceFilePicker(false)}
-                  onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
-                    if (event.key === 'Enter' || event.key === ' ') {
-                      event.preventDefault();
-                      setShowWorkspaceFilePicker(false);
-                    }
-                  }}
                 >
                   <VscClose />
-                </div>
+                </button>
               </div>
               <div className="workspace-file-popover-body">
                 <input
@@ -4049,9 +4118,9 @@ function SidebarComponent(props: any) {
           )}
           {showModeTools && (
             <div
+              ref={modeToolsPopoverRef}
               className="mode-tools-popover"
-              tabIndex={1}
-              autoFocus={true}
+              tabIndex={-1}
               onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
                 if (event.key === 'Escape' || event.key === 'Enter') {
                   event.stopPropagation();
@@ -4077,27 +4146,26 @@ function SidebarComponent(props: any) {
                     <VscTrash />
                   </div>
                   <div>
-                    <a
-                      href="javascript:void(0);"
+                    <button
+                      type="button"
+                      className="link-button"
                       onClick={onClearToolsButtonClicked}
                     >
                       clear
-                    </a>
+                    </button>
                   </div>
                 </div>
-                <div
+                <button
+                  type="button"
                   className="mode-tools-popover-button mode-tools-popover-done-button"
+                  aria-label="Close tools picker"
                   onClick={() => setShowModeTools(false)}
                 >
-                  {/* <button
-                    className="jp-Dialog-button jp-mod-accept jp-mod-styled send-button"
-                  > */}
                   <div>
                     <VscPassFilled />
                   </div>
-                  {/* </button> */}
                   <div>Done</div>
-                </div>
+                </button>
               </div>
               <div className="mode-tools-popover-tool-list">
                 <div className="mode-tools-group-header">Built-in</div>

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -1411,34 +1411,61 @@ function SidebarComponent(props: any) {
     showWorkspaceFilePickerRef.current = showWorkspaceFilePicker;
   }, [showWorkspaceFilePicker]);
 
-  // Focus management for the workspace file picker: move focus into the
-  // popover on open so keyboard users land inside it, then restore focus
-  // to the trigger on close. Restoration runs on the close transition
+  // Focus management for the popovers: move focus into the popover on
+  // open so keyboard users land inside it, then restore focus to the
+  // trigger on close. Restoration runs on the close transition
   // regardless of which exit path (close button, Escape, outside click)
   // dismissed the popover.
+  //
+  // Restoration is guarded by:
+  //   (a) `document.contains(opener)` so a trigger that was unmounted
+  //       between open and close (e.g., chat-mode flipped) doesn't
+  //       throw; and
+  //   (b) "the user hasn't moved focus elsewhere intentionally" — we
+  //       only steal focus back when the activeElement is still inside
+  //       the popover that's closing (i.e., the close came from the
+  //       popover itself, not from the user clicking a sibling control).
+  //       Without this guard, dismissing one popover by clicking the
+  //       trigger of another would yank focus to the first popover's
+  //       trigger right after the second popover focused itself.
   const prevWorkspaceFilePickerRef = useRef(false);
   useEffect(() => {
     if (showWorkspaceFilePicker && !prevWorkspaceFilePickerRef.current) {
       workspaceFilePopoverRef.current?.focus();
     } else if (!showWorkspaceFilePicker && prevWorkspaceFilePickerRef.current) {
       const opener = workspaceFilePickerOpenerRef.current;
+      const popover = workspaceFilePopoverRef.current;
       workspaceFilePickerOpenerRef.current = null;
-      if (opener && document.contains(opener)) {
+      const active = document.activeElement as HTMLElement | null;
+      const focusInsidePopover = popover ? popover.contains(active) : false;
+      const focusOnBody = active === document.body || active === null;
+      if (
+        (focusInsidePopover || focusOnBody) &&
+        opener &&
+        document.contains(opener)
+      ) {
         opener.focus();
       }
     }
     prevWorkspaceFilePickerRef.current = showWorkspaceFilePicker;
   }, [showWorkspaceFilePicker]);
 
-  // Same pattern for the mode-tools popover.
   const prevModeToolsRef = useRef(false);
   useEffect(() => {
     if (showModeTools && !prevModeToolsRef.current) {
       modeToolsPopoverRef.current?.focus();
     } else if (!showModeTools && prevModeToolsRef.current) {
       const opener = modeToolsOpenerRef.current;
+      const popover = modeToolsPopoverRef.current;
       modeToolsOpenerRef.current = null;
-      if (opener && document.contains(opener)) {
+      const active = document.activeElement as HTMLElement | null;
+      const focusInsidePopover = popover ? popover.contains(active) : false;
+      const focusOnBody = active === document.body || active === null;
+      if (
+        (focusInsidePopover || focusOnBody) &&
+        opener &&
+        document.contains(opener)
+      ) {
         opener.focus();
       }
     }
@@ -1452,13 +1479,23 @@ function SidebarComponent(props: any) {
   useEffect(() => {
     if (!showPopover && prevShowPopoverRef.current) {
       const opener = slashPopoverOpenerRef.current;
+      const popover = autocompleteRef.current;
       slashPopoverOpenerRef.current = null;
-      // The slash popover always lives alongside the prompt textarea;
-      // bias toward returning focus there if the recorded opener is gone.
-      if (opener && document.contains(opener)) {
+      const active = document.activeElement as HTMLElement | null;
+      const focusInsidePopover = popover ? popover.contains(active) : false;
+      // The textarea always stays focusable next to the popover and the
+      // user may have been typing inside it the whole time, so leave
+      // focus alone if it's on the textarea. Same "user moved focus
+      // elsewhere intentionally" guard as the other popovers.
+      const focusOnTextarea = active === promptInputRef.current;
+      const focusOnBody = active === document.body || active === null;
+      if (
+        (focusInsidePopover || focusOnBody) &&
+        !focusOnTextarea &&
+        opener &&
+        document.contains(opener)
+      ) {
         opener.focus();
-      } else if (promptInputRef.current) {
-        promptInputRef.current.focus();
       }
     }
     prevShowPopoverRef.current = showPopover;
@@ -3888,16 +3925,15 @@ function SidebarComponent(props: any) {
                 ref={atButtonRef}
                 className="user-input-footer-button user-input-footer-slash-button"
                 onClick={() => {
-                  setShowPopover(prev => {
-                    if (!prev) {
-                      // D030: remember the button so focus returns to it
-                      // on close. Capture before the state flip so we
-                      // record the click target, not whatever the focus
-                      // shift below leaves behind.
-                      slashPopoverOpenerRef.current = atButtonRef.current;
-                    }
-                    return !prev;
-                  });
+                  if (!showPopover) {
+                    // D030: remember the button so focus returns to it
+                    // on close. Capture before the state flip so we
+                    // record the click target, not whatever the focus
+                    // shift below leaves behind. (Pure: side effects
+                    // belong outside the state updater.)
+                    slashPopoverOpenerRef.current = atButtonRef.current;
+                  }
+                  setShowPopover(prev => !prev);
                   promptInputRef.current?.focus();
                 }}
                 title="Slash commands"
@@ -4012,6 +4048,8 @@ function SidebarComponent(props: any) {
               ref={workspaceFilePopoverRef}
               className="workspace-file-popover"
               tabIndex={-1}
+              role="dialog"
+              aria-labelledby="nbi-workspace-popover-title"
               onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
                 if (event.key === 'Escape') {
                   event.stopPropagation();
@@ -4024,7 +4062,10 @@ function SidebarComponent(props: any) {
                 <div className="mode-tools-popover-header-icon">
                   <VscAdd />
                 </div>
-                <div className="mode-tools-popover-title">
+                <div
+                  className="mode-tools-popover-title"
+                  id="nbi-workspace-popover-title"
+                >
                   Add files as context
                 </div>
                 <div style={{ flexGrow: 1 }}></div>
@@ -4037,7 +4078,7 @@ function SidebarComponent(props: any) {
                   title="Refresh file list"
                   aria-label="Refresh workspace file list"
                   aria-busy={workspaceFilesLoading}
-                  disabled={workspaceFilesLoading}
+                  aria-disabled={workspaceFilesLoading}
                   onClick={() => {
                     if (!workspaceFilesLoading) {
                       refreshWorkspaceFiles();
@@ -4121,6 +4162,8 @@ function SidebarComponent(props: any) {
               ref={modeToolsPopoverRef}
               className="mode-tools-popover"
               tabIndex={-1}
+              role="dialog"
+              aria-labelledby="nbi-mode-tools-popover-title"
               onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
                 if (event.key === 'Escape' || event.key === 'Enter') {
                   event.stopPropagation();
@@ -4133,7 +4176,10 @@ function SidebarComponent(props: any) {
                 <div className="mode-tools-popover-header-icon">
                   <VscTools />
                 </div>
-                <div className="mode-tools-popover-title">
+                <div
+                  className="mode-tools-popover-title"
+                  id="nbi-mode-tools-popover-title"
+                >
                   {toolSelectionTitle}
                 </div>
                 <div

--- a/src/components/settings-panel.tsx
+++ b/src/components/settings-panel.tsx
@@ -594,12 +594,13 @@ function SettingsPanelComponentGeneral(props: any) {
                           Ollama
                         </a>{' '}
                         is running and models are downloaded to your computer.{' '}
-                        <a
-                          href="javascript:void(0)"
+                        <button
+                          type="button"
+                          className="link-button"
                           onClick={handleRefreshOllamaModelListClick}
                         >
                           Try again
-                        </a>{' '}
+                        </button>{' '}
                         once ready.
                       </div>
                     )}

--- a/style/base.css
+++ b/style/base.css
@@ -725,21 +725,23 @@ pre:has(.code-block-header) {
 }
 
 /* Anchor-styled button used in place of the old <a href="javascript:void(0)">
-   pattern. Keeps the visual affordance (underline, link color) while
-   participating in the document's natural tab order. */
+   pattern. Keeps the visual affordance (link color + underline) while
+   participating in the document's natural tab order. The color matches
+   JupyterLab's anchor token so the affordance reads as a link, not as
+   plain underlined body text. */
 .link-button {
   background: none;
   border: none;
   padding: 0;
   font: inherit;
-  color: inherit;
+  color: var(--jp-content-link-color);
   text-decoration: underline;
   text-underline-offset: 2px;
   cursor: pointer;
 }
 
 .link-button:hover {
-  color: var(--jp-ui-font-color1);
+  filter: brightness(1.15);
 }
 
 .link-button:focus-visible {
@@ -748,6 +750,19 @@ pre:has(.code-block-header) {
   border-radius: 2px;
 }
 
+/* tabIndex=-1 wrappers receive programmatic focus on open; the popover
+   already carries a brand-color box-shadow as its visual affordance, so
+   the wrapper's default browser focus ring would only stack a second
+   indicator on top. */
+.workspace-file-popover:focus,
+.mode-tools-popover:focus {
+  outline: none;
+}
+
+/* Reset the UA <button> chrome (border, padding, font) on the icon-
+   buttons so the conversion from <div onClick> doesn't shift the 24px
+   header height or push the icons off-center. padding-right keeps the
+   pre-conversion gap from the icon to the next sibling. */
 .mode-tools-popover-button {
   display: flex;
   align-items: center;
@@ -757,7 +772,10 @@ pre:has(.code-block-header) {
   height: 24px;
   color: white;
   background-color: var(--jp-brand-color0);
-  padding-right: 6px;
+  padding: 0 6px 0 0;
+  border: none;
+  font: inherit;
+  line-height: 1;
   border-radius: 2px;
 }
 

--- a/style/base.css
+++ b/style/base.css
@@ -724,6 +724,30 @@ pre:has(.code-block-header) {
   height: 16px;
 }
 
+/* Anchor-styled button used in place of the old <a href="javascript:void(0)">
+   pattern. Keeps the visual affordance (underline, link color) while
+   participating in the document's natural tab order. */
+.link-button {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+
+.link-button:hover {
+  color: var(--jp-ui-font-color1);
+}
+
+.link-button:focus-visible {
+  outline: 2px solid var(--jp-brand-color1);
+  outline-offset: 1px;
+  border-radius: 2px;
+}
+
 .mode-tools-popover-button {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

The chat sidebar's three popovers (workspace file picker, mode-tools, slash commands) had four overlapping accessibility problems: positive `tabIndex={1}` on the wrappers disrupted natural tab order across the entire JupyterLab page; the refresh / close / Done icons inside the popovers were `<div role='button'>` with hand-rolled Enter/Space handlers; the 'clear' affordance was an `<a href='javascript:void(0)'>`; and dismissing any popover left focus on `<body>` instead of returning it to the trigger. This PR addresses all four together.

## Solution

- **`tabIndex={1}` to `-1` + programmatic focus**: the wrappers now receive focus via a ref + `useEffect` on the open transition. The wrappers carry `role='dialog'` and `aria-labelledby` so screen readers announce the dialog and its title when focus lands inside.
- **Real buttons**: the refresh / close / Done icons become `<button type='button'>` so they pick up native Enter/Space, the browser focus ring, and 'button' role announcement. The `.mode-tools-popover-button` rule gets a UA reset (border, padding, font, line-height) so the converted controls stay aligned in the 24px header.
- **Link-button**: a new `.link-button` style (link color + underline + focus-visible ring) replaces the two `javascript:void(0)` anchors (the 'clear' control in the tools popover and 'Try again' in the Ollama settings panel).
- **Focus restoration**: `useEffect`s on each show-state capture `document.activeElement` at open and restore it on the close transition. Restoration is guarded so it only runs when focus is still inside the closing popover or on body, so dismissing one popover by clicking another popover's trigger doesn't yank focus to the first popover's trigger after the second popover focused itself.

## Testing

- `jlpm tsc --noEmit` clean. `jlpm lint:check` clean. `jlpm jest` 181 passed.
- Playwright walk: focused the workspace trigger, pressed Enter, asserted the popover renders with `role='dialog'` + `aria-labelledby` and focus moved into the wrapper; pressed Escape, asserted the popover disappears and focus returns to the trigger button.
- Six-agent review pass surfaced and remediated: dialog semantics, the cross-popover focus-steal race, slash-popover ref capture purity, link-button color matching JupyterLab's anchor token, UA button reset, refresh button `disabled` to `aria-disabled` so it stays focusable while loading.

## Risks / follow-ups

- A focus trap inside the dialog is not added; Tab still walks back into JupyterLab. Could be tightened in a follow-up if user testing shows it matters. The popovers are visually anchored disclosure widgets, not centered modals.
- `claude-session-picker.tsx` still has the `tabIndex={1}` + `autoFocus={true}` anti-pattern that this PR fixed on the other popovers. Deferred to a follow-up so this diff stays scoped.
- No tracked GitHub issue; audit identifiers (D030, D160, D161, D162) are internal.