### PR TITLE
a11y(focus): Ctrl/Cmd+Shift+L global shortcut to focus the chat input

### DIFF
--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -3347,6 +3347,34 @@ function SidebarComponent(props: any) {
     };
   }, [chatMessages]);
 
+  // copilotSidebar:focusPrompt is dispatched from the global keybinding
+  // (Ctrl/Cmd+Shift+L) registered in index.ts. activateById can take
+  // several frames to mount the sidebar when it was collapsed, so the
+  // handler retries up to ~10 frames waiting for the textarea ref to be
+  // populated and on-screen before calling focus(). One frame isn't
+  // enough on a cold-open of the left rail.
+  useEffect(() => {
+    const handler = () => {
+      let attempts = 0;
+      const MAX_ATTEMPTS = 10;
+      const tryFocus = () => {
+        const el = promptInputRef.current;
+        if (el && el.offsetParent !== null) {
+          el.focus();
+          return;
+        }
+        attempts += 1;
+        if (attempts < MAX_ATTEMPTS) {
+          requestAnimationFrame(tryFocus);
+        }
+      };
+      tryFocus();
+    };
+    document.addEventListener('copilotSidebar:focusPrompt', handler);
+    return () =>
+      document.removeEventListener('copilotSidebar:focusPrompt', handler);
+  }, []);
+
   const addOutputContextHandler = useCallback((eventData: any) => {
     const detail = eventData?.detail;
     if (!detail || !detail.outputContext) {

--- a/src/command-ids.ts
+++ b/src/command-ids.ts
@@ -63,4 +63,5 @@ export namespace CommandIDs {
     'notebook-intelligence:open-github-copilot-cli-launcher';
   export const openCodexLauncher = 'notebook-intelligence:open-codex-launcher';
   export const showTour = 'notebook-intelligence:show-tour';
+  export const focusChatInput = 'notebook-intelligence:focus-chat-input';
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -987,30 +987,20 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
     // Ctrl/Cmd+Shift+L mirrors common "focus search / focus input"
     // bindings used by other editors and doesn't collide with any
     // built-in JupyterLab shortcut.
+    //
+    // Implementation: dispatch a CustomEvent the React sidebar listens
+    // for. The sidebar owns `promptInputRef` and can focus the
+    // textarea reliably regardless of whether the panel was collapsed
+    // (the event fires after the React tree has been mounted by the
+    // activate path), so we don't have to race the Lumino layout with
+    // a DOM-id `querySelector`. Matches the existing
+    // `copilotSidebar:*` event pattern used elsewhere in this file.
     app.commands.addCommand(CommandIDs.focusChatInput, {
       label: 'Focus Notebook Intelligence chat input',
       caption: 'Open the NBI sidebar and move focus to the prompt textarea',
       execute: () => {
         app.shell.activateById(panel.id);
-        // After activateById commits, the React tree's textarea is in
-        // the DOM. A frame boundary gives Lumino time to settle the
-        // visibility flip; querying earlier can race the layout and
-        // focus() can no-op on an offscreen node.
-        const focusPromptInput = () => {
-          const textarea = document.querySelector<HTMLTextAreaElement>(
-            '#sidebar-user-input textarea'
-          );
-          if (textarea) {
-            textarea.focus();
-            return true;
-          }
-          return false;
-        };
-        if (!focusPromptInput()) {
-          requestAnimationFrame(() => {
-            focusPromptInput();
-          });
-        }
+        document.dispatchEvent(new CustomEvent('copilotSidebar:focusPrompt'));
       }
     });
     app.commands.addKeyBinding({

--- a/src/index.ts
+++ b/src/index.ts
@@ -981,6 +981,44 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
     app.shell.add(panel, 'left', { rank: 1000 });
     app.shell.activateById(panel.id);
 
+    // Global focus shortcut. Activates the NBI sidebar (revealing it if
+    // collapsed) and lands focus on the prompt textarea, so keyboard-
+    // first users can start typing without mousing through panel tabs.
+    // Ctrl/Cmd+Shift+L mirrors common "focus search / focus input"
+    // bindings used by other editors and doesn't collide with any
+    // built-in JupyterLab shortcut.
+    app.commands.addCommand(CommandIDs.focusChatInput, {
+      label: 'Focus Notebook Intelligence chat input',
+      caption: 'Open the NBI sidebar and move focus to the prompt textarea',
+      execute: () => {
+        app.shell.activateById(panel.id);
+        // After activateById commits, the React tree's textarea is in
+        // the DOM. A frame boundary gives Lumino time to settle the
+        // visibility flip; querying earlier can race the layout and
+        // focus() can no-op on an offscreen node.
+        const focusPromptInput = () => {
+          const textarea = document.querySelector<HTMLTextAreaElement>(
+            '#sidebar-user-input textarea'
+          );
+          if (textarea) {
+            textarea.focus();
+            return true;
+          }
+          return false;
+        };
+        if (!focusPromptInput()) {
+          requestAnimationFrame(() => {
+            focusPromptInput();
+          });
+        }
+      }
+    });
+    app.commands.addKeyBinding({
+      command: CommandIDs.focusChatInput,
+      keys: ['Accel Shift L'],
+      selector: 'body'
+    });
+
     app.docRegistry.addWidgetExtension(
       'Notebook',
       new NotebookGenerationToolbarExtension({
@@ -1916,6 +1954,10 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
 
     palette.addItem({
       command: CommandIDs.openConfigurationDialog,
+      category: 'Notebook Intelligence'
+    });
+    palette.addItem({
+      command: CommandIDs.focusChatInput,
       category: 'Notebook Intelligence'
     });
 


### PR DESCRIPTION
## Summary

Keyboard-first users had no shortcut to land focus on the NBI chat prompt. Reaching it required clicking the side-panel tab and then tabbing past every intervening control in the sidebar.

## Solution

Register a JupyterLab command `notebook-intelligence:focus-chat-input` bound to `Accel Shift L` (Ctrl+Shift+L on Linux/Windows, Cmd+Shift+L on macOS). The handler activates the NBI sidebar via `app.shell.activateById(panel.id)` and dispatches a `copilotSidebar:focusPrompt` CustomEvent. The React sidebar listens for the event and focuses `promptInputRef.current`, retrying across up to 10 animation frames so the cold-collapsed-sidebar case (multi-frame mount) still lands.

Using a CustomEvent instead of `document.querySelector('#sidebar-user-input textarea')` matches the existing `copilotSidebar:runPrompt` / `copilotSidebar:activeDocumentChanged` / `copilotSidebar:addOutputContext` pattern, keeps the command handler decoupled from the DOM id, and lets the React side use the ref it already owns.

Also added to the command palette under "Notebook Intelligence" for discoverability.

## Testing

- `jlpm tsc --noEmit` clean. `jlpm lint:check` clean. `jlpm jest` 181 passed.
- Six-reviewer pass replaced the original `querySelector` + single-rAF approach with the CustomEvent + multi-frame retry pattern.

## Risks / follow-ups

- The shortcut applies globally (`selector: 'body'`). The JupyterLab command-registry shortcut model lets users remap or remove it via their keyboardShortcuts settings.
- A Galata regression test that presses the binding and asserts focus lands on the textarea is deferred.
- Other NBI activate-panel sites use `tabsmenu:activate-by-id` instead of `activateById`; worth aligning in a follow-up for consistency.
- No tracked GitHub issue; audit identifier (D021) is internal.