### PR TITLE
fix(claude-sessions): unify session listing across NBI surfaces, drop history.jsonl gate

### DIFF
--- a/notebook_intelligence/claude_sessions.py
+++ b/notebook_intelligence/claude_sessions.py
@@ -150,6 +150,11 @@ def _read_session_info(path: Path) -> Optional[ClaudeSessionInfo]:
     Returns ``None`` for transcripts that aren't useful to resume: the
     file is unreadable, starts with a sidechain record (subagent probe),
     or contains no user messages at all (snapshot-only).
+
+    The ``cwd`` is sourced from the transcript itself (Claude Code writes
+    a ``cwd`` field on most message envelopes) rather than reverse-
+    engineering from the encoded directory name, which is ambiguous for
+    paths that contain literal dashes (e.g. ``/Users/me/get-noticed``).
     """
     try:
         stat = path.stat()
@@ -160,6 +165,7 @@ def _read_session_info(path: Path) -> Optional[ClaudeSessionInfo]:
     preview = ""
     saw_user_message = False
     first_parsed_obj = True
+    cwd_from_transcript = ""
 
     try:
         with path.open("r", encoding="utf-8") as fh:
@@ -180,13 +186,23 @@ def _read_session_info(path: Path) -> Optional[ClaudeSessionInfo]:
                     first_parsed_obj = False
                     if obj.get("isSidechain") is True:
                         return None
+                # Pick up the cwd as soon as we find a record that
+                # carries one. Most lines do; the first that does wins.
+                if not cwd_from_transcript:
+                    candidate = obj.get("cwd")
+                    if isinstance(candidate, str) and candidate:
+                        cwd_from_transcript = candidate
                 if not _is_user_message(obj):
                     continue
                 saw_user_message = True
                 if _is_skippable_user_message(obj):
                     continue
-                preview = _extract_preview(obj)
-                break
+                if not preview:
+                    preview = _extract_preview(obj)
+                # Keep scanning a few more lines if cwd hasn't been
+                # found yet; otherwise we have everything we need.
+                if cwd_from_transcript:
+                    break
     except OSError as exc:
         log.warning("Could not read Claude session file %s: %s", path, exc)
         return None
@@ -201,6 +217,7 @@ def _read_session_info(path: Path) -> Optional[ClaudeSessionInfo]:
         modified_at=stat.st_mtime,
         created_at=stat.st_ctime,
         preview=preview,
+        cwd=cwd_from_transcript,
     )
 
 
@@ -269,124 +286,118 @@ def _truncate_preview(text: str) -> str:
     return text
 
 
+# Module-level cache: (transcript_path, mtime) -> parsed ClaudeSessionInfo.
+# Avoids re-reading every .jsonl on every list call (D207). Invalidates
+# automatically on mtime change. Capped so a long-running server doesn't
+# unbounded-grow; bumping out the oldest entry is fine since the cache
+# is purely a performance hint.
+_SESSION_INFO_CACHE: "dict[tuple[str, float], Optional[ClaudeSessionInfo]]" = {}
+_SESSION_INFO_CACHE_MAX = 2048
+
+
+def _cached_read_session_info(path: Path) -> Optional[ClaudeSessionInfo]:
+    """``_read_session_info`` with mtime-keyed memoization.
+
+    Returns the cached parse when the file hasn't been touched since the
+    last call, otherwise re-parses. Treats stat failures the same as the
+    underlying function: warn and skip.
+    """
+    try:
+        mtime = path.stat().st_mtime
+    except OSError as exc:
+        log.warning("Could not stat Claude session file %s: %s", path, exc)
+        return None
+    key = (str(path), mtime)
+    cached = _SESSION_INFO_CACHE.get(key)
+    if cached is not None or key in _SESSION_INFO_CACHE:
+        return cached
+    info = _read_session_info(path)
+    # Bound the cache size with a simple FIFO eviction; we're not trying
+    # to be LRU-clever for a few thousand transcripts.
+    if len(_SESSION_INFO_CACHE) >= _SESSION_INFO_CACHE_MAX:
+        try:
+            oldest = next(iter(_SESSION_INFO_CACHE))
+            del _SESSION_INFO_CACHE[oldest]
+        except StopIteration:
+            pass
+    _SESSION_INFO_CACHE[key] = info
+    return info
+
+
+def _decode_cwd_from_dir_name(name: str) -> str:
+    """Best-effort cwd recovery from a Claude project-dir name.
+
+    Used only as a fallback when the transcript itself has no ``cwd``
+    field. Claude encodes path separators as dashes, so ``-Users-me-proj``
+    becomes ``/Users/me/proj``. Paths with literal dashes are ambiguous
+    and will mis-decode; the transcript-derived cwd should be preferred
+    whenever it's available.
+    """
+    if not name:
+        return ""
+    if name.startswith("-"):
+        return "/" + name[1:].replace("-", "/")
+    return name.replace("-", "/")
+
+
 def list_all_sessions(
     cwd: Optional[str] = None,
     claude_home: Optional[str] = None,
 ) -> list[ClaudeSessionInfo]:
-    """List all resumable Claude sessions across all projects, newest first.
+    """List every resumable Claude session on disk, newest first.
 
-    Reads ``~/.claude/history.jsonl`` \u2014 Claude Code writes one entry per
-    prompt, so every session that appears there can actually be resumed.
-    Each session is enriched with its ``cwd`` (project path) so callers
-    can run ``claude --resume <id>`` from the correct directory.
+    Walks ``~/.claude/projects/*/`` directly so the result is the same
+    set of sessions ``claude --resume`` can recover. ``history.jsonl`` is
+    NOT used as a gating source because recent Claude Code versions don't
+    reliably populate it (notably for SDK-driven invocations), and
+    history-first lookups silently dropped real, on-disk sessions.
 
-    If ``cwd`` is provided, sessions from that project directory are also
-    included (e.g. NBI Claude Mode sessions that may not appear in
-    ``history.jsonl``). Results are de-duplicated by session ID.
+    The ``cwd`` is taken from the transcript itself when present (Claude
+    Code writes it on most message envelopes); falls back to a dash-
+    decoded project-dir name when no transcript line carries a cwd.
 
-    Sessions are de-duplicated by session ID and sorted by most recent
-    activity. Only sessions whose ``.jsonl`` transcript file still exists
-    in ``~/.claude/projects/`` are returned.
+    The ``cwd`` argument is retained for backward compatibility; when
+    given it's only used to scope same-cwd sessions whose project dir
+    might not exist yet (e.g. an in-progress NBI Claude Mode session).
+    Cross-project enumeration is unconditional.
+
+    Sessions are de-duplicated by session id and sorted by most recent
+    activity. Per-transcript parse results are mtime-cached so repeated
+    calls don't reparse every file.
     """
     home = Path(claude_home) if claude_home else Path.home() / ".claude"
