### PR TITLE
feat(claude): attach workspace files as @-mention in Claude mode

### DIFF
--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -59,7 +59,7 @@ from notebook_intelligence.claude_sessions import (
 )
 import notebook_intelligence.github_copilot as github_copilot
 from notebook_intelligence.built_in_toolsets import built_in_toolsets
-from notebook_intelligence.util import ThreadSafeWebSocketConnector, get_jupyter_root_dir, set_jupyter_root_dir, is_builtin_tool_enabled_in_env, is_provider_enabled_in_env, VALID_CODING_AGENT_LAUNCHERS, compute_effective_disabled_launchers, validate_coding_agent_launcher_ids, resolve_claude_cli_path, resolve_opencode_cli_path, resolve_pi_cli_path, resolve_copilot_cli_path, resolve_codex_cli_path, safe_anchor_uri, split_csv
+from notebook_intelligence.util import ThreadSafeWebSocketConnector, get_jupyter_root_dir, set_jupyter_root_dir, is_builtin_tool_enabled_in_env, is_provider_enabled_in_env, VALID_CODING_AGENT_LAUNCHERS, compute_effective_disabled_launchers, validate_coding_agent_launcher_ids, resolve_claude_cli_path, resolve_opencode_cli_path, resolve_pi_cli_path, resolve_copilot_cli_path, resolve_codex_cli_path, safe_anchor_uri, has_dangerous_text_codepoints, split_csv
 from notebook_intelligence.context_factory import RuleContextFactory
 from notebook_intelligence.skillset import SKILL_NAME_REGEX
 
