### PR TITLE
feat(skills): track upstream for user-imported GitHub skills

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -34,6 +34,29 @@ Pick the target scope (user or project) and NBI fetches, validates, and installs
 
 GitHub auth for imports uses, in order: `GITHUB_TOKEN` → `GH_TOKEN` → `gh` CLI auth. Public-repo imports work without auth.
 
+## Tracking upstream for user-imported skills
+
+The Import-from-GitHub dialog has a **Track upstream** checkbox. When you tick it, the installed skill is stamped with a `tracks_upstream: true` frontmatter flag and the Skills panel shows a per-skill **Sync** button (↻) and a panel-level **Sync tracking skills** button.
+
+Tracking is opt-in per skill and entirely manual. Clicking Sync probes GitHub for the latest commit at the recorded `source` URL, and:
+
+- If the commit SHA matches the last recorded `tracking_ref`, the bundle is left alone (no tarball fetch, no rewrite).
+- Otherwise NBI fetches the new bundle, replaces the bundle directory on disk, and stamps the new `tracking_ref`.
+
+The bundle on disk is **never deleted** by a sync action, even when:
+
+- The GitHub commits-API probe fails (network outage, rate limit). Sync raises a visible error and the existing bundle stays in place.
+- The tarball fetch fails after a successful probe. The rmtree only happens after staging succeeds, so a mid-fetch failure leaves the previous version intact.
+- The upstream repo or subpath disappears entirely. Sync errors; the bundle stays.
+
+A tracking skill is the user's. You can still edit its `SKILL.md`, rename it, delete it. The next Sync overwrites local edits the same way `git pull` would.
+
+Tracking is mutually exclusive with the org-managed flag: a skill that the reconciler installed via the org manifest cannot also be set to track upstream from the user-skill side. To migrate, remove it from the manifest first.
+
+To toggle tracking on a skill you already imported (without the checkbox), open the skill in the editor. A **Track upstream** toggle appears for any non-managed skill with a recorded source URL. Toggling off removes the `tracks_upstream` and `tracking_ref` frontmatter and the Sync button disappears; the bundle becomes an ordinary user-authored skill.
+
+The admin policy `allow_github_skill_import = False` blocks sync too: the same network egress is gated by the same flag, so an admin who disables imports also disables sync.
+
 ## Managed skills via an org manifest
 
 For organization-wide deployments (e.g., Kubeflow notebooks), NBI can install and keep a curated set of Claude skills in sync from a YAML or JSON manifest. Skills installed this way are marked **Managed** in the UI — they are read-only (edit, rename, and delete are disabled) and refreshed on a schedule.

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -1134,6 +1134,11 @@ class SkillsBaseHandler(PolicyGatedHandler):
     exception_status_map = {
         FileExistsError: 409,
         FileNotFoundError: 404,
+        # RuntimeError is reserved for "upstream unreachable" in the sync
+        # path. 502 reflects the wire reality (we proxied to GitHub and
+        # got nothing usable) rather than the default 400 fallback, which
+        # would mislead clients into thinking the request was malformed.
+        RuntimeError: 502,
     }
 
     @property
@@ -1213,6 +1218,13 @@ class SkillDetailHandler(SkillsBaseHandler):
     def put(self, scope, name):
         data = self._parse_json_body()
         if data is None:
