### PR TITLE
a11y(sidebar): visually-hidden 'Skip to message input' link

### DIFF
--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -3769,17 +3769,20 @@ function SidebarComponent(props: any) {
           button, and feedback button before reaching the prompt; this
           shortcut lands them straight on the textarea. The link is
           revealed only when focused (the .nbi-skip-link CSS) so it
-          stays out of the sighted-user's way. */}
-      <a
-        href="#sidebar-user-input"
-        className="nbi-skip-link"
-        onClick={event => {
-          event.preventDefault();
-          promptInputRef.current?.focus();
-        }}
-      >
-        Skip to message input
-      </a>
+          stays out of the sighted-user's way. Rendered only when
+          chatEnabled is true so the target textarea exists. */}
+      {chatEnabled && (
+        <a
+          href="#sidebar-user-input"
+          className="nbi-skip-link"
+          onClick={event => {
+            event.preventDefault();
+            promptInputRef.current?.focus();
+          }}
+        >
+          Skip to message input
+        </a>
+      )}
       {isDragOver && (
         <div className="drop-zone-overlay">
           <span>Drop files to attach as context</span>

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -3774,7 +3774,7 @@ function SidebarComponent(props: any) {
       {chatEnabled && (
         <a
           href="#sidebar-user-input"
-          className="nbi-skip-link"
+          className="nbi-sr-only nbi-skip-link"
           onClick={event => {
             event.preventDefault();
             promptInputRef.current?.focus();

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -3763,6 +3763,23 @@ function SidebarComponent(props: any) {
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
     >
+      {/* Visually-hidden skip link as the first focusable child of the
+          sidebar. After an assistant reply lands, keyboard users would
+          otherwise have to Tab through every code block, copy / insert
+          button, and feedback button before reaching the prompt; this
+          shortcut lands them straight on the textarea. The link is
+          revealed only when focused (the .nbi-skip-link CSS) so it
+          stays out of the sighted-user's way. */}
+      <a
+        href="#sidebar-user-input"
+        className="nbi-skip-link"
+        onClick={event => {
+          event.preventDefault();
+          promptInputRef.current?.focus();
+        }}
+      >
+        Skip to message input
+      </a>
       {isDragOver && (
         <div className="drop-zone-overlay">
           <span>Drop files to attach as context</span>

--- a/style/base.css
+++ b/style/base.css
@@ -156,24 +156,35 @@
 
 /* Visually-hidden skip link at the top of the chat sidebar; revealed
    only when focused so sighted users never see it and keyboard users
-   land on it as the very first Tab inside the sidebar. */
+   land on it as the very first Tab inside the sidebar. Uses the same
+   clip-based hide pattern as .nbi-sr-only above so a future RTL or
+   reflow can't paint a 9999px-wide ghost box. */
 .nbi-skip-link {
   position: absolute;
-  left: -9999px;
-  top: 0;
   width: 1px;
   height: 1px;
+  padding: 0;
+  margin: -1px;
   overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
   z-index: 1000;
 }
 
 .nbi-skip-link:focus,
 .nbi-skip-link:focus-visible {
   left: 8px;
-  top: 4px;
+
+  /* Below the 25px sidebar header so the focused chip doesn't overlap
+     the "Notebook Intelligence" title. */
+  top: 28px;
   width: auto;
   height: auto;
   padding: 6px 10px;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
   background-color: var(--jp-layout-color1);
   color: var(--jp-content-link-color);
   border: 2px solid var(--jp-brand-color1);

--- a/style/base.css
+++ b/style/base.css
@@ -154,21 +154,10 @@
   }
 }
 
-/* Visually-hidden skip link at the top of the chat sidebar; revealed
-   only when focused so sighted users never see it and keyboard users
-   land on it as the very first Tab inside the sidebar. Uses the same
-   clip-based hide pattern as .nbi-sr-only above so a future RTL or
-   reflow can't paint a 9999px-wide ghost box. */
+/* Skip link at the top of the chat sidebar; hidden via .nbi-sr-only,
+   revealed only when focused so sighted users never see it and keyboard
+   users land on it as the very first Tab inside the sidebar. */
 .nbi-skip-link {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
   z-index: 1000;
 }
 

--- a/style/base.css
+++ b/style/base.css
@@ -154,6 +154,33 @@
   }
 }
 
+/* Visually-hidden skip link at the top of the chat sidebar; revealed
+   only when focused so sighted users never see it and keyboard users
+   land on it as the very first Tab inside the sidebar. */
+.nbi-skip-link {
+  position: absolute;
+  left: -9999px;
+  top: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  z-index: 1000;
+}
+
+.nbi-skip-link:focus,
+.nbi-skip-link:focus-visible {
+  left: 8px;
+  top: 4px;
+  width: auto;
+  height: auto;
+  padding: 6px 10px;
+  background-color: var(--jp-layout-color1);
+  color: var(--jp-content-link-color);
+  border: 2px solid var(--jp-brand-color1);
+  border-radius: 3px;
+  text-decoration: underline;
+}
+
 .chat-message-notice {
   background-color: transparent;
   font-size: 12px;


### PR DESCRIPTION
## Summary

After an assistant reply landed, keyboard-only and screen-reader users had to Tab through every code block, copy / insert button, and feedback button in every prior message before reaching the prompt textarea.

## Solution

Add a "Skip to message input" anchor as the first focusable child of `.sidebar`. The `.nbi-skip-link` CSS uses the same clip-based hide pattern as the existing `.nbi-sr-only` class (consistent with sibling utilities; avoids the 9999px-wide layout box that the `left: -9999px` antipattern leaves behind). On focus the link appears as a brand-bordered chip at `top: 28px` so it sits below the 25px sidebar header rather than over the "Notebook Intelligence" title.

The link is rendered only when `chatEnabled` is true so the target textarea actually exists. Activating it calls `promptInputRef.current?.focus()` so focus lands inside the textarea, not on the wrapper div.

## Testing

- `jlpm tsc --noEmit` clean. `jlpm lint:check` clean. `jlpm jest` 181 passed.
- Six-reviewer pass surfaced three improvements (all applied): clip-based hide, gate on chatEnabled, drop below the sidebar header.

## Risks / follow-ups

- A Galata regression test (Tab into sidebar → link focused → Enter → textarea focused) is deferred; the chat-sidebar spec doesn't yet exercise keyboard nav patterns.
- No tracked GitHub issue; audit identifier (D023) is internal.