@@ -2172,6 +2172,10 @@ class WebsocketCopilotHandler(WebSocketMixin, websocket.WebSocketHandler, Jupyte
             token_limit = 100 if ai_service_manager.chat_model is None else ai_service_manager.chat_model.context_window
             remaining_token_budget = int(0.8 * token_limit)
 
+            # Resolve once; reused for sandbox containment and for
+            # workspace-relative @-mention path computation below.
+            workspace_root = os.path.realpath(NotebookIntelligence.root_dir)
+
             for context in additionalContext:
                 if remaining_token_budget <= 0:
                     break
@@ -2214,7 +2218,6 @@ class WebsocketCopilotHandler(WebSocketMixin, websocket.WebSocketHandler, Jupyte
                     # resolved path against root_dir before reading.
                     joined = path.join(NotebookIntelligence.root_dir, file_path)
                     resolved = os.path.realpath(joined)
-                    workspace_root = os.path.realpath(NotebookIntelligence.root_dir)
                     try:
                         in_workspace = (
                             os.path.commonpath([resolved, workspace_root])
@@ -2253,6 +2256,84 @@ class WebsocketCopilotHandler(WebSocketMixin, websocket.WebSocketHandler, Jupyte
                             })
                         except Exception as e:
                             log.warning(f"Failed to read pasted image '{file_path}': {e}")
+                    continue
+
+                if is_claude_code_mode:
+                    # Hand the agent an @-mention rather than the file's
+                    # contents: Claude's Read tool handles partial reads,
+                    # notebook cell structure, and binary formats natively,
+                    # and avoids the 80% context-window truncation the
+                    # content-injection path would otherwise apply.
+                    if is_upload:
+                        mention_path = file_path
+                    else:
+                        try:
+                            mention_path = path.relpath(file_path, workspace_root)
+                        except ValueError:
+                            mention_path = file_path
+                    # Defense in depth: the path already passed the
+                    # workspace sandbox above, but a filename containing
+                    # newlines, NEL/LS/PS, bidi-override controls, or
+                    # other text-rendering hazards would split or visually
+                    # impersonate the prose envelope once it reaches the
+                    # agent. Reuse the same codepoint set safe_anchor_uri
+                    # uses for the same threat profile.
+                    if has_dangerous_text_codepoints(mention_path):
+                        log.warning(
+                            "Rejecting attachment with disallowed-codepoint "
+                            "filename (prompt-injection hardening): %r",
+                            context["filePath"],
+                        )
+                        continue
+                    # Preserve the pointer prose the legacy path emits so
+                    # the agent still has a cursor for "this cell" /
+                    # "this code" deictic references; the @-mention alone
+                    # gives the agent the file but not the focus.
+                    # - currentCellContents fires when a notebook cell is
+                    #   active with no text selection (cellOutputAsText
+                    #   already bundles execute_result, stream, AND error
+                    #   traceback into the `output` string).
+                    # - startLine/endLine spans fire when the user has
+                    #   selected a range; pass the range as prose rather
+                    #   than the content so large selections don't burn
+                    #   the token budget.
+                    current_cell_contents = context.get("currentCellContents")
+                    pointer_parts = []
+                    if current_cell_contents is not None:
+                        cell_input = current_cell_contents.get("input", "")
+                        cell_output = current_cell_contents.get("output", "")
+                        pointer_parts.append(
+                            f"This is a Jupyter notebook and currently "
+                            f"selected cell input is: ```{cell_input}``` "
+                            f"and currently selected cell output is: "
+                            f"```{cell_output}```. If user asks a question "
+                            f"about 'this' cell then assume that user is "
+                            f"referring to currently selected cell."
+                        )
+                    else:
+                        start_line = context.get("startLine") or 0
+                        end_line = context.get("endLine") or 0
+                        if end_line > start_line > 0:
+                            pointer_parts.append(
+                                f"Their selection spans lines "
+                                f"{start_line}-{end_line}."
+                            )
+                    context_message = " ".join(
+                        [
+                            f"The user attached @{mention_path}.",
+                            *pointer_parts,
+                            "Read it if relevant to the request.",
+                        ]
+                    )
+                    # NB: when the user's prompt begins with `/`, the
+                    # join logic in claude.py (`query_lines[-1].startswith('/')`)
+                    # drops every prior user-role message, including these
+                    # context lines. Pre-existing behavior, not introduced
+                    # by this branch; documented here so a future reader
+                    # doesn't chase the @-mention silently disappearing
+                    # when paired with a slash-command.
+                    remaining_token_budget -= _token_count(context_message)
+                    chat_history.append({"role": "user", "content": context_message})
                     continue
 
                 start_line = context["startLine"]

--- a/notebook_intelligence/util.py
+++ b/notebook_intelligence/util.py
@@ -285,6 +285,17 @@ _DISALLOWED_URI_CODEPOINTS = frozenset(
 )
 
 
+def has_dangerous_text_codepoints(s: str) -> bool:
+    """Return True if ``s`` contains any codepoint in the same set
+    ``safe_anchor_uri`` rejects (C0/DEL/C1, NEL/NBSP/LS/PS/BOM, ZWSP,
+    bidi-override controls). Useful at any boundary that embeds an
+    untrusted string into rendered text or prompt prose where a
+    line-break, visual-impersonation, or bidi-reorder vector would
+    matter.
+    """
+    return any(ord(ch) in _DISALLOWED_URI_CODEPOINTS for ch in s)
+
+
 def safe_anchor_uri(uri: str) -> str:
     """Return ``uri`` when its scheme is in the chat anchor allowlist.
 
@@ -298,9 +309,8 @@ def safe_anchor_uri(uri: str) -> str:
     # Scan the original input — str.strip() treats NEL, NBSP, LS, PS, and
     # other unicode whitespace as trimmable, so checking after stripping
     # would let those codepoints slip past as a trailing edge.
-    for ch in uri:
-        if ord(ch) in _DISALLOWED_URI_CODEPOINTS:
-            return ""
+    if has_dangerous_text_codepoints(uri):
+        return ""
     stripped = uri.strip()
     if not stripped:
         return ""

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -1681,19 +1681,27 @@ function SidebarComponent(props: any) {
     setWorkspaceFileActionPath(file.path);
 
     try {
-      const contentsManager = props.getApp().serviceManager.contents;
-      const model: any = await contentsManager.get(file.path, {
-        content: true
-      });
-      const content = serializeWorkspaceFileContent(model);
-
-      if (content.trim() === '') {
-        throw new Error('Empty files do not provide useful context.');
+      // In Claude Code mode, the agent reads the file itself via the
+      // server's @-mention path. Skip the contents fetch so binary files
+      // (images, PDFs, notebooks) are picker-eligible and large files
+      // aren't truncated by the client-side content-injection budget.
+      let content = '';
+      let lineCount = 0;
+      if (!NBIAPI.config.isInClaudeCodeMode) {
+        const contentsManager = props.getApp().serviceManager.contents;
+        const model: any = await contentsManager.get(file.path, {
+          content: true
+        });
+        content = serializeWorkspaceFileContent(model);
+        if (content.trim() === '') {
+          throw new Error('Empty files do not provide useful context.');
+        }
+        lineCount = countContentLines(content);
       }
 
       const nextSelectedFile: ISelectedContextFile = {
         content,
-        lineCount: countContentLines(content),
+        lineCount,
         path: file.path,
         type: file.type
       };

--- a/tests/test_websocket_handler_integration.py
+++ b/tests/test_websocket_handler_integration.py
@@ -272,3 +272,504 @@ class TestWebsocketHandlerIntegration:
         assert "File contents:" in context_message
         assert 'def greet()' in context_message
         assert 'return "hi"' in context_message
+
+    @patch('notebook_intelligence.extension.ai_service_manager')
+    @patch('notebook_intelligence.extension.NotebookIntelligence')
+    @patch('notebook_intelligence.extension.threading.Thread')
+    def test_on_message_claude_mode_emits_at_mention_not_contents(
+        self, mock_thread, mock_nb_intel, mock_ai_manager
+    ):
+        """In Claude Code mode, workspace file context becomes an @-mention
+        prose message so the agent's Read tool decides how much to read.
+        Pins the issue-326 behavior so a future refactor can't silently
+        regress to client-side content injection (which truncates large
+        files and rejects binary files outright).
+        """
+        mock_nb_intel.root_dir = "/workspace"
+        mock_ai_manager.handle_chat_request = Mock()
+        mock_ai_manager.is_claude_code_mode = True
+        mock_ai_manager.chat_model = Mock()
+        mock_ai_manager.chat_model.context_window = 4096
+
+        mock_factory = Mock(spec=RuleContextFactory)
+        mock_factory.create.return_value = Mock(spec=RuleContext)
+
+        with patch('notebook_intelligence.extension.ThreadSafeWebSocketConnector'):
+            handler = WebsocketCopilotHandler(
+                self._create_mock_application(),
+                self._create_mock_request(),
+                context_factory=mock_factory
+            )
+
+        # Synthesize a 10MB content blob that the non-Claude path would
+        # truncate via _truncate_context_content; the @-mention branch
+        # must not echo it back into the prompt.
+        large_blob = 'x' * (10 * 1024 * 1024)
+        message = {
+            'id': 'test-message-id',
+            'type': 'chat-request',
+            'data': {
+                'chatId': 'test-chat-id',
+                'prompt': 'Summarize the attached file',
+                'language': 'python',
+                'filename': 'notebook.ipynb',
+                'chatMode': 'ask',
+                'toolSelections': {},
+                'additionalContext': [
+                    {
+                        'filePath': 'src/example.py',
+                        'content': large_blob,
+                        'currentCellContents': None,
+                        'startLine': 1,
+                        'endLine': 1
+                    }
+                ]
+            }
+        }
+
+        handler.on_message(json.dumps(message))
+
+        mock_ai_manager.handle_chat_request.assert_called_once()
+        chat_request = mock_ai_manager.handle_chat_request.call_args[0][0]
+
+        assert len(chat_request.chat_history) == 1
+        context_message = chat_request.chat_history[0]["content"]
+        assert "@src/example.py" in context_message
+        assert "File contents:" not in context_message
+        assert large_blob not in context_message
+        # Generous upper bound: the prose envelope is ~80 chars; anything
+        # remotely close to the blob size means content leaked through.
+        assert len(context_message) < 500
+
+    @patch('notebook_intelligence.extension.ai_service_manager')
+    @patch('notebook_intelligence.extension.NotebookIntelligence')
+    @patch('notebook_intelligence.extension.threading.Thread')
+    def test_on_message_claude_mode_image_branch_unchanged(
+        self, mock_thread, mock_nb_intel, mock_ai_manager
+    ):
+        """Pasted images in Claude mode keep the existing path-based
+        message format. The new @-mention branch must not shadow the
+        is_image branch (the latter already does the right thing for
+        pasted-image uploads and changing its wording is out of scope).
+        """
+        mock_nb_intel.root_dir = "/workspace"
+        mock_ai_manager.handle_chat_request = Mock()
+        mock_ai_manager.is_claude_code_mode = True
+        mock_ai_manager.chat_model = Mock()
+        mock_ai_manager.chat_model.context_window = 4096
+
+        mock_factory = Mock(spec=RuleContextFactory)
+        mock_factory.create.return_value = Mock(spec=RuleContext)
+
+        with patch('notebook_intelligence.extension.ThreadSafeWebSocketConnector'):
+            handler = WebsocketCopilotHandler(
+                self._create_mock_application(),
+                self._create_mock_request(),
+                context_factory=mock_factory
+            )
+
+        message = {
+            'id': 'test-message-id',
+            'type': 'chat-request',
+            'data': {
+                'chatId': 'test-chat-id',
+                'prompt': 'What is in this image?',
+                'language': 'python',
+                'filename': 'notebook.ipynb',
+                'chatMode': 'ask',
+                'toolSelections': {},
+                'additionalContext': [
+                    {
+                        'filePath': '/tmp/nbi-uploads-xyz/pasted.png',
+                        'content': '',
+                        'currentCellContents': None,
+                        'startLine': 1,
+                        'endLine': 1,
+                        'isUpload': True,
+                        'isImage': True,
+                        'mimeType': 'image/png'
+                    }
+                ]
+            }
+        }
+
+        handler.on_message(json.dumps(message))
+
+        chat_request = mock_ai_manager.handle_chat_request.call_args[0][0]
+        assert len(chat_request.chat_history) == 1
+        context_message = chat_request.chat_history[0]["content"]
+        assert "The user pasted an image" in context_message
+        assert "/tmp/nbi-uploads-xyz/pasted.png" in context_message
+        # Sanity-check the new @-mention branch didn't intercept this case.
+        assert "@/tmp/nbi-uploads-xyz/pasted.png" not in context_message
+
+    @patch('notebook_intelligence.extension.ai_service_manager')
+    @patch('notebook_intelligence.extension.NotebookIntelligence')
+    @patch('notebook_intelligence.extension.threading.Thread')
+    def test_on_message_claude_mode_rejects_out_of_workspace_path(
+        self, mock_thread, mock_nb_intel, mock_ai_manager
+    ):
+        """The pre-existing sandbox check at extension.py rejects
+        out-of-workspace paths before the new @-mention branch runs. Pin
+        it so a future refactor that reorders the branches can't produce
+        ``@../../etc/passwd`` in the prompt.
+        """
+        mock_nb_intel.root_dir = "/workspace"
+        mock_ai_manager.handle_chat_request = Mock()
+        mock_ai_manager.is_claude_code_mode = True
+        mock_ai_manager.chat_model = Mock()
+        mock_ai_manager.chat_model.context_window = 4096
+
+        mock_factory = Mock(spec=RuleContextFactory)
+        mock_factory.create.return_value = Mock(spec=RuleContext)
+
+        with patch('notebook_intelligence.extension.ThreadSafeWebSocketConnector'):
+            handler = WebsocketCopilotHandler(
+                self._create_mock_application(),
+                self._create_mock_request(),
+                context_factory=mock_factory
+            )
+
+        message = {
+            'id': 'test-message-id',
+            'type': 'chat-request',
+            'data': {
+                'chatId': 'test-chat-id',
+                'prompt': 'Read this file',
+                'language': 'python',
+                'filename': 'notebook.ipynb',
+                'chatMode': 'ask',
+                'toolSelections': {},
+                'additionalContext': [
+                    {
+                        'filePath': '../../etc/passwd',
+                        'content': '',
+                        'currentCellContents': None,
+                        'startLine': 1,
+                        'endLine': 1
+                    }
+                ]
+            }
+        }
+
+        handler.on_message(json.dumps(message))
+
+        chat_request = mock_ai_manager.handle_chat_request.call_args[0][0]
+        # No context message produced; the sandbox rejected the path
+        # before the @-mention branch could format it.
+        assert chat_request.chat_history == []
+
+    @patch('notebook_intelligence.extension.ai_service_manager')
+    @patch('notebook_intelligence.extension.NotebookIntelligence')
+    @patch('notebook_intelligence.extension.threading.Thread')
+    def test_on_message_claude_mode_upload_non_image_uses_absolute_path(
+        self, mock_thread, mock_nb_intel, mock_ai_manager
+    ):
+        """Uploaded text/binary files (non-image) reach the @-mention
+        branch with an absolute path; the relpath-against-workspace
+        computation must not fire for is_upload=True.
+        """
+        mock_nb_intel.root_dir = "/workspace"
+        mock_ai_manager.handle_chat_request = Mock()
+        mock_ai_manager.is_claude_code_mode = True
+        mock_ai_manager.chat_model = Mock()
+        mock_ai_manager.chat_model.context_window = 4096
+
+        mock_factory = Mock(spec=RuleContextFactory)
+        mock_factory.create.return_value = Mock(spec=RuleContext)
+
+        with patch('notebook_intelligence.extension.ThreadSafeWebSocketConnector'):
+            handler = WebsocketCopilotHandler(
+                self._create_mock_application(),
+                self._create_mock_request(),
+                context_factory=mock_factory
+            )
+
+        message = {
+            'id': 'test-message-id',
+            'type': 'chat-request',
+            'data': {
+                'chatId': 'test-chat-id',
+                'prompt': 'What does this PDF say?',
+                'language': 'python',
+                'filename': 'notebook.ipynb',
+                'chatMode': 'ask',
+                'toolSelections': {},
+                'additionalContext': [
+                    {
+                        'filePath': '/tmp/nbi-uploads-abc/report.pdf',
+                        'content': '',
+                        'currentCellContents': None,
+                        'startLine': 1,
+                        'endLine': 1,
+                        'isUpload': True
+                    }
+                ]
+            }
+        }
+
+        handler.on_message(json.dumps(message))
+
+        chat_request = mock_ai_manager.handle_chat_request.call_args[0][0]
+        assert len(chat_request.chat_history) == 1
+        context_message = chat_request.chat_history[0]["content"]
+        assert "@/tmp/nbi-uploads-abc/report.pdf" in context_message
+        assert "Read it if relevant" in context_message
+
+    @patch('notebook_intelligence.extension.ai_service_manager')
+    @patch('notebook_intelligence.extension.NotebookIntelligence')
+    @patch('notebook_intelligence.extension.threading.Thread')
+    def test_on_message_claude_mode_rejects_control_char_filename(
+        self, mock_thread, mock_nb_intel, mock_ai_manager
+    ):
+        """A filename containing newlines / bidi-override controls /
+        other text-rendering hazards is dropped before being embedded
+        in the @-mention prose. Pins the prompt-injection guard so a
+        future refactor can't reintroduce the seam.
+        """
+        mock_nb_intel.root_dir = "/workspace"
+        mock_ai_manager.handle_chat_request = Mock()
+        mock_ai_manager.is_claude_code_mode = True
+        mock_ai_manager.chat_model = Mock()
+        mock_ai_manager.chat_model.context_window = 4096
+
+        mock_factory = Mock(spec=RuleContextFactory)
+        mock_factory.create.return_value = Mock(spec=RuleContext)
+
+        with patch('notebook_intelligence.extension.ThreadSafeWebSocketConnector'):
+            handler = WebsocketCopilotHandler(
+                self._create_mock_application(),
+                self._create_mock_request(),
+                context_factory=mock_factory
+            )
+
+        # Upload path keeps the raw frontend-supplied filePath, so we
+        # don't have to fight the workspace sandbox to exercise the
+        # codepoint guard. Try newline, line-separator, and a bidi
+        # override in sequence; all three must be rejected.
+        hazardous_paths = [
+            "/tmp/nbi-uploads-abc/bad\nname.pdf",
+            "/tmp/nbi-uploads-abc/bad name.pdf",
+            "/tmp/nbi-uploads-abc/bad‮name.pdf",
+        ]
+        for hazardous in hazardous_paths:
+            mock_ai_manager.handle_chat_request.reset_mock()
+            message = {
+                'id': 'test-message-id',
+                'type': 'chat-request',
+                'data': {
+                    'chatId': 'test-chat-id',
+                    'prompt': 'Summarize',
+                    'language': 'python',
+                    'filename': 'notebook.ipynb',
+                    'chatMode': 'ask',
+                    'toolSelections': {},
+                    'additionalContext': [
+                        {
+                            'filePath': hazardous,
+                            'content': '',
+                            'currentCellContents': None,
+                            'startLine': 1,
+                            'endLine': 1,
+                            'isUpload': True
+                        }
+                    ]
+                }
+            }
+
+            handler.on_message(json.dumps(message))
+
+            chat_request = mock_ai_manager.handle_chat_request.call_args[0][0]
+            assert chat_request.chat_history == [], (
+                f"Hazardous path {hazardous!r} produced chat_history "
+                f"entry: {chat_request.chat_history!r}"
+            )
+
+    @patch('notebook_intelligence.extension.ai_service_manager')
+    @patch('notebook_intelligence.extension.NotebookIntelligence')
+    @patch('notebook_intelligence.extension.threading.Thread')
+    def test_on_message_claude_mode_preserves_notebook_cell_pointer(
+        self, mock_thread, mock_nb_intel, mock_ai_manager
+    ):
+        """When a notebook cell is active in Claude mode, the cell's
+        input/output prose must flow through alongside the @-mention so
+        the agent knows which cell the user is asking about. Without
+        this the agent sees only `@notebook.ipynb` and 'this cell'
+        questions lose their referent.
+        """
+        mock_nb_intel.root_dir = "/workspace"
+        mock_ai_manager.handle_chat_request = Mock()
+        mock_ai_manager.is_claude_code_mode = True
+        mock_ai_manager.chat_model = Mock()
+        mock_ai_manager.chat_model.context_window = 4096
+
+        mock_factory = Mock(spec=RuleContextFactory)
+        mock_factory.create.return_value = Mock(spec=RuleContext)
+
+        with patch('notebook_intelligence.extension.ThreadSafeWebSocketConnector'):
+            handler = WebsocketCopilotHandler(
+                self._create_mock_application(),
+                self._create_mock_request(),
+                context_factory=mock_factory
+            )
+
+        message = {
+            'id': 'test-message-id',
+            'type': 'chat-request',
+            'data': {
+                'chatId': 'test-chat-id',
+                'prompt': 'Explain this cell',
+                'language': 'python',
+                'filename': 'analysis.ipynb',
+                'chatMode': 'ask',
+                'toolSelections': {},
+                'additionalContext': [
+                    {
+                        'filePath': 'analysis.ipynb',
+                        'content': '',
+                        'currentCellContents': {
+                            'input': 'df.groupby("col").mean()',
+                            'output': '       col2\ncol\nA    1.5'
+                        },
+                        'cellIndex': 3,
+                        'startLine': 1,
+                        'endLine': 1
+                    }
+                ]
+            }
+        }
+
+        handler.on_message(json.dumps(message))
+
+        chat_request = mock_ai_manager.handle_chat_request.call_args[0][0]
+        assert len(chat_request.chat_history) == 1
+        context_message = chat_request.chat_history[0]["content"]
+        assert "@analysis.ipynb" in context_message
+        assert "currently selected cell input" in context_message
+        assert 'df.groupby("col").mean()' in context_message
+        assert "currently selected cell output" in context_message
+        assert "col2" in context_message
+        assert "'this' cell" in context_message
+
+    @patch('notebook_intelligence.extension.ai_service_manager')
+    @patch('notebook_intelligence.extension.NotebookIntelligence')
+    @patch('notebook_intelligence.extension.threading.Thread')
+    def test_on_message_claude_mode_preserves_selection_line_range(
+        self, mock_thread, mock_nb_intel, mock_ai_manager
+    ):
+        """When the user has a multi-line text selection in Claude mode,
+        the @-mention message gets a 'Their selection spans lines N-M'
+        prose pointer so 'why is this broken' has a referent. The bulk
+        selection text is NOT echoed back — the agent reads the file
+        itself via @-mention and is told where to look.
+        """
+        mock_nb_intel.root_dir = "/workspace"
+        mock_ai_manager.handle_chat_request = Mock()
+        mock_ai_manager.is_claude_code_mode = True
+        mock_ai_manager.chat_model = Mock()
+        mock_ai_manager.chat_model.context_window = 4096
+
+        mock_factory = Mock(spec=RuleContextFactory)
+        mock_factory.create.return_value = Mock(spec=RuleContext)
+
+        with patch('notebook_intelligence.extension.ThreadSafeWebSocketConnector'):
+            handler = WebsocketCopilotHandler(
+                self._create_mock_application(),
+                self._create_mock_request(),
+                context_factory=mock_factory
+            )
+
+        # The frontend passes `content` populated with the selection
+        # text. The Claude branch must ignore the bulk and emit only the
+        # range pointer.
+        selection_text = "def broken():\n    return undefined_thing\n" * 50
+        message = {
+            'id': 'test-message-id',
+            'type': 'chat-request',
+            'data': {
+                'chatId': 'test-chat-id',
+                'prompt': 'Why is this broken?',
+                'language': 'python',
+                'filename': 'src/foo.py',
+                'chatMode': 'ask',
+                'toolSelections': {},
+                'additionalContext': [
+                    {
+                        'filePath': 'src/foo.py',
+                        'content': selection_text,
+                        'currentCellContents': None,
+                        'startLine': 42,
+                        'endLine': 78
+                    }
+                ]
+            }
+        }
+
+        handler.on_message(json.dumps(message))
+
+        chat_request = mock_ai_manager.handle_chat_request.call_args[0][0]
+        assert len(chat_request.chat_history) == 1
+        context_message = chat_request.chat_history[0]["content"]
+        assert "@src/foo.py" in context_message
+        assert "lines 42-78" in context_message
+        # Bulk selection content must NOT have leaked into the message.
+        assert "undefined_thing" not in context_message
+        assert "def broken" not in context_message
+
+    @patch('notebook_intelligence.extension.ai_service_manager')
+    @patch('notebook_intelligence.extension.NotebookIntelligence')
+    @patch('notebook_intelligence.extension.threading.Thread')
+    def test_on_message_claude_mode_no_selection_no_range_pointer(
+        self, mock_thread, mock_nb_intel, mock_ai_manager
+    ):
+        """When the user has the file open with no selection (startLine
+        == endLine), the @-mention message stays clean — no spurious
+        'lines 1-1' pointer that would confuse the agent into thinking
+        the user wants only the first line.
+        """
+        mock_nb_intel.root_dir = "/workspace"
+        mock_ai_manager.handle_chat_request = Mock()
+        mock_ai_manager.is_claude_code_mode = True
+        mock_ai_manager.chat_model = Mock()
+        mock_ai_manager.chat_model.context_window = 4096
+
+        mock_factory = Mock(spec=RuleContextFactory)
+        mock_factory.create.return_value = Mock(spec=RuleContext)
+
+        with patch('notebook_intelligence.extension.ThreadSafeWebSocketConnector'):
+            handler = WebsocketCopilotHandler(
+                self._create_mock_application(),
+                self._create_mock_request(),
+                context_factory=mock_factory
+            )
+
+        message = {
+            'id': 'test-message-id',
+            'type': 'chat-request',
+            'data': {
+                'chatId': 'test-chat-id',
+                'prompt': 'What is this file about?',
+                'language': 'python',
+                'filename': 'src/foo.py',
+                'chatMode': 'ask',
+                'toolSelections': {},
+                'additionalContext': [
+                    {
+                        'filePath': 'src/foo.py',
+                        'content': '',
+                        'currentCellContents': None,
+                        'startLine': 1,
+                        'endLine': 1
+                    }
+                ]
+            }
+        }
+
+        handler.on_message(json.dumps(message))
+
+        chat_request = mock_ai_manager.handle_chat_request.call_args[0][0]
+        assert len(chat_request.chat_history) == 1
+        context_message = chat_request.chat_history[0]["content"]
+        assert "@src/foo.py" in context_message
+        assert "lines" not in context_message
+        assert "selection" not in context_message


### PR DESCRIPTION
## Summary

Closes #326. In Claude Code mode, workspace files attached via the picker no longer get their contents read client-side and injected as a fenced code block. Instead the backend emits a short prose message with the file path prefixed by `@`, letting the agent's Read tool decide what (and how much) to load.

This unblocks three cases the content-injection path couldn't handle:

- **Images** in the workspace: previously rejected by `serializeWorkspaceFileContent`'s binary check, now picker-eligible (the agent uses vision via Read).
- **Large files**: stop silently truncating at the 80% context-window budget; the agent can grep, then read the relevant slice.
- **Notebooks** (`.ipynb`): Claude Code's notebook-aware Read surfaces cells natively instead of dumping the raw JSON.

## Solution

### Backend (`notebook_intelligence/extension.py`)

A new branch in the additional-context loop fires when `is_claude_code_mode` is true, after the existing `is_image` branch and before the legacy `_build_additional_context_message` path. It emits `"The user attached @<workspace-relative-path>. Read it if relevant to the request."` Workspace files use `path.relpath` against the realpath'd root (computed once before the loop); uploads outside the workspace use the absolute server-temp path (parity with the existing pasted-image branch).

The deictic-reference pointer prose the legacy path produced is preserved as a tail on the @-mention message:

- When `currentCellContents` is present (active notebook cell, no text selected), append the cell input/output prose so "explain this cell" still has a referent.
- When the entry carries a multi-line selection (`endLine > startLine`), append `"Their selection spans lines N-M."` The bulk selection text is intentionally not echoed; the agent reads the file via the @-mention and is told where to focus.

Filename codepoint guard: defense-in-depth on a path that already passed the workspace sandbox. The new `has_dangerous_text_codepoints` helper (extracted in `util.py`) wraps the existing `_DISALLOWED_URI_CODEPOINTS` set already used by `safe_anchor_uri` (C0/DEL/C1, NEL/NBSP/LS/PS, BOM, ZWSP, bidi-override controls). A filename containing newlines or U+202E would otherwise split or visually impersonate the prose envelope.

### Frontend (`src/chat-sidebar.tsx`)

`handleWorkspaceFileSelection` short-circuits in Claude mode and skips the `contentsManager.get(..., { content: true })` call (which throws on binary), attaching with `content: ''` and `lineCount: 0`. One fewer HTTP round-trip per pick. The binary-rejection guard is preserved for non-Claude providers via the same call site.

### What stays the same

- The pasted-image branch (`is_image && is_claude_code_mode`) is intentionally untouched: it already does the right thing for uploaded images, and changing its wording is out of scope.
- The structured cell-output bundle path (`outputContext`, from PR #160) is also untouched. It short-circuits at the top of the additional-context loop before reaching the new branch, so the right-click "Explain / Ask / Troubleshoot" menu continues to deliver images and dataframe HTML as proper vision blocks.

## Testing

Seven new tests in `tests/test_websocket_handler_integration.py` pin the contract:

- @-mention emitted in Claude mode; file contents not echoed, even with a 10MB content blob the legacy path would have truncated.
- `is_image` branch unchanged in Claude mode (the new branch must not shadow it).
- Out-of-workspace paths (`../../etc/passwd`) rejected by the pre-existing sandbox before the @-mention branch can format them.
- `is_upload=True` non-image attachments emit the absolute upload path rather than relpath'ing against the workspace root.
- Filename codepoint guard rejects three vectors: literal newline, U+2028 LINE SEPARATOR, U+202E RIGHT-TO-LEFT OVERRIDE.
- Notebook cell-pointer prose flows through when `currentCellContents` is present (the cell input/output and "this cell" referent prose all land in chat history).
- Multi-line selection produces a `"lines N-M"` pointer; bulk selection content does not leak. Whole-document / no-selection cases emit no pointer.

Each new regression test verified to fail against its stashed pre-fix code (cell-pointer test, selection-range test).

Full suite: `pytest tests/ --ignore=tests/test_claude_client.py` (1050 passed), `jlpm tsc --noEmit`, `jlpm lint:check`, `jlpm jest` (254 passed).

Manual: dropped a binary image from the workspace picker in Claude mode and confirmed it attaches without the "Binary files cannot be attached" error.

## Risks / follow-ups

- The pasted-image branch's prose format diverges from the new `@`-mention format (`"It is saved at this path: '<abs>'"` vs `"@<rel>"`). Intentional: pasted-image uploads live outside the workspace where `@<abs>` wouldn't resolve via Claude Code's workspace-anchored mention parser. Could be unified in a follow-up if uploads land inside `jupyter_root`.
- The codepoint guard fires only in the new Claude branch. The existing pasted-image and upload-non-image branches embed filenames into prose without it. Worth a defense-in-depth sweep in a separate hardening PR.
- Multi-file attachments emit one `{role: user, content: ...}` entry per file. The SDK joins them with `\n` on the wire, so a single combined message would be byte-equivalent today; left as separate messages for clarity.
- The Claude Agent SDK's built-in Read tool is not yet path-sandboxed via `safe_jupyter_path` (it falls through to the generic per-tool user confirmation). Pre-existing gap, not introduced by this change; worth a separate PR.
- When the user's prompt begins with `/`, the join logic in `claude.py` (`query_lines[-1].startswith('/')`) drops every prior user-role message, including the new @-mention context lines. Pre-existing behavior, documented inline near the @-mention emit so a future reader doesn't chase the @-mention silently disappearing when paired with a slash-command.

## Issue linkage

Closes #326.