### PR TITLE
a11y(uploading): animated ellipsis + role=status / aria-live

### DIFF
--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -3799,10 +3799,18 @@ function SidebarComponent(props: any) {
                 );
               })}
               {isUploadingFiles && (
+                // The trailing-dots animation runs entirely in CSS
+                // (`.loading-ellipsis::after`), so the live region's DOM
+                // text stays the literal string "Uploading" and screen
+                // readers announce it exactly once on insertion — not on
+                // every dot tick. If a future change moves the dots into
+                // React state, restore the once-announce behavior with a
+                // separate sr-only label.
                 <div
                   className="user-input-context uploading-indicator"
                   role="status"
                   aria-live="polite"
+                  aria-atomic="true"
                   aria-busy="true"
                 >
                   <div className="loading-ellipsis">Uploading</div>

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -3799,7 +3799,12 @@ function SidebarComponent(props: any) {
                 );
               })}
               {isUploadingFiles && (
-                <div className="user-input-context uploading-indicator">
+                <div
+                  className="user-input-context uploading-indicator"
+                  role="status"
+                  aria-live="polite"
+                  aria-busy="true"
+                >
                   <div className="loading-ellipsis">Uploading</div>
                 </div>
               )}

--- a/style/base.css
+++ b/style/base.css
@@ -99,6 +99,48 @@
   color: var(--jp-ui-font-color2);
 }
 
+/* Animated trailing dots ("Uploading...") so the indicator visibly
+   moves while a request is in flight. ::after appends three dots and
+   steps through their reveal in 1.2 seconds. Honors prefers-reduced-
+   motion: vestibular-sensitive users see the literal three dots
+   without animation. */
+.loading-ellipsis::after {
+  content: '\2026';
+  display: inline-block;
+  width: 1.5em;
+  text-align: left;
+  animation: nbi-loading-ellipsis-cycle 1.2s steps(4, end) infinite;
+}
+
+@keyframes nbi-loading-ellipsis-cycle {
+  0% {
+    content: '';
+  }
+
+  25% {
+    content: '.';
+  }
+
+  50% {
+    content: '..';
+  }
+
+  75% {
+    content: '...';
+  }
+
+  100% {
+    content: '';
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .loading-ellipsis::after {
+    animation: none;
+    content: '...';
+  }
+}
+
 .chat-message-notice {
   background-color: transparent;
   font-size: 12px;


### PR DESCRIPTION
## Summary

The "Uploading" indicator rendered `<div className='loading-ellipsis'>Uploading</div>` but `style/base.css` defined no `.loading-ellipsis` rule, so the indicator was just static text. The wrapper also had no `role` / `aria-live`, so screen-reader users had no idea an upload was in progress.

## Solution

- `::after` content + keyframes animate the trailing dots through `''`, `'.'`, `'..'`, `'...'` on a 1.2 s cycle, giving sighted users a clear "in flight" signal.
- A `prefers-reduced-motion` block disables the animation and shows a static `'...'` so vestibular-sensitive users still see the dots but no movement.
- `role='status'` + `aria-live='polite'` + `aria-atomic='true'` + `aria-busy='true'` on the wrapper. The `aria-atomic` mirrors the `generating-label` region elsewhere in the sidebar for consistency.
- An inline comment notes that the CSS-only animation is intentional: AT reads the live region's DOM text once (the literal string "Uploading") rather than re-announcing on every dot tick.

## Testing

- `jlpm tsc --noEmit` clean. `jlpm lint:check` clean. `jlpm jest` 181 passed.
- Six-reviewer pass confirmed the role + aria-live combination and recommended adding `aria-atomic` + a maintenance comment to lock in the once-announce design.

## Risks / follow-ups

- Galata coverage for the upload indicator's role + aria-live attributes is deferred (would need a deterministic upload trigger in the test workspace).
- No tracked GitHub issue; audit identifier (D173) is internal.