### PR TITLE
refactor(settings): move refresh_open_files toggle to NBI config

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,22 +168,23 @@ Most settings panel toggles can be locked by org administrators. Two shapes:
 
 **Boolean policies** use the `*_POLICY` suffix and accept three values: `user-choice` (default — user toggles freely), `force-on` (locked enabled), `force-off` (locked disabled). When forced, the panel control is disabled with a "Locked by your administrator" tooltip and any client-side write is ignored.
 
-| Env var                                    | Locks the Settings panel control for                                                                                         |
-| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| `NBI_EXPLAIN_ERROR_POLICY`                 | "Explain cell errors"                                                                                                        |
-| `NBI_OUTPUT_FOLLOWUP_POLICY`               | "Ask about cell outputs"                                                                                                     |
-| `NBI_OUTPUT_TOOLBAR_POLICY`                | "Show output toolbar"                                                                                                        |
-| `NBI_CLAUDE_MODE_POLICY`                   | "Enable Claude mode"                                                                                                         |
-| `NBI_CLAUDE_CONTINUE_CONVERSATION_POLICY`  | "Remember conversation history"                                                                                              |
-| `NBI_CLAUDE_CODE_TOOLS_POLICY`             | "Claude Code tools"                                                                                                          |
-| `NBI_CLAUDE_JUPYTER_UI_TOOLS_POLICY`       | "Jupyter UI tools"                                                                                                           |
-| `NBI_CLAUDE_SETTING_SOURCE_USER_POLICY`    | Setting source: User                                                                                                         |
-| `NBI_CLAUDE_SETTING_SOURCE_PROJECT_POLICY` | Setting source: Project                                                                                                      |
-| `NBI_STORE_GITHUB_ACCESS_TOKEN_POLICY`     | "Remember my GitHub Copilot access token"                                                                                    |
-| `NBI_SKILLS_MANAGEMENT_POLICY`             | The Skills tab (force-off hides it and 403s the API; also disables the managed-skills reconciler)                            |
-| `NBI_CLAUDE_MCP_MANAGEMENT_POLICY`         | The Claude-mode MCP Servers tab (force-off hides it and 403s `/claude-mcp/*`; independent of the non-Claude MCP Servers tab) |
-| `NBI_CLAUDE_PLUGINS_MANAGEMENT_POLICY`     | The Claude-mode Plugins tab (force-off hides it and 403s `/plugins/*`)                                                       |
-| `NBI_TERMINAL_DRAG_DROP_POLICY`            | Terminal drag-drop file attach feature                                                                                       |
+| Env var                                        | Locks the Settings panel control for                                                                                         |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `NBI_EXPLAIN_ERROR_POLICY`                     | "Explain cell errors"                                                                                                        |
+| `NBI_OUTPUT_FOLLOWUP_POLICY`                   | "Ask about cell outputs"                                                                                                     |
+| `NBI_OUTPUT_TOOLBAR_POLICY`                    | "Show output toolbar"                                                                                                        |
+| `NBI_CLAUDE_MODE_POLICY`                       | "Enable Claude mode"                                                                                                         |
+| `NBI_CLAUDE_CONTINUE_CONVERSATION_POLICY`      | "Remember conversation history"                                                                                              |
+| `NBI_CLAUDE_CODE_TOOLS_POLICY`                 | "Claude Code tools"                                                                                                          |
+| `NBI_CLAUDE_JUPYTER_UI_TOOLS_POLICY`           | "Jupyter UI tools"                                                                                                           |
+| `NBI_CLAUDE_SETTING_SOURCE_USER_POLICY`        | Setting source: User                                                                                                         |
+| `NBI_CLAUDE_SETTING_SOURCE_PROJECT_POLICY`     | Setting source: Project                                                                                                      |
+| `NBI_STORE_GITHUB_ACCESS_TOKEN_POLICY`         | "Remember my GitHub Copilot access token"                                                                                    |
+| `NBI_SKILLS_MANAGEMENT_POLICY`                 | The Skills tab (force-off hides it and 403s the API; also disables the managed-skills reconciler)                            |
+| `NBI_CLAUDE_MCP_MANAGEMENT_POLICY`             | The Claude-mode MCP Servers tab (force-off hides it and 403s `/claude-mcp/*`; independent of the non-Claude MCP Servers tab) |
+| `NBI_CLAUDE_PLUGINS_MANAGEMENT_POLICY`         | The Claude-mode Plugins tab (force-off hides it and 403s `/plugins/*`)                                                       |
+| `NBI_TERMINAL_DRAG_DROP_POLICY`                | Terminal drag-drop file attach feature                                                                                       |
+| `NBI_REFRESH_OPEN_FILES_ON_DISK_CHANGE_POLICY` | "Refresh open files when changed on disk"                                                                                    |
 
 The first three also have matching traitlets on `NotebookIntelligence` (`explain_error_policy`, `output_followup_policy`, `output_toolbar_policy`); add the others as needed in the same shape:
 

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -119,7 +119,7 @@ The full surface, in one table.
 | `NBI_LOG_LEVEL`                                  | str  | `INFO`                      | env                                | Python logging level for the `notebook_intelligence` logger.                                                                                                                                                                                                                                                                                                                                                                                                             |
 | `NBI_DISABLE_OUTPUT_SCRUB`                       | bool | unset                       | env                                | When set (`1` / `true` / `yes` / `on`), disables the shell-tool output scrubber so raw stdout/stderr (including any env-var values that leak) is sent through to chat. Default off; the scrubber redacts values for sensitive-named env vars (`TOKEN`, `SECRET`, `API_KEY`, ...) plus tokens with well-known credential prefixes (`ghp_`, `sk-ant-`, `AKIA`, ...). Opt out only when debugging credential helpers where the redaction interferes.                        |
 | `GITHUB_TOKEN`, `GH_TOKEN`                       | str  | unset                       | env                                | Used (in that order) by user-initiated skill imports and GitHub-sourced plugin marketplace adds for GitHub auth. Falls back to `gh` CLI auth.                                                                                                                                                                                                                                                                                                                            |
