### PR TITLE
security(claude): sandbox UI-bridge tool paths to jupyter_root

### DIFF
--- a/notebook_intelligence/built_in_toolsets.py
+++ b/notebook_intelligence/built_in_toolsets.py
@@ -9,7 +9,18 @@ from pathlib import Path
 import subprocess
 import shlex
 
-from notebook_intelligence.util import get_jupyter_root_dir, redact_env_secrets
+from notebook_intelligence.util import (
+    get_jupyter_root_dir,
+    redact_env_secrets,
+    safe_jupyter_path,
+)
+
+# Backwards-compatible alias: this used to live here as a private helper.
+# Lifted to util.py so Claude-mode tool registrations can share the same
+# gate without an import cycle. Existing call sites in this module keep
+# working through the alias; new code should call ``safe_jupyter_path``
+# directly.
+_get_safe_path = safe_jupyter_path
 
 log = logging.getLogger(__name__)
 
@@ -198,40 +209,6 @@ async def set_file_content(content: str, **args) -> str:
     ui_cmd_response = await response.run_ui_command('notebook-intelligence:set-current-file-content', {"content": content})
 
     return f"Set the file content"
-
-def _get_safe_path(path: str) -> Path:
-    """Validate and return a safe path within jupyter_root_dir.
-    
-    Args:
-        path: Relative or absolute path to validate
-        
-    Returns:
-        Resolved absolute Path object
-        
-    Raises:
-        ValueError: If path is outside jupyter_root_dir
-    """
-    jupyter_root_dir = get_jupyter_root_dir()
-    if jupyter_root_dir is None:
-        raise ValueError("Jupyter root directory is not set")
-
-    root_dir = Path(jupyter_root_dir).expanduser().resolve()
-    target_path = Path(path).expanduser()
-    
-    # If it's a relative path, make it relative to root_dir
-    if not target_path.is_absolute():
-        target_path = root_dir / target_path
-    
-    # Resolve to absolute path
-    target_path = target_path.resolve()
-    
-    # Check if target is within root directory
-    try:
-        target_path.relative_to(root_dir)
-    except ValueError:
-        raise ValueError(f"Path '{path}' is outside allowed directory '{jupyter_root_dir}'")
-    
-    return target_path
 
 @nbapi.tool
 async def search_files(

--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -21,7 +21,7 @@ import logging
 from claude_agent_sdk import AssistantMessage, PermissionResultAllow, PermissionResultDeny, TextBlock, ToolResultBlock, ToolUseBlock, UserMessage, create_sdk_mcp_server, ClaudeAgentOptions, ClaudeSDKClient, tool
 from anthropic.types.text_block import TextBlock as AnthropicTextBlock
 
-from notebook_intelligence.util import ThreadSafeWebSocketConnector, _emit, get_jupyter_root_dir, resolve_claude_cli_path
+from notebook_intelligence.util import ThreadSafeWebSocketConnector, _emit, get_jupyter_root_dir, resolve_claude_cli_path, safe_jupyter_path
 
 log = logging.getLogger(__name__)
 
@@ -1070,16 +1070,36 @@ async def save_notebook(args) -> str:
 @tool("run-command-in-jupyter-terminal", "Runs a shell command in a Jupyter terminal within working_directory.", {"command": str, "working_directory": str})
 async def run_command_in_jupyter_terminal(args) -> str:
     """Run a shell command in a Jupyter terminal within working_directory. This can be used to run long running processes like web applications. Returns the output of the command.
-    
+
     Args:
         command: Shell command to execute in the terminal
         working_directory: Directory to execute command in (relative to Jupyter working directory, default is '' which translates to the Jupyter working directory root)
     """
     try:
+        # Mirror the sandbox the sibling built-in tool applies (see
+        # built_in_toolsets.run_command_in_jupyter_terminal): the cwd is
+        # forwarded to a JupyterLab UI command that opens a real terminal
+        # at any path the user can read, so an LLM-supplied '/etc',
+        # '../../..', or a workspace symlink would otherwise land a shell
+        # outside jupyter_root_dir. Apply the same gate server-side
+        # before the UI bridge is invoked.
+        working_directory = args.get('working_directory', '') or ''
+        try:
+            work_dir = safe_jupyter_path(working_directory)
+        except ValueError as e:
+            return tool_text_response(f"Error: {e}")
+        if not work_dir.exists():
+            return tool_text_response(
+                f"Directory '{working_directory}' does not exist"
+            )
+        if not work_dir.is_dir():
+            return tool_text_response(
+                f"'{working_directory}' is not a directory"
+            )
         response = get_current_response()
         ui_cmd_response = await response.run_ui_command('notebook-intelligence:run-command-in-terminal', {
             'command': args['command'],
-            'cwd': args['working_directory']
+            'cwd': str(work_dir),
         })
         return tool_text_response(ui_cmd_response)
     except Exception as e:
@@ -1089,14 +1109,26 @@ async def run_command_in_jupyter_terminal(args) -> str:
 @tool("open-file-in-jupyter-ui", "Opens a file in the Jupyter UI.", {"file_path": str})
 async def open_file_in_jupyter_ui(args) -> str:
     """Open a file in the Jupyter UI.
-    
+
     Args:
         file_path: Path to the file to open
     """
     try:
+        # ``docmanager:open`` routes the path through JupyterLab's
+        # contents service, which is rooted at ``jupyter_root_dir`` and
+        # rejects out-of-root absolute paths today. Re-apply the same
+        # containment check server-side so we don't depend on that
+        # framework behavior being correct in perpetuity, and so the LLM
+        # gets the same error wording every other path-bearing tool uses
+        # instead of a JupyterLab-internal 404 string.
+        file_path = args.get('file_path', '') or ''
+        try:
+            target = safe_jupyter_path(file_path)
+        except ValueError as e:
+            return tool_text_response(f"Error: {e}")
         response = get_current_response()
         ui_cmd_response = await response.run_ui_command('docmanager:open', {
-            'path': args['file_path']
+            'path': str(target),
         })
         return tool_text_response(ui_cmd_response)
     except Exception as e:

--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -5,6 +5,7 @@ import os
 import sys
 import asyncio
 from enum import Enum
+from pathlib import Path
 from queue import Queue
 import threading
 import time
@@ -152,13 +153,24 @@ def get_current_claude_client() -> ClaudeSDKClient:
     global _current_claude_client
     return _current_claude_client
 
-def tool_text_response(text: Any) -> dict[str, Any]:
-    return {
+def tool_text_response(text: Any, *, is_error: bool = False) -> dict[str, Any]:
+    """Shape an MCP tool result. Set ``is_error=True`` for rejection paths.
+
+    The Claude Agent SDK reads ``result.get("is_error", False)`` and maps
+    it to ``CallToolResult.isError``. Without the flag, model-side retry
+    heuristics treat rejection text as authoritative output instead of a
+    fault to recover from, so a tool call rejected for security reasons
+    can leak into chat as a confusing "successful" result.
+    """
+    result: dict[str, Any] = {
         "content": [{
             "type": "text",
             "text": str(text)
         }]
     }
+    if is_error:
+        result["is_error"] = True
+    return result
 
 def model_info_from_id(model_id: str) -> dict:
     """Get model info, checking cached models first then falling back to defaults."""
@@ -1087,23 +1099,34 @@ async def run_command_in_jupyter_terminal(args) -> str:
         try:
             work_dir = safe_jupyter_path(working_directory)
         except ValueError as e:
-            return tool_text_response(f"Error: {e}")
+            return tool_text_response(f"Error: {e}", is_error=True)
         if not work_dir.exists():
             return tool_text_response(
-                f"Directory '{working_directory}' does not exist"
+                f"Directory '{working_directory}' does not exist",
+                is_error=True,
             )
         if not work_dir.is_dir():
             return tool_text_response(
-                f"'{working_directory}' is not a directory"
+                f"'{working_directory}' is not a directory",
+                is_error=True,
             )
         response = get_current_response()
+        # The frontend command forwards `cwd` directly to JupyterLab's
+        # terminal service (`terminal:create-new`), which hands the
+        # value to a real PTY spawn that honors absolute paths. Send
+        # the sandboxed absolute path so any intermediate that does
+        # cwd-relative resolution can't double-resolve into a different
+        # target.
         ui_cmd_response = await response.run_ui_command('notebook-intelligence:run-command-in-terminal', {
             'command': args['command'],
             'cwd': str(work_dir),
         })
         return tool_text_response(ui_cmd_response)
     except Exception as e:
-        return tool_text_response(f"Error running command in Jupyter terminal: {str(e)}")
+        return tool_text_response(
+            f"Error running command in Jupyter terminal: {str(e)}",
+            is_error=True,
+        )
 
 
 @tool("open-file-in-jupyter-ui", "Opens a file in the Jupyter UI.", {"file_path": str})
@@ -1115,24 +1138,30 @@ async def open_file_in_jupyter_ui(args) -> str:
     """
     try:
         # ``docmanager:open`` routes the path through JupyterLab's
-        # contents service, which is rooted at ``jupyter_root_dir`` and
-        # rejects out-of-root absolute paths today. Re-apply the same
-        # containment check server-side so we don't depend on that
-        # framework behavior being correct in perpetuity, and so the LLM
-        # gets the same error wording every other path-bearing tool uses
-        # instead of a JupyterLab-internal 404 string.
+        # contents service, which is rooted at ``jupyter_root_dir``.
+        # The contents service strips a leading slash and rejoins under
+        # the root (jupyter_server/utils.py: to_os_path), so forwarding
+        # an absolute path would turn '/x/y/foo.ipynb' into
+        # '{root}/x/y/foo.ipynb' and 404. Forward the path *relative to
+        # the workspace root* instead, after safe_jupyter_path has
+        # resolved symlinks / ``..`` and confirmed containment.
         file_path = args.get('file_path', '') or ''
         try:
             target = safe_jupyter_path(file_path)
         except ValueError as e:
-            return tool_text_response(f"Error: {e}")
+            return tool_text_response(f"Error: {e}", is_error=True)
+        root_dir = Path(get_jupyter_root_dir()).expanduser().resolve()
+        relative_path = target.relative_to(root_dir).as_posix()
         response = get_current_response()
         ui_cmd_response = await response.run_ui_command('docmanager:open', {
-            'path': str(target),
+            'path': relative_path,
         })
         return tool_text_response(ui_cmd_response)
     except Exception as e:
-        return tool_text_response(f"Error opening file in Jupyter UI: {str(e)}")
+        return tool_text_response(
+            f"Error opening file in Jupyter UI: {str(e)}",
+            is_error=True,
+        )
 
 async def custom_permission_handler(
     tool_name: str,

--- a/notebook_intelligence/util.py
+++ b/notebook_intelligence/util.py
@@ -37,15 +37,21 @@ def safe_jupyter_path(path: str) -> Path:
     pointing outside is also rejected.
 
     Returns the resolved absolute ``Path``. Raises ``ValueError`` when the
-    workspace root is unset, the input is unrepresentable as a path
-    (e.g. embedded NUL), or the resolved target is outside the workspace.
+    LLM-supplied input is rejected (outside the workspace, embedded NUL,
+    or otherwise unrepresentable). Raises ``RuntimeError`` for the
+    "workspace root not set" case so callers that do ``except ValueError``
+    to surface a sandbox-violation message to the LLM don't accidentally
+    swallow a server-side misconfiguration as if it were user input.
     Callers handle existence / file-vs-directory checks themselves so
     they can produce the contextual error message the LLM needs to
     correct its tool call.
     """
     jupyter_root_dir = get_jupyter_root_dir()
     if jupyter_root_dir is None:
-        raise ValueError("Jupyter root directory is not set")
+        raise RuntimeError(
+            "Jupyter root directory is not set; "
+            "set_jupyter_root_dir was not called before this code path."
+        )
 
     root_dir = Path(jupyter_root_dir).expanduser().resolve()
     target_path = Path(path).expanduser()

--- a/notebook_intelligence/util.py
+++ b/notebook_intelligence/util.py
@@ -5,6 +5,7 @@ import base64
 import re
 import shutil
 import subprocess
+from pathlib import Path
 from typing import Optional, Set
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
@@ -21,6 +22,47 @@ def set_jupyter_root_dir(root_dir: str):
 
 def get_jupyter_root_dir() -> str:
     return _jupyter_root_dir
+
+
+def safe_jupyter_path(path: str) -> Path:
+    """Resolve ``path`` and confirm it stays inside ``jupyter_root_dir``.
+
+    The single chokepoint every tool / handler should funnel an LLM-supplied
+    path through before handing it to ``subprocess.Popen(cwd=...)``,
+    ``docmanager:open``, ``terminal:create-new``, or any other shell- or
+    UI-bridge that would otherwise honor an absolute path or a ``..``
+    traversal. Relative paths are interpreted relative to the workspace
+    root. ``Path.resolve()`` collapses ``..`` segments and chases symlinks
+    before the containment check, so a workspace-internal symlink
+    pointing outside is also rejected.
+
+    Returns the resolved absolute ``Path``. Raises ``ValueError`` when the
+    workspace root is unset, the input is unrepresentable as a path
+    (e.g. embedded NUL), or the resolved target is outside the workspace.
+    Callers handle existence / file-vs-directory checks themselves so
+    they can produce the contextual error message the LLM needs to
+    correct its tool call.
+    """
+    jupyter_root_dir = get_jupyter_root_dir()
+    if jupyter_root_dir is None:
+        raise ValueError("Jupyter root directory is not set")
+
+    root_dir = Path(jupyter_root_dir).expanduser().resolve()
+    target_path = Path(path).expanduser()
+
+    if not target_path.is_absolute():
+        target_path = root_dir / target_path
+
+    target_path = target_path.resolve()
+
+    try:
+        target_path.relative_to(root_dir)
+    except ValueError:
+        raise ValueError(
+            f"Path '{path}' is outside allowed directory '{jupyter_root_dir}'"
+        )
+
+    return target_path
 
 
 _cached_cli_paths: dict[str, Optional[str]] = {}

--- a/tests/test_claude_tool_path_sandbox.py
+++ b/tests/test_claude_tool_path_sandbox.py
@@ -1,0 +1,238 @@
+"""Scope tests for the Claude-mode UI-bridge tools.
+
+The two MCP tools registered in ``claude.py`` (``run-command-in-jupyter-terminal``
+and ``open-file-in-jupyter-ui``) forward their path arguments to JupyterLab
+UI commands (``terminal:create-new`` via ``notebook-intelligence:run-command-in-terminal``
+and ``docmanager:open``). Before this fix the values were passed straight
+through unsanitized: an LLM tool call with ``working_directory='/etc'`` or
+``file_path='../../../etc/passwd'`` would land the bridge outside
+``jupyter_root_dir``. The sibling ``built_in_toolsets`` tools (covered by
+``test_builtin_toolset_cwd_sandbox.py``) already had the gate; this file
+mirrors that coverage for the Claude-mode siblings.
+"""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+import notebook_intelligence.claude as claude_mod
+from notebook_intelligence.util import set_jupyter_root_dir
+
+
+@pytest.fixture
+def jupyter_root(tmp_path):
+    # Workspace lives under tmp_path so the parent remains available as an
+    # "outside the workspace" target for symlink + absolute-path tests.
+    root = tmp_path / "workspace"
+    root.mkdir()
+    set_jupyter_root_dir(str(root))
+    yield root
+    set_jupyter_root_dir(None)
+
+
+@pytest.fixture
+def response_spy():
+    # The tool calls `claude.get_current_response().run_ui_command(...)`.
+    # Inject a spy so each test can observe whether the UI command was
+    # invoked at all, and with what payload when it was.
+    response = MagicMock()
+
+    async def fake_run_ui_command(cmd, payload):
+        return "ok"
+
+    response.run_ui_command.side_effect = fake_run_ui_command
+    claude_mod.set_current_response(response)
+    yield response
+    claude_mod.set_current_response(None)
+
+
+def _invoke_run_command(working_directory: str, command: str = "echo hi"):
+    """Drive run-command-in-jupyter-terminal. Returns the tool's response
+    dict so the test can read the text the LLM would see, plus the
+    response spy so it can assert the UI command (didn't) fire.
+    """
+    handler = claude_mod.run_command_in_jupyter_terminal.handler
+    result = asyncio.run(
+        handler({"command": command, "working_directory": working_directory})
+    )
+    return result, claude_mod.get_current_response().run_ui_command
+
+
+def _invoke_open_file(file_path: str):
+    handler = claude_mod.open_file_in_jupyter_ui.handler
+    result = asyncio.run(handler({"file_path": file_path}))
+    return result, claude_mod.get_current_response().run_ui_command
+
+
+def _text(result) -> str:
+    """Extract the text block from a tool_text_response payload."""
+    return result["content"][0]["text"]
+
+
+class TestRunCommandInJupyterTerminalSandbox:
+    """The Claude-mode sibling of built_in_toolsets.run_command_in_jupyter_terminal.
+    Same security property: the cwd forwarded to the JupyterLab UI command
+    must resolve inside jupyter_root_dir, regardless of what the LLM
+    supplies.
+    """
+
+    def test_rejects_absolute_path_outside_jupyter_root(
+        self, jupyter_root, response_spy
+    ):
+        result, ui_spy = _invoke_run_command("/etc")
+        assert "outside allowed directory" in _text(result)
+        ui_spy.assert_not_called()
+
+    def test_rejects_relative_traversal_outside_jupyter_root(
+        self, jupyter_root, response_spy
+    ):
+        result, ui_spy = _invoke_run_command("../../..")
+        assert "outside allowed directory" in _text(result)
+        ui_spy.assert_not_called()
+
+    def test_rejects_workspace_symlink_pointing_outside(
+        self, jupyter_root, response_spy, tmp_path
+    ):
+        # A symlink inside the workspace pointing to /etc would let the LLM
+        # escape via Path.resolve() chasing it. Pin that resolve() is
+        # called before the relative_to() containment check.
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        link = jupyter_root / "escape"
+        link.symlink_to(outside, target_is_directory=True)
+        result, ui_spy = _invoke_run_command("escape")
+        assert "outside allowed directory" in _text(result)
+        ui_spy.assert_not_called()
+
+    def test_rejects_traversal_via_valid_subdir_prefix(
+        self, jupyter_root, response_spy
+    ):
+        # `valid/../../..` resolves above the root even though the literal
+        # prefix is a real subdir. Pins that resolve() collapses `..`
+        # before the containment check.
+        (jupyter_root / "valid").mkdir()
+        result, ui_spy = _invoke_run_command("valid/../../..")
+        assert "outside allowed directory" in _text(result)
+        ui_spy.assert_not_called()
+
+    def test_rejects_null_byte_in_path(self, jupyter_root, response_spy):
+        # pathlib raises ValueError on embedded NUL bytes. The fix's
+        # try/except converts that to a tool-result error string without
+        # forwarding to the UI command. Pin so a future refactor that
+        # swallows the exception cannot reopen the hole.
+        result, ui_spy = _invoke_run_command("evil\x00")
+        # Either the explicit "outside" branch (after pathlib normalizes)
+        # or the pathlib-raised ValueError → "Error: ..." string. The
+        # load-bearing assertion is that the UI bridge never fired.
+        ui_spy.assert_not_called()
+        assert isinstance(_text(result), str)
+
+    def test_rejects_nonexistent_directory(self, jupyter_root, response_spy):
+        result, ui_spy = _invoke_run_command("does-not-exist")
+        assert "does not exist" in _text(result)
+        ui_spy.assert_not_called()
+
+    def test_rejects_path_that_is_a_file_not_a_directory(
+        self, jupyter_root, response_spy
+    ):
+        f = jupyter_root / "note.txt"
+        f.write_text("hi")
+        result, ui_spy = _invoke_run_command("note.txt")
+        assert "not a directory" in _text(result)
+        ui_spy.assert_not_called()
+
+    def test_allows_relative_subdirectory(self, jupyter_root, response_spy):
+        sub = jupyter_root / "work"
+        sub.mkdir()
+        result, ui_spy = _invoke_run_command("work")
+        assert ui_spy.call_count == 1
+        payload = ui_spy.call_args.args[1]
+        # cwd is the sandboxed absolute path, not the LLM-supplied
+        # relative value. Belt-and-suspenders: the JupyterLab command
+        # gets a fully-resolved path so a future intermediate that does
+        # its own cwd-relative resolution can't double-resolve.
+        assert payload["cwd"] == str(sub.resolve())
+        # Command is forwarded verbatim.
+        assert payload["command"] == "echo hi"
+
+    def test_dot_means_jupyter_root(self, jupyter_root, response_spy):
+        result, ui_spy = _invoke_run_command(".")
+        assert ui_spy.call_count == 1
+        payload = ui_spy.call_args.args[1]
+        assert payload["cwd"] == str(jupyter_root.resolve())
+
+    def test_empty_string_means_jupyter_root(self, jupyter_root, response_spy):
+        # The schema doc says "default is '' which translates to the
+        # Jupyter working directory root". safe_jupyter_path treats an
+        # empty path as the root via the relative-join branch. Pin so a
+        # future ``if not working_directory: ...`` short-circuit can't
+        # bypass the gate by feeding `""` straight through.
+        result, ui_spy = _invoke_run_command("")
+        assert ui_spy.call_count == 1
+        payload = ui_spy.call_args.args[1]
+        assert payload["cwd"] == str(jupyter_root.resolve())
+
+
+class TestOpenFileInJupyterUiSandbox:
+    """The open-file tool routes through ``docmanager:open``, which today
+    rejects out-of-root absolute paths via JupyterLab's contents service.
+    Re-applying the same containment check server-side keeps the security
+    posture from depending on a framework behavior, and gives the LLM the
+    same error wording the other path-bearing tools use instead of a
+    JupyterLab-internal 404 string.
+    """
+
+    def test_rejects_absolute_path_outside_jupyter_root(
+        self, jupyter_root, response_spy
+    ):
+        result, ui_spy = _invoke_open_file("/etc/passwd")
+        assert "outside allowed directory" in _text(result)
+        ui_spy.assert_not_called()
+
+    def test_rejects_relative_traversal_outside_jupyter_root(
+        self, jupyter_root, response_spy
+    ):
+        result, ui_spy = _invoke_open_file("../../etc/passwd")
+        assert "outside allowed directory" in _text(result)
+        ui_spy.assert_not_called()
+
+    def test_rejects_workspace_symlink_pointing_outside(
+        self, jupyter_root, response_spy, tmp_path
+    ):
+        outside = tmp_path / "outside.txt"
+        outside.write_text("secret")
+        link = jupyter_root / "escape.txt"
+        link.symlink_to(outside)
+        result, ui_spy = _invoke_open_file("escape.txt")
+        assert "outside allowed directory" in _text(result)
+        ui_spy.assert_not_called()
+
+    def test_rejects_null_byte_in_path(self, jupyter_root, response_spy):
+        result, ui_spy = _invoke_open_file("foo\x00.txt")
+        ui_spy.assert_not_called()
+        assert isinstance(_text(result), str)
+
+    def test_allows_relative_file_inside_root(self, jupyter_root, response_spy):
+        # Existence isn't a server-side concern here (docmanager:open will
+        # surface a missing-file error in its own UX). The security gate
+        # only verifies containment.
+        (jupyter_root / "notebook.ipynb").write_text("{}")
+        result, ui_spy = _invoke_open_file("notebook.ipynb")
+        assert ui_spy.call_count == 1
+        payload = ui_spy.call_args.args[1]
+        # The sandboxed absolute path is forwarded, not the LLM-supplied
+        # relative value, so any intermediate that does cwd-relative
+        # resolution can't double-resolve into a different file.
+        assert payload["path"] == str((jupyter_root / "notebook.ipynb").resolve())
+
+    def test_allows_file_that_does_not_exist_yet(
+        self, jupyter_root, response_spy
+    ):
+        # docmanager:open is also used to open files about to be created.
+        # The security gate must not require existence (that's a UX
+        # concern, surfaced by docmanager).
+        result, ui_spy = _invoke_open_file("brand-new.ipynb")
+        assert ui_spy.call_count == 1
+        payload = ui_spy.call_args.args[1]
+        assert payload["path"].endswith("brand-new.ipynb")

--- a/tests/test_claude_tool_path_sandbox.py
+++ b/tests/test_claude_tool_path_sandbox.py
@@ -17,34 +17,36 @@ from unittest.mock import MagicMock
 import pytest
 
 import notebook_intelligence.claude as claude_mod
-from notebook_intelligence.util import set_jupyter_root_dir
+from notebook_intelligence import util as util_mod
 
 
 @pytest.fixture
-def jupyter_root(tmp_path):
+def jupyter_root(tmp_path, monkeypatch):
     # Workspace lives under tmp_path so the parent remains available as an
     # "outside the workspace" target for symlink + absolute-path tests.
+    # `monkeypatch.setattr` resets to the prior value on teardown even if
+    # the test raises, so state can't leak across tests; matches the
+    # sibling pattern in test_builtin_toolset_cwd_sandbox.py.
     root = tmp_path / "workspace"
     root.mkdir()
-    set_jupyter_root_dir(str(root))
-    yield root
-    set_jupyter_root_dir(None)
+    monkeypatch.setattr(util_mod, "_jupyter_root_dir", str(root))
+    return root
 
 
 @pytest.fixture
-def response_spy():
+def response_spy(monkeypatch):
     # The tool calls `claude.get_current_response().run_ui_command(...)`.
     # Inject a spy so each test can observe whether the UI command was
-    # invoked at all, and with what payload when it was.
+    # invoked at all, and with what payload when it was. monkeypatch
+    # restores _current_response on teardown even if the test raises.
     response = MagicMock()
 
     async def fake_run_ui_command(cmd, payload):
         return "ok"
 
     response.run_ui_command.side_effect = fake_run_ui_command
-    claude_mod.set_current_response(response)
-    yield response
-    claude_mod.set_current_response(None)
+    monkeypatch.setattr(claude_mod, "_current_response", response)
+    return response
 
 
 def _invoke_run_command(working_directory: str, command: str = "echo hi"):
@@ -221,10 +223,12 @@ class TestOpenFileInJupyterUiSandbox:
         result, ui_spy = _invoke_open_file("notebook.ipynb")
         assert ui_spy.call_count == 1
         payload = ui_spy.call_args.args[1]
-        # The sandboxed absolute path is forwarded, not the LLM-supplied
-        # relative value, so any intermediate that does cwd-relative
-        # resolution can't double-resolve into a different file.
-        assert payload["path"] == str((jupyter_root / "notebook.ipynb").resolve())
+        # `docmanager:open` routes its `path` through
+        # JupyterLab's contents service, which strips the leading slash
+        # and rejoins under root_dir (jupyter_server.utils.to_os_path).
+        # Forwarding an absolute path would 404 the file. The sandbox
+        # forwards the *relative-to-root* form so the lookup succeeds.
+        assert payload["path"] == "notebook.ipynb"
 
     def test_allows_file_that_does_not_exist_yet(
         self, jupyter_root, response_spy
@@ -235,4 +239,81 @@ class TestOpenFileInJupyterUiSandbox:
         result, ui_spy = _invoke_open_file("brand-new.ipynb")
         assert ui_spy.call_count == 1
         payload = ui_spy.call_args.args[1]
-        assert payload["path"].endswith("brand-new.ipynb")
+        assert payload["path"] == "brand-new.ipynb"
+
+    def test_allows_nested_path_relative_to_root(
+        self, jupyter_root, response_spy
+    ):
+        # A deeper path inside the workspace forwards as the relative
+        # POSIX form, not the absolute one.
+        sub = jupyter_root / "notebooks" / "experiments"
+        sub.mkdir(parents=True)
+        result, ui_spy = _invoke_open_file("notebooks/experiments/exp1.ipynb")
+        assert ui_spy.call_count == 1
+        payload = ui_spy.call_args.args[1]
+        assert payload["path"] == "notebooks/experiments/exp1.ipynb"
+
+
+class TestMCPErrorSignalling:
+    """Pin that rejection paths set the MCP ``is_error`` flag. Without
+    this, the Claude Agent SDK treats the rejection text as a successful
+    tool result and model-side retry heuristics can't tell sandbox
+    violations apart from authoritative output. The flag is read at
+    ``claude_agent_sdk/__init__.py``: ``result.get("is_error", False)``
+    → ``CallToolResult.isError``.
+    """
+
+    def test_run_command_outside_root_sets_is_error(
+        self, jupyter_root, response_spy
+    ):
+        result, ui_spy = _invoke_run_command("/etc")
+        assert result.get("is_error") is True
+        ui_spy.assert_not_called()
+
+    def test_run_command_nonexistent_dir_sets_is_error(
+        self, jupyter_root, response_spy
+    ):
+        result, ui_spy = _invoke_run_command("does-not-exist")
+        assert result.get("is_error") is True
+        ui_spy.assert_not_called()
+
+    def test_run_command_happy_path_no_is_error(
+        self, jupyter_root, response_spy
+    ):
+        (jupyter_root / "work").mkdir()
+        result, ui_spy = _invoke_run_command("work")
+        # Successful call must NOT carry the is_error flag, or the SDK
+        # would treat every legitimate response as a fault.
+        assert "is_error" not in result or result["is_error"] is False
+
+    def test_open_file_outside_root_sets_is_error(
+        self, jupyter_root, response_spy
+    ):
+        result, ui_spy = _invoke_open_file("/etc/passwd")
+        assert result.get("is_error") is True
+        ui_spy.assert_not_called()
+
+
+class TestRootNotSet:
+    """``safe_jupyter_path`` raises ``RuntimeError`` (not ``ValueError``)
+    when the workspace root hasn't been configured, so the tool's
+    ``except ValueError`` block can't swallow a server-side
+    misconfiguration as if it were an LLM-supplied bad path.
+    """
+
+    def test_run_command_propagates_runtime_error(
+        self, monkeypatch, response_spy
+    ):
+        # No jupyter_root fixture: leaves _jupyter_root_dir at whatever
+        # the prior test set, so explicitly clear it for this case.
+        monkeypatch.setattr(util_mod, "_jupyter_root_dir", None)
+        # The outer except Exception still catches RuntimeError and
+        # renders an error response, but the response carries is_error
+        # AND mentions "not set" rather than the LLM-facing "outside
+        # allowed directory" wording. That distinction lets ops alerts
+        # distinguish misconfig from LLM tool-call rejection.
+        result, ui_spy = _invoke_run_command(".")
+        assert result.get("is_error") is True
+        text = result["content"][0]["text"]
+        assert "not set" in text
+        ui_spy.assert_not_called()


### PR DESCRIPTION
## Summary

Follow-up to #290. That PR closed the `working_directory` traversal on the two built-in shell tools (`run_command_in_embedded_terminal` and `built_in_toolsets.run_command_in_jupyter_terminal`) but left the two Claude-mode siblings open with the same shape of bug. This PR closes them.

- `run-command-in-jupyter-terminal` at `claude.py:1071` forwarded `working_directory` straight to the JupyterLab UI command `notebook-intelligence:run-command-in-terminal`, which passes it to `terminal:create-new` as `cwd`. An LLM tool call with `working_directory='/etc'`, `'../../..'`, or a workspace symlink pointing outside opened a terminal there and ran the command.
- `open-file-in-jupyter-ui` at `claude.py:1089` forwarded `file_path` to `docmanager:open`. JupyterLab's contents service today rejects out-of-root absolute paths, but relying on framework behavior left the same shape of bug latent.

## Solution

Three layers, one commit each, plus a remediation commit for the six-agent review findings.

- **Lifted `_get_safe_path` from `built_in_toolsets.py` to `util.safe_jupyter_path`** (public, next to `get_jupyter_root_dir`). `util.py` has no NBI imports, so it's a clean chokepoint with no risk of import cycles. The original module keeps a backwards-compat alias so the 8 existing call sites read identically.
- **Applied the gate at both Claude-mode tools.** `run_command_in_jupyter_terminal` validates `working_directory` and forwards the sandboxed absolute path to the UI bridge (terminal:create-new honors absolute cwd via PTY spawn). `open_file_in_jupyter_ui` validates `file_path` and forwards the *relative-to-root* form to `docmanager:open`, since JupyterLab's contents service strips leading slashes and rejoins under root, so an absolute path would 404.
- **`safe_jupyter_path` raises `RuntimeError` (not `ValueError`)** for the "workspace root not set" case so callers' `except ValueError` blocks can't swallow a server-side misconfig as if the LLM had picked a bad path.
- **`tool_text_response` gains an `is_error` keyword** that maps to MCP's `isError` flag. Every rejection path now sets it so the model treats sandbox violations as faults to recover from rather than as authoritative output.

## Testing

`tests/test_claude_tool_path_sandbox.py` ships 21 cases:

- **`TestRunCommandInJupyterTerminalSandbox`** (10): absolute escape, relative traversal, workspace symlink pointing outside, traversal via a valid-subdir prefix (`valid/../../..`, pins that `resolve()` collapses `..` before the containment check), embedded NUL, nonexistent dir, file-not-dir, plus positive cases for relative subdir, `.`, and `""` meaning the root. Every rejection asserts the UI bridge spy was never invoked.
- **`TestOpenFileInJupyterUiSandbox`** (7): absolute escape, relative traversal, workspace symlink, embedded NUL, plus three positive cases including a deeper nested path and a not-yet-existing file (docmanager:open is used for paths the user is about to create, so the gate deliberately doesn't require existence).
- **`TestMCPErrorSignalling`** (4): pins `is_error: True` on rejection paths and its absence on happy-path returns.
- **`TestRootNotSet`** (1): pins that the unset-root case surfaces as a distinct error message ("not set") rather than getting reflected as a sandbox violation.

Mirrors the structure of `tests/test_builtin_toolset_cwd_sandbox.py` from PR #290 so the two test files read side-by-side.

Verified the new tests fail without the fix by stashing `claude.py` and re-running the absolute-escape cases; both flunk, then pass once the fix is reapplied.

Full suite: `pytest tests/ --ignore=tests/test_claude_client.py` → 1029 passed. `jlpm tsc --noEmit`, `jlpm lint:check`, `jlpm jest` all clean.

## Six-agent review

Six reviewers (code reuse, code quality, security, frontend bridge, test architecture, API contract) ran in parallel against the first three commits. The remediation commit lands every convergent fix-before-merge finding:

- Three reviewers converged on the `docmanager:open` regression (security, code quality, frontend bridge): the first revision forwarded `str(target)`, an absolute path, which JupyterLab's contents service would 404 every time. Fixed by forwarding `target.relative_to(root_dir).as_posix()`.
- Two reviewers (code quality, API contract) flagged missing `is_error` on MCP rejections. Fixed.
- Test architecture flagged a fixture leak (yield/teardown can leave state across tests). Migrated to `monkeypatch.setattr`.
- Code quality flagged `ValueError` for the unset-root case. Reclassified as `RuntimeError`.

Documented follow-ups (none security-relevant, deferred to keep this PR scoped): rename the 8 `_get_safe_path` call sites to drop the alias; align `execute_command`'s rejection wording with the two terminal tools; relativize `jupyter_root_dir` out of error text for hosted-deployment safety; document Windows hardlink semantics; add URI-encoded-traversal / whitespace-path / very-long-path test cases.

## Risks

- **Behavior change**: an LLM call with an absolute `working_directory` or `file_path` outside the workspace now gets a `is_error: True` response with the documented "outside allowed directory" wording. Matches the existing built-in tools' UX so the model's existing self-correction patterns apply.
- **`open-file-in-jupyter-ui` path shape**: the forwarded payload changes from "whatever the LLM sent" to "the relative-to-root POSIX form." For a relative path the LLM already supplied, this is a normalize-and-pass-through (same path). For an absolute path inside the workspace, the result is a working open instead of a 404. No regression on legitimate calls.