### PR TITLE
fix(claude-sessions): unwrap NBI preamble when joined with user prompt

### DIFF
--- a/notebook_intelligence/claude_sessions.py
+++ b/notebook_intelligence/claude_sessions.py
@@ -253,10 +253,49 @@ def _is_skippable_user_message(obj: dict) -> bool:
     return False
 
 
+def _strip_nbi_context_preamble(text: str) -> str:
+    """Strip the NBI context-preamble line if it leads ``text``.
+
+    The backend appends the preamble (``Additional context: ...``) as
+    its own user-role message in ``extension.py``, but ``claude.py``
+    joins consecutive user-role entries with ``\\n`` before handing
+    them to the SDK. The session transcript therefore records one
+    combined user message whose first line is the preamble and whose
+    remainder is the user's actual prompt. Returning the remainder
+    here lets the skip and preview logic treat the joined form like
+    the separate form (issue #329).
+
+    Returns ``text`` unchanged when the preamble isn't present.
+    Returns an empty string when the preamble is the entire message
+    (no newline, no following content).
+    """
+    if not text.startswith(NBI_CONTEXT_PREFIX):
+        return text
+    newline_at = text.find("\n")
+    if newline_at == -1:
+        return ""
+    return text[newline_at + 1 :]
+
+
 def _is_skippable_text(text: str) -> bool:
     stripped = text.strip()
     if not stripped:
         return True
+    # Unwrap the NBI preamble before checking the rest of the skip
+    # rules: the preamble itself is skippable, but the user's actual
+    # prompt that follows it (when claude.py joined the two user-role
+    # messages into one) usually isn't. Without this, a single-prompt
+    # session shows no preview because the only user message starts
+    # with the preamble.
+    if stripped.startswith(NBI_CONTEXT_PREFIX):
+        # Recurses at most once. NBI_CONTEXT_PREFIX is single-line, so
+        # the helper strips through the first newline (or returns ""
+        # when no newline exists). The unwrapped tail therefore cannot
+        # itself start with the preamble — the recursive call falls
+        # through to the legacy prefix / control-command checks or
+        # bottoms out on the empty-stripped guard at the top of this
+        # function.
+        return _is_skippable_text(_strip_nbi_context_preamble(stripped))
     if stripped.startswith(_SKIPPABLE_PREFIXES):
         return True
     return stripped in _CONTROL_SLASH_COMMANDS
@@ -276,6 +315,12 @@ def _extract_preview(obj: dict) -> str:
             if block.get("type") == "text" and isinstance(block.get("text"), str):
                 parts.append(block["text"])
         text = "\n".join(parts)
+
+    # Drop the NBI context preamble line if claude.py joined it onto
+    # the front of the user's actual prompt (issue #329). Without
+    # this, the preview reads "Additional context: ..." instead of
+    # what the user asked.
+    text = _strip_nbi_context_preamble(text)
 
     # Collapse whitespace so multi-line prompts render as a single row.
     text = " ".join(text.split())

--- a/tests/test_claude_sessions.py
+++ b/tests/test_claude_sessions.py
@@ -290,6 +290,106 @@ class TestListSessions:
         result = _list_sessions_in_dir(project_cwd, claude_home=str(fake_claude_home))
         assert [s.preview for s in result] == ["Hello world"]
 
+    def test_unwraps_joined_preamble_and_prompt_in_one_message(
+        self, sessions_dir, fake_claude_home, project_cwd
+    ):
+        # Repro for issue #329: claude.py joins consecutive user-role
+        # messages with "\n" before handing them to the SDK, so a session
+        # whose only turn is preamble + prompt gets recorded as one
+        # combined user message. The picker must still surface the user's
+        # prompt as the preview (and must not drop the session as
+        # "all-skippable").
+        joined = _user_line(
+            "real",
+            "Additional context: Current directory open in Jupyter is: ''\n"
+            "How can I load JSON from a URL and save as dataframe?",
+        )
+        _write_jsonl(sessions_dir / "real.jsonl", [joined])
+
+        result = _list_sessions_in_dir(project_cwd, claude_home=str(fake_claude_home))
+        assert len(result) == 1
+        assert (
+            result[0].preview
+            == "How can I load JSON from a URL and save as dataframe?"
+        )
+
+    def test_unwraps_joined_preamble_in_structured_content(
+        self, sessions_dir, fake_claude_home, project_cwd
+    ):
+        # Same joined-on-newline shape, but the content arrives as a
+        # single content block (the Anthropic structured form). The
+        # block.text is the combined preamble + prompt string.
+        joined = _user_line(
+            "real",
+            [
+                {
+                    "type": "text",
+                    "text": (
+                        "Additional context: Current directory open in "
+                        "Jupyter is: ''\nHello world"
+                    ),
+                }
+            ],
+        )
+        _write_jsonl(sessions_dir / "real.jsonl", [joined])
+
+        result = _list_sessions_in_dir(project_cwd, claude_home=str(fake_claude_home))
+        assert [s.preview for s in result] == ["Hello world"]
+
+    def test_joined_preamble_with_skippable_prompt_still_skips(
+        self, sessions_dir, fake_claude_home, project_cwd
+    ):
+        # When the preamble is joined with another skippable form (a
+        # control slash command, here), the combined message must
+        # still be treated as skippable so the picker keeps scanning
+        # for a real prompt instead of using "/exit" as the preview.
+        # Exercises the recursive call's path through the legacy
+        # _CONTROL_SLASH_COMMANDS check.
+        joined = _user_line(
+            "real",
+            "Additional context: Current directory open in Jupyter is: ''\n/exit",
+        )
+        real_prompt = _user_line("real", "Plot a sine wave")
+        _write_jsonl(sessions_dir / "real.jsonl", [joined, real_prompt])
+
+        result = _list_sessions_in_dir(project_cwd, claude_home=str(fake_claude_home))
+        assert [s.preview for s in result] == ["Plot a sine wave"]
+
+    def test_joined_preamble_alone_without_newline_still_skips(
+        self, sessions_dir, fake_claude_home, project_cwd
+    ):
+        # Pins the `newline_at == -1` branch of the helper: when the
+        # transcript records the preamble with no trailing newline /
+        # prompt (a single-context-update turn), the helper returns
+        # an empty string and the recursive _is_skippable_text call
+        # bottoms out on the empty-stripped guard.
+        preamble_only = _user_line(
+            "real",
+            "Additional context: Current directory open in Jupyter is: ''",
+        )
+        _write_jsonl(sessions_dir / "real.jsonl", [preamble_only])
+
+        result = _list_sessions_in_dir(project_cwd, claude_home=str(fake_claude_home))
+        assert len(result) == 1
+        assert result[0].preview == ""
+
+    def test_joined_preamble_with_empty_post_newline_still_skips(
+        self, sessions_dir, fake_claude_home, project_cwd
+    ):
+        # A preamble followed by only whitespace after the newline
+        # should behave like the preamble-alone case. The recursive
+        # _is_skippable_text call sees whitespace-only text, .strip()s
+        # to "", and skips via the empty-stripped guard.
+        whitespace_tail = _user_line(
+            "real",
+            "Additional context: Current directory open in Jupyter is: ''\n   \n",
+        )
+        _write_jsonl(sessions_dir / "real.jsonl", [whitespace_tail])
+
+        result = _list_sessions_in_dir(project_cwd, claude_home=str(fake_claude_home))
+        assert len(result) == 1
+        assert result[0].preview == ""
+
     def test_keeps_skippable_only_session_with_empty_preview(
         self, sessions_dir, fake_claude_home, project_cwd
     ):