-    history_path = home / "history.jsonl"
-
-    if not history_path.exists():
-        if cwd:
-            sessions = _list_sessions_in_dir(cwd, claude_home=claude_home)
-            for s in sessions:
-                s.cwd = cwd
-            return sessions
-        return []
-
-    # Build index: session_id -> .jsonl path for existence check.
     projects_dir = home / "projects"
-    session_to_jsonl: dict[str, Path] = {}
+
+    sessions: list[ClaudeSessionInfo] = []
+    seen_ids: set[str] = set()
+
     if projects_dir.is_dir():
         for project_dir in projects_dir.iterdir():
             if not project_dir.is_dir():
                 continue
+            fallback_cwd = _decode_cwd_from_dir_name(project_dir.name)
             for jsonl_file in project_dir.glob("*.jsonl"):
-                session_to_jsonl[jsonl_file.stem] = jsonl_file
-
-    # Read history.jsonl: group entries by session_id, track first/last timestamps.
-    # Structure: {session_id: {"project": str, "first_ts": int, "last_ts": int, "preview": str}}
-    seen: dict[str, dict] = {}
-    try:
-        with history_path.open("r", encoding="utf-8") as fh:
-            for raw in fh:
-                line = raw.strip()
-                if not line:
+                info = _cached_read_session_info(jsonl_file)
+                if info is None or info.session_id in seen_ids:
                     continue
-                try:
-                    obj = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                session_id = obj.get("sessionId")
-                if not session_id:
-                    continue
-                project = obj.get("project", "")
-                ts = int(obj.get("timestamp", 0))
-                display = obj.get("display", "")
-                if session_id not in seen:
-                    seen[session_id] = {
-                        "project": project,
-                        "first_ts": ts,
-                        "last_ts": ts,
-                        "preview": display,
-                    }
-                else:
-                    if ts < seen[session_id]["first_ts"]:
-                        seen[session_id]["first_ts"] = ts
-                        seen[session_id]["preview"] = display
-                    if ts > seen[session_id]["last_ts"]:
-                        seen[session_id]["last_ts"] = ts
-    except OSError as exc:
-        log.warning("Could not read Claude history file %s: %s", history_path, exc)
-        if cwd:
-            sessions = _list_sessions_in_dir(cwd, claude_home=claude_home)
-            for s in sessions:
-                s.cwd = cwd
-            return sessions
-        return []
+                # Fall back to the dash-decoded dir name only when the
+                # transcript itself didn't yield a cwd.
+                if not info.cwd:
+                    info.cwd = fallback_cwd
+                sessions.append(info)
+                seen_ids.add(info.session_id)
 
-    sessions: list[ClaudeSessionInfo] = []
-    for session_id, data in seen.items():
-        # Only include sessions whose transcript file still exists.
-        if session_id not in session_to_jsonl:
-            continue
-        jsonl_path = session_to_jsonl[session_id]
-        try:
-            stat = jsonl_path.stat()
-        except OSError:
-            continue
-        preview = data["preview"]
-        # When display is skippable, prefer a transcript-derived preview;
-        # if neither yields anything meaningful, leave preview empty so
-        # the picker UI can show only the session id + timestamp instead
-        # of a literal "/exit"-style row (issues #181, #187).
-        if _is_skippable_text(preview):
-            transcript_info = _read_session_info(jsonl_path)
-            preview = transcript_info.preview if transcript_info else ""
-        preview = _truncate_preview(preview)
-        sessions.append(ClaudeSessionInfo(
-            session_id=session_id,
-            path=str(jsonl_path),
-            modified_at=data["last_ts"] / 1000.0,
-            created_at=stat.st_ctime,
-            preview=preview,
-            cwd=data["project"],
-        ))
-
-    # Merge in cwd-scoped sessions (e.g. NBI Claude Mode sessions that may
-    # not appear in history.jsonl), deduplicating by session_id.
+    # Belt and suspenders: if the caller asked for sessions scoped to a
+    # specific cwd whose project dir doesn't exist yet (e.g. a brand-new
+    # NBI Claude Mode session being recorded), surface them too.
     if cwd:
