### PR TITLE
a11y(drop-zone): theme-aware chip text for guaranteed contrast

### DIFF
--- a/style/base.css
+++ b/style/base.css
@@ -37,13 +37,26 @@
   align-items: center;
   justify-content: center;
   font-size: 14px;
+
+  /* The wrapper's color is only used by themes that don't reach the
+     inner <span> (e.g. if a future variant omits the chip). The chip
+     itself uses the theme's body text color so contrast against the
+     solid layer background is guaranteed regardless of how the brand
+     color is tuned. */
   color: var(--jp-brand-color1);
   z-index: 100;
   pointer-events: none;
 }
 
 .drop-zone-overlay span {
+  /* WCAG 1.4.3: 4.5:1 against the layer1 background is the minimum the
+     theme commits to via --jp-ui-font-color0; use that for the chip
+     text and lock the chip background to a solid layer color so the
+     parent's 15%-brand wash never bleeds through and softens contrast.
+     The brand-color border keeps the visual identity of the drop
+     affordance without being load-bearing for legibility. */
   background-color: var(--jp-layout-color1);
+  color: var(--jp-ui-font-color0);
   padding: 8px 16px;
   border-radius: 6px;
   border: 1px solid var(--jp-brand-color1);


### PR DESCRIPTION
## Summary

The "Drop files to attach as context" chip rendered with `color: var(--jp-brand-color1)` inherited from the overlay wrapper. Under custom themes with low-saturation brand colors, the chip text could fall below WCAG 1.4.3's 4.5:1 contrast minimum against the chip's `--jp-layout-color1` background.

## Solution

Lock the chip's text to `var(--jp-ui-font-color0)` — JupyterLab's body-text token, which the theme already commits to adequate contrast against the layer1 surface. The brand border + brand-tinted wash on the wrapper still carry the visual identity of the drop affordance; the chip itself is now legible under every theme.

## Testing

- `jlpm lint:check` clean.
- Pure CSS retoken; no behavior change.

## Risks / follow-ups

- The wrapper's gradient generating border (`.sidebar-user-input.generating`) was flagged in the same audit item but is a separate concern (theme-aware pink/violet conic gradient). Worth its own pass; deferring.
- No tracked GitHub issue; audit identifier (D174) is internal.