### PR TITLE
a11y(checkbox): keyboard activation + WAI-ARIA checkbox role

### DIFF
--- a/src/components/checkbox.tsx
+++ b/src/components/checkbox.tsx
@@ -7,27 +7,49 @@ import { MdOutlineCheckBoxOutlineBlank, MdCheckBox } from '../icons';
 export function CheckBoxItem(props: any) {
   const indent = props.indent || 0;
   const disabled = props.disabled || false;
+  const checked = !!props.checked;
 
+  const activate = (event: React.SyntheticEvent) => {
+    if (!disabled) {
+      props.onClick(event);
+    }
+  };
+
+  // Custom checkbox widget. Tracks the WAI-ARIA pattern: role='checkbox'
+  // + aria-checked + tabIndex=0 + Space/Enter to toggle. Disabled state
+  // is exposed via aria-disabled so the element stays focusable; a
+  // screen reader user can still announce "checkbox, disabled" and hear
+  // what's off without being able to toggle it.
   return (
     <div
       className={`checkbox-item checkbox-item-indent-${indent} ${props.header ? 'checkbox-item-header' : ''}`}
       title={props.tooltip || props.title || ''}
-      onClick={event => {
-        if (!disabled) {
-          props.onClick(event);
+      role="checkbox"
+      aria-checked={checked}
+      aria-disabled={disabled || undefined}
+      tabIndex={disabled ? -1 : 0}
+      onClick={activate}
+      onKeyDown={event => {
+        if (event.key === ' ' || event.key === 'Enter') {
+          // Space scrolls the page by default, Enter is a no-op on a
+          // <div>; prevent both so the checkbox can own them.
+          event.preventDefault();
+          activate(event);
         }
       }}
     >
       <div className="checkbox-item-toggle">
-        {props.checked ? (
+        {checked ? (
           <MdCheckBox
             className="checkbox-icon"
             style={{ opacity: disabled ? 0.5 : 1 }}
+            aria-hidden="true"
           />
         ) : (
           <MdOutlineCheckBoxOutlineBlank
             className="checkbox-icon"
             style={{ opacity: disabled ? 0.5 : 1 }}
+            aria-hidden="true"
           />
         )}
         <span style={{ opacity: disabled ? 0.5 : 1 }}>{props.label}</span>

--- a/style/base.css
+++ b/style/base.css
@@ -1346,6 +1346,12 @@ svg.access-token-warning {
   background-color: var(--jp-layout-color1);
 }
 
+.checkbox-item:focus-visible {
+  outline: 2px solid var(--jp-brand-color1);
+  outline-offset: 1px;
+  border-radius: 2px;
+}
+
 .checkbox-item-indent-0 {
   padding-left: 0;
 }

--- a/tests/ts/checkbox.test.tsx
+++ b/tests/ts/checkbox.test.tsx
@@ -1,0 +1,76 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { CheckBoxItem } from '../../src/components/checkbox';
+
+describe('CheckBoxItem', () => {
+  it('exposes role=checkbox with the current aria-checked state', () => {
+    const onClick = jest.fn();
+    const { rerender } = render(
+      <CheckBoxItem label="On" checked={false} onClick={onClick} />
+    );
+    expect(screen.getByRole('checkbox')).toHaveAttribute(
+      'aria-checked',
+      'false'
+    );
+    rerender(<CheckBoxItem label="On" checked={true} onClick={onClick} />);
+    expect(screen.getByRole('checkbox')).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+  });
+
+  it('toggles on Space and Enter when focused', () => {
+    const onClick = jest.fn();
+    render(<CheckBoxItem label="Test" checked={false} onClick={onClick} />);
+    const checkbox = screen.getByRole('checkbox');
+    checkbox.focus();
+    expect(checkbox).toHaveFocus();
+    fireEvent.keyDown(checkbox, { key: ' ' });
+    fireEvent.keyDown(checkbox, { key: 'Enter' });
+    expect(onClick).toHaveBeenCalledTimes(2);
+  });
+
+  it('still toggles on mouse click for sighted users', () => {
+    const onClick = jest.fn();
+    render(<CheckBoxItem label="Click" checked={false} onClick={onClick} />);
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks itself aria-disabled and ignores activation when disabled', () => {
+    const onClick = jest.fn();
+    render(
+      <CheckBoxItem
+        label="Off"
+        checked={false}
+        disabled={true}
+        onClick={onClick}
+      />
+    );
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).toHaveAttribute('aria-disabled', 'true');
+    fireEvent.click(checkbox);
+    fireEvent.keyDown(checkbox, { key: ' ' });
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('is focusable when enabled and unfocusable when disabled', () => {
+    const onClick = jest.fn();
+    const { rerender } = render(
+      <CheckBoxItem label="X" checked={false} onClick={onClick} />
+    );
+    expect(screen.getByRole('checkbox')).toHaveAttribute('tabindex', '0');
+    rerender(
+      <CheckBoxItem
+        label="X"
+        checked={false}
+        disabled={true}
+        onClick={onClick}
+      />
+    );
+    expect(screen.getByRole('checkbox')).toHaveAttribute('tabindex', '-1');
+  });
+});


### PR DESCRIPTION
## Summary

`CheckBoxItem` (used heavily across the tools popover, settings panel, and notebook-generation popover) rendered a `<div onClick>` with no role, no `aria-checked`, no `tabIndex`, and no `onKeyDown`. Keyboard users could not focus or toggle it; screen readers exposed it as a plain group rather than a checkbox.

## Solution

Apply the WAI-ARIA checkbox pattern: `role='checkbox'`, `aria-checked` driven by the prop, `tabIndex=0` (or `-1` when disabled, so the element stays in the accessibility tree and announces "checkbox, disabled" without being in the tab order). Space and Enter both `preventDefault` and route through the existing `onClick` path. The decorative checkbox icons get `aria-hidden='true'` so AT doesn't double-announce them. A `:focus-visible` outline using `--jp-brand-color1` matches the brand-color focus ring used elsewhere in the codebase.

## Testing

- `jlpm tsc --noEmit` clean. `jlpm lint:check` clean. `jlpm jest` 186 passed (5 new unit cases in `tests/ts/checkbox.test.tsx`).
- Tests pin: `role=checkbox` with `aria-checked` reflecting the prop, Space and Enter both activate, click still activates, disabled exposes `aria-disabled` and blocks activation, `tabIndex` is `0` enabled and `-1` disabled.
- Consolidated six-perspective review surfaced only follow-up items (no fix-before-merge).

## Risks / follow-ups

- Header rows in the tools popover have a "mixed/indeterminate" state when some but not all children are selected; screen readers currently hear "not checked" rather than "mixed." Plumbing `aria-checked='mixed'` is a clean follow-up.
- The `PillItem` component in `skills-panel.tsx` is the same `<span onClick>` antipattern (its `:focus-visible` CSS already exists but the element is unfocusable). Worth migrating with the same fix.
- No tracked GitHub issue; audit identifier (D157) is internal.