-        existing_ids = {s.session_id for s in sessions}
         for s in _list_sessions_in_dir(cwd, claude_home=claude_home):
-            if s.session_id not in existing_ids:
+            if s.session_id in seen_ids:
+                continue
+            if not s.cwd:
                 s.cwd = cwd
-                sessions.append(s)
-                existing_ids.add(s.session_id)
+            sessions.append(s)
+            seen_ids.add(s.session_id)
 
     sessions.sort(key=lambda s: s.modified_at, reverse=True)
     return sessions

--- a/notebook_intelligence/claude_sessions.py
+++ b/notebook_intelligence/claude_sessions.py
@@ -199,8 +199,10 @@ def _read_session_info(path: Path) -> Optional[ClaudeSessionInfo]:
                     continue
                 if not preview:
                     preview = _extract_preview(obj)
-                # Keep scanning a few more lines if cwd hasn't been
-                # found yet; otherwise we have everything we need.
+                # We need both the preview AND the cwd before we can
+                # stop. Most envelopes carry cwd, so this loop usually
+                # exits within the first few lines; otherwise the
+                # _MAX_LINES_SCANNED cap above provides the upper bound.
                 if cwd_from_transcript:
                     break
     except OSError as exc:

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -52,7 +52,6 @@ from notebook_intelligence.claude_mcp_manager import ClaudeMCPManager
 from notebook_intelligence.plugin_manager import PluginManager
 from notebook_intelligence.claude_sessions import (
     NBI_CONTEXT_PREFIX,
-    get_sessions_dir as get_claude_sessions_dir,
     list_all_sessions as list_all_claude_sessions,
 )
 import notebook_intelligence.github_copilot as github_copilot
@@ -1541,9 +1540,16 @@ class ClaudeSessionsListHandler(APIHandler):
             cwd = get_jupyter_root_dir()
             sessions = list_all_claude_sessions(cwd=cwd)
             if scope == "cwd" and cwd:
