### PR TITLE
chore(release): prep 5.0.0 docs and version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,49 +10,132 @@ For each release we list user-facing changes grouped as **Added**, **Changed**, 
 
 ## [Unreleased]
 
+## [5.0.0] - 2026-05-22
+
+5.0.0 is a major release built on top of 4.8.0, gathering a large surface of new admin policies, accessibility work across the chat sidebar / popovers / settings tabs, several security hardening passes, and three new agent-aware UI surfaces. Most existing configuration continues to work; the version bump reflects the breadth of new admin-policy / env-var surface that operators should review, plus the dependency swap from `fastmcp` to the official `mcp` SDK.
+
+### Migration note
+
+5.0.0 ships no traitlet, env-var, REST route, or NBI-owned on-disk format renames or removals. Four items operators should review before upgrading:
+
+- **`fastmcp` is no longer a dependency** (#324). NBI now uses the official `mcp` SDK via a thin internal shim. If your image pinned `fastmcp` because prior docs recommended it, drop that pin. If you have downstream Python code that imported `fastmcp` transitively via NBI, declare `fastmcp` as a direct dependency in your own image.
+- **Shell tool and Claude UI-bridge tool paths are now sandboxed to `jupyter_root`** (#290, #323). An agent-supplied absolute path or `..` traversal that previously resolved outside the workspace is now rejected. Workflows that relied on the agent reaching outside the workspace via these tools need to move that data into the workspace.
+- **Session listing no longer reads `~/.claude/projects/<cwd>/history.jsonl`** (#310). No action required: the unified inventory walks `~/.claude/projects/` directly, and a stale or missing `history.jsonl` no longer hides resumable sessions.
+- **Workspace file attach in Claude mode ships an `@`-mention pointer instead of inlined file content** (#327). Behavior change visible to end users (images, large files, and notebooks now work where they didn't); no admin action required, but Claude's Read tool counts toward tool-use quotas that the prior content-injection path did not.
+- **Copilot WebSocket upgrades require Jupyter session authentication and pass an origin check** (#301). Cross-origin and unauthenticated upgrade attempts that previously succeeded against `WebsocketCopilotHandler` now return 403. If you have a custom client outside the JupyterLab page hitting this endpoint, it needs to pipe through Jupyter's auth (token or cookie) and either set its `Origin` to the lab's origin or have it added to `c.ServerApp.allow_origin`.
+
 ### Added
 
-- **Skills as a top-level Settings tab** (#224). Promoted from a Claude-mode sub-tab; the tab is now visible in any mode, with a hint banner when Claude mode is off. New admin policy `skills_management_policy` (env `NBI_SKILLS_MANAGEMENT_POLICY`); `force-off` hides the tab, returns HTTP 403 from every `/notebook-intelligence/skills/*` route, and suppresses the managed-skills reconciler.
+#### Settings: three new top-level tabs and policy gates
+
+- **Skills as a top-level Settings tab** (#224). Promoted from a Claude-mode sub-tab; visible in any mode, with a hint banner when Claude mode is off. New admin policy `skills_management_policy` (env `NBI_SKILLS_MANAGEMENT_POLICY`); `force-off` hides the tab, returns HTTP 403 from every `/notebook-intelligence/skills/*` route, and suppresses the managed-skills reconciler.
 - **Claude MCP Servers tab** (#225) for managing the user, project, and local-scope MCP entries Claude Code reads from `~/.claude.json` and `<project>/.mcp.json`. Independent of the existing NBI MCP tab; the two never appear at the same time. New admin policy `claude_mcp_management_policy` (env `NBI_CLAUDE_MCP_MANAGEMENT_POLICY`).
-- **Claude Plugins tab** (#226) wrapping `claude plugin` for install / uninstall / enable / disable / marketplace add. New admin policies `claude_plugins_management_policy` (env `NBI_CLAUDE_PLUGINS_MANAGEMENT_POLICY`) and `allow_github_plugin_import` (env `NBI_ALLOW_GITHUB_PLUGIN_IMPORT`), the latter mirroring the existing `allow_github_skill_import` knob for marketplace sources.
+- **Claude Plugins tab** (#226) wrapping `claude plugin` for install / uninstall / enable / disable / marketplace add. New admin policies `claude_plugins_management_policy` (env `NBI_CLAUDE_PLUGINS_MANAGEMENT_POLICY`) and `allow_github_plugin_import` (env `NBI_ALLOW_GITHUB_PLUGIN_IMPORT`), the latter mirroring `allow_github_skill_import` for marketplace sources.
+- **Plugin marketplace picker** (#284). Browse the configured marketplaces and install plugins inline; the picker shows source repo, version, and description for each entry.
+- **Plugin marketplace details + Update button** (#303). The Plugins tab now displays each installed plugin's description, author, version, and source, and surfaces a per-plugin **Update** button when a newer version is available upstream.
+- **Per-workspace MCP server disable** for Claude mode (#286). Toggle individual MCP entries on/off without removing them, scoped to the current Jupyter workspace.
+- **JSON-paste path in the Add MCP server dialog** (#285). Paste a Claude / Cursor / VS Code MCP config blob; NBI parses, validates, and pre-fills the form.
 - **GitHub auth for plugin marketplace add**. Marketplace sources that resolve as GitHub URLs or `owner/repo` shorthand reuse Skills' `GITHUB_TOKEN` / `GH_TOKEN` / `gh auth token` precedence; tokens are injected into the `claude plugin marketplace add` subprocess via env, never argv.
-- **Launcher tiles for opencode, Pi, and GitHub Copilot CLI** (#268), with a follow-on for **OpenAI Codex**. Each tile appears when the corresponding binary is on `PATH` and opens a Jupyter terminal at the file-browser's current directory. CLI path overrides: `NBI_OPENCODE_CLI_PATH`, `NBI_PI_CLI_PATH`, `NBI_GITHUB_COPILOT_CLI_PATH`, `NBI_CODEX_CLI_PATH`. The capabilities response gains matching `*_cli_available` booleans.
+
+#### Launchers
+
+- **Launcher tiles for opencode, Pi, and GitHub Copilot CLI** (#268), with follow-ons for **OpenAI Codex** and brand icons for Codex and opencode (#333). Each tile appears when the corresponding binary is on `PATH` and opens a Jupyter terminal at the file-browser's current directory. CLI path overrides: `NBI_OPENCODE_CLI_PATH`, `NBI_PI_CLI_PATH`, `NBI_GITHUB_COPILOT_CLI_PATH`, `NBI_CODEX_CLI_PATH`. Capabilities response gains matching `*_cli_available` booleans.
+- **Coding-agent launcher tiles can be hidden by admin policy** (#288). New traitlet `disabled_coding_agent_launchers` (list of `claude-code` / `opencode` / `pi` / `github-copilot-cli` / `codex`) with an optional `allow_enabling_coding_agent_launchers_with_env` + `NBI_ENABLED_CODING_AGENT_LAUNCHERS` per-pod re-enable mechanism. The Coding Agent section header now uses the sparkles icon instead of the Claude orange so the section is correctly framed when other tiles are enabled (#325).
 - **Claude Code launcher tile is no longer gated by Claude chat mode** (#239); it appears whenever the `claude` CLI is on `PATH`.
-- **Dynamic GitHub Copilot model discovery** (#269). NBI now queries `https://api.githubcopilot.com/models` on each Copilot token refresh and the chat-model dropdown rebuilds from the live response, falling back to a hardcoded list on transient failure.
-- **Newer GitHub Copilot chat models** added to the fallback list (#255).
-- **Skill GitHub archive cap raised to 100 MB**, configurable (#257). New traitlet `skill_max_archive_mb` (env `NBI_SKILL_MAX_ARCHIVE_MB`); `0` disables the cap.
-- **`additional_skipped_workspace_directories` accepted in NBI `config.json`** (#241), layered additively on top of the existing traitlet, env, and env-prefix layers so a per-user override can extend (rather than replace) the org-wide list.
-- **Real progress feedback during long Claude tasks** (#254). The chat sidebar shows an elapsed-time counter, a heartbeat-driven pulse with a "may be slow" copy flip after 30 seconds, and inline tool-call narration.
-- **"New chat session" button** in the chat sidebar header restarts the Claude SDK client, mirroring the `/clear` slash command (#246).
+- **Choose a start directory from the launcher tile** (#332). Clicking any coding-agent tile (or "New Session" on the Claude resume dialog) opens a directory picker so the terminal starts where the user wants.
+
+#### Chat sidebar and agentic UX
+
+- **Real progress feedback during long Claude tasks** (#254). Elapsed-time counter, heartbeat-driven pulse with a "may be slow" copy flip after 30 seconds, and inline tool-call narration.
+- **"New chat session" button** in the chat sidebar header restarts the Claude SDK client, mirroring `/clear` (#246).
 - **Terminal drag-drop file attach** with `@`-mention or shell-escaped raw modes and a per-terminal toolbar toggle (#256). New admin policy `NBI_TERMINAL_DRAG_DROP_POLICY`; tunables `NBI_UPLOAD_MAX_MB` (default `50`) and `NBI_UPLOAD_RETENTION_HOURS` (default `24`) govern the shared upload-staging endpoint used by both terminal drops and chat-sidebar attachments.
-- **Hover preview for image context thumbnails** in the chat sidebar (#267).
-- **First-run tour of the chat sidebar**. Highlights the gear, file-attach button, chat-mode dropdown, and (when available) the Claude session history icon so new users can discover the popovers and mode picker without scrolling the README. Replays from the command palette via "Show NBI tour"; capability-aware so steps for unavailable CLIs are skipped.
+- **Workspace files attach as `@`-mention in Claude mode** (#327). Instead of reading file contents client-side and injecting them as a fenced code block, the backend emits an `@<workspace-relative-path>` pointer and Claude's Read tool decides what to load. Unblocks images, large files, and notebooks (cell-aware reads) that the content-injection path couldn't handle. Notebook cell-pointer prose and text-selection line ranges are preserved so deictic references ("explain this cell", "why is this broken") still have a referent.
+- **Hover preview for image context thumbnails** (#267).
+- **Reload open document tabs when their files change on disk** (#330, relocated in #339). Polls every open `DocumentWidget` and reverts via `context.revert()` when disk is newer than the in-memory model, skipping when the tab has unsaved local edits. New user setting `refresh_open_files_on_disk_change` (default `true`); flip in the **NBI Settings dialog → External changes**. Closes the agentic-experience gap where Claude edits a file but the open tab keeps showing the pre-edit version. Admins can pin via the matching `NBI_REFRESH_OPEN_FILES_ON_DISK_CHANGE_POLICY` env var or `refresh_open_files_on_disk_change_policy` traitlet.
+- **First-run tour of the chat sidebar** (#304). Highlights the gear, file-attach button, chat-mode dropdown, and (when available) the Claude session history icon. Replays from the command palette via "Show NBI tour"; capability-aware so steps for unavailable CLIs are skipped.
+- **Steered the Claude system prompt away from over-eager notebook creation** (#336). The agent now defaults to answering questions in chat instead of creating a new notebook to hold the answer when the user attaches a file and asks a question about it.
+
+#### Copilot models
+
+- **Dynamic GitHub Copilot model discovery** (#269). NBI queries `https://api.githubcopilot.com/models` on each Copilot token refresh and rebuilds the chat-model dropdown from the live response, falling back to a hardcoded list on transient failure.
+- **Newer GitHub Copilot chat models** added to the fallback list (#255).
+
+#### Skills and workspace config
+
+- **Multi-manifest support** in `NBI_SKILLS_MANIFEST` / `skills_manifest` (#321). Comma-separated list of URLs and/or filesystem paths; manifests are unioned with first-wins URL dedupe and per-entry name-collision surfacing. See [`docs/skills.md`](docs/skills.md#managed-skills-via-an-org-manifest).
+- **Tracks-upstream flag for user-imported GitHub skills** (#322). The Import-from-GitHub dialog adds a **Track upstream** checkbox; tracked skills get a per-skill Sync button and a panel-level **Sync tracking skills** button. Mutually exclusive with the managed-skills reconciler: a skill the reconciler installs can't also be marked tracking.
+- **HTTP kill switch for the managed-skills reconciler** (#291). `POST /notebook-intelligence/skills/reconciler/stop` is authenticated, idempotent, and intentionally has no `/start` companion (a kill switch a script can flip back on isn't a kill switch). The reconciler also re-reads `NBI_SKILLS_MANAGEMENT_POLICY` at the start of each cycle and self-stops when it reads `force-off`.
+- **Skill GitHub archive cap raised to 100 MB**, configurable (#257). New traitlet `skill_max_archive_mb` (env `NBI_SKILL_MAX_ARCHIVE_MB`); `0` disables the cap.
+- **`additional_skipped_workspace_directories` accepted in NBI `config.json`** (#241), layered additively on top of the existing traitlet, env, and env-prefix layers so a per-user override extends rather than replaces the org-wide list.
 
 ### Changed
 
-- Settings tabs are now an ARIA tablist with arrow-key navigation (#206).
-- Accessibility pass across the chat sidebar and popovers covering keyboard and screen-reader behavior (#205).
-- Chat-input footer icons reworded for clarity; the gear button gains a `title` attribute (#271).
-- Cell-tool descriptions mention zero-based indexing so models pick the right cell (#265).
+#### Accessibility (chat sidebar, popovers, settings)
+
+A multi-PR accessibility pass landed across most NBI surfaces. Together these make NBI navigable end-to-end with the keyboard and screen-reader, audited under JupyterLab's light, dark, and high-contrast themes:
+
+- **Chat-sidebar header icons** are real keyboard-reachable buttons (#205, #305) with distinct titles / `aria-label`s and a button reset to avoid double-borders.
+- **Settings tabs** are an ARIA tablist with arrow-key navigation (#206).
+- **Workspace, tools, and slash popovers** are keyboard-first (#306), with focus restoration to the trigger element on close.
+- **Settings checkboxes** have the WAI-ARIA `checkbox` role and respond to Space activation (#309).
+- **Ask-User-Question form** uses `radio` for single-select choices, stable per-form `useId`-driven labels, and real form semantics (#307).
+- **Claude MCP form** wires every input to a `<label>` (#308).
+- **"Open notebook" link in chat replies** is a real button with the notebook path in its accessible name (#311).
+- **Skills panel icons** render as real SVGs with focus-reveal styling; the nested-button wrapper is gone (#312).
+- **Send button** swaps its color to the warn-token and updates its `aria-label` while a request is in flight (#313).
+- **Inline-completion popover** uses JupyterLab theme tokens instead of a fixed pastel background so it reads correctly under dark/high-contrast themes (#314).
+- **Upload-in-progress chip** announces via `role=status`, `aria-live=polite`, `aria-busy=true`, plus an animated ellipsis with `prefers-reduced-motion` honored (#315).
+- **Drop-zone chip** uses theme-aware foreground color so the text is legible against the brand-tinted background (#316).
+- **Generating-state rotating border** pauses under `prefers-reduced-motion` (#317).
+- **Streaming chat replies** announce through an `aria-live=polite` region with chunked boundary announcements (#318).
+- **Visually-hidden skip-to-message-input link** as the first focusable child of the sidebar (#319). Lets keyboard users jump past long transcripts to the prompt input.
+- **Global Ctrl/Cmd+Shift+L shortcut** focuses the NBI chat input from anywhere in the app (#320).
+
+- **Chat-input footer icons reworded** for clarity; the gear button gains a `title` attribute (#271).
+- **Cell-tool descriptions** mention zero-based indexing so models pick the right cell (#265).
+
+### Removed
+
+- **`fastmcp` dependency**, replaced with the official `mcp` SDK (#324). NBI's external behavior is unchanged; downstream code that imported `fastmcp` transitively via NBI now needs to depend on it directly.
+- **`history.jsonl` as the gate for session listing** (#310). The unified inventory walks the projects directory directly.
 
 ### Fixed
 
-- Websocket writes from worker threads no longer raise `BufferError` after `/clear` or "new chat" on Python 3.13+ (#270). All emitter writes now route through `tornado.IOLoop.call_soon_threadsafe`.
-- Cell tools follow the active notebook when the user switches tabs (#253).
-- `is_connected()` stabilized against the Claude worker-spawn resurrection race (#250).
-- Persisted Claude model now displays after a JupyterLab restart (#244).
-- `/clear` no longer duplicated in the `@`-mention autocomplete (#243).
-- `@`-mention picker refreshes when workspace files change (#251) and closes on Escape from the search input (#266).
-- Notebook-toolbar prompt textarea focuses when the popover opens (#240); the update button works outside Claude mode (#238).
-- Inline chat anchors to the cursor line (#191).
-- Disabled send button is styled neutrally instead of as a primary action (#276); Claude tool-result check renders on the right of its label (#277).
-- Plugin Settings row shows the plugin name even when the CLI returns only `id` (#280).
+- **Websocket writes from worker threads** no longer raise `BufferError` after `/clear` or "new chat" on Python 3.13+ (#270). All emitter writes route through `tornado.IOLoop.call_soon_threadsafe`.
+- **WebSocket message-callback handlers** are freed when requests finish, preventing slow accumulation over the lifetime of a session (#294).
+- **Claude session listing** unified across the chat-sidebar picker and the launcher tile; both surfaces read the same on-disk transcript inventory and apply the same "show this session?" filter so they no longer disagree (#310). The legacy `history.jsonl` gate is removed.
+- **Claude session preview** correctly strips the NBI context preamble when `claude.py` joined it onto the user's actual prompt (#331). Single-turn sessions previously showed a blank title; now they show the prompt.
+- **Refresh-on-disk watcher** no longer throws `Invalid area: down` on every poll (post-#330 follow-up). The TS `Area` union lists `'down'`, but `LabShell.widgets()` doesn't implement it.
+- **Cell tools** follow the active notebook when the user switches tabs (#253).
+- **`is_connected()`** stabilized against the Claude worker-spawn resurrection race (#250).
+- **Persisted Claude model** now displays after a JupyterLab restart (#244).
+- **`/clear` no longer duplicated** in the `@`-mention autocomplete (#243).
+- **`@`-mention picker** refreshes when workspace files change (#251) and closes on Escape from the search input (#266).
+- **Notebook-toolbar prompt textarea** focuses when the popover opens (#240); the update button works outside Claude mode (#238).
+- **Inline chat** anchors to the cursor line (#191).
+- **Disabled send button** styled neutrally instead of as a primary action (#276); Claude tool-result check renders on the right of its label (#277).
+- **Plugin Settings row** shows the plugin name even when the CLI returns only `id` (#280).
+
+### Security
+
+- **Shell tool's `working_directory` is sandboxed to `jupyter_root`** (#290). A previously-permitted absolute path or `..` traversal in agent-supplied input is now rejected; the existing path-safety helper handles the canonicalization.
+- **Claude UI-bridge tool paths sandboxed to `jupyter_root`** (#323). `open_file_in_jupyter_ui` and `run_command_in_jupyter_terminal` both route through `safe_jupyter_path` so an agent can't reach files outside the workspace via these tools. The Claude Agent SDK subprocess is itself rooted at `jupyter_root` via its `cwd` option.
+- **Encrypted GitHub token file enforces mode 0o600** (#293). The file holding the AES-GCM-encrypted Copilot token is created and re-tightened to owner-only read/write on every save, so an out-of-band `chmod` that widens permissions is undone on the next write.
+- **Process-env secrets are scrubbed from shell-tool output** (#295). The shell tool no longer leaks `API_KEY` / `TOKEN` / `SECRET`-like env values into the captured stdout/stderr block returned to the model.
+- **MCP user config shape validated before persisting** (#299). Malformed entries in the JSON paste / Add-MCP dialog are rejected server-side (unknown keys, type/command/url consistency, etc.); the client surfaces the rejection as a notification rather than writing through.
+- **Anchor URIs in chat messages filtered against an XSS allowlist** (#296). `javascript:`, `data:`, `vbscript:`, and tab/NEL/bidi-override codepoint smuggling are blocked at render time.
+- **Copilot WebSocket upgrades authenticated and origin-checked** (#301). Cross-origin and unauthenticated upgrade attempts are refused.
+- **GitHub Enterprise host detection for marketplace add** (#292), so a `git.acme.example.com` URL routes through the GHE token / API path instead of being misclassified as public GitHub. Hardened against trailing-dot, userinfo, and other URL-shape edge cases.
+- **`fastmcp` dropped in favor of the official `mcp` Python SDK** (#324). `fastmcp` pinned `python-dotenv>=1.1.0` which conflicted with `litellm`'s `python-dotenv==1.0.1` pin; the swap unblocks installs on Python 3.14 and picks up CVE fixes via `urllib3>=2.7.0` (CVE-2026-44431 / CVE-2026-44432).
+- **Runtime kill switch for the managed-skills reconciler** (#291) provides per-pod incident response without a server restart. See the Skills entry above for the user-facing affordances and the [admin guide](docs/admin-guide.md#disabling-the-skills-tab) for the route and self-stop semantics.
 
 ### Internal
 
-- CVE-driven dependency upgrades (#197); `react-icons` bumped to `~5.6.0` (#245).
-- Galata-based Playwright UI test suite scaffolded (#207) and expanded with user-flow specs covering the chat sidebar, notebook toolbar, cell outputs, and the launcher (#272).
-- Contributor docs cover the traitlet vs env var vs config-file decision (#242).
+- **CVE-driven dependency upgrades** (#197); `react-icons` bumped to `~5.6.0` (#245).
+- **Galata-based Playwright UI test suite scaffolded** (#207) and expanded with user-flow specs covering the chat sidebar, notebook toolbar, cell outputs, and the launcher (#272).
+- **Docs refresh across README, admin guide, skills, and CHANGELOG** (#287) covering the post-4.8.0 surface that this release expands on.
+- **Stop tracking local AI-assistant config files** (`.codex/`, `.claude/scheduled_tasks.lock`) via `.gitignore` so they don't clutter the diff when contributors run the agents inside the repo.
+- **Contributor docs** cover the traitlet vs env var vs config-file decision (#242).
 
 <!-- <END NEW CHANGELOG ENTRY> -->
 
@@ -247,7 +330,8 @@ For each release we list user-facing changes grouped as **Added**, **Changed**, 
 - Settings UI restructured around Claude vs default mode.
 - WebSocket connection reliability improvements.
 
-[unreleased]: https://github.com/notebook-intelligence/notebook-intelligence/compare/v4.8.0...HEAD
+[unreleased]: https://github.com/notebook-intelligence/notebook-intelligence/compare/v5.0.0...HEAD
+[5.0.0]: https://github.com/notebook-intelligence/notebook-intelligence/compare/v4.8.0...v5.0.0
 [4.8.0]: https://github.com/notebook-intelligence/notebook-intelligence/compare/v4.7.0...v4.8.0
 [4.7.0]: https://github.com/notebook-intelligence/notebook-intelligence/compare/v4.6.0...v4.7.0
 [4.6.0]: https://github.com/notebook-intelligence/notebook-intelligence/compare/v4.5.0...v4.6.0

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ NBI is free and open-source. Connect it to a free or paid LLM provider of your c
   - [Chat interface](#chat-interface)
   - [Cell output actions](#cell-output-actions)
   - [Notebook toolbar generation](#notebook-toolbar-generation)
+  - [Reload open files when changed on disk](#reload-open-files-when-changed-on-disk)
 - [Configuration](#configuration)
   - [Configuration files](#configuration-files)
   - [Remembering GitHub Copilot login](#remembering-github-copilot-login)
@@ -91,7 +92,11 @@ If the Claude Code CLI is on `PATH`, NBI launches it automatically. To override 
 
 #### Resuming a previous Claude session
 
-When Claude mode is on, the chat sidebar shows a history icon next to the gear. Click it to list the Claude Code sessions recorded for the current working directory (the same transcripts the Claude Code CLI stores under `~/.claude/projects/`). Selecting a session reconnects via `resume`, so the next message you send continues that transcript with full prior context.
+When Claude mode is on, the chat sidebar shows a history icon next to the gear. Click it to list the Claude Code sessions recorded for the current working directory (the same transcripts the Claude Code CLI stores under `~/.claude/projects/`). Selecting a session reconnects via `resume`, so the next message you send continues that transcript with full prior context. A **New chat session** button next to the gear restarts the SDK client without typing `/clear`.
+
+Long Claude turns surface an elapsed-time counter, a heartbeat-driven pulse with a "may be slow" copy flip after 30 seconds, and inline tool-call narration so the sidebar reflects what the agent is doing rather than appearing stuck.
+
+In Claude mode, workspace files attached as chat context arrive as `@`-mention pointers rather than inlined file contents. Claude's Read tool fetches them on demand, which means images, large files, and notebooks (cell-aware) now work where the older content-injection path silently truncated or skipped them.
 
 #### Claude Code launcher tile
 
@@ -106,7 +111,7 @@ When any of the following CLIs are on `PATH`, the launcher adds a tile for each.
 - **GitHub Copilot CLI** (override path with `NBI_GITHUB_COPILOT_CLI_PATH`)
 - **OpenAI Codex** (override path with `NBI_CODEX_CLI_PATH`)
 
-Tiles add and remove themselves as CLIs become available or unavailable; they do not require Claude mode.
+Tiles add and remove themselves as CLIs become available or unavailable; they do not require Claude mode. Clicking any tile (or **New Session** from the Claude resume dialog) prompts for a start directory, so the terminal opens where you want rather than always at the file-browser cwd.
 
 ### Agent mode
 
@@ -147,6 +152,10 @@ Each is per-user toggleable from Settings (saved as `enable_explain_error`, `ena
 ### Notebook toolbar generation
 
 Active notebooks show a sparkle icon on the toolbar. Click it to open a popover that scopes the generation request to that specific notebook — handy for multi-notebook sessions where you don't want the chat sidebar to compete for context.
+
+### Reload open files when changed on disk
+
+NBI reloads open document tabs when their files change on disk, so edits an AI agent makes via its Read/Write tools appear in the editor without a manual refresh. Tabs with unsaved local edits are skipped so user work is never clobbered. Toggle via the **NBI Settings dialog → External changes → "Refresh open files when changed on disk"** (default on).
 
 ## Configuration
 
@@ -350,11 +359,11 @@ For full details, see [`docs/skills.md`](docs/skills.md).
 
 When Claude mode is enabled and the Claude CLI is available, the Settings panel exposes an **MCP Servers** tab that manages the user, project, and local-scope MCP entries Claude Code reads from `~/.claude.json` and the project's `.mcp.json`. This is a different tab from NBI's own MCP Servers tab (which manages the servers used by the non-Claude chat path); the two never appear together, and the Settings dialog shows whichever one applies to your current mode.
 
-Reads come from Claude's JSON config files directly. Writes (add and remove) shell out to `claude mcp add` and `claude mcp remove` so Claude remains the source of truth for any side effects (project-trust prompts, OAuth bookkeeping). Admins can lock the tab with `NBI_CLAUDE_MCP_MANAGEMENT_POLICY=force-off`.
+Reads come from Claude's JSON config files directly. Writes (add and remove) shell out to `claude mcp add` and `claude mcp remove` so Claude remains the source of truth for any side effects (project-trust prompts, OAuth bookkeeping). Each server entry can be toggled on or off per workspace without removing it, and the **Add MCP server** dialog accepts a JSON-paste path that takes a Claude / Cursor / VS Code MCP config blob and pre-fills the form after validating the shape. Admins can lock the tab with `NBI_CLAUDE_MCP_MANAGEMENT_POLICY=force-off`.
 
 ## Claude Plugins
 
-When Claude mode is enabled and the Claude CLI is available, the Settings panel exposes a **Plugins** tab wrapping `claude plugin` for install, uninstall, enable, disable, and marketplace add (for example: add a marketplace from a GitHub repo, then install plugins it publishes). Marketplaces hosted on GitHub reuse the same `GITHUB_TOKEN` / `GH_TOKEN` / `gh auth token` precedence as Skills imports; the token is passed via env to the subprocess and never appears in argv or DEBUG logs. See Anthropic's [plugin docs](https://code.claude.com/docs/en/plugins) for what a plugin is and how marketplaces work.
+When Claude mode is enabled and the Claude CLI is available, the Settings panel exposes a **Plugins** tab wrapping `claude plugin` for install, uninstall, enable, disable, and marketplace add (for example: add a marketplace from a GitHub repo, then install plugins it publishes). Each installed plugin's description, author, version, and source render inline, and the tab surfaces a per-plugin **Update** button when a newer version is available upstream. A marketplace picker lets you browse the configured marketplaces and install plugins directly from there. Marketplaces hosted on GitHub reuse the same `GITHUB_TOKEN` / `GH_TOKEN` / `gh auth token` precedence as Skills imports; the token is passed via env to the subprocess and never appears in argv or DEBUG logs. See Anthropic's [plugin docs](https://code.claude.com/docs/en/plugins) for what a plugin is and how marketplaces work.
 
 Admins can lock the entire tab with `NBI_CLAUDE_PLUGINS_MANAGEMENT_POLICY=force-off`, or keep the tab and block only GitHub-sourced marketplaces with `NBI_ALLOW_GITHUB_PLUGIN_IMPORT=false`.
 
@@ -396,7 +405,7 @@ The feedback fires an in-process `telemetry` event. Nothing leaves the process b
 
 ## Roadmap
 
-NBI 4.x is stable. New features land in minor releases (4.5, 4.6, …); breaking changes are reserved for the next major (5.x) and will be announced in the [changelog](CHANGELOG.md).
+NBI 5.x is stable. New features land in minor releases (5.1, 5.2, …); breaking changes are reserved for the next major (6.x) and will be announced in the [changelog](CHANGELOG.md). Upgrading from 4.x? See the [5.0.0 migration note](CHANGELOG.md#migration-note) for the `fastmcp` → `mcp` dependency swap, the new path sandboxes, and the workspace-file-attach behavior change.
 
 ## License
 

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -680,6 +680,7 @@ NBI is tested against the JupyterLab and `jupyter_server` versions declared in [
 
 | NBI version | JupyterLab | jupyter_server | Python    |
 | ----------- | ---------- | -------------- | --------- |
+| 5.0.x       | 4.x        | 2.x            | 3.10+     |
 | 4.8.x       | 4.x        | 2.x            | 3.10+     |
 | 4.7.x       | 4.x        | 2.x            | 3.10+     |
 | 4.6.x       | 4.x        | 2.x            | 3.10–3.12 |
@@ -687,18 +688,18 @@ NBI is tested against the JupyterLab and `jupyter_server` versions declared in [
 | 4.4.x       | 4.x        | 2.x            | 3.10–3.12 |
 | 4.3.x       | 4.x        | 2.x            | 3.10–3.12 |
 
-Upper bounds for `litellm`, `claude-agent-sdk`, `anthropic`, and `fastmcp` are not pinned in `pyproject.toml`. For production deployments, pin these in your image build:
+Upper bounds for `litellm`, `claude-agent-sdk`, `anthropic`, and `mcp` are not pinned in `pyproject.toml`. For production deployments, pin these in your image build:
 
 ```bash
 pip install \
-  "notebook-intelligence==4.5.*" \
-  "litellm==1.62.*" \
+  "notebook-intelligence==5.0.*" \
+  "litellm==1.83.*" \
   "claude-agent-sdk==0.x.*" \
   "anthropic==0.x.*" \
-  "fastmcp==2.x.*"
+  "mcp==1.27.*"
 ```
 
-Substitute the versions you've validated. The NBI test suite is currently TypeScript-only (`jlpm test`); end-to-end Python testing is a future work item.
+Substitute the versions you've validated. As of 5.0.0 NBI uses the official `mcp` Python SDK (the prior `fastmcp` dependency was removed); see the [5.0.0 changelog migration note](../CHANGELOG.md#migration-note) if your image previously pinned `fastmcp`. The NBI test suite is currently TypeScript-only (`jlpm test`); end-to-end Python testing is a future work item.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@notebook-intelligence/notebook-intelligence",
-    "version": "5.0.0-a.1",
+    "version": "5.0.0",
     "description": "AI coding assistant for JupyterLab",
     "keywords": [
         "AI",


### PR DESCRIPTION
## Summary

Prep for the 5.0.0 release. Promotes the existing `[Unreleased]` CHANGELOG snapshot to `[5.0.0] - 2026-05-22`, expands it to cover everything merged into `upstream/main` after PR #287's docs refresh, bumps `package.json` from 4.8.0 to 5.0.0, and freshens README + admin-guide for the new surface.

## Solution

### CHANGELOG

- New `[5.0.0]` section covering the post-#287 surface across Added / Changed / Removed / Fixed / Security / Internal.
- New **Migration note** (post-summary, before Added) listing the five behavior changes from 4.x that operators should review:
  - `fastmcp` dependency removed in favor of the official `mcp` SDK (#324).
  - Shell tool and Claude UI-bridge tool paths sandboxed to `jupyter_root` (#290, #323).
  - Session listing no longer reads `history.jsonl` (#310).
  - Workspace file attach in Claude mode ships an `@`-mention pointer instead of inlined content (#327).
  - Copilot WebSocket upgrades require Jupyter auth and pass an origin check (#301).
- Section ordering follows Keep-a-Changelog (Added → Changed → Removed → Fixed → Security → Internal). Sub-headings under Added (`Settings`, `Launchers`, `Chat sidebar and agentic UX`, `Copilot models`, `Skills and workspace config`) earn their keep at this bullet density.

### README

- Roadmap section flipped from 4.x to 5.x framing with a pointer to the migration note.
- New H3 in Feature highlights: **Reload open files when changed on disk** (#330). TOC updated.
- Claude mode prose gains: new chat session button (#246), progress feedback for long turns (#254), `@`-mention behavior change (#327).
- Other coding-agent launcher tiles subsection notes the start-directory picker (#332).
- Plugins section freshened with the marketplace picker (#284) and Update button (#303).
- Claude MCP section freshened with per-workspace toggle (#286) and JSON-paste path (#285).

### `docs/admin-guide.md`

- `pip install` example block swapped from `fastmcp==2.x.*` to `mcp==1.27.*` and `notebook-intelligence==5.0.*`, with a cross-reference to the changelog migration note.
- Version matrix gains a `5.0.x` row.
- New callout in the env-var/traitlet section noting that some NBI settings live in JupyterLab's Settings Editor rather than the NBI Settings dialog. Names `refresh_open_files_on_disk_change` as the notable case and the `overrides.json` path for org-wide overrides.

### `package.json`

- Version bumped from 4.8.0 to 5.0.0. The Python `_version.py` is auto-generated by Hatchling from this value on build, so no separate Python version bump is needed.

## Testing

Documentation and version-bump PR; no executable change.

- `python3 -c "import json; json.load(open('package.json'))"` — package.json is valid JSON.
- Visual check: CHANGELOG renders cleanly, all links resolve, no broken bullets.
- Em-dash grep on added lines returned 0 hits (project convention).

Two rounds of six persona reviewers (changelog fidelity, backward-compat / semver, admin-guide cross-reference, security-claim audit, README freshness, style + Keep-a-Changelog conformance) shaped the final wording:

- Round 1 surfaced overclaims on three Security entries (#293, #299, #323), a #284 vs #303 mis-attribution, the absent migration note, 3 em dashes, and a stale `fastmcp==2.x.*` pin recommendation in the admin guide.
- Round 2 surfaced the missing #301 migration bullet, the missing 5.0.x row in the version matrix, the missing README TOC entry, and two structural nits (an overpromised sub-heading and an orphan bullet).

All fix-before-ship findings applied.

## Risks / follow-ups

- **Cipher description in #293's CHANGELOG entry** says "AES-GCM-encrypted Copilot token". The underlying cipher is Fernet (AES-128-CBC + HMAC). Out of scope for this docs PR; worth a follow-up correction since it's a minor factual nit on a security entry.
- **Admin guide HTTP kill-switch row** in the **Failure modes** table is not added; the kill switch is documented in the dedicated subsection. Worth a future tightening.
- **README first-run tour** mention in Quick start was deferred; the tour is discoverable in the UI on first open.
- **Terminal drag-drop trust-model note** (`docs/admin-guide.md:549`) is mildly imprecise post-#327 (the `@`-mention path bypasses the staging dir for workspace files). Worth a future tweak.

## Issue linkage

No single issue — this is the 5.0.0 release prep PR. Closes the post-4.8.0 doc lag.