### PR TITLE
a11y(transcript): announce streaming chat replies via aria-live

### DIFF
--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -1118,6 +1118,22 @@ function SidebarComponent(props: any) {
   const [loginClickCount, _setLoginClickCount] = useState(0);
   const [copilotRequestInProgress, setCopilotRequestInProgress] =
     useState(false);
+  // sr-only announcement string driven by request-in-progress transitions.
+  // Wrapping the whole transcript in aria-live would queue a polite
+  // announcement per streamed token — hostile for screen reader users.
+  // Instead announce at request boundaries: "Generating response" when
+  // a request starts, "Response complete" when it ends.
+  const [chatStatusAnnouncement, setChatStatusAnnouncement] = useState('');
+  const prevCopilotRequestInProgressRef = useRef(false);
+  useEffect(() => {
+    const prev = prevCopilotRequestInProgressRef.current;
+    if (!prev && copilotRequestInProgress) {
+      setChatStatusAnnouncement('Generating response.');
+    } else if (prev && !copilotRequestInProgress) {
+      setChatStatusAnnouncement('Response complete.');
+    }
+    prevCopilotRequestInProgressRef.current = copilotRequestInProgress;
+  }, [copilotRequestInProgress]);
   const [showPopover, setShowPopover] = useState(false);
   const [originalPrefixes, setOriginalPrefixes] = useState<string[]>([]);
   const [prefixSuggestions, setPrefixSuggestions] = useState<string[]>([]);
@@ -3588,6 +3604,14 @@ function SidebarComponent(props: any) {
           <div className="nbi-status-banner">New chat session started.</div>
         )}
       </div>
+      {/* sr-only polite region for chat-status boundary announcements.
+          The string toggles on copilotRequestInProgress transitions so
+          screen readers announce "Generating response." when a stream
+          starts and "Response complete." when it ends, without
+          re-announcing every streamed token. */}
+      <div className="nbi-sr-only" role="status" aria-live="polite">
+        {chatStatusAnnouncement}
+      </div>
       {!chatEnabled && !ghLoginRequired && (
         <div className="sidebar-login-info">
           Chat is disabled as you don't have a model configured.
@@ -3630,8 +3654,6 @@ function SidebarComponent(props: any) {
           <div
             className="sidebar-messages"
             role="log"
-            aria-live="polite"
-            aria-relevant="additions text"
             aria-label="Chat transcript"
           >
             <div className="sidebar-greeting">
@@ -3642,8 +3664,6 @@ function SidebarComponent(props: any) {
           <div
             className="sidebar-messages"
             role="log"
-            aria-live="polite"
-            aria-relevant="additions text"
             aria-label="Chat transcript"
           >
             {chatMessages.map((msg, index) => {

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -3627,13 +3627,25 @@ function SidebarComponent(props: any) {
 
       {chatEnabled &&
         (chatMessages.length === 0 ? (
-          <div className="sidebar-messages">
+          <div
+            className="sidebar-messages"
+            role="log"
+            aria-live="polite"
+            aria-relevant="additions text"
+            aria-label="Chat transcript"
+          >
             <div className="sidebar-greeting">
               Welcome! How can I assist you today?
             </div>
           </div>
         ) : (
-          <div className="sidebar-messages">
+          <div
+            className="sidebar-messages"
+            role="log"
+            aria-live="polite"
+            aria-relevant="additions text"
+            aria-label="Chat transcript"
+          >
             {chatMessages.map((msg, index) => {
               // Only the most recent copilot message owns the live
               // progress-feedback state. Non-active messages receive


### PR DESCRIPTION
## Summary

Only the elapsed-time label inside the chat sidebar's progress chip was being announced to screen readers; the actual assistant content streamed silently. Users who rely on assistive tech had no audible signal that a response was arriving or that it had completed.

## Solution

A naive approach (wrap the whole transcript in `aria-live='polite'` + `aria-relevant='additions text'`) would queue a polite announcement per streamed token and re-announce the user's own message when it lands in the transcript. Instead:

- Wrap `.sidebar-messages` in `role='log'` + `aria-label='Chat transcript'` so AT exposes the region's name and reading mode. The transcript itself is NOT a live region.
- Add a single persistent `sr-only` region that announces at request boundaries: "Generating response." when `copilotRequestInProgress` flips true and "Response complete." when it flips false. Driven by a `useEffect` watching the boolean's transitions; never re-announces during streaming.

## Testing

- `jlpm tsc --noEmit` clean. `jlpm lint:check` clean. `jlpm jest` 181 passed.
- Six-reviewer pass flagged the original "live transcript" approach as hostile to screen reader users; the boundary-event pattern is the remediation.

## Risks / follow-ups

- A shared `LiveAnnouncer` hook would centralize politeness rules; deferred. Three ad-hoc polite regions now live in chat-sidebar.tsx (status banner, skills reloaded, request-status). Worth consolidating in a follow-up.
- No tracked GitHub issue; audit identifier (D024) is internal.