+            return
+        # The `tracks_upstream` toggle opts a skill into a future sync
+        # action, which would phone home to GitHub. `allow_github_skill_import
+        # = False` is the network-egress kill switch: blocking sync without
+        # also blocking the toggle would let the bit get set on disk while
+        # the admin's kill switch is supposed to be in effect.
+        if "tracks_upstream" in data and self._reject_if_github_import_disabled():
             return
         try:
             skill = self.skill_manager.update_skill(
@@ -1323,6 +1335,12 @@ class SkillsSyncAllTrackingHandler(SkillsBaseHandler):
     skill: a single broken upstream doesn't stop the rest of the sync.
     """
 
+    # Bound concurrency on the GitHub commits-API probe to keep a
+    # 10-tracking-skill click from exhausting the unauthenticated 60/hour
+    # rate limit in a single burst. Three keeps the probes civil while
+    # collapsing serial worst-case (N * 15s) to roughly N/3 * 15s.
+    SYNC_CONCURRENCY = 3
+
     @tornado.web.authenticated
     async def post(self):
         if self._reject_if_github_import_disabled():
@@ -1331,26 +1349,37 @@ class SkillsSyncAllTrackingHandler(SkillsBaseHandler):
         skills = await loop.run_in_executor(
             None, self.skill_manager.list_tracking_skills
         )
-        results = []
-        for skill in skills:
-            try:
-                outcome = await loop.run_in_executor(
-                    None,
-                    lambda s=skill: self.skill_manager.sync_tracking_skill(
-                        s.scope, s.name
-                    ),
-                )
-                results.append({
-                    "scope": skill.scope,
-                    "name": skill.name,
-                    **outcome,
-                })
-            except Exception as e:  # noqa: BLE001 — per-skill isolation
-                results.append({
-                    "scope": skill.scope,
-                    "name": skill.name,
-                    "error": str(e),
-                })
+        if not skills:
+            self.finish(json.dumps({"results": []}))
+            return
+
+        sem = asyncio.Semaphore(self.SYNC_CONCURRENCY)
+
+        async def sync_one(skill):
+            async with sem:
+                try:
+                    # `lambda s=skill:` captures the skill at iteration
+                    # time so all coroutines don't share the same loop
+                    # variable.
+                    outcome = await loop.run_in_executor(
+                        None,
+                        lambda s=skill: self.skill_manager.sync_tracking_skill(
+                            s.scope, s.name
+                        ),
+                    )
+                    return {
+                        "scope": skill.scope,
+                        "name": skill.name,
+                        **outcome,
+                    }
+                except Exception as e:  # noqa: BLE001 — per-skill isolation
+                    return {
+                        "scope": skill.scope,
+                        "name": skill.name,
+                        "error": str(e),
+                    }
+
+        results = await asyncio.gather(*(sync_one(s) for s in skills))
         self.finish(json.dumps({"results": results}))
 
 

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -1221,6 +1221,10 @@ class SkillDetailHandler(SkillsBaseHandler):
                 description=data.get("description"),
                 allowed_tools=data.get("allowed_tools"),
                 body=data.get("body"),
+                # None preserves the current value; explicit True/False applies.
+                # The manager rejects invalid combinations (managed + tracking,
+                # no source + tracking).
+                tracks_upstream=data.get("tracks_upstream"),
             )
             self.finish(json.dumps({"skill": skill.to_dict(include_body=True)}))
         except (FileNotFoundError, ValueError) as e:
@@ -1277,10 +1281,77 @@ class SkillsImportHandler(SkillsBaseHandler):
                 scope=scope,
                 name_override=data.get("name"),
                 overwrite=bool(data.get("overwrite", False)),
+                tracks_upstream=bool(data.get("tracks_upstream", False)),
             )
             self.finish(json.dumps({"skill": skill.to_dict(include_body=True)}))
         except (FileExistsError, FileNotFoundError, ValueError) as e:
             self._error(e)
+
+
+class SkillSyncHandler(SkillsBaseHandler):
+    """Re-fetch a single user-imported skill that has opted into tracking.
+
+    Gated by the same `allow_github_skill_import` policy as the initial
+    import: sync is the same network egress with the same trust
+    boundary, and an admin who's disabled imports does not want sync
+    silently keeping skills fresh on the side.
+    """
+
+    @tornado.web.authenticated
+    async def post(self, scope, name):
+        if self._reject_if_github_import_disabled():
+            return
+        # The sync action does blocking HTTP (commits-API probe plus
+        # optional tarball download). Run off the event loop so the
+        # Tornado IO thread keeps serving other requests.
+        loop = asyncio.get_event_loop()
+        try:
+            result = await loop.run_in_executor(
+                None,
+                lambda: self.skill_manager.sync_tracking_skill(scope, name),
+            )
+            self.finish(json.dumps(result))
+        except (FileNotFoundError, ValueError, RuntimeError) as e:
+            self._error(e)
+
+
+class SkillsSyncAllTrackingHandler(SkillsBaseHandler):
+    """Batch sync every skill that has `tracks_upstream` enabled.
+
+    Returns per-skill results so the UI can show which ones updated,
+    which were unchanged, and which failed. Failures are isolated per
+    skill: a single broken upstream doesn't stop the rest of the sync.
+    """
+
+    @tornado.web.authenticated
+    async def post(self):
+        if self._reject_if_github_import_disabled():
+            return
+        loop = asyncio.get_event_loop()
+        skills = await loop.run_in_executor(
+            None, self.skill_manager.list_tracking_skills
+        )
+        results = []
+        for skill in skills:
+            try:
+                outcome = await loop.run_in_executor(
+                    None,
+                    lambda s=skill: self.skill_manager.sync_tracking_skill(
+                        s.scope, s.name
+                    ),
+                )
+                results.append({
+                    "scope": skill.scope,
+                    "name": skill.name,
+                    **outcome,
+                })
+            except Exception as e:  # noqa: BLE001 — per-skill isolation
+                results.append({
+                    "scope": skill.scope,
+                    "name": skill.name,
+                    "error": str(e),
+                })
+        self.finish(json.dumps({"results": results}))
 
 
 class SkillsReconcileHandler(SkillsBaseHandler):
@@ -2701,6 +2772,8 @@ class NotebookIntelligence(ExtensionApp):
         route_pattern_skills_import_preview = url_path_join(base_url, "notebook-intelligence", "skills", "import", "preview")
         route_pattern_skills_import = url_path_join(base_url, "notebook-intelligence", "skills", "import")
         route_pattern_skills_reconcile = url_path_join(base_url, "notebook-intelligence", "skills", "reconcile")
+        route_pattern_skills_sync_all = url_path_join(base_url, "notebook-intelligence", "skills", "sync-all-tracking")
+        route_pattern_skill_sync = url_path_join(base_url, "notebook-intelligence", "skills", r"(user|project)", skill_name, "sync")
         route_pattern_skills_reconciler_stop = url_path_join(
             base_url, "notebook-intelligence", "skills", "reconciler", "stop"
         )
@@ -2819,6 +2892,8 @@ class NotebookIntelligence(ExtensionApp):
             (route_pattern_skills_import_preview, SkillsImportPreviewHandler),
             (route_pattern_skills_import, SkillsImportHandler),
             (route_pattern_skills_reconcile, SkillsReconcileHandler),
+            (route_pattern_skills_sync_all, SkillsSyncAllTrackingHandler),
+            (route_pattern_skill_sync, SkillSyncHandler),
             # Deliberately not gated by SkillsBaseHandler — the kill switch
             # must remain reachable while skills_management_policy=force-off
             # is the active state. See the handler docstring.

--- a/notebook_intelligence/skill_github_import.py
+++ b/notebook_intelligence/skill_github_import.py
@@ -234,6 +234,29 @@ def _fetch_tarball(
     return data
 
 
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def resolve_desired_sha(
+    ref_info: "GitHubRef", *, token: Optional[str] = None
+) -> Optional[str]:
+    """Resolve the SHA the caller should treat as "latest" for this ref.
+
+    Short-circuits the commits-API probe when the URL already pins a
+    full 40-char SHA (no point round-tripping GitHub to confirm a SHA
+    we already have). Otherwise probes `get_latest_commit_sha`; returns
+    None on any probe failure so the caller can decide whether to fall
+    back to a tarball fetch or surface the outage. Shared between the
+    managed-skills reconciler and the user-skill track-upstream sync
+    path so both paths agree on what "up to date" means.
+    """
+    if ref_info.ref and _SHA_RE.match(ref_info.ref):
+        return ref_info.ref
+    return get_latest_commit_sha(
+        ref_info.owner, ref_info.repo, ref_info.ref, ref_info.subpath, token=token
+    )
+
+
 def get_latest_commit_sha(
     owner: str,
     repo: str,

--- a/notebook_intelligence/skill_manager.py
+++ b/notebook_intelligence/skill_manager.py
@@ -1,5 +1,4 @@
 import logging
-import re
 import shutil
 import threading
 from pathlib import Path
@@ -14,8 +13,8 @@ from notebook_intelligence.skillset import (
     serialize_skill_md,
 )
 from notebook_intelligence.skill_github_import import (
-    get_latest_commit_sha,
     parse_github_url,
+    resolve_desired_sha,
     stage_skill_from_github,
 )
 
@@ -473,11 +472,7 @@ class SkillManager:
         # silently re-downloading: the user clicked the button expecting a
         # fresh check, and a probe-then-fetch dance would mask real outages.
         ref_info = parse_github_url(skill.source)
-        desired_sha = ref_info.ref if (
-            ref_info.ref and re.match(r"^[0-9a-f]{40}$", ref_info.ref)
-        ) else get_latest_commit_sha(
-            ref_info.owner, ref_info.repo, ref_info.ref, ref_info.subpath,
-        )
+        desired_sha = resolve_desired_sha(ref_info)
         if desired_sha is None:
             raise RuntimeError(
                 "Could not probe GitHub for the latest commit; the existing "

--- a/notebook_intelligence/skill_manager.py
+++ b/notebook_intelligence/skill_manager.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import shutil
 import threading
 from pathlib import Path
@@ -12,7 +13,11 @@ from notebook_intelligence.skillset import (
     SkillScope,
     serialize_skill_md,
 )
-from notebook_intelligence.skill_github_import import stage_skill_from_github
+from notebook_intelligence.skill_github_import import (
+    get_latest_commit_sha,
+    parse_github_url,
+    stage_skill_from_github,
+)
 
 log = logging.getLogger(__name__)
 
@@ -202,6 +207,7 @@ class SkillManager:
         description: Optional[str] = None,
         allowed_tools: Optional[List[str]] = None,
         body: Optional[str] = None,
+        tracks_upstream: Optional[bool] = None,
     ) -> Skill:
         skill = self.get_skill(scope, name)
         if skill is None:
@@ -211,6 +217,28 @@ class SkillManager:
         new_allowed_tools = allowed_tools if allowed_tools is not None else skill.allowed_tools
         new_body = body if body is not None else skill.body
 
+        # `tracks_upstream=None` means "leave unchanged" — caller didn't touch
+        # the toggle. Explicit True/False both apply. Managed skills cannot
+        # opt into tracking; the two metadata pairs are mutually exclusive.
+        if tracks_upstream is None:
+            new_tracks_upstream = skill.tracks_upstream
+        else:
+            if tracks_upstream and skill.managed:
+                raise ValueError(
+                    "Managed skills cannot track upstream; remove from the "
+                    "manifest first."
+                )
+            if tracks_upstream and not skill.source:
+                raise ValueError(
+                    f"Skill '{name}' has no recorded source URL; can only "
+                    "track upstream for GitHub-imported skills."
+                )
+            new_tracks_upstream = bool(tracks_upstream)
+        # Toggling off clears tracking_ref so a future re-opt-in starts
+        # from a clean slate; the existing bundle on disk is otherwise
+        # untouched and becomes a plain user-authored skill again.
+        new_tracking_ref = skill.tracking_ref if new_tracks_upstream else ""
+
         md_content = serialize_skill_md(
             name,
             new_description,
@@ -219,6 +247,8 @@ class SkillManager:
             source=skill.source,
             managed_source=skill.managed_source,
             managed_ref=skill.managed_ref,
+            tracks_upstream=new_tracks_upstream,
+            tracking_ref=new_tracking_ref,
         )
         skill.skill_md_path().write_text(md_content, encoding="utf-8")
 
@@ -234,6 +264,8 @@ class SkillManager:
             source=skill.source,
             managed_source=skill.managed_source,
             managed_ref=skill.managed_ref,
+            tracks_upstream=new_tracks_upstream,
+            tracking_ref=new_tracking_ref,
         )
         self._notify_skills_changed()
         return updated
@@ -263,6 +295,8 @@ class SkillManager:
             source=skill.source,
             managed_source=skill.managed_source,
             managed_ref=skill.managed_ref,
+            tracks_upstream=skill.tracks_upstream,
+            tracking_ref=skill.tracking_ref,
         )
         (new_bundle_dir / SKILL_ENTRY_FILE).write_text(md_content, encoding="utf-8")
 
@@ -359,8 +393,16 @@ class SkillManager:
         scope: SkillScope,
         name_override: Optional[str] = None,
         overwrite: bool = False,
+        tracks_upstream: bool = False,
     ) -> Skill:
-        """Fetch, validate, and install a skill from GitHub into the given scope."""
+        """Fetch, validate, and install a skill from GitHub into the given scope.
+
+        When ``tracks_upstream=True``, stamps the skill with a `tracks_upstream`
+        frontmatter flag so a later sync action can re-fetch from the same
+        URL. The initial install doesn't record a `tracking_ref` because
+        the staging API doesn't surface the resolved commit SHA; the next
+        sync probes the commits API and stamps it.
+        """
         staged = stage_skill_from_github(url)
         try:
             name = name_override.strip() if name_override else staged.name
@@ -386,6 +428,7 @@ class SkillManager:
                 staged.allowed_tools,
                 staged.body,
                 source=staged.canonical_url,
+                tracks_upstream=tracks_upstream,
             )
             (target_dir / SKILL_ENTRY_FILE).write_text(md_content, encoding="utf-8")
 
@@ -394,6 +437,81 @@ class SkillManager:
             return skill
         finally:
             shutil.rmtree(staged.tmp_root, ignore_errors=True)
+
+    def sync_tracking_skill(self, scope: SkillScope, name: str) -> dict:
+        """Re-fetch a tracking skill from its recorded GitHub source.
+
+        Returns a status dict ``{updated: bool, ref: str|None}``. Raises
+        ``FileNotFoundError`` if the skill doesn't exist, ``ValueError`` if
+        the skill isn't tracking-eligible (not opted in, no source URL, or
+        managed). Network/parse failures bubble up so the HTTP layer can
+        surface them as errors; the existing bundle on disk is left intact
+        on any error path (the rmtree happens only after staging succeeds).
+        """
+        skill = self.get_skill(scope, name)
+        if skill is None:
+            raise FileNotFoundError(f"Skill '{name}' not found in {scope} scope")
+        if skill.managed:
+            raise ValueError(
+                f"Skill '{name}' is managed by the org manifest; sync is "
+                "handled by the reconciler, not the track-upstream button."
+            )
+        if not skill.tracks_upstream:
+            raise ValueError(
+                f"Skill '{name}' is not tracking upstream; enable tracking "
+                "before syncing."
+            )
+        if not skill.source:
+            raise ValueError(
+                f"Skill '{name}' has no recorded source URL; cannot sync."
+            )
+
+        # SHA probe first. If the commits API returns a SHA equal to the
+        # last-synced ref, skip the tarball fetch entirely — saves bandwidth
+        # and avoids an unnecessary rmtree/copytree of an unchanged bundle.
+        # If the probe fails (None), surface that as an error rather than
+        # silently re-downloading: the user clicked the button expecting a
+        # fresh check, and a probe-then-fetch dance would mask real outages.
+        ref_info = parse_github_url(skill.source)
+        desired_sha = ref_info.ref if (
+            ref_info.ref and re.match(r"^[0-9a-f]{40}$", ref_info.ref)
+        ) else get_latest_commit_sha(
+            ref_info.owner, ref_info.repo, ref_info.ref, ref_info.subpath,
+        )
+        if desired_sha is None:
+            raise RuntimeError(
+                "Could not probe GitHub for the latest commit; the existing "
+                "skill is unchanged. Try again later."
+            )
+        if skill.tracking_ref == desired_sha:
+            return {"updated": False, "ref": desired_sha}
+
+        staged = stage_skill_from_github(skill.source)
+        try:
+            # Stage succeeded; replacing the bundle is the destructive step.
+            # We preserve the on-disk name (the user may have renamed) and
+            # write the tracking pair back so frontmatter stays consistent.
+            shutil.rmtree(skill.root_path)
+            shutil.copytree(staged.skill_root, skill.root_path)
+            md_content = serialize_skill_md(
+                skill.name,
+                staged.description,
+                staged.allowed_tools,
+                staged.body,
+                source=staged.canonical_url,
+                tracks_upstream=True,
+                tracking_ref=desired_sha,
+            )
+            skill.skill_md_path().write_text(md_content, encoding="utf-8")
+        finally:
+            shutil.rmtree(staged.tmp_root, ignore_errors=True)
+
+        self._notify_skills_changed()
+        return {"updated": True, "ref": desired_sha}
+
+    def list_tracking_skills(self) -> List[Skill]:
+        """Return only installed skills with `tracks_upstream` set."""
+        return [s for s in self.list_skills() if s.tracks_upstream]
 
     def install_managed_from_github(
         self,

--- a/notebook_intelligence/skill_reconciler.py
+++ b/notebook_intelligence/skill_reconciler.py
@@ -11,14 +11,13 @@ from __future__ import annotations
 
 import logging
 import os
-import re
 import threading
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, cast
 
 from notebook_intelligence.skill_github_import import (
-    get_latest_commit_sha,
     parse_github_url,
+    resolve_desired_sha,
 )
 from notebook_intelligence.skill_manager import SkillManager
 from notebook_intelligence.skill_manifest import (
@@ -29,8 +28,6 @@ from notebook_intelligence.skill_manifest import (
 from notebook_intelligence.skillset import Skill, SkillScope
 
 log = logging.getLogger(__name__)
-
-_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 
 
 @dataclass
@@ -199,16 +196,7 @@ class SkillReconciler:
             result.added += 1
 
     def _resolve_desired_sha(self, ref_info) -> Optional[str]:
-        # If the ref is already a full SHA, no API probe needed.
-        if ref_info.ref and _SHA_RE.match(ref_info.ref):
-            return ref_info.ref
-        return get_latest_commit_sha(
-            ref_info.owner,
-            ref_info.repo,
-            ref_info.ref,
-            ref_info.subpath,
-            token=self._managed_token,
-        )
+        return resolve_desired_sha(ref_info, token=self._managed_token)
 
     def _remove_stale(
         self,

--- a/notebook_intelligence/skillset.py
+++ b/notebook_intelligence/skillset.py
@@ -33,6 +33,14 @@ class Skill:
     source: str = ""
     managed_source: str = ""
     managed_ref: str = ""
+    # User-imported GitHub skills can opt into "track upstream": a manual
+    # sync button re-fetches the bundle and replaces it on disk. Distinct
+    # from `managed`: managed skills are org-curated (read-only, can be
+    # auto-removed), tracking skills are user-authored (editable, never
+    # auto-removed). `tracking_ref` records the SHA of the last successful
+    # sync so we can skip the tarball fetch when upstream hasn't moved.
+    tracks_upstream: bool = False
+    tracking_ref: str = ""
 
     @classmethod
     def from_path(cls, dir_path: Path, scope: SkillScope) -> 'Skill':
@@ -52,6 +60,8 @@ class Skill:
             source=frontmatter.get("source", "") or "",
             managed_source=frontmatter.get("managed_source", "") or "",
             managed_ref=frontmatter.get("managed_ref", "") or "",
+            tracks_upstream=bool(frontmatter.get("tracks_upstream", False)),
+            tracking_ref=frontmatter.get("tracking_ref", "") or "",
         )
 
     @property
@@ -88,6 +98,8 @@ class Skill:
             "managed": self.managed,
             "managed_source": self.managed_source,
             "managed_ref": self.managed_ref,
+            "tracks_upstream": self.tracks_upstream,
+            "tracking_ref": self.tracking_ref,
         }
         if include_files:
             data["files"] = self.list_files()
@@ -146,8 +158,15 @@ def serialize_skill_md(
     *,
     managed_source: str = "",
     managed_ref: str = "",
+    tracks_upstream: bool = False,
+    tracking_ref: str = "",
 ) -> str:
-    """Render a SKILL.md markdown string from its fields."""
+    """Render a SKILL.md markdown string from its fields.
+
+    The `tracks_upstream` / `tracking_ref` pair only appears in frontmatter
+    when truthy, so a plain user-imported skill that never opted into
+    tracking has identical on-disk content as before this feature landed.
+    """
     frontmatter: Dict[str, Any] = {"name": name, "description": description}
     if allowed_tools:
         frontmatter["allowed-tools"] = list(allowed_tools)
@@ -157,6 +176,10 @@ def serialize_skill_md(
         frontmatter["managed_source"] = managed_source
     if managed_ref:
         frontmatter["managed_ref"] = managed_ref
+    if tracks_upstream:
+        frontmatter["tracks_upstream"] = True
+    if tracking_ref:
+        frontmatter["tracking_ref"] = tracking_ref
     yaml_text = yaml.safe_dump(frontmatter, sort_keys=False, default_flow_style=False).strip()
     body_text = body.rstrip() + "\n" if body.strip() else ""
     return f"---\n{yaml_text}\n---\n\n{body_text}"

--- a/src/api.ts
+++ b/src/api.ts
@@ -194,7 +194,12 @@ export interface ISkillImportPreview {
   existsInProjectScope: boolean;
 }
 
-function skillFromWire(wire: any): ISkillDetail {
+// Exported for direct testing of the wire-format contract. The snake_case
+// keys it consumes (managed_source, managed_ref, tracks_upstream,
+// tracking_ref, allowed_tools) are the load-bearing JSON shape between
+// the Tornado handlers and the panel; a typo here would silently corrupt
+// user state ("I toggled it on but it didn't stick").
+export function skillFromWire(wire: any): ISkillDetail {
   return {
     scope: wire.scope,
     name: wire.name,

--- a/src/api.ts
+++ b/src/api.ts
@@ -156,6 +156,11 @@ export interface ISkillSummary {
   managed: boolean;
   managedSource: string;
   managedRef: string;
+  // User-imported GitHub skills that opted into auto-sync. Distinct
+  // from `managed`: tracking skills are editable and never auto-removed,
+  // only manually replaced when the user clicks Sync.
+  tracksUpstream: boolean;
+  trackingRef: string;
 }
 
 export interface IReconcileResult {
@@ -201,8 +206,23 @@ function skillFromWire(wire: any): ISkillDetail {
     managed: Boolean(wire.managed),
     managedSource: wire.managed_source ?? '',
     managedRef: wire.managed_ref ?? '',
+    tracksUpstream: Boolean(wire.tracks_upstream),
+    trackingRef: wire.tracking_ref ?? '',
     body: wire.body ?? ''
   };
+}
+
+export interface ISyncSkillResult {
+  updated: boolean;
+  ref: string;
+}
+
+export interface ISyncAllTrackingEntry {
+  scope: SkillScope;
+  name: string;
+  updated?: boolean;
+  ref?: string;
+  error?: string;
 }
 
 function claudeModelFromWire(wire: any): IClaudeModelInfo {
@@ -833,6 +853,7 @@ export class NBIAPI {
       description?: string;
       allowedTools?: string[];
       body?: string;
+      tracksUpstream?: boolean;
     }
   ): Promise<ISkillDetail> {
     const wire: any = {};
@@ -844,6 +865,9 @@ export class NBIAPI {
     }
     if (payload.body !== undefined) {
       wire.body = payload.body;
+    }
+    if (payload.tracksUpstream !== undefined) {
+      wire.tracks_upstream = payload.tracksUpstream;
     }
     const data = await requestAPI<any>(
       `skills/${scope}/${encodeURIComponent(name)}`,
@@ -885,6 +909,7 @@ export class NBIAPI {
     scope: SkillScope;
     name?: string;
     overwrite?: boolean;
+    tracksUpstream?: boolean;
   }): Promise<ISkillDetail> {
     const wire: any = { url: payload.url, scope: payload.scope };
     if (payload.name) {
@@ -893,11 +918,44 @@ export class NBIAPI {
     if (payload.overwrite) {
       wire.overwrite = true;
     }
+    if (payload.tracksUpstream) {
+      wire.tracks_upstream = true;
+    }
     const data = await requestAPI<any>('skills/import', {
       method: 'POST',
       body: JSON.stringify(wire)
     });
     return skillFromWire(data.skill);
+  }
+
+  static async syncTrackingSkill(
+    scope: SkillScope,
+    name: string
+  ): Promise<ISyncSkillResult> {
+    const data = await requestAPI<any>(
+      `skills/${scope}/${encodeURIComponent(name)}/sync`,
+      { method: 'POST' }
+    );
+    return {
+      updated: Boolean(data.updated),
+      ref: data.ref ?? ''
+    };
+  }
+
+  static async syncAllTrackingSkills(): Promise<ISyncAllTrackingEntry[]> {
+    const data = await requestAPI<any>('skills/sync-all-tracking', {
+      method: 'POST'
+    });
+    if (!Array.isArray(data?.results)) {
+      return [];
+    }
+    return data.results.map((r: any) => ({
+      scope: r.scope,
+      name: r.name,
+      updated: typeof r.updated === 'boolean' ? r.updated : undefined,
+      ref: typeof r.ref === 'string' ? r.ref : undefined,
+      error: typeof r.error === 'string' ? r.error : undefined
+    }));
   }
 
   static async listClaudeMCPServers(): Promise<IClaudeMCPServer[]> {

--- a/src/components/skills-panel.tsx
+++ b/src/components/skills-panel.tsx
@@ -717,8 +717,8 @@ function GitHubImportDialog(props: {
                     checked={tracksUpstream}
                     onChange={e => setTracksUpstream(e.target.checked)}
                   />
-                  Track upstream — show a Sync button so I can re-pull this
-                  skill from GitHub later
+                  Track upstream. Show a Sync button so I can re-pull this skill
+                  from GitHub later
                 </label>
               </div>
             </>
@@ -1629,7 +1629,7 @@ function SkillEditor(props: {
         </div>
       )}
       {!managed && !effectiveIsNew && skillSource && (
-        <div className="nbi-skills-tracking-row" role="group">
+        <div className="nbi-skills-tracking-row">
           <label className="nbi-checkbox-label">
             <input
               type="checkbox"
@@ -1637,6 +1637,9 @@ function SkillEditor(props: {
               disabled={togglingTracking || saving}
               onChange={async e => {
                 const next = e.target.checked;
+                // Optimistic flip so the checkbox tracks the click while
+                // the PUT is in flight; rolled back on failure below.
+                setTracksUpstream(next);
                 setTogglingTracking(true);
                 setError(null);
                 try {
@@ -1648,6 +1651,9 @@ function SkillEditor(props: {
                   setTracksUpstream(updated.tracksUpstream);
                   setTrackingRef(updated.trackingRef);
                 } catch (err: any) {
+                  // Roll back the optimistic flip so the UI matches the
+                  // server's state (the server kept the prior value).
+                  setTracksUpstream(!next);
                   setError(err?.message ?? String(err));
                 } finally {
                   setTogglingTracking(false);

--- a/src/components/skills-panel.tsx
+++ b/src/components/skills-panel.tsx
@@ -125,6 +125,7 @@ export function SettingsPanelComponentSkills(_props: any): JSX.Element {
     NBIAPI.config.allowGithubSkillImport
   );
   const hasManagedSkills = skills.some(s => s.managed);
+  const hasTrackingSkills = skills.some(s => s.tracksUpstream);
 
   const refresh = async () => {
     setLoading(true);
@@ -186,12 +187,53 @@ export function SettingsPanelComponentSkills(_props: any): JSX.Element {
     setError(null);
     try {
       const r = await NBIAPI.reconcileManagedSkills();
-      const summary = `Sync complete — ${r.added} added, ${r.updated} updated, ${r.removed} removed, ${r.unchanged} unchanged.`;
+      const summary = `Sync complete. ${r.added} added, ${r.updated} updated, ${r.removed} removed, ${r.unchanged} unchanged.`;
       setSyncMessage(
         r.errors.length ? `${summary} (${r.errors.length} error(s))` : summary
       );
       if (r.errors.length) {
         setError(r.errors.join('\n'));
+      }
+      await refresh();
+    } catch (e: any) {
+      setError(`Sync failed: ${e?.message ?? e}`);
+    } finally {
+      setSyncing(false);
+    }
+  };
+
+  const handleSyncTracking = async (skill: ISkillSummary) => {
+    setSyncing(true);
+    setSyncMessage(null);
+    setError(null);
+    try {
+      const r = await NBIAPI.syncTrackingSkill(skill.scope, skill.name);
+      setSyncMessage(
+        r.updated
+          ? `Synced "${skill.name}" to ${r.ref.slice(0, 7)}.`
+          : `"${skill.name}" already up to date at ${r.ref.slice(0, 7)}.`
+      );
+      await refresh();
+    } catch (e: any) {
+      setError(`Sync failed for "${skill.name}": ${e?.message ?? e}`);
+    } finally {
+      setSyncing(false);
+    }
+  };
+
+  const handleSyncAllTracking = async () => {
+    setSyncing(true);
+    setSyncMessage(null);
+    setError(null);
+    try {
+      const results = await NBIAPI.syncAllTrackingSkills();
+      const updated = results.filter(r => r.updated).length;
+      const unchanged = results.filter(r => r.updated === false).length;
+      const errors = results.filter(r => r.error);
+      const summary = `Sync complete. ${updated} updated, ${unchanged} unchanged, ${errors.length} error(s).`;
+      setSyncMessage(summary);
+      if (errors.length) {
+        setError(errors.map(r => `${r.name}: ${r.error}`).join('\n'));
       }
       await refresh();
     } catch (e: any) {
@@ -362,6 +404,18 @@ export function SettingsPanelComponentSkills(_props: any): JSX.Element {
               </div>
             </button>
           )}
+          {hasTrackingSkills && allowGithubImport && (
+            <button
+              className="jp-Dialog-button jp-mod-reject jp-mod-styled"
+              onClick={handleSyncAllTracking}
+              disabled={syncing}
+              title="Re-fetch every skill set to track upstream from GitHub"
+            >
+              <div className="jp-Dialog-buttonLabel">
+                {syncing ? 'Syncing…' : 'Sync tracking skills'}
+              </div>
+            </button>
+          )}
           {allowGithubImport && (
             <button
               className="jp-Dialog-button jp-mod-reject jp-mod-styled"
@@ -410,6 +464,8 @@ export function SettingsPanelComponentSkills(_props: any): JSX.Element {
         onRename={handleRename}
         onDuplicate={handleDuplicate}
         onDelete={handleDelete}
+        onSync={handleSyncTracking}
+        syncDisabled={syncing || !allowGithubImport}
       />
       <SkillScopeSection
         scope="project"
@@ -424,6 +480,8 @@ export function SettingsPanelComponentSkills(_props: any): JSX.Element {
         onRename={handleRename}
         onDuplicate={handleDuplicate}
         onDelete={handleDelete}
+        onSync={handleSyncTracking}
+        syncDisabled={syncing || !allowGithubImport}
       />
       {prompt && (
         <SkillPromptDialog
@@ -465,6 +523,7 @@ function GitHubImportDialog(props: {
   const [preview, setPreview] = useState<ISkillImportPreview | null>(null);
   const [nameOverride, setNameOverride] = useState('');
   const [overwrite, setOverwrite] = useState(false);
+  const [tracksUpstream, setTracksUpstream] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -516,7 +575,8 @@ function GitHubImportDialog(props: {
         url: url.trim(),
         scope,
         name: effectiveName !== preview.name ? effectiveName : undefined,
-        overwrite: collides ? true : undefined
+        overwrite: collides ? true : undefined,
+        tracksUpstream: tracksUpstream || undefined
       });
       await props.onImported();
     } catch (err: any) {
@@ -650,6 +710,17 @@ function GitHubImportDialog(props: {
                   </label>
                 </div>
               )}
+              <div className="nbi-form-field">
+                <label className="nbi-checkbox-label">
+                  <input
+                    type="checkbox"
+                    checked={tracksUpstream}
+                    onChange={e => setTracksUpstream(e.target.checked)}
+                  />
+                  Track upstream — show a Sync button so I can re-pull this
+                  skill from GitHub later
+                </label>
+              </div>
             </>
           )}
         </div>
@@ -717,6 +788,8 @@ function SkillScopeSection(props: {
   onRename: (skill: ISkillSummary) => void;
   onDuplicate: (skill: ISkillSummary) => void;
   onDelete: (skill: ISkillSummary) => void;
+  onSync: (skill: ISkillSummary) => void;
+  syncDisabled: boolean;
 }): JSX.Element {
   return (
     <div className="nbi-skills-section">
@@ -749,6 +822,8 @@ function SkillScopeSection(props: {
           onRename={() => props.onRename(skill)}
           onDuplicate={() => props.onDuplicate(skill)}
           onDelete={() => props.onDelete(skill)}
+          onSync={() => props.onSync(skill)}
+          syncDisabled={props.syncDisabled}
         />
       ))}
     </div>
@@ -766,12 +841,26 @@ function ManagedBadge(props: { source?: string }): JSX.Element {
   );
 }
 
+function TrackingBadge(props: { source: string; ref: string }): JSX.Element {
+  const refSuffix = props.ref ? ` (last sync: ${props.ref.slice(0, 7)})` : '';
+  return (
+    <span
+      className="nbi-skill-tracking-badge"
+      title={`Tracking upstream from ${props.source}${refSuffix}`}
+    >
+      Tracking
+    </span>
+  );
+}
+
 function SkillRow(props: {
   skill: ISkillSummary;
   onEdit: () => void;
   onRename: () => void;
   onDuplicate: () => void;
   onDelete: () => void;
+  onSync: () => void;
+  syncDisabled: boolean;
 }): JSX.Element {
   const { skill } = props;
   const stopAnd = (fn: () => void) => (e: React.MouseEvent) => {
@@ -795,12 +884,27 @@ function SkillRow(props: {
         <div className="nbi-skill-row-name">
           {skill.name}
           {skill.managed && <ManagedBadge source={skill.managedSource} />}
+          {!skill.managed && skill.tracksUpstream && (
+            <TrackingBadge source={skill.source} ref={skill.trackingRef} />
+          )}
         </div>
         {skill.description && (
           <div className="nbi-skill-row-description">{skill.description}</div>
         )}
       </div>
       <div className="nbi-skill-row-actions" onClick={e => e.stopPropagation()}>
+        {!skill.managed && skill.tracksUpstream && (
+          <button
+            type="button"
+            className="nbi-icon-button"
+            aria-label="Sync skill from GitHub"
+            title="Sync from GitHub"
+            onClick={stopAnd(props.onSync)}
+            disabled={props.syncDisabled}
+          >
+            ↻
+          </button>
+        )}
         <button
           type="button"
           className="nbi-icon-button"
@@ -1080,6 +1184,10 @@ function SkillEditor(props: {
   const [hasCreated, setHasCreated] = useState(false);
   const [managed, setManaged] = useState(false);
   const [managedSource, setManagedSource] = useState('');
+  const [tracksUpstream, setTracksUpstream] = useState(false);
+  const [trackingRef, setTrackingRef] = useState('');
+  const [skillSource, setSkillSource] = useState('');
+  const [togglingTracking, setTogglingTracking] = useState(false);
   const [rootPath, setRootPath] = useState('');
   const errorRef = useRef<HTMLDivElement>(null);
 
@@ -1092,6 +1200,9 @@ function SkillEditor(props: {
     setAllowedTools(skill.allowedTools ?? []);
     setManaged(skill.managed);
     setManagedSource(skill.managedSource ?? '');
+    setTracksUpstream(skill.tracksUpstream);
+    setTrackingRef(skill.trackingRef ?? '');
+    setSkillSource(skill.source ?? '');
     setRootPath(skill.rootPath ?? '');
     const skillMdBody = skill.body ?? '';
     setSavedMeta({
@@ -1515,6 +1626,42 @@ function SkillEditor(props: {
         <div className="nbi-skills-managed-banner" role="note">
           This skill is managed by the organization manifest and is read-only.
           Changes will be overwritten on the next sync.
+        </div>
+      )}
+      {!managed && !effectiveIsNew && skillSource && (
+        <div className="nbi-skills-tracking-row" role="group">
+          <label className="nbi-checkbox-label">
+            <input
+              type="checkbox"
+              checked={tracksUpstream}
+              disabled={togglingTracking || saving}
+              onChange={async e => {
+                const next = e.target.checked;
+                setTogglingTracking(true);
+                setError(null);
+                try {
+                  const updated = await NBIAPI.updateSkill(
+                    scope,
+                    effectiveName,
+                    { tracksUpstream: next }
+                  );
+                  setTracksUpstream(updated.tracksUpstream);
+                  setTrackingRef(updated.trackingRef);
+                } catch (err: any) {
+                  setError(err?.message ?? String(err));
+                } finally {
+                  setTogglingTracking(false);
+                }
+              }}
+            />
+            Track upstream
+          </label>
+          <span className="nbi-form-hint">
+            Source: {skillSource}
+            {tracksUpstream &&
+              trackingRef &&
+              ` · last sync: ${trackingRef.slice(0, 7)}`}
+          </span>
         </div>
       )}
 

--- a/style/base.css
+++ b/style/base.css
@@ -1685,9 +1685,12 @@ svg.access-token-warning {
 }
 
 /* Distinct hue from Managed so the two states are visually obvious at a
-   glance: managed = org-curated, tracking = user-opted-in. */
+   glance: managed = org-curated, tracking = user-opted-in.
+   `--jp-info-color3` is the closest semantic match in the JupyterLab
+   theme palette and resolves to a visible color in both light and dark
+   themes. */
 .nbi-skill-tracking-badge {
-  background-color: var(--jp-accept-color3, var(--jp-layout-color2));
+  background-color: var(--jp-info-color3, var(--jp-layout-color3));
 }
 
 .nbi-skills-section {
@@ -2386,6 +2389,11 @@ svg.access-token-warning {
   color: var(--jp-error-color1, #d32f2f);
 }
 
+.nbi-icon-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 .nbi-breadcrumb-link:focus-visible,
 .nbi-skill-editor-tab:focus-visible,
 .nbi-skill-editor-tab-add:focus-visible,
@@ -2394,6 +2402,10 @@ svg.access-token-warning {
 .nbi-icon-button:focus-visible {
   outline: 2px solid var(--jp-brand-color1);
   outline-offset: 1px;
+}
+
+.nbi-icon-button:disabled:hover {
+  background-color: transparent;
 }
 
 .config-dialog-body a {

--- a/style/base.css
+++ b/style/base.css
@@ -1653,18 +1653,41 @@ svg.access-token-warning {
   font-size: var(--jp-ui-font-size1);
 }
 
-.nbi-skill-managed-badge {
+.nbi-skills-tracking-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 6px 12px;
+  margin-bottom: 8px;
+  border-radius: 4px;
+  background-color: var(--jp-layout-color1);
+  border: 1px solid var(--jp-border-color2);
+  font-size: var(--jp-ui-font-size1);
+}
+
+.nbi-skill-managed-badge,
+.nbi-skill-tracking-badge {
   display: inline-block;
   margin-left: 8px;
   padding: 1px 6px;
   border-radius: 10px;
-  background-color: var(--jp-brand-color3, var(--jp-layout-color3));
   color: var(--jp-ui-font-color0);
   font-size: var(--jp-ui-font-size0);
   font-weight: 600;
   vertical-align: middle;
   text-transform: uppercase;
   letter-spacing: 0.04em;
+}
+
+.nbi-skill-managed-badge {
+  background-color: var(--jp-brand-color3, var(--jp-layout-color3));
+}
+
+/* Distinct hue from Managed so the two states are visually obvious at a
+   glance: managed = org-curated, tracking = user-opted-in. */
+.nbi-skill-tracking-badge {
+  background-color: var(--jp-accept-color3, var(--jp-layout-color2));
 }
 
 .nbi-skills-section {

--- a/tests/test_skill_manager.py
+++ b/tests/test_skill_manager.py
@@ -711,7 +711,7 @@ class TestTrackUpstream:
 
     def _patch_sha(self, sha):
         return patch(
-            "notebook_intelligence.skill_manager.get_latest_commit_sha",
+            "notebook_intelligence.skill_github_import.get_latest_commit_sha",
             return_value=sha,
         )
 

--- a/tests/test_skill_manager.py
+++ b/tests/test_skill_manager.py
@@ -693,3 +693,227 @@ class TestInstallManagedFromGithub:
             )
         managed = manager.list_managed_skills()
         assert [s.name for s in managed] == ["mgd"]
+
+
+class TestTrackUpstream:
+    """Sync user-imported GitHub skills that have opted into tracking.
+
+    Distinct from managed skills: tracking skills are editable, never
+    auto-removed by a reconciler, and the user explicitly opts in per
+    bundle.
+    """
+
+    def _patch_tar(self, tar: bytes):
+        return patch(
+            "notebook_intelligence.skill_github_import._fetch_tarball",
+            return_value=tar,
+        )
+
+    def _patch_sha(self, sha):
+        return patch(
+            "notebook_intelligence.skill_manager.get_latest_commit_sha",
+            return_value=sha,
+        )
+
+    def test_import_with_tracks_upstream_stamps_frontmatter(
+        self, manager, skill_dirs
+    ):
+        user_dir, _ = skill_dirs
+        tar = build_tarball({
+            "repo-xyz/SKILL.md": "---\nname: tr\ndescription: d\n---\nb",
+        })
+        with self._patch_tar(tar):
+            skill = manager.import_from_github(
+                "https://github.com/owner/repo",
+                scope="user",
+                tracks_upstream=True,
+            )
+        assert skill.tracks_upstream is True
+        # No tracking_ref yet — first sync will populate it.
+        assert skill.tracking_ref == ""
+        md = (user_dir / "tr" / SKILL_ENTRY_FILE).read_text()
+        assert "tracks_upstream: true" in md
+
+    def test_update_skill_toggles_tracking_off(self, manager, skill_dirs):
+        user_dir, _ = skill_dirs
+        bundle = user_dir / "tr"
+        bundle.mkdir()
+        (bundle / SKILL_ENTRY_FILE).write_text(
+            serialize_skill_md(
+                "tr", "d", [], "b",
+                source="https://github.com/owner/repo",
+                tracks_upstream=True,
+                tracking_ref="abc123",
+            ),
+            encoding="utf-8",
+        )
+        updated = manager.update_skill("user", "tr", tracks_upstream=False)
+        assert updated.tracks_upstream is False
+        # Toggling off clears the ref so re-opt-in starts fresh.
+        assert updated.tracking_ref == ""
+        reloaded = Skill.from_path(bundle, "user")
+        assert reloaded.tracks_upstream is False
+        md = bundle.joinpath(SKILL_ENTRY_FILE).read_text()
+        assert "tracks_upstream" not in md
+        assert "tracking_ref" not in md
+
+    def test_update_skill_rejects_tracking_on_managed(self, manager, skill_dirs):
+        user_dir, _ = skill_dirs
+        bundle = user_dir / "m"
+        bundle.mkdir()
+        (bundle / SKILL_ENTRY_FILE).write_text(
+            serialize_skill_md(
+                "m", "d", [], "b",
+                source="https://github.com/org/repo",
+                managed_source="https://github.com/org/repo",
+                managed_ref="sha",
+            ),
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="Managed skills"):
+            manager.update_skill("user", "m", tracks_upstream=True)
+
+    def test_update_skill_rejects_tracking_on_no_source(
+        self, manager, skill_dirs
+    ):
+        manager.create_skill("user", "plain", "d", [], "b")
+        with pytest.raises(ValueError, match="no recorded source"):
+            manager.update_skill("user", "plain", tracks_upstream=True)
+
+    def test_sync_installs_fresh_bundle(self, manager, skill_dirs):
+        user_dir, _ = skill_dirs
+        # Bootstrap: import skill opting into tracking.
+        first_tar = build_tarball({
+            "repo-xyz/SKILL.md": "---\nname: tr\ndescription: old\n---\nold body",
+        })
+        with self._patch_tar(first_tar):
+            manager.import_from_github(
+                "https://github.com/owner/repo",
+                scope="user",
+                tracks_upstream=True,
+            )
+
+        # Sync: new SHA, new body.
+        new_tar = build_tarball({
+            "repo-xyz/SKILL.md": "---\nname: tr\ndescription: new\n---\nnew body",
+        })
+        with self._patch_sha("def4567"), self._patch_tar(new_tar):
+            result = manager.sync_tracking_skill("user", "tr")
+
+        assert result == {"updated": True, "ref": "def4567"}
+        reloaded = Skill.from_path(user_dir / "tr", "user")
+        assert reloaded.description == "new"
+        assert reloaded.body.strip() == "new body"
+        assert reloaded.tracks_upstream is True
+        assert reloaded.tracking_ref == "def4567"
+
+    def test_sync_skips_when_sha_matches(self, manager, skill_dirs):
+        user_dir, _ = skill_dirs
+        bundle = user_dir / "tr"
+        bundle.mkdir()
+        (bundle / SKILL_ENTRY_FILE).write_text(
+            serialize_skill_md(
+                "tr", "d", [], "old",
+                source="https://github.com/owner/repo",
+                tracks_upstream=True,
+                tracking_ref="sha_match",
+            ),
+            encoding="utf-8",
+        )
+        with self._patch_sha("sha_match"), patch(
+            "notebook_intelligence.skill_github_import._fetch_tarball"
+        ) as fetch:
+            result = manager.sync_tracking_skill("user", "tr")
+        assert result == {"updated": False, "ref": "sha_match"}
+        # Tarball never fetched when SHA matches: saves bandwidth and avoids
+        # an unnecessary rmtree/copytree of an unchanged bundle.
+        fetch.assert_not_called()
+
+    def test_sync_raises_when_probe_fails(self, manager, skill_dirs):
+        user_dir, _ = skill_dirs
+        bundle = user_dir / "tr"
+        bundle.mkdir()
+        (bundle / SKILL_ENTRY_FILE).write_text(
+            serialize_skill_md(
+                "tr", "d", [], "preserved",
+                source="https://github.com/owner/repo",
+                tracks_upstream=True,
+                tracking_ref="abc",
+            ),
+            encoding="utf-8",
+        )
+        with self._patch_sha(None), patch(
+            "notebook_intelligence.skill_github_import._fetch_tarball"
+        ) as fetch:
+            with pytest.raises(RuntimeError, match="probe GitHub"):
+                manager.sync_tracking_skill("user", "tr")
+        # Existing bundle preserved across the failure.
+        reloaded = Skill.from_path(bundle, "user")
+        assert reloaded.body.strip() == "preserved"
+        fetch.assert_not_called()
+
+    def test_sync_rejects_non_tracking_skill(self, manager, skill_dirs):
+        manager.create_skill("user", "plain", "d", [], "b")
+        with pytest.raises(ValueError, match="not tracking upstream"):
+            manager.sync_tracking_skill("user", "plain")
+
+    def test_sync_rejects_managed_skill(self, manager, skill_dirs):
+        user_dir, _ = skill_dirs
+        bundle = user_dir / "m"
+        bundle.mkdir()
+        (bundle / SKILL_ENTRY_FILE).write_text(
+            serialize_skill_md(
+                "m", "d", [], "b",
+                managed_source="https://github.com/org/repo",
+                managed_ref="sha",
+            ),
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="managed by the org"):
+            manager.sync_tracking_skill("user", "m")
+
+    def test_sync_rejects_missing_skill(self, manager):
+        with pytest.raises(FileNotFoundError):
+            manager.sync_tracking_skill("user", "nope")
+
+    def test_sync_preserves_bundle_on_staging_failure(
+        self, manager, skill_dirs
+    ):
+        user_dir, _ = skill_dirs
+        bundle = user_dir / "tr"
+        bundle.mkdir()
+        (bundle / SKILL_ENTRY_FILE).write_text(
+            serialize_skill_md(
+                "tr", "d", [], "preserved",
+                source="https://github.com/owner/repo",
+                tracks_upstream=True,
+                tracking_ref="old",
+            ),
+            encoding="utf-8",
+        )
+        # Probe succeeds with a new SHA, but the tarball fetch raises. The
+        # bundle on disk must NOT be touched (rmtree happens only after
+        # staging succeeds).
+        with self._patch_sha("new_sha"), patch(
+            "notebook_intelligence.skill_github_import._fetch_tarball",
+            side_effect=ValueError("simulated outage"),
+        ):
+            with pytest.raises(ValueError, match="simulated outage"):
+                manager.sync_tracking_skill("user", "tr")
+        reloaded = Skill.from_path(bundle, "user")
+        assert reloaded.body.strip() == "preserved"
+        assert reloaded.tracking_ref == "old"
+
+    def test_list_tracking_skills_filters(self, manager, skill_dirs):
+        manager.create_skill("user", "plain", "d", [], "b")
+        tar = build_tarball({
+            "repo-xyz/SKILL.md": "---\nname: tr\ndescription: d\n---\nb",
+        })
+        with self._patch_tar(tar):
+            manager.import_from_github(
+                "https://github.com/owner/repo",
+                scope="user",
+                tracks_upstream=True,
+            )
+        tracking = manager.list_tracking_skills()
+        assert [s.name for s in tracking] == ["tr"]

--- a/tests/test_skill_manager.py
+++ b/tests/test_skill_manager.py
@@ -156,6 +156,44 @@ class TestManagedFrontmatter:
         assert reloaded.managed_source == "https://github.com/org/repo/tree/main/m"
         assert reloaded.managed_ref == "abc"
 
+    def test_serialize_omits_tracking_keys_when_falsy(self):
+        # A plain user-imported skill that never opted into tracking should
+        # produce identical on-disk content as before the feature landed.
+        content = serialize_skill_md("sk", "d", [], "b")
+        assert "tracks_upstream" not in content
+        assert "tracking_ref" not in content
+
+    def test_from_path_reads_tracking_frontmatter(self, tmp_path):
+        bundle = tmp_path / "sk"
+        bundle.mkdir()
+        (bundle / SKILL_ENTRY_FILE).write_text(
+            serialize_skill_md(
+                "sk", "d", [], "b",
+                source="https://github.com/org/repo/tree/main/sk",
+                tracks_upstream=True,
+                tracking_ref="deadbeef",
+            ),
+            encoding="utf-8",
+        )
+        skill = Skill.from_path(bundle, "user")
+        assert skill.tracks_upstream is True
+        assert skill.tracking_ref == "deadbeef"
+        assert skill.managed is False
+        # `to_dict` exposes both to the frontend.
+        as_dict = skill.to_dict()
+        assert as_dict["tracks_upstream"] is True
+        assert as_dict["tracking_ref"] == "deadbeef"
+
+    def test_from_path_defaults_when_tracking_fields_absent(self, tmp_path):
+        bundle = tmp_path / "sk"
+        bundle.mkdir()
+        (bundle / SKILL_ENTRY_FILE).write_text(
+            serialize_skill_md("sk", "d", [], "b"), encoding="utf-8"
+        )
+        skill = Skill.from_path(bundle, "user")
+        assert skill.tracks_upstream is False
+        assert skill.tracking_ref == ""
+
     def test_rename_skill_preserves_managed_fields(self, manager, skill_dirs):
         user_dir, _ = skill_dirs
         bundle = user_dir / "oldname"

--- a/tests/test_skill_reconciler.py
+++ b/tests/test_skill_reconciler.py
@@ -40,8 +40,11 @@ def _patch_tarball(tar: bytes):
 
 
 def _patch_sha(sha):
+    # Patch at the definition site so it covers both direct callers and the
+    # shared `resolve_desired_sha` wrapper that consumers (reconciler, sync)
+    # both go through.
     return patch(
-        "notebook_intelligence.skill_reconciler.get_latest_commit_sha",
+        "notebook_intelligence.skill_github_import.get_latest_commit_sha",
         return_value=sha,
     )
 
@@ -140,7 +143,7 @@ class TestReconcileInstall:
         reconciler = SkillReconciler(manager, manifest, interval_seconds=60)
 
         with _patch_tarball(tar), patch(
-            "notebook_intelligence.skill_reconciler.get_latest_commit_sha"
+            "notebook_intelligence.skill_github_import.get_latest_commit_sha"
         ) as probe:
             result = reconciler.reconcile()
 
@@ -315,7 +318,7 @@ class TestManagedToken:
         )
 
         with patch(
-            "notebook_intelligence.skill_reconciler.get_latest_commit_sha",
+            "notebook_intelligence.skill_github_import.get_latest_commit_sha",
             return_value="abc123",
         ) as probe, patch(
             "notebook_intelligence.skill_github_import._fetch_tarball",

--- a/tests/test_skills_handlers.py
+++ b/tests/test_skills_handlers.py
@@ -61,6 +61,12 @@ def _make_handler(handler_cls, body: bytes = b"", query_args: dict | None = None
     handler.allow_github_skill_import = SkillsBaseHandler.allow_github_skill_import
     # `_error` reads the real dict, not the spec'd mock proxy.
     handler.exception_status_map = SkillsBaseHandler.exception_status_map
+    # Bind real class attributes from the handler so MagicMock auto-proxies
+    # don't return MagicMock placeholders when handler code reads them
+    # (e.g. SkillsSyncAllTrackingHandler.SYNC_CONCURRENCY).
+    for attr in ("SYNC_CONCURRENCY",):
+        if hasattr(handler_cls, attr):
+            setattr(handler, attr, getattr(handler_cls, attr))
     return handler
 
 
@@ -147,6 +153,89 @@ class TestSkillDetail:
         SkillDetailHandler.put(handler, "user", "x")
         body = _parse_response(handler)
         assert body["skill"]["description"] == "new"
+
+    def test_put_tracks_upstream_on_managed_returns_400(self, skill_manager):
+        # The manager raises ValueError for managed + tracking; the handler
+        # must map that to 400 rather than letting it bubble as a 500.
+        user_dir = skill_manager.scope_dir("user")
+        bundle = user_dir / "m"
+        bundle.mkdir()
+        (bundle / SKILL_ENTRY_FILE).write_text(
+            "---\nname: m\ndescription: d\n"
+            "managed_source: https://github.com/org/repo\n"
+            "managed_ref: sha\n---\nbody",
+            encoding="utf-8",
+        )
+        handler = _make_handler(
+            SkillDetailHandler,
+            body=json.dumps({"tracks_upstream": True}).encode(),
+        )
+        SkillDetailHandler.put(handler, "user", "m")
+        handler.set_status.assert_called_with(400)
+        body = _parse_response(handler)
+        assert "Managed skills" in body["error"]
+
+    def test_put_tracks_upstream_on_no_source_returns_400(self, skill_manager):
+        # A skill with no recorded source URL cannot opt into tracking;
+        # the manager raises ValueError and the handler maps to 400.
+        skill_manager.create_skill("user", "plain", "d", [], "b")
+        handler = _make_handler(
+            SkillDetailHandler,
+            body=json.dumps({"tracks_upstream": True}).encode(),
+        )
+        SkillDetailHandler.put(handler, "user", "plain")
+        handler.set_status.assert_called_with(400)
+        body = _parse_response(handler)
+        assert "no recorded source" in body["error"]
+
+    def test_put_tracks_upstream_blocked_when_github_import_disabled(
+        self, skill_manager
+    ):
+        # The toggle would let an admin's "imports disabled" kill switch
+        # leak: bit gets set, sync still blocked. Reject the toggle when
+        # the policy is off.
+        tar = build_tarball({
+            "repo-x/SKILL.md": "---\nname: x\ndescription: d\n---\nb",
+        })
+        with patch(
+            "notebook_intelligence.skill_github_import._fetch_tarball",
+            return_value=tar,
+        ):
+            skill_manager.import_from_github(
+                "https://github.com/owner/repo", scope="user"
+            )
+        handler = _make_handler(
+            SkillDetailHandler,
+            body=json.dumps({"tracks_upstream": True}).encode(),
+        )
+        handler.allow_github_skill_import = False
+        SkillDetailHandler.put(handler, "user", "x")
+        handler.set_status.assert_called_with(403)
+
+    def test_put_without_tracks_upstream_preserves_current(self, skill_manager):
+        # Regression pin: a PUT body that omits `tracks_upstream` must NOT
+        # silently flip the bit off. The handler passes None for that field
+        # and the manager treats None as "leave unchanged."
+        tar = build_tarball({
+            "repo-x/SKILL.md": "---\nname: x\ndescription: d\n---\nb",
+        })
+        with patch(
+            "notebook_intelligence.skill_github_import._fetch_tarball",
+            return_value=tar,
+        ):
+            skill_manager.import_from_github(
+                "https://github.com/owner/repo",
+                scope="user",
+                tracks_upstream=True,
+            )
+        handler = _make_handler(
+            SkillDetailHandler,
+            body=json.dumps({"description": "new"}).encode(),
+        )
+        SkillDetailHandler.put(handler, "user", "x")
+        body = _parse_response(handler)
+        assert body["skill"]["description"] == "new"
+        assert body["skill"]["tracks_upstream"] is True
 
     def test_update_can_toggle_tracks_upstream(self, skill_manager):
         # Bootstrap a user-imported skill that has a source but isn't
@@ -379,7 +468,7 @@ class TestSkillSyncHandler:
 
     def _patch_sha(self, sha):
         return patch(
-            "notebook_intelligence.skill_manager.get_latest_commit_sha",
+            "notebook_intelligence.skill_github_import.get_latest_commit_sha",
             return_value=sha,
         )
 
@@ -443,6 +532,17 @@ class TestSkillSyncHandler:
         body = _parse_response(handler)
         assert "not tracking upstream" in body["error"]
 
+    def test_sync_probe_failure_maps_to_502(self, skill_manager):
+        # Probe failure raises RuntimeError. The exception_status_map sends
+        # that to 502 (upstream unreachable) rather than the default 400
+        # (which would mislead the client into thinking the request was
+        # malformed).
+        self._bootstrap_tracking_skill(skill_manager)
+        handler = _make_handler(SkillSyncHandler)
+        with self._patch_sha(None):
+            asyncio.run(SkillSyncHandler.post(handler, "user", "tr"))
+        handler.set_status.assert_called_with(502)
+
     def test_sync_returns_403_when_github_import_disabled(self, skill_manager):
         self._bootstrap_tracking_skill(skill_manager)
         handler = _make_handler(SkillSyncHandler)
@@ -454,7 +554,7 @@ class TestSkillSyncHandler:
 class TestSkillsSyncAllTrackingHandler:
     def _patch_sha(self, sha):
         return patch(
-            "notebook_intelligence.skill_manager.get_latest_commit_sha",
+            "notebook_intelligence.skill_github_import.get_latest_commit_sha",
             return_value=sha,
         )
 

--- a/tests/test_skills_handlers.py
+++ b/tests/test_skills_handlers.py
@@ -17,6 +17,8 @@ from notebook_intelligence.extension import (
     SkillsListHandler,
     SkillsReconcileHandler,
     SkillsReconcilerStopHandler,
+    SkillsSyncAllTrackingHandler,
+    SkillSyncHandler,
 )
 from notebook_intelligence.skill_reconciler import ReconcileResult
 from notebook_intelligence.skill_manager import SkillManager
@@ -145,6 +147,27 @@ class TestSkillDetail:
         SkillDetailHandler.put(handler, "user", "x")
         body = _parse_response(handler)
         assert body["skill"]["description"] == "new"
+
+    def test_update_can_toggle_tracks_upstream(self, skill_manager):
+        # Bootstrap a user-imported skill that has a source but isn't
+        # tracking yet. PUT with tracks_upstream=true flips it on.
+        tar = build_tarball({
+            "repo-x/SKILL.md": "---\nname: x\ndescription: d\n---\nbody",
+        })
+        with patch(
+            "notebook_intelligence.skill_github_import._fetch_tarball",
+            return_value=tar,
+        ):
+            skill_manager.import_from_github(
+                "https://github.com/owner/repo", scope="user"
+            )
+        handler = _make_handler(
+            SkillDetailHandler,
+            body=json.dumps({"tracks_upstream": True}).encode(),
+        )
+        SkillDetailHandler.put(handler, "user", "x")
+        body = _parse_response(handler)
+        assert body["skill"]["tracks_upstream"] is True
 
     def test_update_missing_returns_404(self, skill_manager):
         handler = _make_handler(
@@ -326,6 +349,180 @@ class TestSkillsImportHandlers:
         )
         handler.allow_github_skill_import = False
         SkillsImportHandler.post(handler)
+        handler.set_status.assert_called_with(403)
+
+    def test_import_passes_tracks_upstream_flag_through(self, skill_manager):
+        tar = build_tarball({
+            "repo-x/SKILL.md": "---\nname: tr\ndescription: d\n---\nbody",
+        })
+        handler = _make_handler(
+            SkillsImportHandler,
+            body=json.dumps({
+                "url": "https://github.com/owner/repo",
+                "scope": "user",
+                "tracks_upstream": True,
+            }).encode(),
+        )
+        with patch(
+            "notebook_intelligence.skill_github_import._fetch_tarball",
+            return_value=tar,
+        ):
+            SkillsImportHandler.post(handler)
+        body = _parse_response(handler)
+        assert body["skill"]["tracks_upstream"] is True
+
+
+class TestSkillSyncHandler:
+    """Per-skill sync action: re-fetch bundle, replace on disk, surface
+    failures without touching the existing install.
+    """
+
+    def _patch_sha(self, sha):
+        return patch(
+            "notebook_intelligence.skill_manager.get_latest_commit_sha",
+            return_value=sha,
+        )
+
+    def _patch_tar(self, tar):
+        return patch(
+            "notebook_intelligence.skill_github_import._fetch_tarball",
+            return_value=tar,
+        )
+
+    def _bootstrap_tracking_skill(self, manager):
+        tar = build_tarball({
+            "repo-x/SKILL.md": "---\nname: tr\ndescription: old\n---\nold",
+        })
+        with self._patch_tar(tar):
+            manager.import_from_github(
+                "https://github.com/owner/repo",
+                scope="user",
+                tracks_upstream=True,
+            )
+
+    def test_sync_updates_when_sha_changes(self, skill_manager):
+        self._bootstrap_tracking_skill(skill_manager)
+        new_tar = build_tarball({
+            "repo-x/SKILL.md": "---\nname: tr\ndescription: new\n---\nnew",
+        })
+        handler = _make_handler(SkillSyncHandler)
+        with self._patch_sha("def4567"), self._patch_tar(new_tar):
+            asyncio.run(SkillSyncHandler.post(handler, "user", "tr"))
+        body = _parse_response(handler)
+        assert body == {"updated": True, "ref": "def4567"}
+
+    def test_sync_unchanged_short_circuits(self, skill_manager):
+        self._bootstrap_tracking_skill(skill_manager)
+        # First sync stamps the ref. Second sync with same SHA → unchanged.
+        new_tar = build_tarball({
+            "repo-x/SKILL.md": "---\nname: tr\ndescription: d\n---\nb",
+        })
+        handler1 = _make_handler(SkillSyncHandler)
+        with self._patch_sha("aaa"), self._patch_tar(new_tar):
+            asyncio.run(SkillSyncHandler.post(handler1, "user", "tr"))
+
+        handler2 = _make_handler(SkillSyncHandler)
+        with self._patch_sha("aaa"), patch(
+            "notebook_intelligence.skill_github_import._fetch_tarball"
+        ) as fetch:
+            asyncio.run(SkillSyncHandler.post(handler2, "user", "tr"))
+        body = _parse_response(handler2)
+        assert body == {"updated": False, "ref": "aaa"}
+        fetch.assert_not_called()
+
+    def test_sync_returns_404_for_missing_skill(self, skill_manager):
+        handler = _make_handler(SkillSyncHandler)
+        asyncio.run(SkillSyncHandler.post(handler, "user", "ghost"))
+        handler.set_status.assert_called_with(404)
+
+    def test_sync_rejects_non_tracking_skill(self, skill_manager):
+        skill_manager.create_skill("user", "plain", "d", [], "b")
+        handler = _make_handler(SkillSyncHandler)
+        asyncio.run(SkillSyncHandler.post(handler, "user", "plain"))
+        # ValueError maps to 400 via exception_status_map.
+        body = _parse_response(handler)
+        assert "not tracking upstream" in body["error"]
+
+    def test_sync_returns_403_when_github_import_disabled(self, skill_manager):
+        self._bootstrap_tracking_skill(skill_manager)
+        handler = _make_handler(SkillSyncHandler)
+        handler.allow_github_skill_import = False
+        asyncio.run(SkillSyncHandler.post(handler, "user", "tr"))
+        handler.set_status.assert_called_with(403)
+
+
+class TestSkillsSyncAllTrackingHandler:
+    def _patch_sha(self, sha):
+        return patch(
+            "notebook_intelligence.skill_manager.get_latest_commit_sha",
+            return_value=sha,
+        )
+
+    def _patch_tar(self, tar):
+        return patch(
+            "notebook_intelligence.skill_github_import._fetch_tarball",
+            return_value=tar,
+        )
+
+    def test_sync_all_isolates_per_skill_failures(self, skill_manager):
+        # Two tracking skills, one of which will fail to sync.
+        tar = build_tarball({
+            "repo-x/SKILL.md": "---\nname: alpha\ndescription: d\n---\nb",
+        })
+        with self._patch_tar(tar):
+            skill_manager.import_from_github(
+                "https://github.com/owner/alpha-repo",
+                scope="user",
+                tracks_upstream=True,
+            )
+        tar2 = build_tarball({
+            "repo-x/SKILL.md": "---\nname: beta\ndescription: d\n---\nb",
+        })
+        with self._patch_tar(tar2):
+            skill_manager.import_from_github(
+                "https://github.com/owner/beta-repo",
+                scope="user",
+                tracks_upstream=True,
+            )
+        # Probe returns SHA for both; tarball for alpha succeeds, beta
+        # raises (simulated upstream failure).
+        new_tar = build_tarball({
+            "repo-x/SKILL.md": "---\nname: alpha\ndescription: new\n---\nnew",
+        })
+        fetch_calls = {"n": 0}
+
+        def fake_fetch(owner, repo, ref, *, token=None):
+            fetch_calls["n"] += 1
+            if "beta" in repo:
+                raise ValueError("beta upstream offline")
+            return new_tar
+
+        handler = _make_handler(SkillsSyncAllTrackingHandler)
+        with self._patch_sha("sha1"), patch(
+            "notebook_intelligence.skill_github_import._fetch_tarball",
+            side_effect=fake_fetch,
+        ):
+            asyncio.run(SkillsSyncAllTrackingHandler.post(handler))
+        body = _parse_response(handler)
+        results = {r["name"]: r for r in body["results"]}
+        # Alpha synced; beta surfaced an error.
+        assert results["alpha"]["updated"] is True
+        assert "error" in results["beta"]
+        assert "beta upstream offline" in results["beta"]["error"]
+
+    def test_sync_all_with_no_tracking_skills_returns_empty(self, skill_manager):
+        skill_manager.create_skill("user", "plain", "d", [], "b")
+        handler = _make_handler(SkillsSyncAllTrackingHandler)
+        asyncio.run(SkillsSyncAllTrackingHandler.post(handler))
+        body = _parse_response(handler)
+        assert body == {"results": []}
+
+    def test_sync_all_returns_403_when_github_import_disabled(
+        self, skill_manager
+    ):
+        handler = _make_handler(SkillsSyncAllTrackingHandler)
+        handler.allow_github_skill_import = False
+        asyncio.run(SkillsSyncAllTrackingHandler.post(handler))
         handler.set_status.assert_called_with(403)
 
 

--- a/tests/ts/skill-wire-format.test.ts
+++ b/tests/ts/skill-wire-format.test.ts
@@ -1,0 +1,84 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+// Pin the JSON wire-format contract for skills. The HTTP layer speaks
+// snake_case; the panel/API speaks camelCase. A typo in either direction
+// would silently corrupt the most important user-facing state ("I
+// toggled tracking on but it didn't stick after reload"), and the Python
+// tests can't catch it because they test the response shape they
+// produce, not the names the TS layer reads.
+//
+// Tested via the exported `skillFromWire` decoder. Encoders are validated
+// in the panel/API call sites; their snake-case fields are direct
+// literals in the request body, easy to read in src/api.ts.
+
+import { skillFromWire } from '../../src/api';
+
+describe('skillFromWire', () => {
+  function baseWire(extras: Record<string, unknown> = {}) {
+    return {
+      scope: 'user',
+      name: 'sk',
+      description: 'd',
+      allowed_tools: ['Read'],
+      root_path: '/r',
+      files: ['SKILL.md'],
+      source: 'https://github.com/owner/repo',
+      managed: false,
+      managed_source: '',
+      managed_ref: '',
+      tracks_upstream: false,
+      tracking_ref: '',
+      body: 'body',
+      ...extras
+    };
+  }
+
+  it('reads tracks_upstream and tracking_ref from wire snake_case', () => {
+    const skill = skillFromWire(
+      baseWire({ tracks_upstream: true, tracking_ref: 'deadbeef' })
+    );
+    expect(skill.tracksUpstream).toBe(true);
+    expect(skill.trackingRef).toBe('deadbeef');
+  });
+
+  it('defaults tracking fields when absent', () => {
+    // Older backend that doesn't know about the feature: snake_case keys
+    // are missing entirely. Frontend must still produce a well-typed
+    // ISkillDetail with falsy tracking fields rather than NaN/undefined.
+    const wire: any = { ...baseWire() };
+    delete wire.tracks_upstream;
+    delete wire.tracking_ref;
+    const skill = skillFromWire(wire);
+    expect(skill.tracksUpstream).toBe(false);
+    expect(skill.trackingRef).toBe('');
+  });
+
+  it('coerces non-boolean tracks_upstream to false', () => {
+    // The wire field is server-controlled, but the coercion belt-and-
+    // suspenders catches the case where a manually-edited SKILL.md
+    // surfaces a truthy-string ("true") that pyyaml didn't normalize.
+    const skill = skillFromWire(baseWire({ tracks_upstream: 'true' as any }));
+    expect(skill.tracksUpstream).toBe(true); // Boolean('true') is true
+    const skill2 = skillFromWire(baseWire({ tracks_upstream: 0 as any }));
+    expect(skill2.tracksUpstream).toBe(false);
+  });
+
+  it('reads managed and tracking fields independently', () => {
+    // The two metadata pairs are mutually exclusive in practice but
+    // the wire format treats them as independent. Confirm both decode
+    // separately so a future refactor that unifies them has a clean
+    // failure mode.
+    const skill = skillFromWire(
+      baseWire({
+        managed: true,
+        managed_source: 'https://github.com/org/repo',
+        managed_ref: 'sha1'
+      })
+    );
+    expect(skill.managed).toBe(true);
+    expect(skill.managedSource).toBe('https://github.com/org/repo');
+    expect(skill.managedRef).toBe('sha1');
+    // Default tracking fields untouched.
+    expect(skill.tracksUpstream).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

User-imported GitHub skills can now opt into tracking upstream. The Import-from-GitHub dialog has a new **Track upstream** checkbox; ticking it stamps the installed skill with a `tracks_upstream` frontmatter flag and lights up a per-skill **Sync** button (and a panel-level **Sync tracking skills** batch action).

Sync re-fetches the bundle from the recorded `source` URL and replaces the on-disk content. Distinct from the existing managed-skills reconciler: tracking is **opt-in per skill, never auto-scheduled, never auto-removed**. The bundle on disk is preserved across every failure path (probe failure, tarball fetch failure, upstream repo deletion); the user clicked Sync, they're shown the error, and the existing bundle stays put.

## Solution highlights

- **Schema** (`skillset.py`): two new optional frontmatter keys, `tracks_upstream` and `tracking_ref`. Default falsy and omitted from serialized SKILL.md when unset, so existing user-imported skills are unchanged on disk.
- **`SkillManager.sync_tracking_skill(scope, name)`**: probes the commits API for the latest SHA at the recorded source, short-circuits when the SHA matches `tracking_ref` (no tarball fetch, no rmtree). When the SHA differs, stages the new bundle, atomically replaces, stamps the new ref. Probe failure raises rather than silently re-downloading. Tarball-fetch failure preserves the existing bundle on disk (rmtree only happens after staging succeeds).
- **HTTP**: `POST /skills/{scope}/{name}/sync` and `POST /skills/sync-all-tracking` route through `run_in_executor`. The batch endpoint runs per-skill syncs through an `asyncio.Semaphore(3)` so N skills don't take N * 15s in the worst case. Both gated by `allow_github_skill_import` (same network egress, same trust boundary). PUT `/skills/{scope}/{name}` accepts a `tracks_upstream` field for toggling on existing skills; that toggle is also gated by `allow_github_skill_import` so an admin's kill switch can't leak.
- **Shared SHA helper** (`skill_github_import.py`): new `resolve_desired_sha(ref_info, token)` consolidates the "if 40-char SHA short-circuit else probe" dance that the managed reconciler and the new sync path both run.
- **Frontend**: a "Tracking" badge (distinct from "Managed" by color and tooltip), a per-row sync button with disabled-state styling, a panel toolbar batch button, and an editor toggle for opting in/out post-import. The toggle flips optimistically and rolls back on PUT failure so the checkbox always reflects server state.

## Mutual exclusion

A skill cannot be both managed and tracking. The manager refuses to enable tracking on a managed skill (ValueError → 400 at the HTTP layer). The two metadata pairs (`managed_source`/`managed_ref` vs `tracks_upstream`/`tracking_ref`) are independent on the wire but enforced exclusive at the manager.

## Never-delete invariants

The "never delete" contract is enforced by the call ordering:
- `rmtree(skill.root_path)` runs **only after** `stage_skill_from_github` succeeds (which is the only step that can throw on a network or 404 error).
- A probe failure raises before rmtree is even reached.
- The reconciler is not extended to touch tracking skills; only the manual sync action can mutate them.

## Testing

- **`tests/test_skill_manager.py`**: 12 new cases in `TestTrackUpstream` (import opt-in, toggle on/off via update_skill, sync happy path, sync skips on matching SHA, sync raises on probe failure, sync rejects non-tracking/managed/missing skills, sync preserves bundle on staging failure, `list_tracking_skills` filter) plus 3 cases in `TestManagedFrontmatter` for the schema fields.
- **`tests/test_skills_handlers.py`**: 9 new cases (`SkillSyncHandler` happy path, unchanged short-circuit, missing-skill 404, non-tracking rejection, 403 when imports disabled, **502 on probe failure**, plus 4 PUT-toggle cases for managed/no-source/imports-disabled rejection and the regression pin that omitting `tracks_upstream` preserves the current value) plus 3 cases on `SkillsSyncAllTrackingHandler`.
- **`tests/ts/skill-wire-format.test.ts`** (new): 4 cases pinning the `skillFromWire` snake_case ↔ camelCase contract.

Verification: `pytest tests/ --ignore=tests/test_claude_client.py` → 905 passed. `jlpm tsc --noEmit` clean. `jlpm jest` → 185 passed. `jlpm lint:check` clean.

## Risks and follow-ups

- **Concurrent same-skill syncs** (e.g. two browser tabs clicking the per-row Sync button simultaneously) race the `rmtree`/`copytree`. Sync-all is batched within a single handler so cross-skill is safe; only same-skill cross-handler is exposed. A per-skill lock on `SkillManager` is the principled fix; deferred to keep this PR focused.
- **`SkillEditor` state sprawl**: pre-existing trend (now 22+ hooks) amplified by this PR's toggle. `useReducer` would be the right refactor; deferred.
- **No incremental progress feedback during sync-all**: the UI shows "Syncing..." for the whole batch with no per-skill ticker. A future iteration could surface per-skill progress via streaming, but for the typical 1-5 tracking skills the current UX is fine.

Six-agent review pass (code-reuse, code-quality, efficiency, backend/contract, frontend/a11y, test architecture) ran on the four-commit base; the consolidated fix-before-merge items all landed in the final commit (5/5). Remaining items above are documented follow-ups with no immediate impact.