### PR TITLE
a11y(ask-user-question): radio for single-select, form-scoped ids

### DIFF
--- a/src/components/ask-user-question.tsx
+++ b/src/components/ask-user-question.tsx
@@ -1,12 +1,24 @@
 // Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
 
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 export function AskUserQuestion(props: any) {
   const userQuestions = props.userQuestions.content;
   const [selectedAnswers, setSelectedAnswers] = useState<{
     [key: string]: string[];
   }>({});
+
+  // Form-scoped id prefix so DOM ids stay unique even when two questions
+  // share label text (or several AskUserQuestion forms render in the same
+  // chat transcript). Falls back to a render-stable random suffix when
+  // the form-level identifier is absent.
+  const formIdPrefix = useMemo(() => {
+    const id = userQuestions.identifier?.id;
+    if (typeof id === 'string' && id.length > 0) {
+      return `nbi-auq-${id}`;
+    }
+    return `nbi-auq-${Math.random().toString(36).slice(2, 10)}`;
+  }, [userQuestions.identifier?.id]);
 
   const onOptionSelected = (question: any, option: any) => {
     if (question.multiSelect) {
@@ -42,45 +54,64 @@ export function AskUserQuestion(props: any) {
         </div>
       ) : null}
       {userQuestions.message ? <div>{userQuestions.message}</div> : null}
-      {userQuestions.questions.map((question: any) => (
-        <div className="ask-user-question-container" key={question.question}>
-          <form className="ask-user-question-form">
-            <div className="ask-user-question-question">
-              {question.question}
-            </div>
-            <div className="ask-user-question-header">{question.header}</div>
-            <div className="ask-user-question-options">
-              {question.options.map((option: any) => (
-                <div className="ask-user-question-option" key={option.label}>
-                  <div className="ask-user-question-option-input-container">
-                    <input
-                      id={option.label}
-                      type="checkbox"
-                      checked={
-                        selectedAnswers[question.question]?.includes(
-                          option.label
-                        ) ?? false
-                      }
-                      onChange={() => onOptionSelected(question, option)}
-                    />
-                    <label
-                      htmlFor={option.label}
-                      className="ask-user-question-option-label-container"
-                    >
-                      <div className="ask-user-question-option-label">
-                        {option.label}
+      {userQuestions.questions.map((question: any, qIndex: number) => {
+        const questionDomId = `${formIdPrefix}-q${qIndex}`;
+        // A single-select group is a radio group with a shared name so
+        // screen readers announce "1 of N selected" rather than treating
+        // each option as an independent checkbox.
+        const inputType = question.multiSelect ? 'checkbox' : 'radio';
+        return (
+          <div
+            className="ask-user-question-container"
+            key={questionDomId}
+            role="group"
+            aria-labelledby={`${questionDomId}-label`}
+          >
+            <form className="ask-user-question-form">
+              <div
+                className="ask-user-question-question"
+                id={`${questionDomId}-label`}
+              >
+                {question.question}
+              </div>
+              <div className="ask-user-question-header">{question.header}</div>
+              <div className="ask-user-question-options">
+                {question.options.map((option: any, oIndex: number) => {
+                  const optionDomId = `${questionDomId}-o${oIndex}`;
+                  return (
+                    <div className="ask-user-question-option" key={optionDomId}>
+                      <div className="ask-user-question-option-input-container">
+                        <input
+                          id={optionDomId}
+                          name={questionDomId}
+                          type={inputType}
+                          checked={
+                            selectedAnswers[question.question]?.includes(
+                              option.label
+                            ) ?? false
+                          }
+                          onChange={() => onOptionSelected(question, option)}
+                        />
+                        <label
+                          htmlFor={optionDomId}
+                          className="ask-user-question-option-label-container"
+                        >
+                          <div className="ask-user-question-option-label">
+                            {option.label}
+                          </div>
+                          <div className="ask-user-question-option-description">
+                            {option.description}
+                          </div>
+                        </label>
                       </div>
-                      <div className="ask-user-question-option-description">
-                        {option.description}
-                      </div>
-                    </label>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </form>
-        </div>
-      ))}
+                    </div>
+                  );
+                })}
+              </div>
+            </form>
+          </div>
+        );
+      })}
       <div className="ask-user-question-footer">
         <button
           className="jp-Dialog-button jp-mod-accept jp-mod-styled"

--- a/src/components/ask-user-question.tsx
+++ b/src/components/ask-user-question.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
 
-import React, { useMemo, useState } from 'react';
+import React, { useId, useState } from 'react';
 
 export function AskUserQuestion(props: any) {
   const userQuestions = props.userQuestions.content;
@@ -9,16 +9,19 @@ export function AskUserQuestion(props: any) {
   }>({});
 
   // Form-scoped id prefix so DOM ids stay unique even when two questions
-  // share label text (or several AskUserQuestion forms render in the same
-  // chat transcript). Falls back to a render-stable random suffix when
-  // the form-level identifier is absent.
-  const formIdPrefix = useMemo(() => {
-    const id = userQuestions.identifier?.id;
-    if (typeof id === 'string' && id.length > 0) {
-      return `nbi-auq-${id}`;
-    }
-    return `nbi-auq-${Math.random().toString(36).slice(2, 10)}`;
-  }, [userQuestions.identifier?.id]);
+  // share label text (or several AskUserQuestion forms render in the
+  // same chat transcript). React.useId() is the purpose-built primitive
+  // here: stable for the component's lifetime, SSR-safe, and survives
+  // StrictMode double-render without producing mismatched id/htmlFor
+  // pairs (a Math.random fallback could mis-pair under cache eviction).
+  // The server-provided identifier is preferred when present so two
+  // remounts of the same form keep the same DOM ids.
+  const reactId = useId();
+  const serverId = userQuestions.identifier?.id;
+  const formIdPrefix =
+    typeof serverId === 'string' && serverId.length > 0
+      ? `nbi-auq-${serverId}`
+      : `nbi-auq${reactId}`;
 
   const onOptionSelected = (question: any, option: any) => {
     if (question.multiSelect) {
@@ -54,20 +57,30 @@ export function AskUserQuestion(props: any) {
         </div>
       ) : null}
       {userQuestions.message ? <div>{userQuestions.message}</div> : null}
-      {userQuestions.questions.map((question: any, qIndex: number) => {
-        const questionDomId = `${formIdPrefix}-q${qIndex}`;
-        // A single-select group is a radio group with a shared name so
-        // screen readers announce "1 of N selected" rather than treating
-        // each option as an independent checkbox.
-        const inputType = question.multiSelect ? 'checkbox' : 'radio';
-        return (
-          <div
-            className="ask-user-question-container"
-            key={questionDomId}
-            role="group"
-            aria-labelledby={`${questionDomId}-label`}
-          >
-            <form className="ask-user-question-form">
+      <form
+        className="ask-user-question-form"
+        onSubmit={event => {
+          event.preventDefault();
+          props.onSubmit(selectedAnswers);
+        }}
+      >
+        {userQuestions.questions.map((question: any, qIndex: number) => {
+          const questionDomId = `${formIdPrefix}-q${qIndex}`;
+          // A single-select group is a radio group with a shared name so
+          // screen readers announce "1 of N selected" rather than
+          // treating each option as an independent checkbox. The wrapper
+          // role mirrors the input type: radiogroup for radios, group
+          // (the ARIA-1.2 fallback when no dedicated checkbox-group role
+          // exists) for checkboxes.
+          const inputType = question.multiSelect ? 'checkbox' : 'radio';
+          const groupRole = question.multiSelect ? 'group' : 'radiogroup';
+          return (
+            <div
+              className="ask-user-question-container"
+              key={questionDomId}
+              role={groupRole}
+              aria-labelledby={`${questionDomId}-label`}
+            >
               <div
                 className="ask-user-question-question"
                 id={`${questionDomId}-label`}
@@ -108,32 +121,31 @@ export function AskUserQuestion(props: any) {
                   );
                 })}
               </div>
-            </form>
-          </div>
-        );
-      })}
-      <div className="ask-user-question-footer">
-        <button
-          className="jp-Dialog-button jp-mod-accept jp-mod-styled"
-          onClick={() => {
-            props.onSubmit(selectedAnswers);
-          }}
-        >
-          <div className="jp-Dialog-buttonLabel">
-            {userQuestions.submitLabel}
-          </div>
-        </button>
-        <button
-          className="jp-Dialog-button jp-mod-reject jp-mod-styled"
-          onClick={() => {
-            props.onCancel();
-          }}
-        >
-          <div className="jp-Dialog-buttonLabel">
-            {userQuestions.cancelLabel}
-          </div>
-        </button>
-      </div>
+            </div>
+          );
+        })}
+        <div className="ask-user-question-footer">
+          <button
+            type="submit"
+            className="jp-Dialog-button jp-mod-accept jp-mod-styled"
+          >
+            <div className="jp-Dialog-buttonLabel">
+              {userQuestions.submitLabel}
+            </div>
+          </button>
+          <button
+            type="button"
+            className="jp-Dialog-button jp-mod-reject jp-mod-styled"
+            onClick={() => {
+              props.onCancel();
+            }}
+          >
+            <div className="jp-Dialog-buttonLabel">
+              {userQuestions.cancelLabel}
+            </div>
+          </button>
+        </div>
+      </form>
     </>
   );
 }

--- a/tests/ts/ask-user-question.test.tsx
+++ b/tests/ts/ask-user-question.test.tsx
@@ -1,0 +1,168 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { AskUserQuestion } from '../../src/components/ask-user-question';
+
+function makeProps(opts: {
+  multiSelect: boolean;
+  questions: { question: string; options: { label: string }[] }[];
+  identifierId?: string;
+  onSubmit?: jest.Mock;
+}) {
+  return {
+    userQuestions: {
+      content: {
+        identifier: { id: opts.identifierId ?? 'form-1', callback_id: 'cb-1' },
+        title: '',
+        message: '',
+        submitLabel: 'Submit',
+        cancelLabel: 'Cancel',
+        questions: opts.questions.map(q => ({
+          question: q.question,
+          header: '',
+          multiSelect: opts.multiSelect,
+          options: q.options.map(o => ({ label: o.label, description: '' }))
+        }))
+      }
+    },
+    onSubmit: opts.onSubmit ?? jest.fn(),
+    onCancel: jest.fn()
+  };
+}
+
+describe('AskUserQuestion', () => {
+  it('renders type=radio inputs when multiSelect is false', () => {
+    render(
+      <AskUserQuestion
+        {...makeProps({
+          multiSelect: false,
+          questions: [
+            { question: 'Pick one', options: [{ label: 'A' }, { label: 'B' }] }
+          ]
+        })}
+      />
+    );
+    const inputs = screen.getAllByRole('radio');
+    expect(inputs).toHaveLength(2);
+    // Both share a name attribute so they form a native radio group.
+    expect(inputs[0].getAttribute('name')).toBe(inputs[1].getAttribute('name'));
+    // And no checkbox markup is rendered for this single-select question.
+    expect(screen.queryAllByRole('checkbox')).toHaveLength(0);
+  });
+
+  it('renders type=checkbox inputs when multiSelect is true', () => {
+    render(
+      <AskUserQuestion
+        {...makeProps({
+          multiSelect: true,
+          questions: [
+            { question: 'Pick any', options: [{ label: 'A' }, { label: 'B' }] }
+          ]
+        })}
+      />
+    );
+    expect(screen.getAllByRole('checkbox')).toHaveLength(2);
+    expect(screen.queryAllByRole('radio')).toHaveLength(0);
+  });
+
+  it('wraps single-select questions in role=radiogroup and multi-select in role=group', () => {
+    render(
+      <>
+        <AskUserQuestion
+          {...makeProps({
+            multiSelect: false,
+            questions: [
+              { question: 'Single', options: [{ label: 'A' }, { label: 'B' }] }
+            ],
+            identifierId: 'form-single'
+          })}
+        />
+        <AskUserQuestion
+          {...makeProps({
+            multiSelect: true,
+            questions: [
+              { question: 'Multi', options: [{ label: 'A' }, { label: 'B' }] }
+            ],
+            identifierId: 'form-multi'
+          })}
+        />
+      </>
+    );
+    expect(screen.getByRole('radiogroup')).toHaveAccessibleName('Single');
+    expect(screen.getByRole('group')).toHaveAccessibleName('Multi');
+  });
+
+  it('keeps duplicate option labels across two questions independent', () => {
+    const onSubmit = jest.fn();
+    render(
+      <AskUserQuestion
+        {...makeProps({
+          multiSelect: false,
+          identifierId: 'form-dup',
+          questions: [
+            { question: 'First', options: [{ label: 'Yes' }, { label: 'No' }] },
+            { question: 'Second', options: [{ label: 'Yes' }, { label: 'No' }] }
+          ],
+          onSubmit
+        })}
+      />
+    );
+    // Click the first question's "Yes" by targeting the label associated
+    // with the input via the form-scoped id. Querying by label text
+    // alone would be ambiguous with the duplicate "Yes" in question 2.
+    const radios = screen.getAllByRole('radio');
+    // Order in the DOM: q0-o0 ("Yes" of First), q0-o1, q1-o0 ("Yes" of Second), q1-o1.
+    fireEvent.click(radios[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const submitted = onSubmit.mock.calls[0][0];
+    expect(submitted.First).toEqual(['Yes']);
+    // The second question's "Yes" must remain unselected (the DOM ids
+    // are form-scoped so the click on the first did not cross-toggle).
+    expect(submitted.Second).toBeUndefined();
+    expect(radios[0]).toBeChecked();
+    expect(radios[2]).not.toBeChecked();
+  });
+
+  it('replaces selection on a fresh single-select click', () => {
+    const onSubmit = jest.fn();
+    render(
+      <AskUserQuestion
+        {...makeProps({
+          multiSelect: false,
+          questions: [
+            { question: 'Q', options: [{ label: 'A' }, { label: 'B' }] }
+          ],
+          onSubmit
+        })}
+      />
+    );
+    const [a, b] = screen.getAllByRole('radio');
+    fireEvent.click(a);
+    fireEvent.click(b);
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    expect(onSubmit.mock.calls[0][0]).toEqual({ Q: ['B'] });
+  });
+
+  it('accumulates selections in a multi-select question', () => {
+    const onSubmit = jest.fn();
+    render(
+      <AskUserQuestion
+        {...makeProps({
+          multiSelect: true,
+          questions: [
+            { question: 'Q', options: [{ label: 'A' }, { label: 'B' }] }
+          ],
+          onSubmit
+        })}
+      />
+    );
+    const [a, b] = screen.getAllByRole('checkbox');
+    fireEvent.click(a);
+    fireEvent.click(b);
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    expect(onSubmit.mock.calls[0][0]).toEqual({ Q: ['A', 'B'] });
+  });
+});


### PR DESCRIPTION
## Summary

The AskUserQuestion form had two overlapping bugs. It always rendered `<input type='checkbox'>` regardless of `question.multiSelect`, so screen readers announced single-select questions as a multi-select group. And it used `option.label` as both the input id and label `htmlFor`, which produced invalid HTML for labels containing spaces and crossed associations across questions when two labels happened to be identical (clicking 'Yes' in question 2 could toggle 'Yes' in question 1).

## Solution

- **Input type**: `radio` when `multiSelect` is false, `checkbox` when it's true. Radios share a `name` attribute (the per-question DOM id) so they form a native radio group with correct "1 of N selected" announcement.
- **Stable form-scoped ids**: a per-form prefix is built from `useId()` (with the server-provided identifier preferred when present). Inputs use `${prefix}-q${qIndex}-o${oIndex}` and labels point at the matching id; duplicate option labels across questions can no longer cross-toggle.
- **Group semantics**: each question wraps in `role='radiogroup'` (single-select) or `role='group'` (multi-select) with `aria-labelledby` pointing at the question text so the option set announces its name when the user tabs in.
- **Real form**: one outer `<form>` with an `onSubmit` handler, an explicit `type='submit'` submit button and `type='button'` cancel button. Enter-to-submit from inside any option group now works.

## Testing

- `jlpm tsc --noEmit` clean. `jlpm lint:check` clean. `jlpm jest` 187 passed (6 new cases in `tests/ts/ask-user-question.test.tsx`).
- New tests pin: radio markup vs checkbox markup based on multiSelect; the radiogroup/group role split; duplicate option labels staying independent across questions; single-select replace vs multi-select accumulate.
- Six-agent review pass surfaced and remediated: useId over Math.random, conditional radiogroup role, real form structure with explicit button types.

## Risks / follow-ups

- Internal state is still keyed by `question.question` (the question text) to preserve the onSubmit contract with the chat-sidebar consumer. Two questions with identical text in the same form would still share state; the wire-protocol contract change is a separate refactor.
- The `<form>` lacks an accessible name. Could be added with the existing `userQuestions.title` if/when that field is reliably populated.
- No tracked GitHub issue; audit identifiers (D158, D159) are internal.