### PR TITLE
a11y(claude-mcp): wire form labels to their inputs

### DIFF
--- a/src/components/claude-mcp-panel.tsx
+++ b/src/components/claude-mcp-panel.tsx
@@ -381,8 +381,9 @@ function ClaudeMCPAddDialog(props: {
       onSubmit={handleSubmit}
     >
       <div className="nbi-form-field">
-        <label>Scope</label>
+        <label htmlFor="nbi-mcp-add-scope">Scope</label>
         <select
+          id="nbi-mcp-add-scope"
           value={scope}
           onChange={e => setScope(e.target.value as ClaudeMCPScope)}
         >
@@ -468,8 +469,9 @@ function ClaudeMCPAddDialog(props: {
             />
           </div>
           <div className="nbi-form-field">
-            <label>Transport</label>
+            <label htmlFor="nbi-mcp-add-transport">Transport</label>
             <select
+              id="nbi-mcp-add-transport"
               value={transport}
               onChange={e => setTransport(e.target.value as ClaudeMCPTransport)}
             >
@@ -481,8 +483,11 @@ function ClaudeMCPAddDialog(props: {
             </select>
           </div>
           <div className="nbi-form-field">
-            <label>{transport === 'stdio' ? 'Command' : 'URL'}</label>
+            <label htmlFor="nbi-mcp-add-command-or-url">
+              {transport === 'stdio' ? 'Command' : 'URL'}
+            </label>
             <input
+              id="nbi-mcp-add-command-or-url"
               type="text"
               value={commandOrUrl}
               onChange={e => setCommandOrUrl(e.target.value)}
@@ -493,8 +498,9 @@ function ClaudeMCPAddDialog(props: {
           </div>
           {transport === 'stdio' && (
             <div className="nbi-form-field">
-              <label>Args (one per line)</label>
+              <label htmlFor="nbi-mcp-add-args">Args (one per line)</label>
               <textarea
+                id="nbi-mcp-add-args"
                 rows={3}
                 value={argsText}
                 onChange={e => setArgsText(e.target.value)}
@@ -504,8 +510,11 @@ function ClaudeMCPAddDialog(props: {
           )}
           {transport === 'stdio' && (
             <div className="nbi-form-field">
-              <label>Environment (KEY=value, one per line)</label>
+              <label htmlFor="nbi-mcp-add-env">
+                Environment (KEY=value, one per line)
+              </label>
               <textarea
+                id="nbi-mcp-add-env"
                 rows={3}
                 value={envText}
                 onChange={e => setEnvText(e.target.value)}
@@ -515,8 +524,11 @@ function ClaudeMCPAddDialog(props: {
           )}
           {transport !== 'stdio' && (
             <div className="nbi-form-field">
-              <label>Headers (Name: value, one per line)</label>
+              <label htmlFor="nbi-mcp-add-headers">
+                Headers (Name: value, one per line)
+              </label>
               <textarea
+                id="nbi-mcp-add-headers"
                 rows={3}
                 value={headersText}
                 onChange={e => setHeadersText(e.target.value)}


### PR DESCRIPTION
## Summary

The Claude MCP Add-server form rendered six `<label>` elements (Scope, Transport, Command/URL, Args, Environment, Headers) with no `htmlFor` and no matching input `id`. Click-to-focus did not work and screen readers announced each input as unlabeled.

## Solution

Add stable per-field ids matching the form's existing `nbi-mcp-add-*` prefix (already used on Name, Input mode, and JSON), and wire `htmlFor` on each label. The dynamic Command/URL label keeps a single id (`nbi-mcp-add-command-or-url`) because it labels one input whose text alternates on transport change.

## Testing

- `jlpm tsc --noEmit` clean. `jlpm lint:check` clean. `jlpm jest` 181 passed (no logic changed; this is pure markup).
- The change is mechanical; risk of regression is bounded to whether downstream CSS targets the bare-label structure. Verified by `grep -n "nbi-form-field >" style/` (no specific selectors that would care).

## Risks / follow-ups

- No tracked GitHub issue; audit identifier (D165) is internal.