-| `NBI_*_POLICY`                                   | str  | `user-choice`               | env                                | Lock individual Settings panel toggles. See [README → Admin policies](../README.md#admin-policies) for the full list of `*_POLICY` env vars and matching traitlets, including `NBI_SKILLS_MANAGEMENT_POLICY`, `NBI_CLAUDE_MCP_MANAGEMENT_POLICY`, `NBI_CLAUDE_PLUGINS_MANAGEMENT_POLICY`, and `NBI_TERMINAL_DRAG_DROP_POLICY`.                                                                                                                                           |
+| `NBI_*_POLICY`                                   | str  | `user-choice`               | env                                | Lock individual Settings panel toggles. See [README → Admin policies](../README.md#admin-policies) for the full list of `*_POLICY` env vars and matching traitlets, including `NBI_SKILLS_MANAGEMENT_POLICY`, `NBI_CLAUDE_MCP_MANAGEMENT_POLICY`, `NBI_CLAUDE_PLUGINS_MANAGEMENT_POLICY`, `NBI_TERMINAL_DRAG_DROP_POLICY`, and `NBI_REFRESH_OPEN_FILES_ON_DISK_CHANGE_POLICY`.                                                                                           |
 
 Configure traitlets in `jupyter_server_config.py`:
 
@@ -538,6 +538,18 @@ c.NotebookIntelligence.terminal_drag_drop_policy = "force-off"
 Or via env: `NBI_TERMINAL_DRAG_DROP_POLICY=force-off`.
 
 Force-off hides the per-terminal drag-drop toolbar toggle and rejects upload-staging POSTs from a terminal context. Drag-drop is **enabled by default**; flip it off in regulated tenants where the staging file write or the resulting `@`-mention path is undesirable.
+
+### Disabling the open-files refresh watcher
+
+```python
+c.NotebookIntelligence.refresh_open_files_on_disk_change_policy = "force-off"
+```
+
+Or via env: `NBI_REFRESH_OPEN_FILES_ON_DISK_CHANGE_POLICY=force-off`.
+
+The refresh watcher reloads open notebook and file editor tabs when their content changes on disk (for example, when an agent edits a file). It skips tabs with unsaved local edits. Enabled by default; users can opt out in the NBI Settings dialog. Use `force-off` in deployments where automatic reloads could surprise users editing the same files via external tooling, or `force-on` to mandate the behavior tenant-wide.
+
+---
 
 Terminal drag-drop and chat-sidebar file attach both write to the shared upload-staging directory under the JupyterLab process's `tempfile.gettempdir()`. Two tunables govern that endpoint:
 

--- a/notebook_intelligence/config.py
+++ b/notebook_intelligence/config.py
@@ -206,6 +206,11 @@ class NBIConfig:
         return bool(self.get('enable_output_toolbar', True))
 
     @property
+    def refresh_open_files_on_disk_change(self) -> bool:
+        """User preference for the open-files refresh watcher (default on)."""
+        return bool(self.get('refresh_open_files_on_disk_change', True))
+
+    @property
     def rules_directory(self) -> str:
         """Get the rules directory path."""
         return os.path.join(self.nbi_user_dir, 'rules')

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -329,6 +329,11 @@ FEATURE_POLICY_SPEC = (
         "NBI_TERMINAL_DRAG_DROP_POLICY",
         "terminal_drag_drop_policy",
     ),
+    (
+        "refresh_open_files_on_disk_change",
+        "NBI_REFRESH_OPEN_FILES_ON_DISK_CHANGE_POLICY",
+        "refresh_open_files_on_disk_change_policy",
+    ),
 )
 FEATURE_POLICY_NAMES = tuple(name for name, _, _ in FEATURE_POLICY_SPEC)
 
@@ -380,6 +385,7 @@ def _build_feature_policies_response(policies: dict, nbi_config) -> dict:
         "claude_mcp_management": True,
         "claude_plugins_management": True,
         "terminal_drag_drop": True,
+        "refresh_open_files_on_disk_change": nbi_config.refresh_open_files_on_disk_change,
     }
 
     response = {}
