### PR TITLE
fix(deps): drop fastmcp for the official mcp SDK; pin urllib3 for CVE fixes

### DIFF
--- a/notebook_intelligence/mcp_client.py
+++ b/notebook_intelligence/mcp_client.py
@@ -1,0 +1,157 @@
+# Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+"""Thin client adapter backed by the official ``mcp`` Python SDK.
+
+Exposes the small surface NBI uses (``Client``, ``StdioTransport``,
+``StreamableHttpTransport``) so the rest of ``mcp_manager.py`` reads
+identically to its prior ``fastmcp``-backed implementation. The
+underlying protocol types (``Tool``, ``Prompt``, ``Implementation``,
+``TextContent``, ``ImageContent``, etc.) are shared with the SDK, so
+no shape translation is needed at the consumer.
+
+Why this exists rather than just using ``fastmcp``: every ``fastmcp``
+release that NBI's pinned floor (``>=2.11.2``) admits requires
+``python-dotenv>=1.1.0``, while every ``litellm`` release that picks
+up the recent CVE fixes (1.83.1+) hard-pins ``python-dotenv==1.0.1``.
+The two are mutually unsatisfiable; ``pip install -e .`` on a fresh
+Python 3.14 against ``main`` reports ``ResolutionImpossible``. The
+official ``mcp`` SDK is already in NBI's dep tree (via
+``claude-agent-sdk``) and lists ``python-dotenv`` only as an optional
+``cli`` extra, so swapping ``fastmcp`` → ``mcp`` here unblocks the
+install without losing any CVE fix.
+
+Tracked upstream at BerriAI/litellm#25231 (relax the python-dotenv
+pin). Once that lands and propagates through ``fastmcp``-shaped
+clients, this shim can be reverted to a direct ``fastmcp`` import.
+"""
+
+from contextlib import AsyncExitStack
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+from mcp.client.streamable_http import streamablehttp_client
+from mcp.types import Implementation
+
+
+@dataclass
+class StdioTransport:
+    """Constructor-shape parity with ``fastmcp.client.StdioTransport``."""
+
+    command: str
+    args: List[str] = field(default_factory=list)
+    env: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class StreamableHttpTransport:
+    """Constructor-shape parity with ``fastmcp.client.StreamableHttpTransport``."""
+
+    url: str
+    headers: Dict[str, str] = field(default_factory=dict)
+
+
+class Client:
+    """Async context manager that opens an MCP session over the given transport.
+
+    Mirrors the subset of ``fastmcp.Client`` that NBI's MCP manager uses:
+    ``__aenter__``/``__aexit__``, ``ping``, ``list_tools``, ``call_tool``,
+    ``list_prompts``, ``get_prompt``. Return values are the underlying
+    SDK objects (Pydantic models from ``mcp.types``) — the same shapes
+    ``fastmcp`` returned, since fastmcp itself is a thin layer over mcp.
+    """
+
+    def __init__(
+        self,
+        transport,
+        client_info: Optional[Implementation] = None,
+    ):
+        self._transport = transport
+        self._client_info = client_info
+        self._stack: Optional[AsyncExitStack] = None
+        self._session: Optional[ClientSession] = None
+
+    async def __aenter__(self) -> "Client":
+        stack = AsyncExitStack()
+        await stack.__aenter__()
+        try:
+            if isinstance(self._transport, StdioTransport):
+                params = StdioServerParameters(
+                    command=self._transport.command,
+                    args=list(self._transport.args),
+                    env=dict(self._transport.env) if self._transport.env else None,
+                )
+                read, write = await stack.enter_async_context(stdio_client(params))
+            elif isinstance(self._transport, StreamableHttpTransport):
+                # The streamable-http transport yields three values; the
+                # third is a session-id callable we don't use.
+                read, write, _ = await stack.enter_async_context(
+                    streamablehttp_client(
+                        self._transport.url,
+                        headers=dict(self._transport.headers) if self._transport.headers else None,
+                    )
+                )
+            else:
+                raise TypeError(
+                    f"Unsupported MCP transport: {type(self._transport).__name__}"
+                )
+            session = await stack.enter_async_context(
+                ClientSession(read, write, client_info=self._client_info)
+            )
+            await session.initialize()
+        except BaseException:
+            # The exit stack owns every context we entered above; let it
+            # tear them down in reverse order before re-raising so we
+            # don't leak the stdio subprocess or the HTTP connection on
+            # a partially-constructed session.
+            await stack.__aexit__(*_current_exc())
+            raise
+        self._stack = stack
+        self._session = session
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        stack = self._stack
+        self._stack = None
+        self._session = None
+        if stack is None:
+            return False
+        return await stack.__aexit__(exc_type, exc, tb)
+
+    def _require_session(self) -> ClientSession:
+        if self._session is None:
+            raise RuntimeError(
+                "MCP client is not connected. Use `async with client:` first."
+            )
+        return self._session
+
+    async def ping(self) -> Any:
+        return await self._require_session().send_ping()
+
+    async def list_tools(self):
+        """Return a list of ``mcp.types.Tool``, matching fastmcp's shape."""
+        result = await self._require_session().list_tools()
+        return result.tools
+
+    async def call_tool(self, name: str, arguments: dict):
+        """Return ``mcp.types.CallToolResult`` (has ``.content``)."""
+        return await self._require_session().call_tool(name, arguments)
+
+    async def list_prompts(self):
+        """Return a list of ``mcp.types.Prompt``."""
+        result = await self._require_session().list_prompts()
+        return result.prompts
+
+    async def get_prompt(self, name: str, arguments: dict):
+        """Return ``mcp.types.GetPromptResult`` (has ``.messages``)."""
+        return await self._require_session().get_prompt(name, arguments)
+
+
+def _current_exc():
+    """Return ``(exc_type, exc, tb)`` for the in-flight exception, or
+    ``(None, None, None)`` if there isn't one. Used by ``__aenter__`` to
+    forward the original failure to the exit-stack cleanup so partial
+    setup unwinds cleanly."""
+    import sys
+    return sys.exc_info()

