### PR TITLE
a11y(generating): pause rotating border under prefers-reduced-motion

### DIFF
--- a/style/base.css
+++ b/style/base.css
@@ -418,6 +418,15 @@ pre:has(.code-block-header) {
   .generating-pulse {
     animation: none;
   }
+
+  /* The conic-gradient generating border on the chat input and inline-
+     completion editor rotates indefinitely while a response streams in.
+     Pause it for vestibular-sensitive users so the brand-tinted border
+     becomes a static indicator instead of a rotating one. */
+  .sidebar-user-input.generating,
+  .jp-InputArea-editor.generating {
+    animation: none;
+  }
 }
 
 .chat-message-timestamp {


### PR DESCRIPTION
## Summary

`.sidebar-user-input.generating` and `.jp-InputArea-editor.generating` rotate a brand-tinted conic-gradient border on a 4 s linear loop while a response streams. The existing `prefers-reduced-motion: reduce` media query only paused `.generating-pulse`; both rotating borders kept spinning, making the indicator hostile to vestibular-sensitive users.

## Solution

Extend the existing `@media (prefers-reduced-motion: reduce)` block to also `animation: none` on the two `.generating` rules. The static brand-tinted border still appears (just doesn't rotate), so the "in progress" affordance is preserved.

## Testing

- `jlpm lint:check` clean.
- Pure CSS addition; no behavior change for users without the OS-level preference.

## Risks / follow-ups

- No tracked GitHub issue; audit identifier (D040) is internal.