-                target = str(get_claude_sessions_dir(cwd))
+                # Compare realpaths so symlinked workspaces (common on
+                # JupyterHub with NFS user dirs) match transcripts that
+                # were written against the resolved path. The old
+                # implementation compared the encoded directory name,
+                # which produced different strings whenever the user's
+                # cwd was a symlink alias.
+                target = os.path.realpath(cwd)
                 sessions = [
-                    s for s in sessions if os.path.dirname(s.path) == target
+                    s for s in sessions
+                    if s.cwd and os.path.realpath(s.cwd) == target
                 ]
             self.finish(json.dumps({
                 "sessions": [asdict(s) for s in sessions],

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -1546,10 +1546,30 @@ class ClaudeSessionsListHandler(APIHandler):
                 # implementation compared the encoded directory name,
                 # which produced different strings whenever the user's
                 # cwd was a symlink alias.
+                #
+                # `realpath` can be an NFS round trip per call, so cache
+                # per-cwd within this request — many sessions share the
+                # same cwd and re-resolving each time turns a 1k-session
+                # filter into 1k NFS lookups.
+                #
+                # Sessions whose cwd is empty (older transcripts that
+                # carried no cwd field and whose project dir name also
+                # failed the dash-decode fallback) are dropped from
+                # scope=cwd results: they cannot be matched against the
+                # current cwd anyway. They remain visible under
+                # scope=all.
                 target = os.path.realpath(cwd)
+                realpath_cache: dict[str, str] = {}
+
+                def _rp(p: str) -> str:
+                    cached = realpath_cache.get(p)
+                    if cached is None:
+                        cached = os.path.realpath(p)
+                        realpath_cache[p] = cached
+                    return cached
+
                 sessions = [
-                    s for s in sessions
-                    if s.cwd and os.path.realpath(s.cwd) == target
+                    s for s in sessions if s.cwd and _rp(s.cwd) == target
                 ]
             self.finish(json.dumps({
                 "sessions": [asdict(s) for s in sessions],

--- a/src/components/launcher-picker.tsx
+++ b/src/components/launcher-picker.tsx
@@ -13,6 +13,18 @@ export interface ILauncherPickerProps {
   onSessionSelected: (session: IClaudeSessionInfo) => void;
 }
 
+// Pick a short, glanceable label for a session's project. The basename
+// of the cwd is usually the project's actual name; the full path stays
+// available via the row's `title` attribute on hover.
+function projectLabel(cwd: string | undefined | null): string {
+  if (!cwd) {
+    return '';
+  }
+  const trimmed = cwd.replace(/\/+$/, '');
+  const idx = trimmed.lastIndexOf('/');
+  return idx >= 0 ? trimmed.slice(idx + 1) : trimmed;
+}
+
 export function LauncherPicker({
   onSessionSelected
 }: ILauncherPickerProps): JSX.Element {
@@ -187,8 +199,15 @@ export function LauncherPicker({
                   <span className="nbi-claude-code-picker-session-id">
                     {session.session_id.slice(0, 8)}
                   </span>
-                  <span className="nbi-claude-code-picker-time">
-                    {session.cwd}
+                  {/* Render the basename of the project as the inline
+                      label; keep the full path on hover via title so a
+                      user with several similarly-named projects can
+                      disambiguate without losing the path entirely. */}
+                  <span
+                    className="nbi-claude-code-picker-session-project"
+                    title={session.cwd}
+                  >
+                    {projectLabel(session.cwd)}
                   </span>
                 </div>
                 {session.preview && (

--- a/src/components/launcher-picker.tsx
+++ b/src/components/launcher-picker.tsx
@@ -202,13 +202,25 @@ export function LauncherPicker({
                   {/* Render the basename of the project as the inline
                       label; keep the full path on hover via title so a
                       user with several similarly-named projects can
-                      disambiguate without losing the path entirely. */}
-                  <span
-                    className="nbi-claude-code-picker-session-project"
-                    title={session.cwd}
-                  >
-                    {projectLabel(session.cwd)}
-                  </span>
+                      disambiguate without losing the path entirely.
+                      Screen readers don't expose `title` on <span>
+                      reliably, so duplicate the full path into
+                      aria-label whenever it differs from the visible
+                      basename. */}
+                  {(() => {
+                    const full = session.cwd ?? '';
+                    const label = projectLabel(full);
+                    const fullDiffersFromLabel = full && full !== label;
+                    return (
+                      <span
+                        className="nbi-claude-code-picker-session-project"
+                        title={full}
+                        aria-label={fullDiffersFromLabel ? full : undefined}
+                      >
+                        {label}
+                      </span>
+                    );
+                  })()}
                 </div>
                 {session.preview && (
                   <div className="nbi-claude-code-picker-msg">

--- a/style/base.css
+++ b/style/base.css
@@ -929,6 +929,21 @@ pre:has(.code-block-header) {
   color: var(--jp-ui-font-color3);
 }
 
+/* The session row's project basename rides at the right edge,
+   mirroring the old `time` slot. Keeps long paths from blowing out the
+   row while leaving the full cwd available on hover via the title attr.
+   (Named `-session-project` not `-project` to avoid colliding with the
+   project-grouping header class higher up in this stylesheet.) */
+.nbi-claude-code-picker-session-project {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--jp-ui-font-color3);
+  max-width: 50%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .nbi-claude-code-picker-msg {
   font-size: var(--jp-ui-font-size1);
   color: var(--jp-ui-font-color2);

--- a/tests/test_claude_sessions.py
+++ b/tests/test_claude_sessions.py
@@ -52,6 +52,22 @@ def _assistant_line(session_id: str, cwd: str = "") -> dict:
     return line
 
 
+@pytest.fixture(autouse=True)
+def _clear_session_cache():
+    """Drop the module-level _SESSION_INFO_CACHE between tests.
+
+    The cache is keyed by (path, mtime), so under tmp_path per-test
+    isolation collisions are theoretical; explicit clearing keeps test
+    ordering, single-test reruns, and future cache-introspection tests
+    deterministic instead of relying on tmp_path entropy.
+    """
+    from notebook_intelligence import claude_sessions
+
+    claude_sessions._SESSION_INFO_CACHE.clear()
+    yield
+    claude_sessions._SESSION_INFO_CACHE.clear()
+
+
 @pytest.fixture
 def fake_claude_home(tmp_path):
     """Create an empty ~/.claude stand-in under a tmp_path."""
@@ -686,14 +702,20 @@ class TestListAllSessions:
 
 
 class TestCrossSurfaceConsistency:
-    """Pin that the three session-listing surfaces (chat sidebar, launcher
-    tile, /resume inside Claude) converge on the same set of resumable
-    sessions.
+    """Pin that NBI's session-listing surfaces converge on the same
+    on-disk set ``claude --resume`` consumes.
 
-    /resume's authoritative source is the on-disk transcript files under
-    ``~/.claude/projects/*/``. Both NBI pickers must enumerate that same
-    set so users never see a session "missing" from one surface that
-    shows up on another.
+    Three surfaces care about session enumeration: the chat sidebar's
+    Resume button (scope=cwd), the Launcher tile picker (scope=all), and
+    Claude Code's own ``/resume`` (external; not shelled out by these
+    tests). The authoritative ground truth all three share is the set
+    of ``.jsonl`` transcripts under ``~/.claude/projects/*/``. These
+    tests assert that NBI's two listing paths enumerate that set, so a
+    user can't see a session in one surface and not the other. Whether
+    Claude Code's own ``/resume`` enumerates the same set is its
+    contract to keep, not ours; a Galata or shell-out integration test
+    that runs ``claude --resume`` and diffs IDs against ours is the
+    cross-binary check, deferred to follow-up.
     """
 
     def test_launcher_returns_every_on_disk_session(

--- a/tests/test_claude_sessions.py
+++ b/tests/test_claude_sessions.py
@@ -21,12 +21,15 @@ def _write_jsonl(path: Path, lines: list[dict]) -> None:
             fh.write(json.dumps(obj) + "\n")
 
 
-def _user_line(session_id: str, text: str) -> dict:
-    return {
+def _user_line(session_id: str, text: str, cwd: str = "") -> dict:
+    line = {
         "type": "user",
         "message": {"role": "user", "content": text},
         "sessionId": session_id,
     }
+    if cwd:
+        line["cwd"] = cwd
+    return line
 
 
 def _sidechain_line(session_id: str, content: str = "Warmup") -> dict:
@@ -38,12 +41,15 @@ def _sidechain_line(session_id: str, content: str = "Warmup") -> dict:
     }
 
 
-def _assistant_line(session_id: str) -> dict:
-    return {
+def _assistant_line(session_id: str, cwd: str = "") -> dict:
+    line = {
         "type": "assistant",
         "message": {"role": "assistant", "content": "ok"},
         "sessionId": session_id,
     }
+    if cwd:
+        line["cwd"] = cwd
+    return line
 
 
 @pytest.fixture
@@ -498,8 +504,11 @@ class TestListAllSessions:
     def test_returns_cwd_sessions_when_history_missing(
         self, fake_claude_home, sessions_dir, project_cwd
     ):
+        # The project-walk path finds the session even when history.jsonl
+        # is absent (the common case on recent Claude Code releases).
         _write_jsonl(
-            sessions_dir / "s1.jsonl", [_user_line("s1", "nbi session")]
+            sessions_dir / "s1.jsonl",
+            [_user_line("s1", "nbi session", cwd=project_cwd)],
         )
         result = list_all_sessions(cwd=project_cwd, claude_home=str(fake_claude_home))
         assert len(result) == 1
@@ -573,31 +582,36 @@ class TestListAllSessions:
         match = next(s for s in result if s.session_id == session_id)
         assert match.preview == ""
 
-    def test_keeps_history_display_when_meaningful(
+    def test_transcript_is_authoritative_for_preview(
         self, fake_claude_home, sessions_dir, project_cwd
     ):
-        # When history.jsonl already has a meaningful display, the
-        # transcript fall-through must not run (and even if it did, the
-        # display value should win — it's what the user actually typed).
+        # The transcript on disk is now the source of truth for the
+        # preview. history.jsonl can drift (Claude Code skipped writing
+        # it for some flows), so listing relies on what's actually in the
+        # transcript file. If history.jsonl says one thing and the
+        # transcript says another, the transcript wins.
         session_id = "good1234"
         jsonl_path = sessions_dir / f"{session_id}.jsonl"
         _write_jsonl(
             jsonl_path,
-            [_user_line(session_id, "transcript-recorded text")],
+            [_user_line(session_id, "transcript-recorded text", cwd=project_cwd)],
         )
 
         _write_history(
             fake_claude_home,
             [
                 _history_line(
-                    session_id, project_cwd, 1_700_000_000_000, "what the user typed"
+                    session_id,
+                    project_cwd,
+                    1_700_000_000_000,
+                    "stale history display",
                 )
             ],
         )
 
         result = list_all_sessions(cwd=project_cwd, claude_home=str(fake_claude_home))
         match = next(s for s in result if s.session_id == session_id)
-        assert match.preview == "what the user typed"
+        assert match.preview == "transcript-recorded text"
 
     def test_deduplicates_sessions_in_both_sources(
         self, fake_claude_home, sessions_dir, project_cwd
@@ -669,3 +683,172 @@ class TestListAllSessions:
 
         assert chat_picker_session.preview == launcher_session.preview
         assert chat_picker_session.preview == "Plot the closing prices for AAPL"
+
+
+class TestCrossSurfaceConsistency:
+    """Pin that the three session-listing surfaces (chat sidebar, launcher
+    tile, /resume inside Claude) converge on the same set of resumable
+    sessions.
+
+    /resume's authoritative source is the on-disk transcript files under
+    ``~/.claude/projects/*/``. Both NBI pickers must enumerate that same
+    set so users never see a session "missing" from one surface that
+    shows up on another.
+    """
+
+    def test_launcher_returns_every_on_disk_session(
+        self, fake_claude_home, project_cwd, tmp_path
+    ):
+        # Three projects, each with a session. The launcher (scope=all)
+        # must enumerate all three regardless of whether history.jsonl
+        # exists or names them.
+        proj_a = project_cwd
+        proj_b = str(tmp_path / "projects" / "second-project")
+        proj_c = str(tmp_path / "projects" / "third-project")
+        Path(proj_b).mkdir(parents=True)
+        Path(proj_c).mkdir(parents=True)
+
+        for sid, cwd in [
+            ("a-sess", proj_a),
+            ("b-sess", proj_b),
+            ("c-sess", proj_c),
+        ]:
+            sdir = get_sessions_dir(cwd, claude_home=str(fake_claude_home))
+            sdir.mkdir(parents=True, exist_ok=True)
+            _write_jsonl(sdir / f"{sid}.jsonl", [_user_line(sid, sid, cwd=cwd)])
+
+        result = list_all_sessions(claude_home=str(fake_claude_home))
+        ids = {s.session_id for s in result}
+        assert ids == {"a-sess", "b-sess", "c-sess"}
+
+    def test_launcher_finds_sessions_without_history_jsonl(
+        self, fake_claude_home, project_cwd
+    ):
+        # /resume inside Claude works whether or not history.jsonl exists,
+        # so the launcher must too. This is the user-reported bug: empty
+        # or stale history.jsonl made cross-project sessions disappear
+        # from the launcher tile.
+        sdir = get_sessions_dir(project_cwd, claude_home=str(fake_claude_home))
+        sdir.mkdir(parents=True)
+        _write_jsonl(
+            sdir / "abc.jsonl",
+            [_user_line("abc", "Find me later", cwd=project_cwd)],
+        )
+
+        # No history.jsonl on disk at all.
+        result = list_all_sessions(claude_home=str(fake_claude_home))
+        assert {s.session_id for s in result} == {"abc"}
+
+    def test_cwd_scope_is_subset_of_all_scope(
+        self, fake_claude_home, project_cwd, tmp_path
+    ):
+        # Whatever the chat-sidebar (cwd-scoped) shows must be a subset of
+        # what the launcher (all-scoped) shows. This is the structural
+        # invariant we never want to violate, regardless of how the picker
+        # filters internally.
+        other_cwd = str(tmp_path / "projects" / "elsewhere")
+        Path(other_cwd).mkdir(parents=True)
+
+        my_dir = get_sessions_dir(project_cwd, claude_home=str(fake_claude_home))
+        my_dir.mkdir(parents=True)
+        _write_jsonl(
+            my_dir / "mine.jsonl",
+            [_user_line("mine", "in my project", cwd=project_cwd)],
+        )
+
+        other_dir = get_sessions_dir(other_cwd, claude_home=str(fake_claude_home))
+        other_dir.mkdir(parents=True)
+        _write_jsonl(
+            other_dir / "theirs.jsonl",
+            [_user_line("theirs", "in another project", cwd=other_cwd)],
+        )
+
+        all_sessions = list_all_sessions(
+            cwd=project_cwd, claude_home=str(fake_claude_home)
+        )
+        cwd_only = [
+            s
+            for s in all_sessions
+            if os.path.realpath(s.cwd) == os.path.realpath(project_cwd)
+        ]
+        all_ids = {s.session_id for s in all_sessions}
+        cwd_ids = {s.session_id for s in cwd_only}
+        assert cwd_ids.issubset(all_ids)
+        assert cwd_ids == {"mine"}
+        assert all_ids == {"mine", "theirs"}
+
+    def test_cross_project_session_carries_its_cwd_for_resume(
+        self, fake_claude_home, tmp_path
+    ):
+        # The launcher tile resumes cross-project sessions by issuing
+        # `cd ${session.cwd} && claude --resume <id>` in a new terminal.
+        # That only works if the cwd field is populated AND accurate.
+        # Pin: every session returned by the project-walk carries the
+        # transcript-recorded cwd.
+        proj = str(tmp_path / "projects" / "real-project")
+        Path(proj).mkdir(parents=True)
+        sdir = get_sessions_dir(proj, claude_home=str(fake_claude_home))
+        sdir.mkdir(parents=True)
+        _write_jsonl(
+            sdir / "sess.jsonl",
+            [_user_line("sess", "prompt", cwd=proj)],
+        )
+
+        result = list_all_sessions(claude_home=str(fake_claude_home))
+        assert len(result) == 1
+        assert result[0].cwd == proj
+
+    def test_dash_decoded_cwd_fallback_when_transcript_omits_cwd(
+        self, fake_claude_home
+    ):
+        # Older transcripts (and synthetic test fixtures) may not carry a
+        # cwd field. The dash-decoded directory name is the fallback. The
+        # decoding is lossy for paths with literal dashes — pin the
+        # mechanical behavior of the fallback (dashes -> slashes,
+        # leading-dash -> root slash) so a regression in the decoder is
+        # surfaced immediately.
+        encoded_dir_name = "-Users-someone-clean"
+        sdir = fake_claude_home / "projects" / encoded_dir_name
+        sdir.mkdir(parents=True)
+        _write_jsonl(
+            sdir / "sess.jsonl",
+            # No cwd in the line — exercises the fallback path.
+            [_user_line("sess", "prompt")],
+        )
+
+        result = list_all_sessions(claude_home=str(fake_claude_home))
+        assert len(result) == 1
+        assert result[0].cwd == "/Users/someone/clean"
+
+    def test_mtime_cache_skips_reparse_on_unchanged_file(
+        self, fake_claude_home, sessions_dir, project_cwd, monkeypatch
+    ):
+        # The project-walk reads every .jsonl on every call by default
+        # (D207). We cache parse results by (path, mtime) so a no-op
+        # refresh doesn't re-open files. Pin: a second list call doesn't
+        # invoke the underlying reader for unchanged transcripts.
+        from notebook_intelligence import claude_sessions
+
+        _write_jsonl(
+            sessions_dir / "cached.jsonl",
+            [_user_line("cached", "prompt", cwd=project_cwd)],
+        )
+
+        first = list_all_sessions(claude_home=str(fake_claude_home))
+        assert len(first) == 1
+
+        # Wrap _read_session_info to count calls on the second pass.
+        call_count = {"n": 0}
+        real_reader = claude_sessions._read_session_info
+
+        def counting_reader(path):
+            call_count["n"] += 1
+            return real_reader(path)
+
+        monkeypatch.setattr(
+            claude_sessions, "_read_session_info", counting_reader
+        )
+
+        second = list_all_sessions(claude_home=str(fake_claude_home))
+        assert len(second) == 1
+        assert call_count["n"] == 0  # served from cache

--- a/tests/test_claude_sessions_handler.py
+++ b/tests/test_claude_sessions_handler.py
@@ -51,14 +51,16 @@ def claude_mode_off():
         yield mock_asm
 
 
-def _session(session_id: str, path: str) -> ClaudeSessionInfo:
+def _session(
+    session_id: str, path: str, cwd: str = ""
+) -> ClaudeSessionInfo:
     return ClaudeSessionInfo(
         session_id=session_id,
         path=path,
         modified_at=1.0,
         created_at=0.0,
         preview="hello",
-        cwd="",
+        cwd=cwd,
     )
 
 
@@ -119,9 +121,12 @@ class TestClaudeSessionsListHandler:
         self, claude_mode_on, tmp_path
     ):
         cwd = str(tmp_path / "proj")
-        cwd_dir = ext_module.get_claude_sessions_dir(cwd)
-        in_cwd = _session("abc", str(cwd_dir / "abc.jsonl"))
-        elsewhere = _session("xyz", str(tmp_path / "other-project" / "xyz.jsonl"))
+        in_cwd = _session("abc", str(tmp_path / "proj" / "abc.jsonl"), cwd=cwd)
+        elsewhere = _session(
+            "xyz",
+            str(tmp_path / "other-project" / "xyz.jsonl"),
+            cwd=str(tmp_path / "other-project"),
+        )
         with patch.object(
             ext_module, "list_all_claude_sessions", return_value=[in_cwd, elsewhere]
         ):
@@ -138,10 +143,17 @@ class TestClaudeSessionsListHandler:
     def test_scope_cwd_filters_to_current_sessions_dir(
         self, claude_mode_on, tmp_path
     ):
+        # scope=cwd is a realpath compare on the session's cwd field, not
+        # on the transcript path. Sessions in another project must drop
+        # out; sessions in the same project (even through a symlink alias)
+        # stay.
         cwd = str(tmp_path / "proj")
-        cwd_dir = ext_module.get_claude_sessions_dir(cwd)
-        in_cwd = _session("abc", str(cwd_dir / "abc.jsonl"))
-        elsewhere = _session("xyz", str(tmp_path / "other-project" / "xyz.jsonl"))
+        in_cwd = _session("abc", str(tmp_path / "proj" / "abc.jsonl"), cwd=cwd)
+        elsewhere = _session(
+            "xyz",
+            str(tmp_path / "other-project" / "xyz.jsonl"),
+            cwd=str(tmp_path / "other-project"),
+        )
         with patch.object(
             ext_module, "list_all_claude_sessions", return_value=[in_cwd, elsewhere]
         ):
@@ -160,9 +172,12 @@ class TestClaudeSessionsListHandler:
         # query arg should produce the same behavior so curl/test callers
         # don't have to remember the param.
         cwd = str(tmp_path / "proj")
-        cwd_dir = ext_module.get_claude_sessions_dir(cwd)
-        in_cwd = _session("abc", str(cwd_dir / "abc.jsonl"))
-        elsewhere = _session("xyz", str(tmp_path / "other-project" / "xyz.jsonl"))
+        in_cwd = _session("abc", str(tmp_path / "proj" / "abc.jsonl"), cwd=cwd)
+        elsewhere = _session(
+            "xyz",
+            str(tmp_path / "other-project" / "xyz.jsonl"),
+            cwd=str(tmp_path / "other-project"),
+        )
         with patch.object(
             ext_module, "list_all_claude_sessions", return_value=[in_cwd, elsewhere]
         ):
@@ -174,3 +189,31 @@ class TestClaudeSessionsListHandler:
 
         body = _parse_response(handler)
         assert {s["session_id"] for s in body["sessions"]} == {"abc", "xyz"}
+
+    def test_scope_cwd_matches_via_symlink_alias(self, claude_mode_on, tmp_path):
+        # A symlinked workspace (common on JupyterHub user dirs) means
+        # the jupyter root and the session's recorded cwd may differ as
+        # strings but resolve to the same realpath. scope=cwd compares
+        # realpaths so the picker still finds the user's own sessions.
+        target = tmp_path / "real"
+        target.mkdir()
+        alias = tmp_path / "alias"
+        alias.symlink_to(target)
+
+        in_cwd = _session(
+            "abc",
+            str(target / "abc.jsonl"),
+            cwd=str(target),
+        )
+        with patch.object(
+            ext_module, "list_all_claude_sessions", return_value=[in_cwd]
+        ):
+            with patch.object(
+                ext_module, "get_jupyter_root_dir", return_value=str(alias)
+            ):
+                handler = _make_handler(scope="cwd")
+                ClaudeSessionsListHandler.get(handler)
+
+        body = _parse_response(handler)
+        ids = {s["session_id"] for s in body["sessions"]}
+        assert ids == {"abc"}

--- a/tests/test_claude_sessions_handler.py
+++ b/tests/test_claude_sessions_handler.py
@@ -190,6 +190,32 @@ class TestClaudeSessionsListHandler:
         body = _parse_response(handler)
         assert {s["session_id"] for s in body["sessions"]} == {"abc", "xyz"}
 
+    def test_scope_cwd_drops_sessions_with_empty_cwd(
+        self, claude_mode_on, tmp_path
+    ):
+        # A session whose transcript carried no cwd field AND whose
+        # project-dir name failed dash-decoding ends up with cwd="".
+        # Such a session cannot be realpath-compared against the current
+        # cwd, so the handler drops it from scope=cwd. (It stays visible
+        # under scope=all so the user can still find it.) Pin the drop
+        # so a future refactor doesn't accidentally start including
+        # un-matched empty-cwd rows.
+        cwd = str(tmp_path / "proj")
+        in_cwd = _session("abc", str(tmp_path / "proj" / "abc.jsonl"), cwd=cwd)
+        no_cwd = _session("xyz", str(tmp_path / "other" / "xyz.jsonl"), cwd="")
+        with patch.object(
+            ext_module, "list_all_claude_sessions", return_value=[in_cwd, no_cwd]
+        ):
+            with patch.object(
+                ext_module, "get_jupyter_root_dir", return_value=cwd
+            ):
+                handler = _make_handler(scope="cwd")
+                ClaudeSessionsListHandler.get(handler)
+
+        body = _parse_response(handler)
+        ids = {s["session_id"] for s in body["sessions"]}
+        assert ids == {"abc"}
+
     def test_scope_cwd_matches_via_symlink_alias(self, claude_mode_on, tmp_path):
         # A symlinked workspace (common on JupyterHub user dirs) means
         # the jupyter root and the session's recorded cwd may differ as

--- a/tests/ts/launcher-picker.test.tsx
+++ b/tests/ts/launcher-picker.test.tsx
@@ -1,0 +1,73 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+
+jest.mock('../../src/api', () => ({
+  NBIAPI: {
+    listClaudeSessions: jest.fn()
+  }
+}));
+
+import { NBIAPI } from '../../src/api';
+import { LauncherPicker } from '../../src/components/launcher-picker';
+
+const api = NBIAPI as any;
+
+describe('LauncherPicker', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the basename of each session.cwd as the project label', async () => {
+    api.listClaudeSessions.mockResolvedValue({
+      sessions: [
+        {
+          session_id: 'aaaaaaaa-1111-1111-1111-111111111111',
+          path: '/Users/me/.claude/projects/-Users-me-foo/x.jsonl',
+          modified_at: 100,
+          created_at: 50,
+          preview: 'first prompt',
+          cwd: '/Users/me/foo'
+        },
+        {
+          session_id: 'bbbbbbbb-2222-2222-2222-222222222222',
+          path: '/Users/me/.claude/projects/-Users-me-bar-baz/y.jsonl',
+          modified_at: 200,
+          created_at: 150,
+          preview: 'second prompt',
+          cwd: '/Users/me/bar-baz'
+        }
+      ],
+      currentCwd: '/Users/me/foo'
+    });
+
+    render(<LauncherPicker onSessionSelected={jest.fn()} />);
+
+    // Wait for the async fetch to land before asserting labels.
+    await screen.findByText('first prompt');
+
+    expect(api.listClaudeSessions).toHaveBeenCalledWith('all');
+    // Basename labels, not full paths.
+    expect(screen.getByText('foo')).toBeInTheDocument();
+    expect(screen.getByText('bar-baz')).toBeInTheDocument();
+    // Full path is preserved on the project label's title attr so a
+    // user with several similarly-named projects can disambiguate.
+    expect(screen.getByText('foo').getAttribute('title')).toBe('/Users/me/foo');
+  });
+
+  it('shows an empty-state message when no sessions exist', async () => {
+    api.listClaudeSessions.mockResolvedValue({
+      sessions: [],
+      currentCwd: '/Users/me/foo'
+    });
+
+    render(<LauncherPicker onSessionSelected={jest.fn()} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('No previous sessions found.')
+      ).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

A user reported that the Launcher tile's Claude Code session picker showed "No previous sessions found" while `/resume` inside the same Claude session listed previous sessions. Root cause: the backend used `~/.claude/history.jsonl` as the gating source for session listing. Recent Claude Code releases don't reliably populate that file for SDK-driven invocations, and the cwd-only fallback path only scanned the Jupyter root's transcript dir, so any session launched from a different cwd disappeared from both NBI pickers while Claude Code's own `/resume` (which walks the project dirs directly) continued to find them.

## Solution

Rebuild `list_all_sessions` on a direct walk of `~/.claude/projects/*/`, which is the durable on-disk source `/resume` consumes. The cwd for each session comes from the transcript's own `"cwd"` field (Claude Code writes it on most message envelopes) so paths with literal dashes round-trip correctly; a dash-decode of the directory name is only used as a fallback for older transcripts that lack the field.

The handler's `scope=cwd` filter switches from comparing transcript-path dirnames to a realpath compare on `session.cwd`, fixing symlink-alias mismatches common on JupyterHub user dirs (NFS / EFS), and memoizes the per-session realpath inside the request so a 1k-session filter on NFS doesn't fan out to 1k network round trips.

A mtime-keyed cache memoizes per-transcript parse results so repeated list calls don't re-open every `.jsonl` on each click (addresses D207 from the audit).

The Launcher tile's row now renders the cwd basename as the inline label with the full path duplicated on both `title` and `aria-label` so screen-reader users get the disambiguating path too.

## Testing

- `pytest tests/ --ignore=tests/test_claude_client.py -q` 882 passed (6 new TestCrossSurfaceConsistency cases, 1 new symlink-alias handler case, 1 new empty-cwd silent-drop pin, autouse fixture clears `_SESSION_INFO_CACHE` between tests).
- `jlpm tsc --noEmit` clean. `jlpm lint:check` clean. `jlpm jest` 183 passed (2 new `tests/ts/launcher-picker.test.tsx` cases).
- Playwright end-to-end from a fresh `notebook-dir=/tmp/nbitour`: `scope=all` returned 107 cross-project sessions (every project on the machine), each row labeled with its project basename and the full path on `title` + `aria-label`. `scope=cwd` returned 0 (no transcripts for `/tmp/nbitour`), confirming the realpath filter works.
- Six-agent review surfaced: realpath memoization in handler (applied), autouse cache fixture (applied), aria-label fallback on the span (applied), empty-cwd silent-drop test pin (applied), tightened class docstring (applied), corrected misleading code comment (applied).

## Risks / follow-ups

- The PR replaces the chat-sidebar Resume button's underlying data source but keeps it scoped to the current cwd. Cross-cwd resume from the sidebar (open a terminal + `cd` + `claude --resume`) is deferred to a follow-up; the Launcher tile remains the path for cross-project resumes.
- A shell-out integration test that runs `claude --resume` non-interactively and diffs session ids against ours is the right cross-binary check but is deferred (it needs the CLI on the Galata runner's PATH).
- `mtime` resolution on some filesystems (HFS+ 1s) could theoretically serve stale cache entries; the cache is a perf hint, not authoritative for correctness, and transcripts are append-only so collision odds are essentially zero in practice. Worth a note but not worth complicating the cache key.