### PR TITLE
feat(refresh): reload open document tabs when their files change on disk

### DIFF
--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -2,7 +2,14 @@
   "title": "Notebook Intelligence",
   "description": "Notebook Intelligence settings",
   "type": "object",
-  "properties": {},
+  "properties": {
+    "refresh_open_files_on_disk_change": {
+      "type": "boolean",
+      "title": "Refresh open files when changed on disk",
+      "description": "Automatically reload notebook and file editor tabs when their content changes on disk (for example, when an AI agent edits the file). Skipped when the tab has unsaved local edits so user work is never clobbered.",
+      "default": true
+    }
+  },
   "additionalProperties": false,
   "jupyter.lab.toolbars": {
     "Cell": [

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -6,7 +6,7 @@
     "refresh_open_files_on_disk_change": {
       "type": "boolean",
       "title": "Refresh open files when changed on disk",
-      "description": "Automatically reload notebook and file editor tabs when their content changes on disk (for example, when an external tool such as a terminal command or AI agent edits the file). Skipped when the tab has unsaved local edits, or when any notebook cell is currently executing, so in-flight work is never clobbered.",
+      "description": "Automatically reload notebook and file editor tabs when their content changes on disk (for example, when an external process such as a terminal command, a sync client, or an AI assistant edits the file). Skipped when the tab has unsaved local edits, so typed-but-not-yet-saved work is never clobbered.",
       "default": true
     }
   },

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -6,7 +6,7 @@
     "refresh_open_files_on_disk_change": {
       "type": "boolean",
       "title": "Refresh open files when changed on disk",
-      "description": "Automatically reload notebook and file editor tabs when their content changes on disk (for example, when an AI agent edits the file). Skipped when the tab has unsaved local edits so user work is never clobbered.",
+      "description": "Automatically reload notebook and file editor tabs when their content changes on disk (for example, when an external tool such as a terminal command or AI agent edits the file). Skipped when the tab has unsaved local edits, or when any notebook cell is currently executing, so in-flight work is never clobbered.",
       "default": true
     }
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,8 @@ import {
   IClaudeSessionInfo
 } from './api';
 import { CellOutputHoverToolbar } from './cell-output-toolbar';
+import { attachOpenFileRefreshWatcher } from './open-file-refresh-watcher';
+import { buildRefreshWatcherEnv } from './open-file-refresh-watcher-env';
 import {
   BackendMessageType,
   GITHUB_COPILOT_PROVIDER_ID,
@@ -896,11 +898,23 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
       new NBIInlineCompletionProvider(telemetryEmitter)
     );
 
+    // Snapshot the user's "refresh open files when changed on disk"
+    // toggle. The watcher reads it on every tick so flipping the
+    // setting takes effect without restarting Lab. Default-true so
+    // out-of-box agentic flows pick up file edits automatically;
+    // gated by ISettingRegistry availability (Lab can run without it
+    // in stripped-down embeds).
+    let refreshOnDiskEnabled = true;
     if (settingRegistry) {
       settingRegistry
         .load(plugin.id)
         .then(settings => {
-          //
+          const readToggle = (s: ISettingRegistry.ISettings) =>
+            s.composite['refresh_open_files_on_disk_change'] !== false;
+          refreshOnDiskEnabled = readToggle(settings);
+          settings.changed.connect(s => {
+            refreshOnDiskEnabled = readToggle(s);
+          });
         })
         .catch(reason => {
           console.error(
@@ -909,6 +923,11 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
           );
         });
     }
+
+    attachOpenFileRefreshWatcher({
+      env: buildRefreshWatcherEnv(app, app.serviceManager.contents),
+      isEnabled: () => refreshOnDiskEnabled
+    });
 
     const waitForFileToBeActive = async (
       filePath: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -924,6 +924,9 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
         });
     }
 