### PR DESCRIPTION
## Summary

Closes #329. When a Claude Code session has only a single user turn, the chat-history picker showed no preview / summary for that session — only the id and timestamp. The cause was a skip filter that treated the joined preamble + prompt string as if it were only the preamble.

## Solution

`claude.py` joins consecutive user-role chat-history entries with `\n` before handing them to the Claude Agent SDK. `extension.py` emits the NBI context preamble (`"Additional context: Current directory open in Jupyter is: ..."`) as its own user-role entry, so a single-turn session records ONE combined user message whose first line is the preamble and whose remainder is the user's actual prompt.

The previous skip filter at `notebook_intelligence/claude_sessions.py` checked `stripped.startswith(_SKIPPABLE_PREFIXES)` against the full text, matched the preamble, and dropped the whole message. The session's only user message was thereby skipped, leaving the picker preview blank.

The load-bearing change is a new `_strip_nbi_context_preamble` helper that drops the preamble line (everything up to and including the first newline) when present. It plugs into the two consumers:

- `_is_skippable_text` unwraps before applying the rest of the skip rules so the message is judged by the real-prompt content. The unwrap recurses at most once because `NBI_CONTEXT_PREFIX` is single-line: the unwrapped tail can never itself lead with the preamble, and the recursive call falls through to the legacy prefix / control-command checks (or bottoms out on the empty-stripped guard).
- `_extract_preview` unwraps before whitespace-collapsing so the preview reads as the user's prompt rather than the boilerplate.

The helper deliberately doesn't trim or normalize the unwrapped tail beyond stripping the preamble line: both callers normalize whitespace themselves (`_is_skippable_text` via `.strip()`, `_extract_preview` via `" ".join(text.split())`), and trailing whitespace in the result belongs to the user's prompt either way.

## Testing

Five new tests in `tests/test_claude_sessions.py` pin the contract:

- `test_unwraps_joined_preamble_and_prompt_in_one_message` — the exact bug from the issue body (preamble + `\n` + prompt as a single string content).
- `test_unwraps_joined_preamble_in_structured_content` — same shape, Anthropic structured-content form with the joined string inside one text block.
- `test_joined_preamble_with_skippable_prompt_still_skips` — preamble joined with a control slash command (`/exit`); the combined message must remain skippable so the picker keeps scanning for a real prompt.
- `test_joined_preamble_alone_without_newline_still_skips` — preamble recorded with no trailing newline; helper returns empty string and the recursive call bottoms out on the empty-stripped guard.
- `test_joined_preamble_with_empty_post_newline_still_skips` — preamble followed by whitespace-only tail; same end state as preamble-alone.

The first two are verified to fail against the pre-fix code; the latter three document downstream behavior the picker has always honored.

All four gates green: `pytest tests/ --ignore=tests/test_claude_client.py` (1055 passed, 66 in `test_claude_sessions.py`), `jlpm tsc --noEmit`, `jlpm lint:check`, `jlpm jest` (254 passed).

## Risks / follow-ups

- A user prompt that happens to start with the literal phrase `"Additional context: Current directory open in Jupyter is:"` would have its first line stripped. The pre-existing `_SKIPPABLE_PREFIXES` tuple already had the same trade-off (called out in the existing comment at lines 47-49); the helper inherits it.
- Multi-block structured content where one block is the preamble and another block is the prompt isn't observed today (the SDK joins at the string level, not at the block level). If that shape ever lands, `_is_skippable_user_message` would need to mirror `_extract_preview`'s block-join behavior. Filed mentally as a follow-up.
- The `NBI_CONTEXT_PREFIX` constant remains in `_SKIPPABLE_PREFIXES` as a backstop. The new early branch consumes the preamble first, but the tuple entry still handles edge cases where the preamble somehow reaches the fallthrough.

## Issue linkage

Closes #329.