### PR TITLE
fix(claude): steer system prompt away from over-eager notebook creation

### DIFF
--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -39,8 +39,35 @@ CLAUDE_DEFAULT_INLINE_COMPLETION_MODEL = "claude-sonnet-4-5"
 CLAUDE_CODE_CHAT_PARTICIPANT_ID = "claude-code"
 CLAUDE_CODE_MAX_BUFFER_SIZE = 20 * 1024 * 1024 # 20MB
 
-JUPYTER_UI_TOOLS_SYSTEM_PROMPT = """You can interact with the JupyterLab UI (notebook / file editor, terminal, etc.) using the tools provided in 'nbi' MCP server. Tools in 'nbi' MCP server, directly interact with the JupyterLab UI, accessing notebooks and files in the UI. When interacting with JupyterLab UI, use relative file paths for file paths. If you create a notebook or run it, save it after creating or running it.
+JUPYTER_UI_TOOLS_SYSTEM_PROMPT = """You can interact with the JupyterLab UI (notebook / file editor, terminal, etc.) using the tools provided in 'nbi' MCP server. Tools in 'nbi' MCP server, directly interact with the JupyterLab UI, accessing notebooks and files open in the UI. When interacting with JupyterLab UI, use relative file paths for file paths. If the user has asked you to create a notebook, save it afterward.
 """
+
+
+def build_claude_system_prompt(
+    jupyter_ui_tools_enabled: bool,
+    jupyter_root_dir: str,
+) -> str:
+    """Build the system prompt for the Claude Code chat participant.
+
+    Module-level so the test suite can pin the answer-don't-create
+    bias guard (issue #335) without instantiating the chat
+    participant or touching JupyterLab runtime state.
+
+    Order is load-bearing: the chat-default guard paragraph must
+    appear BEFORE the UI-tools block. The UI-tools block ends with
+    a conditional save instruction whose recency would otherwise
+    dilute the guard's "default to chat reply" framing.
+    """
+    return f"""You are an AI programming assistant hosted in JupyterLab. JupyterLab supports Jupyter notebooks, plain file editors, and terminals; treat all three as first-class surfaces.
+Assume Python if the language is not specified.
+JupyterLab is launched from a working directory and it can only access files in this directory and its subdirectories. Follow the same rule for file system access. Working directory for current session is '{jupyter_root_dir}'.
+If messages contain relative file paths, assume they are relative to the working directory.
+If you need to install a Python package within a notebook cell code, use %pip install <package_name> instead of !pip install <package_name>.
+
+Default to answering questions directly in your chat reply. Many user prompts are questions about code, data, or files ("summarize this", "explain this", "what does this output mean", "how would I do X", "debug this", "show me what this does") and the right response is prose in your reply, not a new artifact. Do not create a notebook, file, or other workspace artifact unless the user explicitly asks for one (for example: "create a notebook that...", "write me a script to...", "save this as a file", "show me a notebook that..."). When the user attaches a file and asks a question about it, read the file if you need to and answer in your reply; do not produce a new notebook to hold the answer.
+{JUPYTER_UI_TOOLS_SYSTEM_PROMPT if jupyter_ui_tools_enabled else ""}
+"""
+
 
 class ClaudeAgentEventType(str, Enum):
     GetServerInfo = 'get-server-info'
@@ -1438,13 +1465,10 @@ class ClaudeCodeChatParticipant(BaseChatParticipant):
         return client_options
 
     def _create_system_prompt(self, jupyter_ui_tools_enabled: bool) -> str:
-        return f"""You are an AI programming assistant integrated into JupyterLab which is an IDE for Jupyter notebooks.
-Assume Python if the language is not specified.
-JupyterLab is launched from a working directory and it can only access files in this directory and its subdirectories. Follow the same rule for file system access. Working directory for current session is '{get_jupyter_root_dir()}'.
-If messages contain relative file paths, assume they are relative to the working directory.
-If you need to install a Python package within a notebook cell code, use %pip install <package_name> instead of !pip install <package_name>.
-{JUPYTER_UI_TOOLS_SYSTEM_PROMPT if jupyter_ui_tools_enabled else ""}
-"""
+        return build_claude_system_prompt(
+            jupyter_ui_tools_enabled,
+            get_jupyter_root_dir(),
+        )
 
     def clear_chat_history(self):
         self._client.clear_chat_history()

--- a/tests/test_claude_system_prompt.py
+++ b/tests/test_claude_system_prompt.py
@@ -1,0 +1,118 @@
+"""Regression tests for the Claude Code chat participant's system
+prompt (`build_claude_system_prompt` in `notebook_intelligence/claude.py`).
+
+The prompt is the only knob we have to steer the agent's bias toward
+"create a notebook to answer this" vs. "reply in chat" without
+disabling the Jupyter UI tools entirely. Issue #335 documented the
+former case (attach a file, ask "summarize this", agent creates a
+notebook to hold the summary). The fix is a paragraph in the prompt
+telling the agent to default to chat replies and only create
+artifacts on explicit request.
+
+These tests pin the load-bearing phrases of that paragraph so a
+future "tighten the prompt" rewrite can't silently drop the guard.
+"""
+
+from notebook_intelligence.claude import (
+    JUPYTER_UI_TOOLS_SYSTEM_PROMPT,
+    build_claude_system_prompt,
+)
+
+
+class TestBuildClaudeSystemPrompt:
+    def test_includes_default_to_chat_reply_guidance(self):
+        """The 'default to chat' paragraph is the load-bearing fix for
+        issue #335; dropping it silently regresses the
+        attach-and-ask-question flow back to the notebook-creation
+        bias."""
+        prompt = build_claude_system_prompt(
+            jupyter_ui_tools_enabled=True,
+            jupyter_root_dir="/workspace",
+        )
+        assert "Default to answering questions directly in your chat reply" in prompt
+        assert (
+            "Do not create a notebook, file, or other workspace artifact "
+            "unless the user explicitly asks for one"
+        ) in prompt
+
+    def test_includes_attached_file_question_carveout(self):
+        """The specific example from issue #335 (attach a file, ask a
+        question, agent creates a notebook) is called out so a future
+        prompt rewrite can't drop the most common manifestation of
+        the bias."""
+        prompt = build_claude_system_prompt(
+            jupyter_ui_tools_enabled=True,
+            jupyter_root_dir="/workspace",
+        )
+        assert "When the user attaches a file and asks a question" in prompt
+        assert "do not produce a new notebook to hold the answer" in prompt
+
+    def test_includes_jupyter_ui_tools_prompt_when_enabled(self):
+        prompt = build_claude_system_prompt(
+            jupyter_ui_tools_enabled=True,
+            jupyter_root_dir="/workspace",
+        )
+        assert JUPYTER_UI_TOOLS_SYSTEM_PROMPT.strip() in prompt
+
+    def test_excludes_jupyter_ui_tools_prompt_when_disabled(self):
+        prompt = build_claude_system_prompt(
+            jupyter_ui_tools_enabled=False,
+            jupyter_root_dir="/workspace",
+        )
+        # Pick a distinctive phrase that only appears in the tools
+        # prompt, so a future rephrase of the surrounding prose can't
+        # accidentally pass this assertion.
+        assert "nbi' MCP server" not in prompt
+
+    def test_default_to_chat_guidance_persists_without_ui_tools(self):
+        """The chat-default bias guard must apply regardless of
+        whether the UI-tools section is included — the agent can
+        still produce notebooks via the built-in `Write` tool, and
+        issue #335's mechanism (over-eager artifact creation) is
+        independent of the NBI MCP toolset."""
+        prompt = build_claude_system_prompt(
+            jupyter_ui_tools_enabled=False,
+            jupyter_root_dir="/workspace",
+        )
+        assert "Default to answering questions directly in your chat reply" in prompt
+
+    def test_chat_default_guidance_precedes_jupyter_ui_tools_block(self):
+        """The UI-tools block ends with "If the user has asked you to
+        create a notebook, save it...", which a model with strong
+        recency bias could read as permission. Pin that the
+        chat-default paragraph sits BEFORE the UI-tools block so the
+        last word the model sees on the create-or-not question is the
+        guard, not the conditional-save instruction."""
+        prompt = build_claude_system_prompt(
+            jupyter_ui_tools_enabled=True,
+            jupyter_root_dir="/workspace",
+        )
+        guard_position = prompt.index("Default to answering questions")
+        tools_position = prompt.index("nbi' MCP server")
+        assert guard_position < tools_position
+
+    def test_pins_explicit_request_examples(self):
+        """The explicit-request examples are as load-bearing as the
+        prohibition: they tell the model WHICH user prompts DO call
+        for artifact creation. Without these the guard could be
+        rewritten into a blanket "never create" that breaks legitimate
+        "write me a notebook" requests."""
+        prompt = build_claude_system_prompt(
+            jupyter_ui_tools_enabled=True,
+            jupyter_root_dir="/workspace",
+        )
+        assert '"create a notebook that..."' in prompt
+        assert '"write me a script to..."' in prompt
+        assert '"save this as a file"' in prompt
+        # "show me a notebook that..." disambiguates the "show me"
+        # verb (which also appears in the question-style example
+        # list); pin it so a future edit can't collapse the two
+        # surfaces and reintroduce the bias.
+        assert '"show me a notebook that..."' in prompt
+
+    def test_interpolates_jupyter_root_dir(self):
+        prompt = build_claude_system_prompt(
+            jupyter_ui_tools_enabled=True,
+            jupyter_root_dir="/home/user/proj",
+        )
+        assert "'/home/user/proj'" in prompt


### PR DESCRIPTION
## Summary

Closes #335. In Claude mode the agent was creating a notebook in response to question-style prompts. Canonical repro from the issue: attach `package.json`, ask "load this json file and summarize for me", and the agent created a notebook to hold the summary instead of replying in chat. The fix refines the system prompt, per the issue thread's consensus that a UI toggle or out-of-box skills would be more surprising than a prompt edit.

## Solution

Three pieces of steering work together in `_create_system_prompt`:

- **Soften the anchor concept**: the prompt no longer opens with "JupyterLab which is an IDE for Jupyter notebooks" (tautologically primes notebook-thinking). It now names notebooks, plain file editors, and terminals as first-class surfaces.
- **Add an explicit chat-default paragraph** naming the common question patterns (`"summarize this"`, `"explain this"`, `"what does this output mean"`, `"how would I do X"`, `"debug this"`, `"show me what this does"`) and the create-case patterns (`"create a notebook that..."`, `"write me a script to..."`, `"save this as a file"`, `"show me a notebook that..."`). Calls out the attach-a-file-and-ask manifestation that #335 reported.
- **Tighten the `JUPYTER_UI_TOOLS_SYSTEM_PROMPT` conditional**: was "If you create a notebook or run it, save it after creating or running it" (structurally permissive, vestigial run-save tail). Now: "If the user has asked you to create a notebook, save it afterward." Reinforces the chat-default rather than softly contradicting it.

Refactored the prompt assembly out of `ClaudeCodeChatParticipant._create_system_prompt` into a module-level `build_claude_system_prompt(jupyter_ui_tools_enabled, jupyter_root_dir)` so the test suite can pin the load-bearing phrases without instantiating the chat participant or touching JupyterLab runtime state. **Order is load-bearing** (recency bias): the chat-default paragraph must appear before the UI-tools block; pinned by an explicit ordering test.

## Testing

Eight new tests in `tests/test_claude_system_prompt.py`:

- The imperative core: "Default to answering questions directly in your chat reply".
- The attached-file carveout: "When the user attaches a file..." / "do not produce a new notebook to hold the answer".
- The explicit-request examples (four variants, including `"show me a notebook that..."` which disambiguates the "show me" verb).
- UI-tools inclusion when `jupyter_ui_tools_enabled=True`, exclusion when `False`.
- The chat-default guidance survives without UI tools (the bias is independent of the NBI MCP toolset).
- The chat-default paragraph appears BEFORE the UI-tools block (defends against future edits that reorder sections).
- Root-dir interpolation.

Substring assertions pin specific phrases so a future "tighten the prompt" rewrite is forced to update the test, surfacing the intent question.

Full suite: `pytest tests/ --ignore=tests/test_claude_client.py` (1063 passed), `jlpm tsc --noEmit` (clean), `jlpm lint:check` (clean), `jlpm jest` (259 passed). No Playwright check ran — this is a Python-only prompt edit with no JL runtime touchpoints, and the unit tests pin the contract directly.

## Risks / follow-ups

- **Same bias may live in `notebook_intelligence/prompts.CHAT_SYSTEM_PROMPT`** (used by the generic + GitHub Copilot participants). Worth an empirical spot-check; port the chat-default paragraph if it repros.
- **Claude Agent SDK accepts both `system_prompt=str` (replaces Claude Code's default) and `{"type": "preset", "preset": "claude_code", "append": str}` (augments CC's default)**. NBI passes a string, so CC's own system prompt is replaced. Switching to the preset/append form would let CC's anti-over-eager guidance reinforce ours instead of getting clobbered. Pre-existing behavior, not introduced here; larger refactor.
- **Prompt brittleness**: the substring assertions will fail on cosmetic rewrites. That's intentional (forces a review of whether the intent is preserved) but worth noting for the next maintainer who touches the prompt.

## Issue linkage

Closes #335.