### PR TITLE
a11y(inline-popover): use JupyterLab theme tokens for background

### DIFF
--- a/style/base.css
+++ b/style/base.css
@@ -1048,8 +1048,12 @@ button.send-button:disabled:active {
   /* Use the JupyterLab layer token so the inline prompt picks up the
      ambient theme (light, dark, high-contrast, solarized, etc.). The
      previous fixed #f2f3ff / #14162b values bypassed the theme and
-     could yield insufficient text contrast under custom themes. */
-  background-color: var(--jp-layout-color1);
+     could yield insufficient text contrast under custom themes.
+     --jp-layout-color2 matches the elevation pattern used by the
+     sibling popovers (mode-tools-popover, workspace-file-popover) so
+     the popover surface sits above the inner footer (color1) rather
+     than reading as recessed. */
+  background-color: var(--jp-layout-color2);
   color: var(--jp-content-font-color1);
 }
 

--- a/style/base.css
+++ b/style/base.css
@@ -1044,11 +1044,13 @@ button.send-button:disabled:active {
   display: flex;
   flex-direction: column;
   position: absolute;
-  background-color: #f2f3ff;
-}
 
-body[data-jp-theme-light='false'] .inline-popover {
-  background-color: #14162b;
+  /* Use the JupyterLab layer token so the inline prompt picks up the
+     ambient theme (light, dark, high-contrast, solarized, etc.). The
+     previous fixed #f2f3ff / #14162b values bypassed the theme and
+     could yield insufficient text contrast under custom themes. */
+  background-color: var(--jp-layout-color1);
+  color: var(--jp-content-font-color1);
 }
 
 .inline-prompt-container {


### PR DESCRIPTION
## Summary

`.inline-popover` hardcoded `background-color: #f2f3ff` for the light theme and `#14162b` for the dark theme, bypassing JupyterLab's theme tokens entirely. Users on custom themes (high-contrast, solarized, brand-tinted themes) saw a fixed pastel background that might not contrast adequately with the foreground text.

## Solution

Switch to `var(--jp-layout-color2)` plus an explicit `color: var(--jp-content-font-color1)`. The popover surface now picks up the active theme, and the choice of `color2` (not `color1`) matches the elevation pattern used by the sibling `.mode-tools-popover` and `.workspace-file-popover` rules so the inner footer reads as recessed from the outer popover, not the other way around. The `body[data-jp-theme-light='false']` override block was removed since the layer token already swaps with the theme.

## Testing

- `jlpm lint:check` clean.
- Pure CSS retoken; no behavior change.
- Six-reviewer pass flagged the initial `--jp-layout-color1` choice as inverting the elevation pattern (would have caused the footer to read as raised instead of recessed); switched to `color2` to match the sibling popovers.

## Risks / follow-ups

- Galata visual-regression coverage for theme-aware popover rendering is deferred.
- No tracked GitHub issue; audit identifier (D171) is internal.