### PR TITLE
use sparkles icon for coding agent section

### DIFF
--- a/style/base.css
+++ b/style/base.css
@@ -3052,9 +3052,7 @@ svg.access-token-warning {
 
   /* Hide the default SVG fill to show only the masked shape */
   fill: transparent;
-
-  /* Jupyter orange */
-  color: #f37627;
+  color: var(--jp-brand-color1);
 }
 
 /* First-run tour overlay. Rendered into document.body via portal so

--- a/style/base.css
+++ b/style/base.css
@@ -3038,11 +3038,23 @@ svg.access-token-warning {
   z-index: 100;
 }
 
-/* Coding Agent launcher tile: Anthropic orange icon.
-   Placed last to satisfy no-descending-specificity lint rule. */
-.jp-LauncherCard[data-category='Coding Agent'] .jp-LauncherCard-icon svg,
-.jp-Launcher-sectionHeader svg[data-icon='notebook-intelligence:claude-icon'] {
+/* Set Claude Code launcher title color to Anthropic orange */
+.jp-LauncherCard-icon svg[data-icon='notebook-intelligence:claude-icon'] {
   color: #d97757;
+}
+
+/* Set Claude Code launcher category icon to sparkles.svg */
+.jp-Launcher-sectionHeader svg[data-icon='notebook-intelligence:claude-icon'] {
+  /* Use sparkles.svg from the project assets via a mask + background-image trick */
+  mask: url('../style/icons/sparkles.svg') no-repeat center / contain;
+  -webkit-mask: url('../style/icons/sparkles.svg') no-repeat center / contain;
+  background-color: currentcolor;
+
+  /* Hide the default SVG fill to show only the masked shape */
+  fill: transparent;
+
+  /* Jupyter orange */
+  color: #f37627;
 }
 
 /* First-run tour overlay. Rendered into document.body via portal so


### PR DESCRIPTION

<img width="403" height="190" alt="Screenshot 2026-05-19 at 9 20 09 AM" src="https://github.com/user-attachments/assets/53f5b422-bc61-47b4-bc8b-56a874af0809" />

fixes #275 