--- a/notebook_intelligence/mcp_client.py
+++ b/notebook_intelligence/mcp_client.py
@@ -25,6 +25,7 @@ pin). Once that lands and propagates through ``fastmcp``-shaped
 clients, this shim can be reverted to a direct ``fastmcp`` import.
 """
 
+import sys
 from contextlib import AsyncExitStack
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
@@ -104,8 +105,11 @@ class Client:
             # The exit stack owns every context we entered above; let it
             # tear them down in reverse order before re-raising so we
             # don't leak the stdio subprocess or the HTTP connection on
-            # a partially-constructed session.
-            await stack.__aexit__(*_current_exc())
+            # a partially-constructed session. ``sys.exc_info()`` inside
+            # an except block returns the in-flight exception triple,
+            # which AsyncExitStack.__aexit__ uses to invoke each entered
+            # context's __aexit__ as if the unwind were native.
+            await stack.__aexit__(*sys.exc_info())
             raise
         self._stack = stack
         self._session = session
@@ -146,12 +150,3 @@ class Client:
     async def get_prompt(self, name: str, arguments: dict):
         """Return ``mcp.types.GetPromptResult`` (has ``.messages``)."""
         return await self._require_session().get_prompt(name, arguments)
-
-
-def _current_exc():
-    """Return ``(exc_type, exc, tb)`` for the in-flight exception, or
-    ``(None, None, None)`` if there isn't one. Used by ``__aenter__`` to
-    forward the original failure to the exit-stack cleanup so partial
-    setup unwinds cleanly."""
-    import sys
-    return sys.exc_info()

--- a/notebook_intelligence/mcp_manager.py
+++ b/notebook_intelligence/mcp_manager.py
@@ -9,7 +9,11 @@ import threading
 import time
 from typing import Any, Optional, Union
 import uuid
-from fastmcp.client import StdioTransport, StreamableHttpTransport
+from notebook_intelligence.mcp_client import (
+    Client,
+    StdioTransport,
+    StreamableHttpTransport,
+)
 from mcp import StdioServerParameters
 import mcp
 from mcp.client.stdio import get_default_environment as mcp_get_default_environment
@@ -18,7 +22,6 @@ from notebook_intelligence.api import BackendMessageType, ChatCommand, ChatReque
 from notebook_intelligence.base_chat_participant import BaseChatParticipant
 import logging
 from enum import Enum
-from fastmcp import Client
 from ._version import __version__ as NBI_VERSION
 EDITOR_VERSION = f"NotebookIntelligence/{NBI_VERSION}"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,16 @@ dependencies = [
     "litellm>=1.83.7",
     "openai",
     "ollama",
-    "fastmcp>=2.11.2",
+    # The official Anthropic MCP Python SDK. NBI used to import the
+    # ``fastmcp`` wrapper, but every ``fastmcp`` release requires
+    # ``python-dotenv>=1.1.0`` which is mutually unsatisfiable with the
+    # ``python-dotenv==1.0.1`` hard-pin in ``litellm 1.83.1+``. The
+    # adapter at ``notebook_intelligence/mcp_client.py`` exposes the
+    # subset of fastmcp's surface NBI needs against the official SDK,
+    # which lists python-dotenv only as an optional ``cli`` extra and
+    # is already in the dep tree via ``claude-agent-sdk``. Track
+    # BerriAI/litellm#25231 for the upstream fix.
+    "mcp>=1.27.0",
     "claude-agent-sdk",
     "anthropic>=0.22.1",
     # Transitive lower bounds for known CVEs whose parents don't pin
@@ -49,11 +58,14 @@ dependencies = [
     # cap the upper bound. 2.7.0 picks up CVE-2026-44431 (cross-origin
     # redirect handling) and CVE-2026-44432 (streaming API).
     "urllib3>=2.7.0",
-    # python-dotenv CVE-2026-28684 (fix: 1.2.2) is NOT pinned here because
-    # litellm 1.83.7 hard-pins python-dotenv==1.0.1. Adding a >=1.2.2 lower
-    # bound would force pip to fail resolution on fresh installs. Track
-    # https://github.com/BerriAI/litellm/ for a release that loosens the
-    # pin and re-add this then.
+    # python-dotenv: ``litellm 1.83.1+`` hard-pins ``==1.0.1`` and refuses
+    # to bump it (see BerriAI/litellm#25231 / #26435). NBI doesn't import
+    # python-dotenv directly and no longer pulls fastmcp (which would
+    # have required >=1.1.0), so pip can resolve python-dotenv==1.0.1
+    # from litellm's constraint alone. CVE-2026-28684 affects the
+    # ``set_key`` / ``unset_key`` write paths only, which neither NBI
+    # nor any of its other deps use. Re-add a ``>=1.2.2`` lower bound
+    # when litellm loosens its pin.
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,13 @@ dependencies = [
     "fuzy-jon==0.1.0",
     "tiktoken",
     "cryptography",
-    # 1.83.7 picks up CVE-2026-42203 / CVE-2026-42208 / CVE-2026-42271 fixes.
+    # 1.83.7 picks up CVE-2026-42203 / CVE-2026-42208 / CVE-2026-42271
+    # fixes. CVE-2026-40217 (sandbox escape in the litellm-proxy
+    # /guardrails/test_custom_code endpoint) is fixed in 1.83.10 per
+    # the GHSA-wxxx-gvqv-xp7p advisory, but 1.83.10 has not yet been
+    # released to PyPI. NBI imports litellm as a client library and
+    # does not expose the proxy server endpoints, so the gap is
+    # latent-not-exposed; bump the lower bound when 1.83.10 ships.
     "litellm>=1.83.7",
     "openai",
     "ollama",
@@ -39,6 +45,10 @@ dependencies = [
     # tightly enough on their own.
     "mistune>=3.2.1",  # CVE-2026-33441
     "python-multipart>=0.0.27",  # CVE-2026-42561
+    # urllib3 reaches us via `requests` (tiktoken's dep), which doesn't
+    # cap the upper bound. 2.7.0 picks up CVE-2026-44431 (cross-origin
+    # redirect handling) and CVE-2026-44432 (streaming API).
+    "urllib3>=2.7.0",
     # python-dotenv CVE-2026-28684 (fix: 1.2.2) is NOT pinned here because
     # litellm 1.83.7 hard-pins python-dotenv==1.0.1. Adding a >=1.2.2 lower
     # bound would force pip to fail resolution on fresh installs. Track

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,22 @@ dependencies = [
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 
 [project.optional-dependencies]
-test = ["pytest>=7.0,<9", "pyyaml"]
+# pytest-timeout caps any single test at the [tool.pytest.ini_options]
+# default below. Specific need: the async stdio-subprocess tests in
+# tests/test_mcp_client_shim.py have no internal timeout, so a hung
+# pipe in the underlying ``mcp`` SDK would otherwise hang the entire
+# CI job. ``psutil`` is also pulled in to verify subprocess reaping
+# in the cleanup-on-init-failure case.
+test = ["pytest>=7.0,<9", "pytest-timeout>=2.3.0", "psutil", "pyyaml"]
+
+[tool.pytest.ini_options]
+# Cap every test at 30 seconds. The async stdio-subprocess tests in
+# tests/test_mcp_client_shim.py spawn a real MCP server and rely on
+# the underlying ``mcp`` SDK's pipes; if a pipe ever deadlocks (the
+# SDK has no built-in timeout), the test would otherwise hang the CI
+# job. Other tests in the suite run in milliseconds, so 30s is
+# generous headroom rather than a target.
+timeout = 30
 
 [tool.hatch.version]
 source = "nodejs"

--- a/tests/test_mcp_client_shim.py
+++ b/tests/test_mcp_client_shim.py
@@ -1,0 +1,265 @@
+# Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+"""End-to-end smoke test for the fastmcp -> mcp client adapter.
+
+Spins up a minimal MCP server over stdio in a subprocess, drives the
+shim's full surface against it (ping, list_tools, call_tool,
+list_prompts, get_prompt), and verifies the return shapes match what
+NBI's ``mcp_manager.py`` expects. Without this, a future refactor that
+silently drops the ``await session.initialize()`` call or returns a
+Pydantic envelope where a list was expected would still pass NBI's
+existing test suite — none of which exercise the MCP code path.
+
+Why end-to-end rather than mocked: every claim this shim makes is
+about wire compatibility with the underlying ``mcp`` SDK. Mocking the
+SDK would test the shim's call shape but not the contract it relies
+on. The minimal stdio server is fast (sub-second), uses no network,
+and runs in CI without extra setup beyond the existing ``mcp`` dep.
+"""
+
+import asyncio
+import os
+import sys
+import tempfile
+import textwrap
+
+import pytest
+
+from mcp.types import Implementation
+
+from notebook_intelligence.mcp_client import (
+    Client,
+    StdioTransport,
+    StreamableHttpTransport,
+)
+
+
+_SERVER_SCRIPT = textwrap.dedent(
+    """
+    import asyncio
+    from mcp.server import Server
+    from mcp.server.stdio import stdio_server
+    from mcp.types import (
+        Tool,
+        TextContent,
+        Prompt,
+        PromptArgument,
+        PromptMessage,
+        GetPromptResult,
+    )
+
+    server = Server("nbi-shim-test")
+
+    @server.list_tools()
+    async def list_tools():
+        return [
+            Tool(
+                name="echo",
+                description="Echo input back as text.",
+                inputSchema={
+                    "type": "object",
+                    "properties": {"text": {"type": "string"}},
+                    "required": ["text"],
+                },
+            )
+        ]
+
+    @server.call_tool()
+    async def call_tool(name, args):
+        return [TextContent(type="text", text=f"You said: {args['text']}")]
+
+    @server.list_prompts()
+    async def list_prompts():
+        return [
+            Prompt(
+                name="greet",
+                title="Greet",
+                description="Greet someone by name.",
+                arguments=[
+                    PromptArgument(
+                        name="who",
+                        description="Person to greet.",
+                        required=True,
+                    )
+                ],
+            )
+        ]
+
+    @server.get_prompt()
+    async def get_prompt(name, args):
+        return GetPromptResult(
+            description="Greeting.",
+            messages=[
+                PromptMessage(
+                    role="user",
+                    content=TextContent(type="text", text=f"Hello, {args['who']}!"),
+                )
+            ],
+        )
+
+    async def main():
+        async with stdio_server() as (read, write):
+            await server.run(read, write, server.create_initialization_options())
+
+    asyncio.run(main())
+    """
+)
+
+
+@pytest.fixture(scope="module")
+def server_script_path():
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".py", delete=False
+    ) as f:
+        f.write(_SERVER_SCRIPT)
+        path = f.name
+    try:
+        yield path
+    finally:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+def _stdio_transport(server_script_path: str) -> StdioTransport:
+    return StdioTransport(
+        command=sys.executable,
+        args=[server_script_path],
+        # The MCP server inherits the current process env so it can find
+        # site-packages on PATH; ``stdio_client`` defaults env=None to
+        # ``inherit`` but we pass it explicitly so the adapter's dict
+        # forwarding is also exercised.
+        env=dict(os.environ),
+    )
+
+
+def _client_info() -> Implementation:
+    return Implementation(
+        name="nbi-shim-test", title="NBI shim test", version="0.0.0"
+    )
+
+
+def test_transport_dataclasses_match_fastmcp_shape():
+    # The shim's transports are dataclasses with the same constructor
+    # signature fastmcp.client.StdioTransport / StreamableHttpTransport
+    # accepted, so NBI's existing call sites (e.g.
+    # mcp_manager._create_client) work without translation. Pin the
+    # field names so a future rename can't silently break wire format.
+    stdio = StdioTransport(command="cmd", args=["a"], env={"K": "V"})
+    assert stdio.command == "cmd"
+    assert stdio.args == ["a"]
+    assert stdio.env == {"K": "V"}
+
+    http = StreamableHttpTransport(url="https://x", headers={"Auth": "Bearer x"})
+    assert http.url == "https://x"
+    assert http.headers == {"Auth": "Bearer x"}
+
+
+def test_session_required_before_calls():
+    # Using any Client method before ``async with client:`` is a
+    # programmer error, not user input. Raise loudly so a missing
+    # await on ``__aenter__`` surfaces at the call site rather than
+    # silently producing AttributeError on a None session.
+    client = Client(transport=StdioTransport(command="x"))
+
+    async def call_without_context():
+        await client.list_tools()
+
+    with pytest.raises(RuntimeError, match="not connected"):
+        asyncio.run(call_without_context())
+
+
+def test_unsupported_transport_type_raises():
+    client = Client(transport="not a transport")
+
+    async def go():
+        async with client:
+            pass
+
+    with pytest.raises(TypeError, match="Unsupported MCP transport"):
+        asyncio.run(go())
+
+
+def test_end_to_end_against_real_stdio_server(server_script_path):
+    """The load-bearing test. Drives every shim method against a real
+    MCP server over stdio and asserts the return shapes are exactly
+    what NBI's mcp_manager.py expects to read off them.
+    """
+
+    async def go():
+        transport = _stdio_transport(server_script_path)
+        async with Client(transport, client_info=_client_info()) as client:
+            await client.ping()
+
+            tools = await client.list_tools()
+            # mcp_manager.get_tools() reads tool.name / tool.description
+            # / tool.inputSchema. Pin them.
+            assert len(tools) == 1
+            assert tools[0].name == "echo"
+            assert tools[0].description == "Echo input back as text."
+            assert tools[0].inputSchema["properties"]["text"]["type"] == "string"
+
+            # mcp_manager.handle_tool_call inspects result.content and
+            # iterates TextContent / ImageContent entries.
+            tool_result = await client.call_tool("echo", {"text": "hi"})
+            assert hasattr(tool_result, "content")
+            assert len(tool_result.content) == 1
+            assert tool_result.content[0].type == "text"
+            assert tool_result.content[0].text == "You said: hi"
+
+            # mcp_manager.get_prompts() reads prompt.name / prompt.title /
+            # prompt.description / prompt.arguments[i].{name,description,required}.
+            prompts = await client.list_prompts()
+            assert len(prompts) == 1
+            assert prompts[0].name == "greet"
+            assert prompts[0].title == "Greet"
+            assert prompts[0].description == "Greet someone by name."
+            assert len(prompts[0].arguments) == 1
+            assert prompts[0].arguments[0].name == "who"
+            assert prompts[0].arguments[0].required is True
+
+            # mcp_manager.handle_get_prompt reads message.content.text /
+            # .type. Pin the GetPromptResult.messages shape.
+            prompt_result = await client.get_prompt("greet", {"who": "world"})
+            assert hasattr(prompt_result, "messages")
+            assert len(prompt_result.messages) == 1
+            message = prompt_result.messages[0]
+            assert message.role == "user"
+            assert message.content.type == "text"
+            assert message.content.text == "Hello, world!"
+
+    asyncio.run(go())
+
+
+def test_context_cleanup_on_initialize_failure(tmp_path):
+    """If the server fails to initialize, ``__aenter__`` must unwind
+    every context it entered (the stdio subprocess) before re-raising,
+    so a partial connect doesn't leak processes. Drives an
+    intentionally-broken server script.
+    """
+    bad_script = tmp_path / "bad_server.py"
+    bad_script.write_text(
+        textwrap.dedent(
+            """
+            import sys
+            # Exit immediately so the MCP handshake fails. The shim's
+            # __aenter__ must still tear down the stdio subprocess
+            # cleanly rather than leaving zombies.
+            sys.exit(1)
+            """
+        )
+    )
+
+    async def go():
+        transport = StdioTransport(
+            command=sys.executable,
+            args=[str(bad_script)],
+            env=dict(os.environ),
+        )
+        client = Client(transport, client_info=_client_info())
+        with pytest.raises(Exception):
+            async with client:
+                pass  # pragma: no cover
+
+    asyncio.run(go())

--- a/tests/test_mcp_client_shim.py
+++ b/tests/test_mcp_client_shim.py
@@ -22,7 +22,9 @@ import os
 import sys
 import tempfile
 import textwrap
+import time
 
+import psutil
 import pytest
 
 from mcp.types import Implementation
@@ -236,7 +238,10 @@ def test_context_cleanup_on_initialize_failure(tmp_path):
     """If the server fails to initialize, ``__aenter__`` must unwind
     every context it entered (the stdio subprocess) before re-raising,
     so a partial connect doesn't leak processes. Drives an
