### PR TITLE
a11y(skills-panel): real icons, focus reveal, drop nested-button wrapper

### DIFF
--- a/src/components/skills-panel.tsx
+++ b/src/components/skills-panel.tsx
@@ -8,6 +8,7 @@ import React, {
   useState
 } from 'react';
 import { Dialog, showDialog } from '@jupyterlab/apputils';
+import { VscCopy, VscEdit, VscTrash } from '../icons';
 import {
   ISkillDetail,
   ISkillImportPreview,
@@ -778,19 +779,16 @@ function SkillRow(props: {
     e.stopPropagation();
     fn();
   };
+  // The wrapper div is no longer interactive. Nested interactive widgets
+  // (role=button on a div that contains <button> children) violate ARIA
+  // semantics and confuse screen readers and form serialisation. The
+  // visible Edit button is the canonical activation path; the wrapper
+  // keeps its click handler purely as a sighted-user convenience so a
+  // click anywhere on the row still opens the editor, but it's no longer
+  // in the keyboard tab order — that role belongs to the explicit
+  // buttons below.
   return (
-    <div
-      className="nbi-skill-row"
-      onClick={props.onEdit}
-      role="button"
-      tabIndex={0}
-      onKeyDown={e => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          props.onEdit();
-        }
-      }}
-    >
+    <div className="nbi-skill-row" onClick={props.onEdit}>
       <div className="nbi-skill-row-main">
         <div className="nbi-skill-row-name">
           {skill.name}
@@ -808,7 +806,7 @@ function SkillRow(props: {
           title={skill.managed ? 'View (managed, read-only)' : 'Edit'}
           onClick={stopAnd(props.onEdit)}
         >
-          ✎
+          <VscEdit aria-hidden="true" />
         </button>
         {!skill.managed && (
           <button
@@ -818,7 +816,9 @@ function SkillRow(props: {
             title="Rename"
             onClick={stopAnd(props.onRename)}
           >
-            Aa
+            <span aria-hidden="true" className="nbi-icon-button-text">
+              Aa
+            </span>
           </button>
         )}
         <button
@@ -828,7 +828,7 @@ function SkillRow(props: {
           title="Duplicate"
           onClick={stopAnd(props.onDuplicate)}
         >
-          ⧉
+          <VscCopy aria-hidden="true" />
         </button>
         {!skill.managed && (
           <button
@@ -838,7 +838,7 @@ function SkillRow(props: {
             title="Delete"
             onClick={stopAnd(props.onDelete)}
           >
-            🗑
+            <VscTrash aria-hidden="true" />
           </button>
         )}
       </div>

--- a/style/base.css
+++ b/style/base.css
@@ -1718,7 +1718,12 @@ svg.access-token-warning {
   background-color: var(--jp-layout-color2);
 }
 
-.nbi-skill-row:focus {
+/* Highlight the whole row whenever any of its action buttons receives
+   keyboard focus, so a sighted keyboard user can tell which row they're
+   acting on. The row itself isn't focusable any more (the explicit
+   action buttons are); :focus-within bubbles the affordance up from
+   them. */
+.nbi-skill-row:focus-within {
   outline: 2px solid var(--jp-brand-color1);
   outline-offset: -2px;
 }
@@ -1779,8 +1784,7 @@ svg.access-token-warning {
 }
 
 .nbi-skill-row:hover .nbi-skill-row-actions,
-.nbi-skill-row:focus-within .nbi-skill-row-actions,
-.nbi-skill-row:focus .nbi-skill-row-actions {
+.nbi-skill-row:focus-within .nbi-skill-row-actions {
   opacity: 1;
 }
 
@@ -2352,15 +2356,36 @@ svg.access-token-warning {
   color: var(--jp-ui-font-color1);
   font-size: var(--jp-ui-font-size1);
   line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .nbi-icon-button:hover {
   background-color: var(--jp-layout-color3);
 }
 
+/* The rename action has no obvious icon, so it falls back to a short
+   text glyph ("Aa") rendered with the same vertical metrics as the SVG
+   icons so the row stays visually balanced. */
+.nbi-icon-button-text {
+  font-weight: 600;
+  font-size: 12px;
+  line-height: 1;
+}
+
+/* Destructive action: the icon-only delete button signals risk through
+   color + a hover border. Color alone is a WCAG 1.4.1 issue (color is
+   not the only signal); the rest border + focus ring together give a
+   non-color affordance. */
+.nbi-icon-button.danger {
+  color: var(--jp-error-color1, #d32f2f);
+}
+
 .nbi-icon-button.danger:hover {
   background-color: var(--jp-error-color3, rgb(230 100 100 / 20%));
   color: var(--jp-error-color1, #d32f2f);
+  outline: 1px solid var(--jp-error-color1, #d32f2f);
 }
 
 .nbi-breadcrumb-link:focus-visible,


### PR DESCRIPTION
## Summary

`SkillRow` in the skills panel had three overlapping accessibility issues. Each action button rendered a raw glyph (✎, Aa, ⧉, 🗑), so emoji rendering varied by OS/font and the wastebasket-emoji delete affordance conveyed risk via color only. The row wrapper carried `role="button"` `tabIndex={0}` and an `onKeyDown` while also containing four child `<button>` elements, nesting interactive widgets in a way ARIA explicitly forbids. And with the wrapper removed from the tab order, the previous hover-only opacity reveal needed to key on `:focus-within` rather than `:focus` so keyboard users can still see the action buttons.

## Solution

- **Real icons (D167)**: VscEdit / VscCopy / VscTrash from `src/icons.ts`. The rename text "Aa" is preserved but wrapped in an aria-hidden span so screen readers don't read it phonetically.
- **Destructive Delete non-color signal**: the red text color stays, plus a red outline on hover, so color-blind users get a second signal of risk before the click lands.
- **Drop nested interactive (D169)**: SkillRow's wrapper loses `role="button"`, `tabIndex`, and the keydown handler. The visible Edit child button is the canonical keyboard activation path. The wrapper keeps its `onClick` as a sighted-user convenience so a click anywhere on the row still opens the editor.
- **Focus reveal (D168)**: the action row's reveal selector switches from `:focus` to `:focus-within` (so any of the four buttons grabbing focus reveals them all), and the row's outline rule does the same so a keyboard user can tell which row they're acting on.

## Testing

- `jlpm tsc --noEmit` clean. `jlpm lint:check` clean. `jlpm jest` 181 passed (no SkillRow unit test exists yet; an RTL test for icon role + keyboard activation would be a clean follow-up).
- Manual: the action row's visual size and alignment are preserved (the icons match the previous glyphs' approximate footprint thanks to `display: inline-flex; align-items: center;` on `.nbi-icon-button`).

## Risks / follow-ups

- The wrapper used to be a single Tab stop; users who liked Tab-to-row + Enter now have to Tab one extra time to reach the explicit Edit button. The change matches ARIA semantics and the explicit Edit affordance is unambiguous; if user testing surfaces friction, a richer rework would move actions outside the row entirely.
- No tracked GitHub issue; audit identifiers (D167, D168, D169) are internal.