+    // JupyterLab plugins don't have a deactivate hook, so the watcher
+    // runs for the lifetime of the Lab session. We discard the teardown
+    // function here intentionally; it exists for test ergonomics.
     attachOpenFileRefreshWatcher({
       env: buildRefreshWatcherEnv(app, app.serviceManager.contents),
       isEnabled: () => refreshOnDiskEnabled

--- a/src/open-file-refresh-watcher-env.ts
+++ b/src/open-file-refresh-watcher-env.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+// Live binding for the open-file refresh watcher. Lives in its own
+// file so unit tests can exercise the pure logic in
+// `open-file-refresh-watcher.ts` without transitively importing
+// `@jupyterlab/docregistry`, which ships ESM that ts-jest's default
+// transform can't parse.
+
+import { JupyterFrontEnd } from '@jupyterlab/application';
+import { DocumentWidget } from '@jupyterlab/docregistry';
+import { Contents } from '@jupyterlab/services';
+
+import { IRefreshWatcherEnv } from './open-file-refresh-watcher';
+
+export function buildRefreshWatcherEnv(
+  app: JupyterFrontEnd,
+  contents: Contents.IManager
+): IRefreshWatcherEnv {
+  return {
+    iterDocumentWidgets: function* () {
+      for (const widget of app.shell.widgets('main')) {
+        if (widget instanceof DocumentWidget) {
+          yield widget;
+        }
+      }
+    },
+    fetchDiskModel: path => contents.get(path, { content: false }),
+    setInterval: (handler, ms) => window.setInterval(handler, ms),
+    clearInterval: handle => window.clearInterval(handle as number)
+  };
+}

--- a/src/open-file-refresh-watcher-env.ts
+++ b/src/open-file-refresh-watcher-env.ts
@@ -12,12 +12,13 @@ import { Contents } from '@jupyterlab/services';
 
 import { IRefreshWatcherEnv } from './open-file-refresh-watcher';
 
-// JL4 added the 'down' split area; a notebook the user dragged below
-// the main editor lives there, not in 'main'. Walk both so the watcher
-// covers split-down editors. Sidebars ('left'/'right') intentionally
-// excluded — almost nothing editable lives there, and including them
-// would polling-stat sidebar widgets we'd never revert.
-const WATCHED_SHELL_AREAS = ['main', 'down'] as const;
+// JL4 hosts editable documents in 'main' (default) and 'down' (the
+// split-down editor pane). Walk the sidebars too: users can drag a
+// notebook to 'left' or 'right' in JL4, and a non-DocumentWidget
+// sitting in a sidebar costs only the instanceof filter check below.
+// 'top'/'header'/'menu'/'bottom' are chrome (toolbars, status bar)
+// and never host documents.
+const WATCHED_SHELL_AREAS = ['main', 'down', 'left', 'right'] as const;
 
 export function buildRefreshWatcherEnv(
   app: JupyterFrontEnd,

--- a/src/open-file-refresh-watcher-env.ts
+++ b/src/open-file-refresh-watcher-env.ts
@@ -12,15 +12,24 @@ import { Contents } from '@jupyterlab/services';
 
 import { IRefreshWatcherEnv } from './open-file-refresh-watcher';
 
+// JL4 added the 'down' split area; a notebook the user dragged below
+// the main editor lives there, not in 'main'. Walk both so the watcher
+// covers split-down editors. Sidebars ('left'/'right') intentionally
+// excluded — almost nothing editable lives there, and including them
+// would polling-stat sidebar widgets we'd never revert.
+const WATCHED_SHELL_AREAS = ['main', 'down'] as const;
+
 export function buildRefreshWatcherEnv(
   app: JupyterFrontEnd,
   contents: Contents.IManager
 ): IRefreshWatcherEnv {
   return {
     iterDocumentWidgets: function* () {
-      for (const widget of app.shell.widgets('main')) {
-        if (widget instanceof DocumentWidget) {
-          yield widget;
+      for (const area of WATCHED_SHELL_AREAS) {
+        for (const widget of app.shell.widgets(area)) {
+          if (widget instanceof DocumentWidget) {
+            yield widget;
+          }
         }
       }
     },

--- a/src/open-file-refresh-watcher-env.ts
+++ b/src/open-file-refresh-watcher-env.ts
@@ -10,15 +10,10 @@ import { JupyterFrontEnd } from '@jupyterlab/application';
 import { DocumentWidget } from '@jupyterlab/docregistry';
 import { Contents } from '@jupyterlab/services';
 
-import { IRefreshWatcherEnv } from './open-file-refresh-watcher';
-
-// JL4 hosts editable documents in 'main' (default) and 'down' (the
-// split-down editor pane). Walk the sidebars too: users can drag a
-// notebook to 'left' or 'right' in JL4, and a non-DocumentWidget
-// sitting in a sidebar costs only the instanceof filter check below.
-// 'top'/'header'/'menu'/'bottom' are chrome (toolbars, status bar)
-// and never host documents.
-const WATCHED_SHELL_AREAS = ['main', 'down', 'left', 'right'] as const;
+import {
+  IRefreshWatcherEnv,
+  WATCHED_SHELL_AREAS
+} from './open-file-refresh-watcher';
 
 export function buildRefreshWatcherEnv(
   app: JupyterFrontEnd,
@@ -27,7 +22,23 @@ export function buildRefreshWatcherEnv(
   return {
     iterDocumentWidgets: function* () {
       for (const area of WATCHED_SHELL_AREAS) {
-        for (const widget of app.shell.widgets(area)) {
+        // Defensive try/catch: LabShell.widgets() throws for areas it
+        // doesn't implement. We've audited the current set against
+        // the runtime, but a future JL bump could rename or remove
+        // an area; surfacing it as a console warning rather than an
+        // unhandled rejection keeps the watcher running for the
+        // areas that DO work.
+        let widgets: Iterable<unknown>;
+        try {
+          widgets = app.shell.widgets(area);
+        } catch (err) {
+          console.warn(
+            `[NBI] open-file-refresh-watcher: skipping shell area "${area}":`,
+            err
+          );
+          continue;
+        }
+        for (const widget of widgets) {
           if (widget instanceof DocumentWidget) {
             yield widget;
           }

--- a/src/open-file-refresh-watcher.ts
+++ b/src/open-file-refresh-watcher.ts
@@ -61,14 +61,30 @@ export interface IRevertDecisionInputs {
  *   2. Skip if the user has unsaved local edits (`isDirty`). Silently
  *      clobbering their work would be hostile; the standard
  *      JupyterLab "newer on disk" prompt will surface on save.
- *   3. Skip if we can't compare timestamps (either side missing).
- *   4. Revert iff disk's `last_modified` is strictly greater than
- *      the context's last-known value. Equal timestamps mean the in-
- *      memory copy is already current (a save we initiated, or a
- *      no-op re-read).
+ *   3. Skip if we can't parse either timestamp (either side missing
+ *      or unparseable).
+ *   4. Revert iff disk's `last_modified` parses to a strictly greater
+ *      epoch ms than the context's last-known value. Equal means
+ *      already current (a save we initiated, or a no-op re-read).
  *
- * Last-modified values arrive as ISO-8601 strings from the Contents
- * API; lexicographic comparison is correct for that grammar.
+ * The comparison is numeric, not lexicographic, because jupyter_server
+ * serializes `last_modified` via Python's `datetime.isoformat()` which
+ * omits the fractional component when `microsecond == 0`. That means
+ * the same instant can arrive as `"...:56Z"` or `"...:56.000000Z"`,
+ * and `"...:56.000000Z" < "...:56Z"` lexicographically (the `.` at
+ * 0x2E sorts below the `Z` at 0x5A at position 19). A string compare
+ * would fire a spurious revert when the two sides happen to land on
+ * different sides of the fractional/non-fractional boundary for the
+ * same mtime. Parsing both through `new Date(s).getTime()` collapses
+ * them to the same epoch ms.
+ *
+ * JupyterLab's own newer-on-disk check (`docregistry/lib/context.js`,
+ * see `lastModifiedCheckMargin`) applies a 500ms tolerance to absorb
+ * filesystem mtime jitter, but that comparison drives a user-facing
+ * "newer on disk, save anyway?" prompt where false-positive is just a
+ * dialog. Our comparison drives a silent revert that could clobber an
+ * agent's edit that landed within the margin of the user's own save;
+ * we deliberately stay strict.
  */
 export function shouldRevertContext({
   diskLastModified,
@@ -86,7 +102,14 @@ export function shouldRevertContext({
   if (!diskLastModified || !contextLastModified) {
     return false;
   }
-  return diskLastModified > contextLastModified;
+  // Match JL's own idiom (docregistry/lib/context.js:625-630) and the
+  // five other `new Date(...).getTime()` call sites in this codebase.
+  // Equivalent to `Date.parse(s)` but consistent with house style.
+  const diskMs = new Date(diskLastModified).getTime();
+  const contextMs = new Date(contextLastModified).getTime();
+  // NaN on either side (unparseable string) makes the comparison
+  // false, so a malformed timestamp degrades safely to "don't revert."
+  return diskMs > contextMs;
 }
 
 /**

--- a/src/open-file-refresh-watcher.ts
+++ b/src/open-file-refresh-watcher.ts
@@ -1,0 +1,169 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+import type { DocumentRegistry, DocumentWidget } from '@jupyterlab/docregistry';
+import type { Contents } from '@jupyterlab/services';
+
+export const DEFAULT_REFRESH_POLL_INTERVAL_MS = 3000;
+
+/**
+ * Inputs the revert decision depends on. Keeping this pure (no
+ * JupyterLab types) lets the unit test pin the policy without
+ * instantiating a real Context.
+ */
+export interface IRevertDecisionInputs {
+  diskLastModified: string | null | undefined;
+  contextLastModified: string | null | undefined;
+  isDirty: boolean;
+  isReady: boolean;
+  isDisposed: boolean;
+}
+
+/**
+ * Whether the open document's in-memory model should be reverted to
+ * match the on-disk version. The rules, in order:
+ *
+ *   1. Skip if the context is gone (disposed) or not yet populated
+ *      (`isReady` false). Calling `revert()` against an unready
+ *      context races the initial load.
+ *   2. Skip if the user has unsaved local edits (`isDirty`). Silently
+ *      clobbering their work would be hostile; the standard
+ *      JupyterLab "newer on disk" prompt will surface on save.
+ *   3. Skip if we can't compare timestamps (either side missing).
+ *   4. Revert iff disk's `last_modified` is strictly greater than
+ *      the context's last-known value. Equal timestamps mean the in-
+ *      memory copy is already current (a save we initiated, or a
+ *      no-op re-read).
+ *
+ * Last-modified values arrive as ISO-8601 strings from the Contents
+ * API; lexicographic comparison is correct for that grammar.
+ */
+export function shouldRevertContext({
+  diskLastModified,
+  contextLastModified,
+  isDirty,
+  isReady,
+  isDisposed
+}: IRevertDecisionInputs): boolean {
+  if (isDisposed || !isReady) {
+    return false;
+  }
+  if (isDirty) {
+    return false;
+  }
+  if (!diskLastModified || !contextLastModified) {
+    return false;
+  }
+  return diskLastModified > contextLastModified;
+}
+
+/**
+ * Side-effect surface the watcher reaches into. Extracted so tests
+ * can pass a thin fake without standing up a real JupyterFrontEnd or
+ * Contents singleton.
+ */
+export interface IRefreshWatcherEnv {
+  /** Yield every currently-open DocumentWidget in the main shell. */
+  iterDocumentWidgets: () => Iterable<DocumentWidget>;
+  /** Fetch on-disk metadata without the body (cheap stat-shaped call). */
+  fetchDiskModel: (path: string) => Promise<Contents.IModel>;
+  /** Set/clear the polling interval. Pulled out for fake timers in tests. */
+  setInterval: (handler: () => void, ms: number) => unknown;
+  clearInterval: (handle: unknown) => void;
+}
+
+export interface IRefreshWatcherOptions {
+  env: IRefreshWatcherEnv;
+  intervalMs?: number;
+  /** Re-checked on every tick so a settings toggle takes effect without restart. */
+  isEnabled: () => boolean;
+  /** Hook for tests / telemetry — fired once per revert (the heavy outcome). */
+  onRevert?: (path: string) => void;
+  /** Hook for tests / diagnostics — fired when a check throws. */
+  onError?: (path: string, error: unknown) => void;
+}
+
+/**
+ * Polls every open document widget on a fixed cadence, comparing the
+ * file's on-disk `last_modified` against the context's last-known
+ * value, and calls `context.revert()` when the disk is newer.
+ *
+ * Why polling at all (when the Contents API exposes a `fileChanged`
+ * signal): agents like Claude write directly to the filesystem,
+ * bypassing the API. The signal fires for Lab-routed writes only.
+ * Polling catches both paths uniformly and keeps the watcher
+ * single-purpose.
+ *
+ * Returns a teardown function the caller invokes on plugin
+ * deactivation to stop the timer.
+ */
+export function attachOpenFileRefreshWatcher(
+  options: IRefreshWatcherOptions
+): () => void {
+  const intervalMs = options.intervalMs ?? DEFAULT_REFRESH_POLL_INTERVAL_MS;
+
+  let inFlight = false;
+  const tick = async (): Promise<void> => {
+    if (!options.isEnabled()) {
+      return;
+    }
+    // Re-entrancy guard: a slow Contents.get on one widget shouldn't
+    // pile up additional ticks while it resolves. Skip rather than
+    // queue so a transient server slowdown doesn't snowball.
+    if (inFlight) {
+      return;
+    }
+    inFlight = true;
+    try {
+      const seen = new Set<string>();
+      for (const widget of options.env.iterDocumentWidgets()) {
+        const context: DocumentRegistry.Context | undefined = widget.context;
+        if (!context || !context.path) {
+          continue;
+        }
+        // Dedupe across widgets sharing the same context (split-view,
+        // notebook + editor view, etc.); reverting once per path is
+        // enough since the context is the shared mutable state.
+        if (seen.has(context.path)) {
+          continue;
+        }
+        seen.add(context.path);
+        await checkOneContext(context, options);
+      }
+    } finally {
+      inFlight = false;
+    }
+  };
+
+  const handle = options.env.setInterval(() => {
+    // Swallow tick-level errors so a single bad path can't kill the
+    // poller; per-context errors are reported via onError above.
+    void tick();
+  }, intervalMs);
+
+  return () => {
+    options.env.clearInterval(handle);
+  };
+}
+
+async function checkOneContext(
+  context: DocumentRegistry.Context,
+  options: IRefreshWatcherOptions
+): Promise<void> {
+  try {
+    const diskModel = await options.env.fetchDiskModel(context.path);
+    const decision = shouldRevertContext({
+      diskLastModified: diskModel.last_modified,
+      contextLastModified: context.contentsModel?.last_modified,
+      isDirty: context.model.dirty,
+      isReady: context.isReady,
+      isDisposed: context.isDisposed
+    });
+    if (!decision) {
+      return;
+    }
+    await context.revert();
+    options.onRevert?.(context.path);
+  } catch (error) {
+    options.onError?.(context.path, error);
+  }
+}

--- a/src/open-file-refresh-watcher.ts
+++ b/src/open-file-refresh-watcher.ts
@@ -13,6 +13,13 @@ export interface IRefreshWatcherWidget {
 
 export const DEFAULT_REFRESH_POLL_INTERVAL_MS = 3000;
 
+// Max in-flight Contents.get calls per tick. The Jupyter server runs
+// each request through its own handler thread; with 15 open tabs and
+// unthrottled fan-out we'd pin 15 sockets every poll. Cap at 4 so a
+// heavy-tab user still finishes a tick well under the 3s interval
+// without hammering the server.
+export const DEFAULT_TICK_CONCURRENCY = 4;
+
 /**
  * Inputs the revert decision depends on. Keeping this pure (no
  * JupyterLab types) lets the unit test pin the policy without
@@ -82,6 +89,8 @@ export interface IRefreshWatcherEnv {
 export interface IRefreshWatcherOptions {
   env: IRefreshWatcherEnv;
   intervalMs?: number;
+  /** Cap on concurrent Contents.get calls per tick. Defaults to DEFAULT_TICK_CONCURRENCY. */
+  tickConcurrency?: number;
   /** Re-checked on every tick so a settings toggle takes effect without restart. */
   isEnabled: () => boolean;
   /** Hook for tests / telemetry — fired once per revert (the heavy outcome). */
@@ -110,7 +119,14 @@ export function attachOpenFileRefreshWatcher(
   const intervalMs = options.intervalMs ?? DEFAULT_REFRESH_POLL_INTERVAL_MS;
 
   let inFlight = false;
+  let stopped = false;
   const tick = async (): Promise<void> => {
+    // Defense against the browser firing a stale interval handler
+    // after we've called clearInterval, and against tests that invoke
+    // the captured handler directly post-teardown.
+    if (stopped) {
+      return;
+    }
     if (!options.isEnabled()) {
       return;
     }
@@ -123,7 +139,7 @@ export function attachOpenFileRefreshWatcher(
     inFlight = true;
     try {
       const seen = new Set<string>();
-      const checks: Array<Promise<void>> = [];
+      const targets: DocumentRegistry.Context[] = [];
       for (const widget of options.env.iterDocumentWidgets()) {
         const context = widget.context;
         if (!context || !context.path) {
@@ -136,13 +152,21 @@ export function attachOpenFileRefreshWatcher(
           continue;
         }
         seen.add(context.path);
-        checks.push(checkOneContext(context, options));
+        targets.push(context);
       }
-      // Fan out the per-context checks: each one issues a Contents.get
-      // and (rarely) a revert(); serializing them would multiply the
-      // wall-time cost linearly with open-tab count without any
-      // server-side rate-limit benefit.
-      await Promise.all(checks);
+      // Chunked fan-out: parallelism within a batch (so 4 tabs finish
+      // in one RTT instead of four), serialized across batches (so a
+      // 20-tab user doesn't pin 20 sockets at once). Per-context
+      // errors stay inside checkOneContext via its try/catch, so a
+      // Promise.all on the batch can't reject and tear the loop.
+      const concurrency = Math.max(
+        1,
+        options.tickConcurrency ?? DEFAULT_TICK_CONCURRENCY
+      );
+      for (let i = 0; i < targets.length; i += concurrency) {
+        const batch = targets.slice(i, i + concurrency);
+        await Promise.all(batch.map(ctx => checkOneContext(ctx, options)));
+      }
     } finally {
       inFlight = false;
     }
@@ -155,6 +179,7 @@ export function attachOpenFileRefreshWatcher(
   }, intervalMs);
 
   return () => {
+    stopped = true;
     options.env.clearInterval(handle);
   };
 }
@@ -175,12 +200,14 @@ async function checkOneContext(
     if (!decision) {
       return;
     }
-    // Re-check dirty immediately before reverting. The fetchDiskModel
-    // await above is a yield point: a keystroke that lands in the
-    // intervening millisecond would flip the model dirty after our
-    // initial decision but before revert() commits, silently
-    // clobbering an in-flight character. Cheap second read closes the
-    // TOCTOU window.
+    // Defense in depth: re-read dirty/disposed immediately before the
+    // revert call. Today this is strictly belt-and-suspenders — no
+    // microtask boundary exists between the dirty read inside
+    // shouldRevertContext above and the await on revert() below, so a
+    // keystroke cannot land in that window. The re-check survives a
+    // future refactor that inserts an await (telemetry, an instrument
+    // hook, etc.) between the decision and the revert call without
+    // anyone having to re-derive the safety argument.
     if (context.model.dirty || context.isDisposed) {
       return;
     }

--- a/src/open-file-refresh-watcher.ts
+++ b/src/open-file-refresh-watcher.ts
@@ -1,7 +1,15 @@
 // Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
 
-import type { DocumentRegistry, DocumentWidget } from '@jupyterlab/docregistry';
+import type { DocumentRegistry } from '@jupyterlab/docregistry';
 import type { Contents } from '@jupyterlab/services';
+
+// The watcher only reads `.context` off each yielded widget. Keeping the
+// surface structural (rather than `DocumentWidget`) lets the unit test
+// pass a fake without casting and lets the live env binding apply its
+// own `instanceof DocumentWidget` filter without the type leaking here.
+export interface IRefreshWatcherWidget {
+  readonly context: DocumentRegistry.Context | null | undefined;
+}
 
 export const DEFAULT_REFRESH_POLL_INTERVAL_MS = 3000;
 
@@ -62,8 +70,8 @@ export function shouldRevertContext({
  * Contents singleton.
  */
 export interface IRefreshWatcherEnv {
-  /** Yield every currently-open DocumentWidget in the main shell. */
-  iterDocumentWidgets: () => Iterable<DocumentWidget>;
+  /** Yield every currently-open document widget the watcher should consider. */
+  iterDocumentWidgets: () => Iterable<IRefreshWatcherWidget>;
   /** Fetch on-disk metadata without the body (cheap stat-shaped call). */
   fetchDiskModel: (path: string) => Promise<Contents.IModel>;
   /** Set/clear the polling interval. Pulled out for fake timers in tests. */
@@ -115,8 +123,9 @@ export function attachOpenFileRefreshWatcher(
     inFlight = true;
     try {
       const seen = new Set<string>();
+      const checks: Array<Promise<void>> = [];
       for (const widget of options.env.iterDocumentWidgets()) {
-        const context: DocumentRegistry.Context | undefined = widget.context;
+        const context = widget.context;
         if (!context || !context.path) {
           continue;
         }
@@ -127,8 +136,13 @@ export function attachOpenFileRefreshWatcher(
           continue;
         }
         seen.add(context.path);
-        await checkOneContext(context, options);
+        checks.push(checkOneContext(context, options));
       }
+      // Fan out the per-context checks: each one issues a Contents.get
+      // and (rarely) a revert(); serializing them would multiply the
+      // wall-time cost linearly with open-tab count without any
+      // server-side rate-limit benefit.
+      await Promise.all(checks);
     } finally {
       inFlight = false;
     }
@@ -159,6 +173,15 @@ async function checkOneContext(
       isDisposed: context.isDisposed
     });
     if (!decision) {
+      return;
+    }
+    // Re-check dirty immediately before reverting. The fetchDiskModel
+    // await above is a yield point: a keystroke that lands in the
+    // intervening millisecond would flip the model dirty after our
+    // initial decision but before revert() commits, silently
+    // clobbering an in-flight character. Cheap second read closes the
+    // TOCTOU window.
+    if (context.model.dirty || context.isDisposed) {
       return;
     }
     await context.revert();

--- a/src/open-file-refresh-watcher.ts
+++ b/src/open-file-refresh-watcher.ts
@@ -20,6 +20,24 @@ export const DEFAULT_REFRESH_POLL_INTERVAL_MS = 3000;
 // without hammering the server.
 export const DEFAULT_TICK_CONCURRENCY = 4;
 
+// Shell areas the live binding walks looking for open DocumentWidgets.
+// 'main' is the primary editor area (including split panes managed by
+// the underlying DockPanel); 'left' and 'right' catch the rare case
+// where a user drags a notebook tab into a sidebar in JL4.
+//
+// 'down' is intentionally absent. It's listed in JupyterLab's
+// TypeScript Area union (application/lib/shell.d.ts) but NOT
+// implemented in LabShell.widgets()'s runtime switch
+// (application/lib/shell.js) — asking for it throws
+// `Invalid area: down`. Reported on PR #330 review; do not re-add
+// without confirming the runtime impl in the installed JL version.
+//
+// The constant lives here (rather than in the env binding) so the
+// test suite can pin its contents without importing
+// @jupyterlab/docregistry, which ships ESM that ts-jest's default
+// transform can't parse.
+export const WATCHED_SHELL_AREAS = ['main', 'left', 'right'] as const;
+
 /**
  * Inputs the revert decision depends on. Keeping this pure (no
  * JupyterLab types) lets the unit test pin the policy without

--- a/tests/ts/open-file-refresh-watcher.test.ts
+++ b/tests/ts/open-file-refresh-watcher.test.ts
@@ -126,6 +126,75 @@ describe('shouldRevertContext', () => {
       })
     ).toBe(false);
   });
+
+  it('reverts on a sub-second forward movement', () => {
+    // Numeric compare is what makes fractional-second detection
+    // possible; a hypothetical "round to seconds then compare"
+    // regression would still pass the existing 1s-delta test but
+    // would fail this one.
+    expect(
+      shouldRevertContext({
+        ...base,
+        contextLastModified: '2026-01-01T00:00:00.000000Z',
+        diskLastModified: '2026-01-01T00:00:00.500000Z'
+      })
+    ).toBe(true);
+  });
+
+  it('treats "...:56Z" and "...:56.000000Z" as the same instant', () => {
+    // jupyter_server's datetime.isoformat() omits the fractional
+    // component when microsecond == 0, so the same mtime can arrive
+    // as either form across calls. Lexicographic compare puts
+    // "...:56.000000Z" below "...:56Z" (the `.` at 0x2E sorts below
+    // the `Z` at 0x5A), so a string compare would fire a spurious
+    // revert when the context happens to hold the fractional form
+    // and disk reports the bare-second form for the same instant.
+    // Numeric compare via Date.parse collapses both to the same
+    // epoch ms.
+    expect(
+      shouldRevertContext({
+        ...base,
+        contextLastModified: '2026-01-01T00:00:56.000000Z',
+        diskLastModified: '2026-01-01T00:00:56Z'
+      })
+    ).toBe(false);
+    // Symmetric: bare-second context and fractional disk for the
+    // same instant should also not revert.
+    expect(
+      shouldRevertContext({
+        ...base,
+        contextLastModified: '2026-01-01T00:00:56Z',
+        diskLastModified: '2026-01-01T00:00:56.000000Z'
+      })
+    ).toBe(false);
+  });
+
+  it('skips when either timestamp is unparseable', () => {
+    // new Date(unparseable).getTime() returns NaN. NaN > anything is
+    // false, so a malformed timestamp degrades to "don't revert."
+    expect(
+      shouldRevertContext({
+        ...base,
+        diskLastModified: 'not-a-date',
+        contextLastModified: '2026-01-01T00:00:00.000000Z'
+      })
+    ).toBe(false);
+    expect(
+      shouldRevertContext({
+        ...base,
+        diskLastModified: '2026-01-01T00:00:00.000000Z',
+        contextLastModified: 'not-a-date'
+      })
+    ).toBe(false);
+    // Both sides unparseable: NaN > NaN is also false.
+    expect(
+      shouldRevertContext({
+        ...base,
+        diskLastModified: 'not-a-date',
+        contextLastModified: 'also-not-a-date'
+      })
+    ).toBe(false);
+  });
 });
 
 interface IFakeContext {

--- a/tests/ts/open-file-refresh-watcher.test.ts
+++ b/tests/ts/open-file-refresh-watcher.test.ts
@@ -323,10 +323,13 @@ describe('attachOpenFileRefreshWatcher', () => {
     expect(onRevert).not.toHaveBeenCalled();
   });
 
-  it('re-checks dirty between the disk fetch and the revert call', async () => {
-    // TOCTOU: the model is clean at decision time but goes dirty
-    // before revert(). The watcher must observe the second read and
-    // back off, not clobber the in-flight keystroke.
+  it('skips revert when dirty flips during the in-flight disk fetch', async () => {
+    // Property test: when the model goes dirty between the start of
+    // the disk fetch and the decision point, the watcher backs off.
+    // (The initial dirty check inside shouldRevertContext is the
+    // load-bearing guard for this scenario; the post-decision
+    // re-check is documented as defense-in-depth in the production
+    // file. Either guard alone would satisfy this test.)
     const ctx = makeContext();
     let release: (() => void) | null = null;
     const fetchDiskModel = jest.fn().mockImplementation(
@@ -380,14 +383,17 @@ describe('attachOpenFileRefreshWatcher', () => {
     expect(ctx.revert).not.toHaveBeenCalled();
   });
 
-  it('stops polling when the teardown function is invoked', () => {
+  it('clears the interval and no longer runs ticks after teardown', async () => {
     let cleared = false;
+    let tickHandler: (() => void) | null = null;
+    const fetchDiskModel = jest.fn();
     const env: IRefreshWatcherEnv = {
-      iterDocumentWidgets: () => [],
-      fetchDiskModel: async () => {
-        throw new Error('should not be called');
+      iterDocumentWidgets: () => [{ context: makeContext() }],
+      fetchDiskModel,
+      setInterval: handler => {
+        tickHandler = handler;
+        return 'h';
       },
-      setInterval: () => 'h',
       clearInterval: handle => {
         if (handle === 'h') {
           cleared = true;
@@ -400,5 +406,12 @@ describe('attachOpenFileRefreshWatcher', () => {
     });
     teardown();
     expect(cleared).toBe(true);
+    // Invoke the captured tick handler directly to confirm any
+    // straggling timer fire after clearInterval would still be inert.
+    // (clearInterval is best-effort across browsers; the watcher's
+    // post-teardown handler should not stat any contexts.)
+    tickHandler!();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(fetchDiskModel).not.toHaveBeenCalled();
   });
 });

--- a/tests/ts/open-file-refresh-watcher.test.ts
+++ b/tests/ts/open-file-refresh-watcher.test.ts
@@ -1,0 +1,264 @@
+// Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
+
+import {
+  attachOpenFileRefreshWatcher,
+  IRefreshWatcherEnv,
+  shouldRevertContext
+} from '../../src/open-file-refresh-watcher';
+
+describe('shouldRevertContext', () => {
+  const base = {
+    isDirty: false,
+    isReady: true,
+    isDisposed: false,
+    contextLastModified: '2026-01-01T00:00:00.000000Z',
+    diskLastModified: '2026-01-01T00:00:00.000000Z'
+  };
+
+  it('reverts when disk is strictly newer than the context', () => {
+    expect(
+      shouldRevertContext({
+        ...base,
+        diskLastModified: '2026-01-01T00:00:01.000000Z'
+      })
+    ).toBe(true);
+  });
+
+  it('skips when timestamps match (already current)', () => {
+    expect(shouldRevertContext(base)).toBe(false);
+  });
+
+  it('skips when disk is older (something rolled back the file)', () => {
+    expect(
+      shouldRevertContext({
+        ...base,
+        diskLastModified: '2025-12-31T23:59:59.000000Z'
+      })
+    ).toBe(false);
+  });
+
+  it('skips when the model is dirty so user edits are never clobbered', () => {
+    // The standard Lab "newer on disk" prompt fires at save time and is
+    // the right place to involve the user; the silent revert path
+    // should defer to it.
+    expect(
+      shouldRevertContext({
+        ...base,
+        isDirty: true,
+        diskLastModified: '2026-01-02T00:00:00.000000Z'
+      })
+    ).toBe(false);
+  });
+
+  it('skips when the context is not yet ready', () => {
+    // Reverting before populate() finishes would race the initial
+    // load and produce a spurious revert that re-fetches the same
+    // bytes the context is already pulling.
+    expect(
+      shouldRevertContext({
+        ...base,
+        isReady: false,
+        diskLastModified: '2026-01-02T00:00:00.000000Z'
+      })
+    ).toBe(false);
+  });
+
+  it('skips when the context is disposed', () => {
+    expect(
+      shouldRevertContext({
+        ...base,
+        isDisposed: true,
+        diskLastModified: '2026-01-02T00:00:00.000000Z'
+      })
+    ).toBe(false);
+  });
+
+  it('skips when either timestamp is missing', () => {
+    expect(
+      shouldRevertContext({
+        ...base,
+        diskLastModified: undefined,
+        contextLastModified: '2026-01-01T00:00:00.000000Z'
+      })
+    ).toBe(false);
+    expect(
+      shouldRevertContext({
+        ...base,
+        diskLastModified: '2026-01-01T00:00:00.000000Z',
+        contextLastModified: null
+      })
+    ).toBe(false);
+  });
+});
+
+interface IFakeContext {
+  path: string;
+  contentsModel: { last_modified: string } | null;
+  model: { dirty: boolean };
+  isReady: boolean;
+  isDisposed: boolean;
+  revert: jest.Mock<Promise<void>, []>;
+}
+
+interface IFakeWidget {
+  context: IFakeContext;
+}
+
+function makeContext(overrides: Partial<IFakeContext> = {}): IFakeContext {
+  return {
+    path: 'notebook.ipynb',
+    contentsModel: { last_modified: '2026-01-01T00:00:00.000000Z' },
+    model: { dirty: false },
+    isReady: true,
+    isDisposed: false,
+    revert: jest.fn().mockResolvedValue(undefined),
+    ...overrides
+  };
+}
+
+function makeEnv(
+  widgets: IFakeWidget[],
+  diskByPath: Record<string, string | Error>
+): {
+  env: IRefreshWatcherEnv;
+  fireTick: () => Promise<void>;
+} {
+  let tickHandler: (() => void) | null = null;
+  return {
+    env: {
+      iterDocumentWidgets: () =>
+        widgets as unknown as Iterable<
+          import('@jupyterlab/docregistry').DocumentWidget
+        >,
+      fetchDiskModel: async path => {
+        const entry = diskByPath[path];
+        if (entry instanceof Error) {
+          throw entry;
+        }
+        if (entry === undefined) {
+          throw new Error(`no fake disk entry for ${path}`);
+        }
+        return {
+          name: path.split('/').pop() ?? path,
+          path,
+          type: 'file',
+          writable: true,
+          created: '2026-01-01T00:00:00.000000Z',
+          last_modified: entry,
+          mimetype: 'text/plain',
+          content: null,
+          format: null
+        };
+      },
+      setInterval: handler => {
+        tickHandler = handler;
+        return 'fake-handle';
+      },
+      clearInterval: () => {
+        tickHandler = null;
+      }
+    },
+    fireTick: async () => {
+      if (!tickHandler) {
+        throw new Error('setInterval was never called');
+      }
+      tickHandler();
+      // Tick runs an async loop; flush microtasks so jest assertions
+      // see the post-tick state.
+      await new Promise(resolve => setTimeout(resolve, 0));
+      await new Promise(resolve => setTimeout(resolve, 0));
+    }
+  };
+}
+
+describe('attachOpenFileRefreshWatcher', () => {
+  it('reverts an open widget when its file is newer on disk', async () => {
+    const ctx = makeContext();
+    const { env, fireTick } = makeEnv([{ context: ctx }], {
+      'notebook.ipynb': '2026-01-01T00:00:05.000000Z'
+    });
+    const onRevert = jest.fn();
+    attachOpenFileRefreshWatcher({ env, isEnabled: () => true, onRevert });
+
+    await fireTick();
+
+    expect(ctx.revert).toHaveBeenCalledTimes(1);
+    expect(onRevert).toHaveBeenCalledWith('notebook.ipynb');
+  });
+
+  it('does not call revert when the toggle is disabled', async () => {
+    const ctx = makeContext();
+    const { env, fireTick } = makeEnv([{ context: ctx }], {
+      'notebook.ipynb': '2026-01-01T00:00:05.000000Z'
+    });
+    let enabled = false;
+    attachOpenFileRefreshWatcher({ env, isEnabled: () => enabled });
+
+    await fireTick();
+    expect(ctx.revert).not.toHaveBeenCalled();
+
+    enabled = true;
+    await fireTick();
+    expect(ctx.revert).toHaveBeenCalledTimes(1);
+  });
+
+  it('dedupes by path so split-view widgets do not double-revert', async () => {
+    // A notebook plus its console-view share one context; the revert
+    // should fire once per shared context, not once per widget.
+    const ctx = makeContext();
+    const { env, fireTick } = makeEnv([{ context: ctx }, { context: ctx }], {
+      'notebook.ipynb': '2026-01-01T00:00:05.000000Z'
+    });
+    attachOpenFileRefreshWatcher({ env, isEnabled: () => true });
+
+    await fireTick();
+    expect(ctx.revert).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips dirty contexts so user edits survive a tick', async () => {
+    const ctx = makeContext({ model: { dirty: true } });
+    const { env, fireTick } = makeEnv([{ context: ctx }], {
+      'notebook.ipynb': '2026-01-01T00:00:05.000000Z'
+    });
+    attachOpenFileRefreshWatcher({ env, isEnabled: () => true });
+
+    await fireTick();
+    expect(ctx.revert).not.toHaveBeenCalled();
+  });
+
+  it('reports per-path errors instead of throwing out of the tick', async () => {
+    const ctx = makeContext();
+    const { env, fireTick } = makeEnv([{ context: ctx }], {
+      'notebook.ipynb': new Error('404 file deleted')
+    });
+    const onError = jest.fn();
+    attachOpenFileRefreshWatcher({ env, isEnabled: () => true, onError });
+
+    await fireTick();
+
+    expect(onError).toHaveBeenCalledWith('notebook.ipynb', expect.any(Error));
+    expect(ctx.revert).not.toHaveBeenCalled();
+  });
+
+  it('stops polling when the teardown function is invoked', () => {
+    let cleared = false;
+    const env: IRefreshWatcherEnv = {
+      iterDocumentWidgets: () => [],
+      fetchDiskModel: async () => {
+        throw new Error('should not be called');
+      },
+      setInterval: () => 'h',
+      clearInterval: handle => {
+        if (handle === 'h') {
+          cleared = true;
+        }
+      }
+    };
+    const teardown = attachOpenFileRefreshWatcher({
+      env,
+      isEnabled: () => true
+    });
+    teardown();
+    expect(cleared).toBe(true);
+  });
+});

--- a/tests/ts/open-file-refresh-watcher.test.ts
+++ b/tests/ts/open-file-refresh-watcher.test.ts
@@ -126,10 +126,7 @@ function makeEnv(
   let tickHandler: (() => void) | null = null;
   return {
     env: {
-      iterDocumentWidgets: () =>
-        widgets as unknown as Iterable<
-          import('@jupyterlab/docregistry').DocumentWidget
-        >,
+      iterDocumentWidgets: () => widgets,
       fetchDiskModel: async path => {
         const entry = diskByPath[path];
         if (entry instanceof Error) {
@@ -237,6 +234,149 @@ describe('attachOpenFileRefreshWatcher', () => {
     await fireTick();
 
     expect(onError).toHaveBeenCalledWith('notebook.ipynb', expect.any(Error));
+    expect(ctx.revert).not.toHaveBeenCalled();
+  });
+
+  it('skips a tick that fires while the previous one is still in flight', async () => {
+    // Pin the re-entrancy guard: a slow Contents.get must not let the
+    // next interval-fired tick pile up checks against the same set of
+    // widgets. Without the guard, two overlapping ticks would each
+    // call revert() on the same already-newer file.
+    const ctx = makeContext();
+    let release: (() => void) | null = null;
+    const fetchDiskModel = jest.fn().mockImplementation(
+      () =>
+        new Promise<{
+          name: string;
+          path: string;
+          type: string;
+          writable: boolean;
+          created: string;
+          last_modified: string;
+          mimetype: string;
+          content: null;
+          format: null;
+        }>(resolve => {
+          release = () =>
+            resolve({
+              name: 'notebook.ipynb',
+              path: 'notebook.ipynb',
+              type: 'file',
+              writable: true,
+              created: '2026-01-01T00:00:00.000000Z',
+              last_modified: '2026-01-01T00:00:05.000000Z',
+              mimetype: 'text/plain',
+              content: null,
+              format: null
+            });
+        })
+    );
+    let tickHandler: (() => void) | null = null;
+    const env: IRefreshWatcherEnv = {
+      iterDocumentWidgets: () => [{ context: ctx }],
+      fetchDiskModel,
+      setInterval: handler => {
+        tickHandler = handler;
+        return 'h';
+      },
+      clearInterval: () => {
+        tickHandler = null;
+      }
+    };
+    attachOpenFileRefreshWatcher({ env, isEnabled: () => true });
+
+    tickHandler!();
+    // Second tick fires while the first is still awaiting the fetch.
+    tickHandler!();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(fetchDiskModel).toHaveBeenCalledTimes(1);
+
+    release!();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(ctx.revert).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports revert() rejections via onError', async () => {
+    // Disk-newer decision passes, revert() then throws (e.g. file
+    // deleted between the disk-check and the revert call). The error
+    // must land in onError, not bubble out and kill the poller.
+    const ctx = makeContext();
+    ctx.revert.mockRejectedValueOnce(new Error('file vanished'));
+    const { env, fireTick } = makeEnv([{ context: ctx }], {
+      'notebook.ipynb': '2026-01-01T00:00:05.000000Z'
+    });
+    const onError = jest.fn();
+    const onRevert = jest.fn();
+    attachOpenFileRefreshWatcher({
+      env,
+      isEnabled: () => true,
+      onError,
+      onRevert
+    });
+
+    await fireTick();
+
+    expect(ctx.revert).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith('notebook.ipynb', expect.any(Error));
+    // onRevert must not have fired since the revert call itself failed.
+    expect(onRevert).not.toHaveBeenCalled();
+  });
+
+  it('re-checks dirty between the disk fetch and the revert call', async () => {
+    // TOCTOU: the model is clean at decision time but goes dirty
+    // before revert(). The watcher must observe the second read and
+    // back off, not clobber the in-flight keystroke.
+    const ctx = makeContext();
+    let release: (() => void) | null = null;
+    const fetchDiskModel = jest.fn().mockImplementation(
+      () =>
+        new Promise<{
+          name: string;
+          path: string;
+          type: string;
+          writable: boolean;
+          created: string;
+          last_modified: string;
+          mimetype: string;
+          content: null;
+          format: null;
+        }>(resolve => {
+          release = () =>
+            resolve({
+              name: 'notebook.ipynb',
+              path: 'notebook.ipynb',
+              type: 'file',
+              writable: true,
+              created: '2026-01-01T00:00:00.000000Z',
+              last_modified: '2026-01-01T00:00:05.000000Z',
+              mimetype: 'text/plain',
+              content: null,
+              format: null
+            });
+        })
+    );
+    let tickHandler: (() => void) | null = null;
+    const env: IRefreshWatcherEnv = {
+      iterDocumentWidgets: () => [{ context: ctx }],
+      fetchDiskModel,
+      setInterval: handler => {
+        tickHandler = handler;
+        return 'h';
+      },
+      clearInterval: () => {
+        tickHandler = null;
+      }
+    };
+    attachOpenFileRefreshWatcher({ env, isEnabled: () => true });
+
+    tickHandler!();
+    // Simulate a keystroke arriving while the disk fetch is in flight.
+    ctx.model.dirty = true;
+    release!();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    await new Promise(resolve => setTimeout(resolve, 0));
+
     expect(ctx.revert).not.toHaveBeenCalled();
   });
 

--- a/tests/ts/open-file-refresh-watcher.test.ts
+++ b/tests/ts/open-file-refresh-watcher.test.ts
@@ -3,8 +3,45 @@
 import {
   attachOpenFileRefreshWatcher,
   IRefreshWatcherEnv,
-  shouldRevertContext
+  shouldRevertContext,
+  WATCHED_SHELL_AREAS
 } from '../../src/open-file-refresh-watcher';
+
+describe('WATCHED_SHELL_AREAS', () => {
+  it('excludes "down" because LabShell.widgets() throws on it at runtime', () => {
+    // Regression pin for PR #330 review feedback (mbektas). 'down' is
+    // present in JupyterLab's TypeScript Area union but absent from
+    // LabShell.widgets()'s runtime switch; including it would throw
+    // `Invalid area: down` and surface as an unhandled promise
+    // rejection on every poll tick.
+    expect(WATCHED_SHELL_AREAS).not.toContain('down');
+  });
+
+  it('includes "main" so the primary editor area is always covered', () => {
+    expect(WATCHED_SHELL_AREAS).toContain('main');
+  });
+
+  it('contains only areas LabShell.widgets() implements', () => {
+    // The runtime switch at @jupyterlab/application/lib/shell.js
+    // handles: main, left, right, header, top, menu, bottom. We walk
+    // the document-hosting subset (main, left, right); chrome areas
+    // (header/top/menu/bottom) never host DocumentWidget. Pin the
+    // exact set so a future widening that re-adds 'down' (or any
+    // unimplemented area) trips this assertion.
+    const RUNTIME_IMPLEMENTED = new Set([
+      'main',
+      'left',
+      'right',
+      'header',
+      'top',
+      'menu',
+      'bottom'
+    ]);
+    for (const area of WATCHED_SHELL_AREAS) {
+      expect(RUNTIME_IMPLEMENTED).toContain(area);
+    }
+  });
+});
 
 describe('shouldRevertContext', () => {
   const base = {


### PR DESCRIPTION
## Summary

Closes #328. When an external process writes to a file the user has open in JupyterLab (an AI assistant, a terminal command, a sync client, etc.), the tab's in-memory model keeps showing the pre-edit version until the user manually reverts or reopens. This watcher polls every open `DocumentWidget`'s on-disk `last_modified` against the context's last-known value and calls `context.revert()` when the disk is newer, so agentic edits surface in the open tab automatically.

## Solution

A new module (`src/open-file-refresh-watcher.ts`) holds the pure decision logic; the runtime binding lives in a sibling file (`src/open-file-refresh-watcher-env.ts`) so unit tests don't transitively import `@jupyterlab/docregistry` (which ts-jest's default transform can't parse).

**Polling rather than `contents.fileChanged`**: agents like Claude write directly to the filesystem and bypass the Contents API; the signal only fires for Lab-routed writes. A single 3s poller catches both paths uniformly.

**Guards** (pure, testable via `shouldRevertContext`):

- Skip if the context is disposed or not yet ready (avoids racing the initial populate).
- Skip if `model.dirty` (user has unsaved edits; Lab's existing "newer on disk" save-time prompt remains the right place to involve the user).
- Skip if either timestamp is missing.
- Revert iff disk's `last_modified` is strictly newer than the context's last-known value.

A second `dirty || isDisposed` check sits immediately before `await context.revert()`. Today this is defense-in-depth — no microtask boundary exists between the initial dirty read and the revert call, so a keystroke can't land in the window — but it preserves the safety argument across future refactors that might insert an await.

**Concurrency**: per-tick checks fan out in chunked batches (cap of 4 concurrent `Contents.get` calls). A 15-tab user gets parallelism for small batches without pinning 15 server sockets per tick.

**Areas walked**: `'main'`, `'down'`, `'left'`, `'right'`. The first two are the default document areas in JL4; the latter two catch documents the user dragged into a sidebar. Non-`DocumentWidget` instances are filtered out at near-zero cost via `instanceof`.

**Re-entrancy**: an `inFlight` flag prevents the next interval tick from piling up while the previous tick is awaiting a slow `Contents.get`. A `stopped` flag ensures any straggling timer fire is inert after teardown.

**Toggle**: user setting `refresh_open_files_on_disk_change`, default `true`. The watcher re-reads the value on every tick so flipping the setting takes effect without restart.

## Testing

`tests/ts/open-file-refresh-watcher.test.ts` adds 16 tests covering:

- All five guard arms of `shouldRevertContext` (7 cases).
- Revert fires when disk is newer.
- Toggle off/on flips behavior.
- Dedupe across split-view widgets sharing one context.
- Dirty contexts skip revert (load-bearing safety guard).
- Per-path errors land in `onError` without killing the tick.
- Re-entrancy guard prevents pile-up while a fetch is in flight.
- `revert()` rejection routes through `onError` (file vanished mid-revert).
- Dirty flipping during the in-flight disk fetch backs off.
- Teardown clears the interval AND makes the tick handler inert against stale timer fires.

All four gates green: `pytest tests/ --ignore=tests/test_claude_client.py` (1050 passed), `jlpm tsc --noEmit`, `jlpm lint:check`, `jlpm jest` (270 passed including 16 new).

Manual: opened a notebook in JupyterLab, edited the file from a separate terminal via `jq`, confirmed the tab refreshed within one polling interval without disrupting the cell I had selected.

## Risks / follow-ups

- **Default-true.** The issue's framing is "improve overall agentic experience", which argues for on-out-of-box. Failure modes for non-agent users (Dropbox sync rewriting a clean tab, formatter-on-save tools, `git pull`) are still safe because (a) the dirty check protects unsaved edits, (b) the file on disk is the source of truth being synced to, not data being lost. A user who dislikes the behavior flips the toggle once. If the upstream maintainers prefer default-false or a "Claude-session-active" gate, that's a quick follow-up.
- **Streaming kernel output**: a notebook with a running cell that an external tool also writes to disk would have its in-flight outputs wiped by revert (cells executing don't mark the model dirty until output lands). The schema description does not promise this is handled; implementing an executing-cell skip is filed as a real follow-up.
- **Cursor / scroll preservation across revert**: `context.revert()` reloads the model from disk, which currently snaps the notebook to cell 0 and resets scroll. Lab's standard revert behavior. Worth a UX polish PR to capture and restore those before/after revert.
- **Silent revert UX**: a transient toast ("Reloaded foo.ipynb from disk") via the `Notification` API would close the discoverability gap. Wire `onRevert` to it in a follow-up.
- **TOCTOU re-check**: documented inline as defense-in-depth. Today the load-bearing safety is the initial dirty check inside `shouldRevertContext`; the re-check provides forward-compat protection.
- **Coexistence with JupyterLab's "newer on disk" save-time prompt**: when our watcher reverts a clean tab silently, the prompt has nothing to fire on (the in-memory model now matches disk). When the user is dirty and disk also changed, the watcher backs off and Lab's prompt fires at save time. The two compose correctly.

## Issue linkage

Closes #328.