@@ -588,6 +594,7 @@ class ConfigHandler(APIHandler):
             "enable_explain_error",
             "enable_output_followup",
             "enable_output_toolbar",
+            "refresh_open_files_on_disk_change",
         ])
         # Top-level keys whose write is rejected outright when locked.
         locked_keys = set()
@@ -599,6 +606,8 @@ class ConfigHandler(APIHandler):
             locked_keys.add("enable_output_toolbar")
         if is_locked(self.feature_policies.get("store_github_access_token", POLICY_USER_CHOICE)):
             locked_keys.add("store_github_access_token")
+        if is_locked(self.feature_policies.get("refresh_open_files_on_disk_change", POLICY_USER_CHOICE)):
+            locked_keys.add("refresh_open_files_on_disk_change")
         # chat_model / inline_completion_model are locked when *either* of their
         # provider/id env vars is set; the resolver below preserves the locked
         # subfield so a user can still update the unlocked one.
@@ -2781,6 +2790,19 @@ class NotebookIntelligence(ExtensionApp):
         for hardened deployments that don't want files staged through
         the upload endpoint. Overridden by the
         NBI_TERMINAL_DRAG_DROP_POLICY env var.
+        """,
+        config=True,
+    )
+
+    refresh_open_files_on_disk_change_policy = TraitletEnum(
+        list(VALID_POLICIES),
+        default_value=POLICY_USER_CHOICE,
+        help="""
+        Org-wide policy for the open-files refresh watcher. "user-choice"
+        (default) honors the user's `refresh_open_files_on_disk_change`
+        setting from config.json. "force-on" pins the watcher on
+        regardless of the user setting; "force-off" pins it off. Overridden
+        by the NBI_REFRESH_OPEN_FILES_ON_DISK_CHANGE_POLICY env var.
         """,
         config=True,
     )

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -2,14 +2,7 @@
   "title": "Notebook Intelligence",
   "description": "Notebook Intelligence settings",
   "type": "object",
-  "properties": {
-    "refresh_open_files_on_disk_change": {
-      "type": "boolean",
-      "title": "Refresh open files when changed on disk",
-      "description": "Automatically reload notebook and file editor tabs when their content changes on disk (for example, when an external process such as a terminal command, a sync client, or an AI assistant edits the file). Skipped when the tab has unsaved local edits, so typed-but-not-yet-saved work is never clobbered.",
-      "default": true
-    }
-  },
+  "properties": {},
   "additionalProperties": false,
   "jupyter.lab.toolbars": {
     "Cell": [

--- a/src/api.ts
+++ b/src/api.ts
@@ -276,7 +276,8 @@ export type FeaturePolicyName =
   | 'skills_management'
   | 'claude_mcp_management'
   | 'claude_plugins_management'
-  | 'terminal_drag_drop';
+  | 'terminal_drag_drop'
+  | 'refresh_open_files_on_disk_change';
 
 export type IFeaturePolicies = Record<
   FeaturePolicyName,
@@ -496,17 +497,21 @@ export class NBIConfig {
       'skills_management',
       'claude_mcp_management',
       'claude_plugins_management',
-      'terminal_drag_drop'
+      'terminal_drag_drop',
+      'refresh_open_files_on_disk_change'
     ];
-    // Admin-only management gates (no per-user toggle) default *open* when
-    // missing — a new frontend hitting an older backend without these
-    // capability fields must keep the tab visible. The other policies pair
-    // with a user-toggle and default closed (a missing field means "no
-    // user pref recorded yet, treat as off"), matching prior semantics.
+    // Policies that default *open* when the capability field is missing,
+    // covering two cases: admin-only management gates (no user toggle) where
+    // a new frontend on an older backend must keep the tab visible, and the
+    // open-files refresh watcher whose documented default is on so its
+    // first ticks before capabilities land don't silently no-op. The other
+    // policies pair with a user toggle and default closed (missing means
+    // "no user pref recorded yet, treat as off").
     const defaultOpen: ReadonlySet<FeaturePolicyName> = new Set([
       'skills_management',
       'claude_mcp_management',
-      'claude_plugins_management'
+      'claude_plugins_management',
+      'refresh_open_files_on_disk_change'
     ]);
     const result = {} as IFeaturePolicies;
     for (const name of names) {

--- a/src/components/settings-panel.tsx
+++ b/src/components/settings-panel.tsx
@@ -384,6 +384,13 @@ function SettingsPanelComponentGeneral(props: any) {
     });
   };
 
+  const toggleRefreshOpenFilesOnDiskChange = () => {
+    NBIAPI.setConfig({
+      refresh_open_files_on_disk_change:
+        !featurePolicies.refresh_open_files_on_disk_change.enabled
+    });
+  };
+
   const updateModelOptionsForProvider = (
     providerId: string,
     modelType: 'chat' | 'inline-completion'
@@ -860,6 +867,30 @@ function SettingsPanelComponentGeneral(props: any) {
                   disabled={featurePolicies.output_toolbar.locked}
                   tooltip={lockedTip(featurePolicies.output_toolbar.locked)}
                   onClick={toggleOutputToolbar}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="model-config-section">
+          <div className="model-config-section-header">External changes</div>
+          <div className="model-config-section-body">
+            <div className="model-config-section-row">
+              <div className="model-config-section-column">
+                <CheckBoxItem
+                  label="Refresh open files when changed on disk"
+                  title="Automatically reload notebook and file editor tabs when an external process (terminal command, sync client, or AI agent) edits the file. Skipped when the tab has unsaved local edits."
+                  checked={
+                    featurePolicies.refresh_open_files_on_disk_change.enabled
+                  }
+                  disabled={
+                    featurePolicies.refresh_open_files_on_disk_change.locked
+                  }
+                  tooltip={lockedTip(
+                    featurePolicies.refresh_open_files_on_disk_change.locked
+                  )}
+                  onClick={toggleRefreshOpenFilesOnDiskChange}
                 />
               </div>
             </div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -838,7 +838,6 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
   // ours. Cast through the top-level Token type to keep the plugin
   // declaration well-typed for the other optionals.
   optional: [
-    ISettingRegistry,
     IStatusBar,
     ILauncher,
     ITerminalTracker as unknown as Token<unknown>
@@ -852,7 +851,6 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
     languageRegistry: IEditorLanguageRegistry,
     palette: ICommandPalette,
     mainMenu: IMainMenu,
-    settingRegistry: ISettingRegistry | null,
     statusBar: IStatusBar | null,
     launcher: ILauncher | null,
     terminalTracker: ITerminalTracker | null
@@ -911,38 +909,13 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
       new NBIInlineCompletionProvider(telemetryEmitter)
     );
 
-    // Snapshot the user's "refresh open files when changed on disk"
-    // toggle. The watcher reads it on every tick so flipping the
-    // setting takes effect without restarting Lab. Default-true so
-    // out-of-box agentic flows pick up file edits automatically;
-    // gated by ISettingRegistry availability (Lab can run without it
-    // in stripped-down embeds).
-    let refreshOnDiskEnabled = true;
-    if (settingRegistry) {
-      settingRegistry
-        .load(plugin.id)
-        .then(settings => {
-          const readToggle = (s: ISettingRegistry.ISettings) =>
-            s.composite['refresh_open_files_on_disk_change'] !== false;
-          refreshOnDiskEnabled = readToggle(settings);
-          settings.changed.connect(s => {
-            refreshOnDiskEnabled = readToggle(s);
-          });
-        })
-        .catch(reason => {
-          console.error(
-            'Failed to load settings for @notebook-intelligence/notebook-intelligence.',
-            reason
-          );
-        });
-    }
-
-    // JupyterLab plugins don't have a deactivate hook, so the watcher
-    // runs for the lifetime of the Lab session. We discard the teardown
-    // function here intentionally; it exists for test ergonomics.
+    // JL plugins have no deactivate hook, so the watcher runs for the
+    // lifetime of the Lab session and the returned teardown is intentionally
+    // discarded (it exists for test ergonomics).
     attachOpenFileRefreshWatcher({
       env: buildRefreshWatcherEnv(app, app.serviceManager.contents),
-      isEnabled: () => refreshOnDiskEnabled
+      isEnabled: () =>
+        NBIAPI.config.featurePolicies.refresh_open_files_on_disk_change.enabled
     });
 
     const waitForFileToBeActive = async (

--- a/tests/test_cell_output_features_response.py
+++ b/tests/test_cell_output_features_response.py
@@ -26,6 +26,7 @@ def _config(
     followup=True,
     toolbar=True,
     store_token=False,
+    refresh_open_files=True,
     claude_settings=None,
 ):
     return SimpleNamespace(
@@ -33,6 +34,7 @@ def _config(
         enable_output_followup=followup,
         enable_output_toolbar=toolbar,
         store_github_access_token=store_token,
+        refresh_open_files_on_disk_change=refresh_open_files,
         claude_settings=claude_settings if claude_settings is not None else {},
     )
 
@@ -167,6 +169,35 @@ class TestBuildFeaturePoliciesResponse:
         # is added to the spec but not to the response builder.
         response = _build_feature_policies_response({}, _config())
         assert set(response.keys()) == set(FEATURE_POLICY_NAMES)
+
+    def test_refresh_open_files_reflects_user_pref_when_unforced(self):
+        response = _build_feature_policies_response(
+            {}, _config(refresh_open_files=False)
+        )
+        assert response["refresh_open_files_on_disk_change"] == {
+            "enabled": False,
+            "locked": False,
+        }
+
+    def test_refresh_open_files_force_off_locks_against_user_on(self):
+        response = _build_feature_policies_response(
+            {"refresh_open_files_on_disk_change": POLICY_FORCE_OFF},
+            _config(refresh_open_files=True),
+        )
+        assert response["refresh_open_files_on_disk_change"] == {
+            "enabled": False,
+            "locked": True,
+        }
+
+    def test_refresh_open_files_force_on_locks_against_user_off(self):
+        response = _build_feature_policies_response(
+            {"refresh_open_files_on_disk_change": POLICY_FORCE_ON},
+            _config(refresh_open_files=False),
+        )
+        assert response["refresh_open_files_on_disk_change"] == {
+            "enabled": True,
+            "locked": True,
+        }
 
 
 class TestBuildSettingLocksResponse:


### PR DESCRIPTION
## Summary

Issue #337 asks that the `refresh_open_files_on_disk_change` setting (introduced in #330) live in NBI's own config and Settings dialog rather than JupyterLab's Settings Editor, for consistency with the other user-toggleable booleans (`enable_explain_error`, `enable_output_followup`, `enable_output_toolbar`). This PR relocates it.

## Solution

The setting now lives in `~/.jupyter/nbi/config.json` (read via `NBIConfig.refresh_open_files_on_disk_change`) and renders as a checkbox in a new **External changes** section of the NBI Settings dialog. It is wired through the standard admin-policy triad: a `FEATURE_POLICY_SPEC` entry, a `TraitletEnum`, and a `NBI_REFRESH_OPEN_FILES_ON_DISK_CHANGE_POLICY` env var, so deployments can pin it `force-on`/`force-off` without touching code.

Key changes:

- `notebook_intelligence/extension.py`: `FEATURE_POLICY_SPEC` entry, new `refresh_open_files_on_disk_change_policy` TraitletEnum, `_build_feature_policies_response` user value, `ConfigHandler.valid_keys` + `locked_keys` gating.
- `notebook_intelligence/config.py`: `refresh_open_files_on_disk_change` property (default `True`).
- `src/api.ts`: extends `FeaturePolicyName` union, the `featurePolicies` getter, and the `defaultOpen` set so the watcher's boot-window read survives until capabilities land.
- `src/index.ts`: the watcher's `isEnabled` callback now re-reads NBI capabilities every tick, so toggling in the Settings dialog applies without a Lab restart.
- `src/components/settings-panel.tsx`: new "External changes" section with a `CheckBoxItem` that honors `featurePolicies.refresh_open_files_on_disk_change.locked`.
- `schema/plugin.json`: removed the orphan property (the schema retains `jupyter.lab.toolbars` and `jupyter.lab.shortcuts` blocks).
- Docs: README "Admin policies" table row and a new `docs/admin-guide.md` section.

Note that the prior home for this setting was only exposed in 5.0.0-alpha, so a runtime migration of stale JL Settings Registry values is not included; an alpha user who toggled it `false` will revert to the default `true` and can opt out again in the new dialog.

## Testing

- `pytest tests/ --ignore=tests/test_claude_client.py -q`: 1066 passed.
- `jlpm tsc --noEmit`: clean.
- `jlpm lint:check`: clean.
- `jlpm jest`: 281 passed.
- Three new pytest cases in `tests/test_cell_output_features_response.py` pin the capabilities-response shape across `user-choice`, `force-on`, and `force-off`.
- Playwright verification in a local Lab session: confirmed the dialog renders the new section, the toggle round-trips to `~/.jupyter/nbi/config.json` and the capabilities response, and `NBI_REFRESH_OPEN_FILES_ON_DISK_CHANGE_POLICY=force-off` correctly disables the checkbox and returns `{enabled: false, locked: true}`.

Two reviewer rounds (six agents each: three /simplify and three persona reviewers covering JL extension lifecycle, frontend a11y, and API contract). All `fix-before-merge` findings were applied in round 2; remaining notes are scoped as follow-ups.

## Risks / follow-ups

- The `featurePolicies` getter in `src/api.ts` allocates per call; the watcher tick reads it every 3 s. Round 2 efficiency review confirmed this is sub-microsecond and dwarfed by the watcher's own filesystem fan-out. A future pass could memoize the getter against `this.capabilities` identity for broader benefit, but it isn't load-bearing for this change.
- `model-config-section-header` is a styled `<div>` rather than a semantic heading; this is pre-existing across the whole Settings dialog and out of scope here.

## Screenshots

Default (unlocked, checked) and `force-off` (locked, disabled) attached locally at `nbi-settings-external-changes.png` and `nbi-settings-force-off-locked.png`; will drop into this description via the web UI.

Closes #337.