-    intentionally-broken server script.
+    intentionally-broken server script and verifies via psutil that no
+    Python child process survives the failure. Without the psutil
+    check, the shim could silently regress to leaking subprocesses and
+    the test would still pass on the ``pytest.raises`` alone.
     """
     bad_script = tmp_path / "bad_server.py"
     bad_script.write_text(
@@ -251,6 +256,23 @@ def test_context_cleanup_on_initialize_failure(tmp_path):
         )
     )
 
+    parent = psutil.Process(os.getpid())
+
+    def _shim_children() -> list[psutil.Process]:
+        """Return live children whose command line invoked our bad
+        server. Filters out unrelated subprocesses pytest itself may
+        spawn (xdist workers, coverage helpers) so the assertion
+        isolates the shim's own footprint.
+        """
+        out = []
+        for child in parent.children(recursive=True):
+            try:
+                if str(bad_script) in child.cmdline():
+                    out.append(child)
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                pass
+        return out
+
     async def go():
         transport = StdioTransport(
             command=sys.executable,
@@ -262,4 +284,19 @@ def test_context_cleanup_on_initialize_failure(tmp_path):
             async with client:
                 pass  # pragma: no cover
 
+    assert _shim_children() == []
     asyncio.run(go())
+
+    # Briefly poll for the subprocess to be reaped. The shim's
+    # AsyncExitStack unwind happens synchronously inside __aenter__'s
+    # except branch, but the OS-level wait for SIGCHLD may lag a tick.
+    # A 2-second budget is generous; in practice this resolves under
+    # 50ms locally.
+    deadline = time.monotonic() + 2.0
+    while _shim_children() and time.monotonic() < deadline:
+        time.sleep(0.05)
+    leaked = _shim_children()
+    assert not leaked, (
+        f"shim leaked {len(leaked)} subprocess(es) on init failure: "
+        f"{[p.pid for p in leaked]}"
+    )


### PR DESCRIPTION
## Summary

Two related fixes:

1. **NBI's `pyproject.toml` on `main` is currently un-installable on a fresh Python 3.14 environment.** `litellm>=1.83.7` (the floor that picks up CVE-2026-42203 / CVE-2026-42208 / CVE-2026-42271 fixes) hard-pins `python-dotenv==1.0.1`, and every `fastmcp>=2.11.2` release requires `python-dotenv>=1.1.0`. The constraints are mutually unsatisfiable; `pip install -e .` reports `ResolutionImpossible`. Verified in a clean venv.

   This PR drops the `fastmcp` dep entirely and routes `mcp_manager.py` through a thin local shim implemented against the official `mcp` Python SDK, which lists `python-dotenv` only as an optional `cli` extra and is already in NBI's dep tree via `claude-agent-sdk`. Fresh installs succeed.

2. **`urllib3` 2.6.3 has two open CVEs.** Pinned `urllib3>=2.7.0` to pick up CVE-2026-44431 (cross-origin redirect handling) and CVE-2026-44432 (streaming API). Reaches NBI via `requests`, which doesn't cap the upper bound, so a single lower bound in NBI's pyproject is enough.

## Solution

**fastmcp → mcp swap** (`notebook_intelligence/mcp_client.py`, new file):

- Thin shim exposing the subset of fastmcp's surface NBI used (`Client`, `StdioTransport`, `StreamableHttpTransport`) implemented on top of the official `mcp` SDK. Constructor signatures and method shapes match fastmcp's so the call sites in `mcp_manager.py` change in two lines (the two imports).
- Return values are unchanged: the underlying Pydantic models are the same in both libraries, since fastmcp itself is a thin layer over `mcp`.
- `pyproject.toml`: `fastmcp>=2.11.2` → `mcp>=1.27.0`. The python-dotenv resolution now lands on 1.0.1 (forced by litellm; CVE-2026-28684 affects only `set_key` / `unset_key` write paths which neither NBI nor any other dep exercises).

**urllib3 pin** (`pyproject.toml`):

- One added line: `"urllib3>=2.7.0"`. Comment explains the transitive path through `requests` and which CVEs the bump addresses.

## Testing

- **`tests/test_mcp_client_shim.py`** (5 new cases): constructor parity, programmer-error guards (methods-before-context, unsupported transport), and an end-to-end smoke test against a real stdio MCP server (spawns a subprocess, drives `ping` / `list_tools` / `call_tool` / `list_prompts` / `get_prompt`, asserts the exact attribute paths `mcp_manager.py` reads off the responses). Plus a cleanup-on-failure case that pins the stdio subprocess unwinds cleanly when initialization fails.
- Full pytest suite: 1012 passed. TS gates clean. End-to-end stdio test runs in under a second.
- **Fresh-venv install verification**: `python -m venv /tmp/fresh && /tmp/fresh/bin/pip install -e .` on Python 3.14 now succeeds. Previously: `ResolutionImpossible`.

## Why this is the right temporary fix

The principled fix lives upstream in BerriAI/litellm#25231 (relax the `python-dotenv` pin from `==1.0.1` to `>=1.0.1`). That PR has been open since 2026-04-06 with no maintainer engagement, and a parallel CVE-fix bump (#26435) was closed without merge. NBI can't ship a working install while waiting on upstream.

The shim is small (~120 lines), tested end-to-end, and the docstring + pyproject comment both point at the upstream PR to revert to once it lands. The official `mcp` SDK is a stable Anthropic-maintained library, not a vendored fork — there's no maintenance burden beyond keeping the shim's method signatures aligned with `mcp`'s public API.

Tracked upstream:
- BerriAI/litellm#25231 — relax python-dotenv pin (open, 7 weeks no movement)
- BerriAI/litellm#26435 — bump python-dotenv to 1.2.2 for CVE-2026-28684 (closed without merge)

## Risks

- **None practically expected.** The full pytest suite stays green. The end-to-end shim test exercises every method `mcp_manager.py` calls. JupyterLab's MCP integration paths haven't been touched.
- The shim is a new module to learn; the docstring lays out exactly why it exists and how to revert. Two imports in `mcp_manager.py` change shape; the consumer behavior is byte-for-byte identical.