### PR TITLE
a11y(chat): make 'open notebook' link reachable by keyboard

### DIFF
--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -973,6 +973,7 @@ function ChatResponse(props: any) {
             type="button"
             className="copilot-generated-notebook-link"
             data-ref={msg.notebookLink}
+            aria-label={`Open notebook ${msg.notebookLink}`}
             onClick={openNotebook}
           >
             open notebook

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -969,13 +969,14 @@ function ChatResponse(props: any) {
         })}
 
         {msg.notebookLink && (
-          <a
+          <button
+            type="button"
             className="copilot-generated-notebook-link"
             data-ref={msg.notebookLink}
             onClick={openNotebook}
           >
             open notebook
-          </a>
+          </button>
         )}
       </div>
       {msg.from === 'copilot' &&

--- a/style/base.css
+++ b/style/base.css
@@ -573,9 +573,29 @@ pre:has(.code-block-header) {
   height: 14px;
 }
 
+/* Rendered as a real <button> so it picks up Tab order, Enter/Space
+   activation, and "button" role announcement. The visual presentation
+   stays anchor-like: underline + link color so users still recognise it
+   as a clickable "open notebook" affordance. */
 .copilot-generated-notebook-link {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--jp-content-link-color);
   text-decoration: underline;
+  text-underline-offset: 2px;
   cursor: pointer;
+}
+
+.copilot-generated-notebook-link:hover {
+  filter: brightness(1.15);
+}
+
+.copilot-generated-notebook-link:focus-visible {
+  outline: 2px solid var(--jp-brand-color1);
+  outline-offset: 1px;
+  border-radius: 2px;
 }
 
 .sidebar-login-info {


### PR DESCRIPTION
## Summary

The "open notebook" affordance after a Copilot-generated notebook rendered as `<a className='copilot-generated-notebook-link' data-ref=... onClick>` with no `href` and no `tabIndex`. Keyboard users could not reach it; screen readers announced it as a link without a destination.

## Solution

Convert to `<button type='button'>`. The existing `.copilot-generated-notebook-link` rule gets a button-chrome reset (background/border/padding/font) so the visual treatment stays anchor-style (link color + underline) while the element participates in the document's natural tab order. A `:focus-visible` outline using `--jp-brand-color1` matches the brand-color focus indicator used elsewhere in this stylesheet.

The button carries an `aria-label` that includes the notebook path, so screen-reader users hear "Open notebook /path/to/notebook.ipynb, button" rather than just the visible text "open notebook" — useful when several responses each emit one of these links and the user needs to tell them apart.

The `openNotebook` handler reads `event.target.dataset['ref']`, which works identically on `<button>` as on `<a>`, so no event-handler change was needed.

## Testing

- `jlpm tsc --noEmit` clean. `jlpm lint:check` clean. `jlpm jest` 181 passed.
- Visual: button renders inline within the chat message body with the same link-style underline.
- Six-reviewer pass: applied the descriptive-aria-label suggestion; deferred a unit test + Galata coverage as follow-ups.

## Risks / follow-ups

- A Galata regression test (Tab to the button, Enter, assert openFile fires) would lock in the keyboard contract; deferring to a follow-up.
- An RTL unit test for `notebookLink` rendering + Enter activation is also worth adding once a chat-sidebar mounting harness exists.
- No tracked GitHub issue; audit identifier (D166) is internal.