### PR TITLE
feat(copilot): route Codex chat models through /responses endpoint

### DIFF
--- a/notebook_intelligence/github_copilot.py
+++ b/notebook_intelligence/github_copilot.py
@@ -59,6 +59,16 @@ github_auth = {
 # stay current.
 copilot_models_cache: list[dict] = []
 
+# Per-model HTTP path under API_ENDPOINT. Codex-class models advertise only
+# `/responses` (the OpenAI Responses API mirror) and 400 on `/chat/completions`;
+# everything else stays on `/chat/completions`. Populated by
+# `fetch_copilot_models` from each model entry's `supported_endpoints` field.
+# Lookup falls back to `/chat/completions` for unknown ids so the hardcoded
+# fallback model list keeps working before the first live fetch.
+_COPILOT_CHAT_ENDPOINT = "/chat/completions"
+_COPILOT_RESPONSES_ENDPOINT = "/responses"
+copilot_model_endpoints: dict[str, str] = {}
+
 # Conservative floor when the Copilot API omits limits for a model. Picked
 # to match the smallest token cap any Copilot-served model has historically
 # carried, so the token-budget meter (extension.py: `remaining_token_budget`)
@@ -419,6 +429,7 @@ def fetch_copilot_models() -> list[dict]:
 
     raw_models = payload.get("data", []) if isinstance(payload, dict) else []
     normalized: list[dict] = []
+    endpoints: dict[str, str] = {}
     seen_ids: set[str] = set()
     for entry in raw_models:
         if not isinstance(entry, dict):
@@ -426,7 +437,15 @@ def fetch_copilot_models() -> list[dict]:
         if not entry.get("model_picker_enabled"):
             continue
         caps = entry.get("capabilities", {}) or {}
-        if caps.get("type") != "chat":
+        supported = entry.get("supported_endpoints") or []
+        if not isinstance(supported, list):
+            supported = []
+        # Codex-class models advertise only `/responses` and may report a
+        # non-chat capability `type`. Accept them when the endpoint list says
+        # they're chattable, so they reach the dispatcher in `chat(...)`.
+        is_chat_type = caps.get("type") == "chat"
+        has_responses = _COPILOT_RESPONSES_ENDPOINT in supported
+        if not (is_chat_type or has_responses):
             continue
         model_id = entry.get("id")
         if not isinstance(model_id, str) or not model_id or model_id in seen_ids:
@@ -445,6 +464,15 @@ def fetch_copilot_models() -> list[dict]:
             context_window = _COPILOT_DEFAULT_CONTEXT_WINDOW
         if context_window <= 0:
             context_window = _COPILOT_DEFAULT_CONTEXT_WINDOW
+        # Prefer `/chat/completions` whenever the model advertises it; only
+        # route through `/responses` when that's the model's sole supported
+        # path. Mirrors codecompanion.nvim's Copilot adapter: dual-listing
+        # exists for forward compatibility, but established chat flows are
+        # still cheaper on the older endpoint.
+        if has_responses and _COPILOT_CHAT_ENDPOINT not in supported:
+            endpoints[model_id] = _COPILOT_RESPONSES_ENDPOINT
+        else:
+            endpoints[model_id] = _COPILOT_CHAT_ENDPOINT
         normalized.append({
             "id": model_id,
             "name": str(name),
@@ -460,12 +488,33 @@ def fetch_copilot_models() -> list[dict]:
 
     copilot_models_cache.clear()
     copilot_models_cache.extend(normalized)
+    copilot_model_endpoints.clear()
+    copilot_model_endpoints.update(endpoints)
     return list(copilot_models_cache)
 
 
 def invalidate_copilot_models_cache() -> None:
     """Clear the memoized Copilot chat-model list. Mostly used by tests."""
     copilot_models_cache.clear()
+    copilot_model_endpoints.clear()
+
+
+def _model_chat_endpoint(model_id: str) -> str:
+    """Pick the HTTP path for a Copilot chat request.
+
+    Trusts the live catalogue first: `fetch_copilot_models` populates
+    `copilot_model_endpoints` after login from each model's
+    `supported_endpoints` field. For ids the cache doesn't know (the
+    hardcoded fallback list, an offline session, a /models fetch that
+    failed), falls back to a substring heuristic: any id containing `codex`
+    routes to `/responses`, since the entire Codex family only accepts that
+    endpoint. Everything else stays on `/chat/completions`.
+    """
+    if model_id in copilot_model_endpoints:
+        return copilot_model_endpoints[model_id]
+    if "codex" in model_id.lower():
+        return _COPILOT_RESPONSES_ENDPOINT
+    return _COPILOT_CHAT_ENDPOINT
 
 def get_token_thread_func():
     global github_auth, get_token_thread, last_token_fetch_time
@@ -626,6 +675,309 @@ def _aggregate_streaming_response(client: sseclient.SSEClient) -> dict:
                     final_tool_calls[index]['function']['arguments'] += tool_call['function']['arguments']
 
     return _format_llm_response()
+
+def _messages_to_responses_input(messages: list[dict]) -> tuple[list[dict], str | None]:
+    """Translate an OpenAI chat-completions `messages` array into the shape
+    Copilot's `/responses` endpoint accepts.
+
+    System messages collapse into the top-level ``instructions`` field
+    (newline-joined when more than one is present). Assistant tool calls
+    expand to `function_call` items, tool results to `function_call_output`
+    items, and the remaining role/content pairs pass through with their
+    original role. Matches what codecompanion.nvim sends and what OpenAI's
+    own Responses migration guide documents.
+    """
+    instructions_parts: list[str] = []
+    input_items: list[dict] = []
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role")
+        content = msg.get("content")
+        if role == "system":
+            if isinstance(content, str) and content:
+                instructions_parts.append(content)
+            continue
+        if role == "tool":
+            output = content if isinstance(content, str) else json.dumps(content)
+            input_items.append({
+                "type": "function_call_output",
+                "call_id": msg.get("tool_call_id"),
+                "output": output,
+            })
+            continue
+        if role == "assistant" and msg.get("tool_calls"):
+            for tc in msg["tool_calls"]:
+                fn = (tc.get("function") or {}) if isinstance(tc, dict) else {}
+                call_id = tc.get("id") if isinstance(tc, dict) else None
+                input_items.append({
+                    "type": "function_call",
+                    "call_id": call_id,
+                    "name": fn.get("name"),
+                    "arguments": fn.get("arguments", ""),
+                })
+            if isinstance(content, str) and content:
+                input_items.append({"role": role, "content": content})
+            continue
+        input_items.append({"role": role, "content": content if content is not None else ""})
+    instructions = "\n".join(instructions_parts) if instructions_parts else None
+    return input_items, instructions
+
+
+def _chat_tools_to_responses_tools(tools: list[dict] | None) -> list[dict] | None:
+    """Flatten chat-completions tool schemas to Responses-API shape.
+
+    Chat completions nests under ``{type: "function", function: {name, ...}}``;
+    Responses expects the function fields at the top level. The transform is
+    purely structural so a caller can keep emitting one schema upstream.
+    """
+    if not tools:
+        return None
+    out: list[dict] = []
+    for tool in tools:
+        if not isinstance(tool, dict) or tool.get("type") != "function":
+            out.append(tool)
+            continue
+        fn = tool.get("function") or {}
+        out.append({
+            "type": "function",
+            "name": fn.get("name"),
+            "description": fn.get("description"),
+            "parameters": fn.get("parameters"),
+        })
+    return out
+
+
+# Responses-API SSE event types that mean the server gave up mid-stream.
+# Treated as hard failures so callers see an exception instead of a silent
+# empty assistant turn; `response.incomplete` (max-tokens cap, etc.) is
+# included because Codex emits it in place of `response.completed` and the
+# partial content alone isn't enough signal for the chat sidebar.
+_RESPONSES_TERMINAL_ERROR_EVENTS = frozenset({
+    "response.failed",
+    "response.error",
+    "response.incomplete",
+    "error",
+})
+
+
+def _responses_error_message(chunk: dict) -> str:
+    """Extract the most descriptive error string a `response.failed` /
+    `response.error` event carries. Falls back to the raw type when the
+    server omits a message field."""
+    if not isinstance(chunk, dict):
+        return "GitHub Copilot returned an unparseable error event."
+    response_obj = chunk.get("response") or {}
+    for source in (chunk, response_obj):
+        if not isinstance(source, dict):
+            continue
+        err = source.get("error") if isinstance(source.get("error"), dict) else None
+        if err:
+            msg = err.get("message") or err.get("code")
+            if isinstance(msg, str) and msg:
+                return msg
+        msg = source.get("message")
+        if isinstance(msg, str) and msg:
+            return msg
+    return f"GitHub Copilot Responses stream emitted {chunk.get('type', 'unknown')!r} without a message."
+
+
+def _function_call_item_to_chat_tool(item: dict, *, fallback_arguments: str = "") -> dict | None:
+    """Turn a Responses-API `function_call` output item into the
+    chat-completions tool_call shape the rest of the codebase expects.
+    Returns None if the item should be skipped (wrong type, in-progress
+    status).
+    """
+    if not isinstance(item, dict) or item.get("type") != "function_call":
+        return None
+    if item.get("status") not in (None, "completed"):
+        return None
+    return {
+        "id": item.get("call_id") or item.get("id"),
+        "type": "function",
+        "function": {
+            "name": item.get("name") or "",
+            "arguments": item.get("arguments") or fallback_arguments or "{}",
+        },
+    }
+
+
+def _aggregate_responses_streaming(client: sseclient.SSEClient) -> dict:
+    """Drain a `/responses` SSE stream and return the same chat-completions
+    shape `_aggregate_streaming_response` emits, so callers see one wire
+    format regardless of which endpoint served the model.
+    """
+    final_content = ""
+    final_tool_calls: list[dict] = []
+    # Some Codex variants stream function-call arguments incrementally as
+    # `response.function_call_arguments.delta` events and only ship a
+    # zero-byte `arguments` field in the terminal `response.completed`
+    # item. Accumulate by `item_id` so we can stitch them back together
+    # if the terminal payload comes through empty.
+    arg_buffers: dict[str, str] = {}
+    for event in client.events():
+        if not event.data:
+            continue
+        try:
+            chunk = json.loads(event.data)
+        except (ValueError, json.JSONDecodeError):
+            continue
+        event_type = chunk.get("type")
+        if event_type in _RESPONSES_TERMINAL_ERROR_EVENTS:
+            raise Exception(_responses_error_message(chunk))
+        if event_type == "response.output_text.delta":
+            delta = chunk.get("delta")
+            if isinstance(delta, str):
+                final_content += delta
+        elif event_type == "response.function_call_arguments.delta":
+            item_id = chunk.get("item_id")
+            delta = chunk.get("delta")
+            if isinstance(item_id, str) and isinstance(delta, str):
+                arg_buffers[item_id] = arg_buffers.get(item_id, "") + delta
+        elif event_type == "response.completed":
+            resp_obj = chunk.get("response") or {}
+            for item in resp_obj.get("output") or []:
+                if not isinstance(item, dict):
+                    continue
+                buffered = arg_buffers.get(item.get("id") or "")
+                tc = _function_call_item_to_chat_tool(item, fallback_arguments=buffered or "")
+                if tc is not None:
+                    final_tool_calls.append(tc)
+            break
+    return {
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": final_content,
+                "tool_calls": final_tool_calls if final_tool_calls else None,
+            }
+        }]
+    }
+
+
+def responses(model_id, messages, tools = None, response: ChatResponse = None, cancel_token: CancelToken = None, options: dict = {}) -> Any:
+    """Send a chat turn through Copilot's `/responses` endpoint.
+
+    Required for Codex-class models, which 400 on `/chat/completions`. The
+    aggregate and streaming return shapes match `completions()` so callers
+    don't need an endpoint branch above this layer.
+    """
+    aggregate = response is None
+
+    try:
+        input_items, instructions = _messages_to_responses_input(messages)
+        data: dict[str, Any] = {
+            "model": model_id,
+            "input": input_items,
+            "stream": True,
+        }
+        if instructions:
+            data["instructions"] = instructions
+        responses_tools = _chat_tools_to_responses_tools(tools)
+        if responses_tools:
+            data["tools"] = responses_tools
+        if "tool_choice" in options:
+            data["tool_choice"] = options["tool_choice"]
+
+        if cancel_token is not None and cancel_token.is_cancel_requested:
+            if response is not None:
+                response.finish()
+            return
+
+        request = requests.post(
+            f"{API_ENDPOINT}{_COPILOT_RESPONSES_ENDPOINT}",
+            headers=generate_copilot_headers(),
+            json=data,
+            stream=True,
+        )
+
+        if request.status_code != 200:
+            msg = f"Failed to get responses from GitHub Copilot: [{request.status_code}]: {request.text}"
+            log.error(msg)
+            if response is not None:
+                response.stream(MarkdownData(msg))
+                response.finish()
+            raise Exception(msg)
+
+        client = sseclient.SSEClient(request)
+        if aggregate:
+            return _aggregate_responses_streaming(client)
+
+        # Streaming: translate typed Responses events into chat-completions
+        # delta chunks the existing frontend consumer already knows how to
+        # render. The shape `{choices: [{delta: {role, content}}]}` matches
+        # what `_aggregate_streaming_response` and `response.stream(...)`
+        # below produce for `/chat/completions`.
+        arg_buffers: dict[str, str] = {}
+        for event in client.events():
+            if cancel_token is not None and cancel_token.is_cancel_requested:
+                response.finish()
+                return
+            if not event.data:
+                continue
+            try:
+                chunk = json.loads(event.data)
+            except (ValueError, json.JSONDecodeError):
+                continue
+            event_type = chunk.get("type")
+            if event_type in _RESPONSES_TERMINAL_ERROR_EVENTS:
+                msg = _responses_error_message(chunk)
+                log.error(f"GitHub Copilot Responses stream failed: {msg}")
+                response.stream(MarkdownData(msg))
+                response.finish()
+                raise Exception(msg)
+            if event_type == "response.output_text.delta":
+                delta = chunk.get("delta")
+                if isinstance(delta, str) and delta:
+                    response.stream({
+                        "choices": [{
+                            "delta": {"role": "assistant", "content": delta}
+                        }]
+                    })
+            elif event_type == "response.function_call_arguments.delta":
+                item_id = chunk.get("item_id")
+                delta = chunk.get("delta")
+                if isinstance(item_id, str) and isinstance(delta, str):
+                    arg_buffers[item_id] = arg_buffers.get(item_id, "") + delta
+            elif event_type == "response.completed":
+                resp_obj = chunk.get("response") or {}
+                tool_calls: list[dict] = []
+                for idx, item in enumerate(resp_obj.get("output") or []):
+                    if not isinstance(item, dict):
+                        continue
+                    buffered = arg_buffers.get(item.get("id") or "")
+                    tc = _function_call_item_to_chat_tool(item, fallback_arguments=buffered or "")
+                    if tc is None:
+                        continue
+                    tc["index"] = idx
+                    tool_calls.append(tc)
+                if tool_calls:
+                    response.stream({
+                        "choices": [{
+                            "delta": {"role": "assistant", "tool_calls": tool_calls}
+                        }]
+                    })
+                response.finish()
+                return
+        response.finish()
+        return
+    except requests.exceptions.ConnectionError:
+        raise Exception("Connection error")
+    except Exception as e:
+        log.error(f"Failed to get responses from GitHub Copilot: {e}")
+        raise e
+
+
+def chat(model_id, messages, tools = None, response: ChatResponse = None, cancel_token: CancelToken = None, options: dict = {}) -> Any:
+    """Endpoint-aware chat entry point. Routes Codex-class models to
+    `/responses` and everything else to `/chat/completions`. Callers from
+    the LLM provider should go through this rather than `completions(...)`
+    directly so per-model dispatch stays in one place.
+    """
+    if _model_chat_endpoint(model_id) == _COPILOT_RESPONSES_ENDPOINT:
+        return responses(model_id, messages, tools, response, cancel_token, options)
+    return completions(model_id, messages, tools, response, cancel_token, options)
+
 
 def completions(model_id, messages, tools = None, response: ChatResponse = None, cancel_token: CancelToken = None, options: dict = {}) -> Any:
     aggregate = response is None

--- a/notebook_intelligence/llm_providers/github_copilot_llm_provider.py
+++ b/notebook_intelligence/llm_providers/github_copilot_llm_provider.py
@@ -5,7 +5,7 @@ from typing import Any
 import requests
 from notebook_intelligence.api import ChatModel, EmbeddingModel, InlineCompletionModel, LLMProvider, CancelToken, ChatResponse, CompletionContext
 from notebook_intelligence import github_copilot as gh_copilot
-from notebook_intelligence.github_copilot import generate_copilot_headers, completions, inline_completions
+from notebook_intelligence.github_copilot import chat as copilot_chat, generate_copilot_headers, inline_completions
 import logging
 
 log = logging.getLogger(__name__)
@@ -37,7 +37,7 @@ class GitHubCopilotChatModel(ChatModel):
         return self._supports_tools
 
     def completions(self, messages: list[dict], tools: list[dict] = None, response: ChatResponse = None, cancel_token: CancelToken = None, options: dict = {}) -> Any:
-        return completions(self._model_id, messages, tools, response, cancel_token, options)
+        return copilot_chat(self._model_id, messages, tools, response, cancel_token, options)
 
 class GitHubCopilotInlineCompletionModel(InlineCompletionModel):
     def __init__(self, provider: LLMProvider, model_id: str, model_name: str):

--- a/tests/test_github_copilot_llm_provider.py
+++ b/tests/test_github_copilot_llm_provider.py
@@ -9,8 +9,10 @@ from notebook_intelligence.llm_providers.github_copilot_llm_provider import GitH
 @pytest.fixture(autouse=True)
 def _reset_models_cache():
     gh_copilot.invalidate_copilot_models_cache()
+    original_token = gh_copilot.github_auth.get("token")
     yield
     gh_copilot.invalidate_copilot_models_cache()
+    gh_copilot.github_auth["token"] = original_token
 
 
 def test_chat_models_include_recent_github_copilot_models():
@@ -164,3 +166,486 @@ def test_fetch_copilot_models_swallows_http_failure():
 
     with patch("notebook_intelligence.github_copilot.requests.get", return_value=response):
         assert gh_copilot.fetch_copilot_models() == []
+
+
+class _FakeEvent:
+    def __init__(self, data: str):
+        self.data = data
+
+
+class _FakeSSEClient:
+    """Minimal sseclient.SSEClient stand-in for replaying canned events."""
+
+    def __init__(self, events: list[_FakeEvent]):
+        self._events = events
+
+    def events(self):
+        yield from self._events
+
+
+def _responses_event(payload: dict) -> _FakeEvent:
+    import json as _json
+
+    return _FakeEvent(_json.dumps(payload))
+
+
+class TestMessagesToResponsesInput:
+    def test_extracts_system_messages_into_instructions(self):
+        msgs = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hi"},
+        ]
+        items, instructions = gh_copilot._messages_to_responses_input(msgs)
+        assert instructions == "You are helpful."
+        assert items == [{"role": "user", "content": "Hi"}]
+
+    def test_concatenates_multiple_system_messages(self):
+        msgs = [
+            {"role": "system", "content": "Be terse."},
+            {"role": "system", "content": "Never apologize."},
+            {"role": "user", "content": "ok"},
+        ]
+        _, instructions = gh_copilot._messages_to_responses_input(msgs)
+        assert instructions == "Be terse.\nNever apologize."
+
+    def test_assistant_tool_calls_emit_function_call_items(self):
+        msgs = [
+            {"role": "user", "content": "Run it"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_42",
+                        "type": "function",
+                        "function": {"name": "do_thing", "arguments": '{"x": 1}'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_42", "content": "ok"},
+        ]
+        items, instructions = gh_copilot._messages_to_responses_input(msgs)
+        assert instructions is None
+        assert items[0] == {"role": "user", "content": "Run it"}
+        assert items[1] == {
+            "type": "function_call",
+            "call_id": "call_42",
+            "name": "do_thing",
+            "arguments": '{"x": 1}',
+        }
+        assert items[2] == {
+            "type": "function_call_output",
+            "call_id": "call_42",
+            "output": "ok",
+        }
+
+    def test_tool_result_with_dict_content_is_json_serialized(self):
+        msgs = [
+            {"role": "tool", "tool_call_id": "c1", "content": {"value": 7}},
+        ]
+        items, _ = gh_copilot._messages_to_responses_input(msgs)
+        assert items[0]["output"] == '{"value": 7}'
+
+
+class TestChatToolsToResponsesTools:
+    def test_flattens_function_wrapper(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "search",
+                    "description": "Search the index.",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ]
+        result = gh_copilot._chat_tools_to_responses_tools(tools)
+        assert result == [
+            {
+                "type": "function",
+                "name": "search",
+                "description": "Search the index.",
+                "parameters": {"type": "object"},
+            }
+        ]
+
+    def test_empty_or_none_passes_through_as_none(self):
+        assert gh_copilot._chat_tools_to_responses_tools(None) is None
+        assert gh_copilot._chat_tools_to_responses_tools([]) is None
+
+
+class TestAggregateResponsesStreaming:
+    def test_aggregates_text_deltas_into_message_content(self):
+        events = [
+            _responses_event({"type": "response.created", "response": {"id": "r1"}}),
+            _responses_event({"type": "response.output_text.delta", "delta": "Hello, "}),
+            _responses_event({"type": "response.output_text.delta", "delta": "world"}),
+            _responses_event({
+                "type": "response.completed",
+                "response": {"output": []},
+            }),
+        ]
+        result = gh_copilot._aggregate_responses_streaming(_FakeSSEClient(events))
+        assert result == {
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "Hello, world",
+                    "tool_calls": None,
+                }
+            }]
+        }
+
+    def test_extracts_function_calls_from_completed_event(self):
+        events = [
+            _responses_event({"type": "response.output_text.delta", "delta": "Calling now"}),
+            _responses_event({
+                "type": "response.completed",
+                "response": {
+                    "output": [
+                        {
+                            "type": "function_call",
+                            "status": "completed",
+                            "id": "fc_1",
+                            "call_id": "call_x",
+                            "name": "lookup",
+                            "arguments": '{"q": "foo"}',
+                        }
+                    ]
+                },
+            }),
+        ]
+        result = gh_copilot._aggregate_responses_streaming(_FakeSSEClient(events))
+        assert result["choices"][0]["message"]["tool_calls"] == [
+            {
+                "id": "call_x",
+                "type": "function",
+                "function": {"name": "lookup", "arguments": '{"q": "foo"}'},
+            }
+        ]
+
+    def test_skips_malformed_event_data(self):
+        events = [
+            _FakeEvent(""),
+            _FakeEvent("not-json"),
+            _responses_event({"type": "response.output_text.delta", "delta": "ok"}),
+            _responses_event({"type": "response.completed", "response": {"output": []}}),
+        ]
+        result = gh_copilot._aggregate_responses_streaming(_FakeSSEClient(events))
+        assert result["choices"][0]["message"]["content"] == "ok"
+
+
+class TestModelChatEndpoint:
+    def test_defaults_to_chat_completions_for_unknown_model(self):
+        assert gh_copilot._model_chat_endpoint("gpt-4.1") == "/chat/completions"
+
+    def test_codex_substring_falls_back_to_responses(self):
+        # No live catalogue entry; the substring heuristic protects the
+        # hardcoded fallback list and offline sessions.
+        assert gh_copilot._model_chat_endpoint("gpt-5.3-codex") == "/responses"
+        assert gh_copilot._model_chat_endpoint("FUTURE-Codex-Mini") == "/responses"
+
+    def test_live_catalogue_overrides_heuristic(self):
+        gh_copilot.copilot_model_endpoints["gpt-5.3-codex"] = "/chat/completions"
+        try:
+            assert gh_copilot._model_chat_endpoint("gpt-5.3-codex") == "/chat/completions"
+        finally:
+            gh_copilot.copilot_model_endpoints.clear()
+
+
+class TestFetchCopilotModelsEndpointMap:
+    def test_supported_endpoints_responses_only_routes_to_responses(self):
+        gh_copilot.github_auth["token"] = "fake-bearer-token"
+        response = MagicMock(status_code=200)
+        response.json.return_value = {
+            "data": [
+                {
+                    "id": "gpt-5.3-codex",
+                    "name": "GPT-5.3-Codex",
+                    "model_picker_enabled": True,
+                    "capabilities": {"type": "chat"},
+                    "supported_endpoints": ["/responses"],
+                },
+                {
+                    "id": "gpt-4.1",
+                    "name": "GPT-4.1",
+                    "model_picker_enabled": True,
+                    "capabilities": {"type": "chat"},
+                    "supported_endpoints": ["/chat/completions"],
+                },
+            ]
+        }
+        with patch("notebook_intelligence.github_copilot.requests.get", return_value=response):
+            gh_copilot.fetch_copilot_models()
+        assert gh_copilot.copilot_model_endpoints == {
+            "gpt-5.3-codex": "/responses",
+            "gpt-4.1": "/chat/completions",
+        }
+
+    def test_dual_listed_model_prefers_chat_completions(self):
+        gh_copilot.github_auth["token"] = "fake-bearer-token"
+        response = MagicMock(status_code=200)
+        response.json.return_value = {
+            "data": [
+                {
+                    "id": "future-dual",
+                    "model_picker_enabled": True,
+                    "capabilities": {"type": "chat"},
+                    "supported_endpoints": ["/chat/completions", "/responses"],
+                }
+            ]
+        }
+        with patch("notebook_intelligence.github_copilot.requests.get", return_value=response):
+            gh_copilot.fetch_copilot_models()
+        assert gh_copilot.copilot_model_endpoints["future-dual"] == "/chat/completions"
+
+    def test_non_chat_type_admitted_when_responses_supported(self):
+        # Defensive: future Codex models may drop `capabilities.type == chat`.
+        # If they list /responses, accept and route them.
+        gh_copilot.github_auth["token"] = "fake-bearer-token"
+        response = MagicMock(status_code=200)
+        response.json.return_value = {
+            "data": [
+                {
+                    "id": "future-codex",
+                    "model_picker_enabled": True,
+                    "capabilities": {"type": "responses"},
+                    "supported_endpoints": ["/responses"],
+                }
+            ]
+        }
+        with patch("notebook_intelligence.github_copilot.requests.get", return_value=response):
+            result = gh_copilot.fetch_copilot_models()
+        assert [m["id"] for m in result] == ["future-codex"]
+        assert gh_copilot.copilot_model_endpoints["future-codex"] == "/responses"
+
+
+class TestResponsesDispatch:
+    def test_chat_routes_codex_through_responses(self):
+        sentinel = object()
+        with patch.object(gh_copilot, "responses", return_value=sentinel) as mock_responses, \
+             patch.object(gh_copilot, "completions") as mock_completions:
+            result = gh_copilot.chat("gpt-5.3-codex", [{"role": "user", "content": "hi"}])
+        assert result is sentinel
+        mock_responses.assert_called_once()
+        mock_completions.assert_not_called()
+
+    def test_chat_routes_non_codex_through_completions(self):
+        sentinel = object()
+        with patch.object(gh_copilot, "completions", return_value=sentinel) as mock_completions, \
+             patch.object(gh_copilot, "responses") as mock_responses:
+            result = gh_copilot.chat("gpt-4.1", [{"role": "user", "content": "hi"}])
+        assert result is sentinel
+        mock_completions.assert_called_once()
+        mock_responses.assert_not_called()
+
+
+class TestResponsesEndToEnd:
+    """Pins the actual wire behavior: when a Codex model is selected, the
+    HTTP POST must target `/responses`, not `/chat/completions`. The bug
+    in issue #340 was that this was reversed; without this assertion a
+    refactor that swapped the URL would still pass every transform test.
+    """
+
+    def _make_request_mock(self, events: list[_FakeEvent]):
+        request_mock = MagicMock(status_code=200)
+        sse_mock = MagicMock(events=lambda: iter(events))
+        return request_mock, sse_mock
+
+    def test_chat_dispatches_codex_to_responses_url(self):
+        events = [
+            _responses_event({"type": "response.output_text.delta", "delta": "Hi"}),
+            _responses_event({"type": "response.completed", "response": {"output": []}}),
+        ]
+        request_mock, sse_mock = self._make_request_mock(events)
+        with patch.object(gh_copilot, "generate_copilot_headers", return_value={}), \
+             patch("notebook_intelligence.github_copilot.requests.post", return_value=request_mock) as post, \
+             patch("notebook_intelligence.github_copilot.sseclient.SSEClient", return_value=sse_mock):
+            gh_copilot.chat("gpt-5.3-codex", [{"role": "user", "content": "hi"}])
+        called_url = post.call_args.args[0]
+        assert called_url.endswith("/responses")
+        assert "input" in post.call_args.kwargs["json"]
+
+    def test_chat_dispatches_gpt4_to_chat_completions_url(self):
+        request_mock, sse_mock = self._make_request_mock([_FakeEvent("[DONE]")])
+        with patch.object(gh_copilot, "generate_copilot_headers", return_value={}), \
+             patch("notebook_intelligence.github_copilot.requests.post", return_value=request_mock) as post, \
+             patch("notebook_intelligence.github_copilot.sseclient.SSEClient", return_value=sse_mock):
+            gh_copilot.chat("gpt-4.1", [{"role": "user", "content": "hi"}])
+        called_url = post.call_args.args[0]
+        assert called_url.endswith("/chat/completions")
+        assert "messages" in post.call_args.kwargs["json"]
+
+
+class TestResponsesStreamingMode:
+    """Covers the non-aggregate branch of `responses()`. The aggregate path
+    is what `chat_model.completions(...)` returns when no `response` arg
+    is passed; the streaming path is what powers the chat sidebar."""
+
+    class _FakeChatResponse:
+        def __init__(self):
+            self.chunks: list = []
+            self.finished_count = 0
+
+        def stream(self, data):
+            self.chunks.append(data)
+
+        def finish(self):
+            self.finished_count += 1
+
+    def _drive(self, events: list[_FakeEvent], model_id: str = "gpt-5.3-codex"):
+        request_mock = MagicMock(status_code=200)
+        sse_mock = MagicMock(events=lambda: iter(events))
+        chat_response = self._FakeChatResponse()
+        with patch.object(gh_copilot, "generate_copilot_headers", return_value={}), \
+             patch("notebook_intelligence.github_copilot.requests.post", return_value=request_mock), \
+             patch("notebook_intelligence.github_copilot.sseclient.SSEClient", return_value=sse_mock):
+            gh_copilot.responses(model_id, [{"role": "user", "content": "hi"}], response=chat_response)
+        return chat_response
+
+    def test_text_deltas_stream_as_chat_completions_chunks(self):
+        chat_response = self._drive([
+            _responses_event({"type": "response.output_text.delta", "delta": "Hi "}),
+            _responses_event({"type": "response.output_text.delta", "delta": "there"}),
+            _responses_event({"type": "response.completed", "response": {"output": []}}),
+        ])
+        contents = [c["choices"][0]["delta"]["content"] for c in chat_response.chunks if "content" in c["choices"][0]["delta"]]
+        assert contents == ["Hi ", "there"]
+        assert chat_response.finished_count == 1
+
+    def test_function_call_in_completed_event_emits_tool_calls_chunk(self):
+        chat_response = self._drive([
+            _responses_event({"type": "response.output_text.delta", "delta": "Calling"}),
+            _responses_event({
+                "type": "response.completed",
+                "response": {
+                    "output": [
+                        {
+                            "type": "function_call",
+                            "status": "completed",
+                            "id": "fc_1",
+                            "call_id": "call_x",
+                            "name": "lookup",
+                            "arguments": '{"q": "foo"}',
+                        }
+                    ]
+                },
+            }),
+        ])
+        tool_chunks = [c for c in chat_response.chunks if "tool_calls" in c["choices"][0]["delta"]]
+        assert len(tool_chunks) == 1
+        tc = tool_chunks[0]["choices"][0]["delta"]["tool_calls"][0]
+        assert tc["id"] == "call_x"
+        assert tc["function"] == {"name": "lookup", "arguments": '{"q": "foo"}'}
+        assert "index" in tc
+
+    def test_function_call_arguments_deltas_stitched_when_completed_arguments_empty(self):
+        # Defensive against a future Codex variant that streams the tool
+        # arguments and ships an empty `arguments` in the terminal item.
+        chat_response = self._drive([
+            _responses_event({
+                "type": "response.function_call_arguments.delta",
+                "item_id": "fc_1",
+                "delta": '{"q":',
+            }),
+            _responses_event({
+                "type": "response.function_call_arguments.delta",
+                "item_id": "fc_1",
+                "delta": ' "foo"}',
+            }),
+            _responses_event({
+                "type": "response.completed",
+                "response": {
+                    "output": [
+                        {
+                            "type": "function_call",
+                            "status": "completed",
+                            "id": "fc_1",
+                            "call_id": "call_x",
+                            "name": "lookup",
+                            "arguments": "",
+                        }
+                    ]
+                },
+            }),
+        ])
+        tc = chat_response.chunks[-1]["choices"][0]["delta"]["tool_calls"][0]
+        assert tc["function"]["arguments"] == '{"q": "foo"}'
+
+    def test_http_error_raises_and_streams_message(self):
+        request_mock = MagicMock(status_code=400, text="bad model")
+        chat_response = self._FakeChatResponse()
+        with patch.object(gh_copilot, "generate_copilot_headers", return_value={}), \
+             patch("notebook_intelligence.github_copilot.requests.post", return_value=request_mock):
+            with pytest.raises(Exception, match="bad model"):
+                gh_copilot.responses("gpt-5.3-codex", [{"role": "user", "content": "hi"}], response=chat_response)
+        assert chat_response.finished_count == 1
+        assert any(getattr(c, "content", "") and "bad model" in c.content for c in chat_response.chunks)
+
+    def test_response_failed_event_raises(self):
+        chat_response = self._FakeChatResponse()
+        events = [
+            _responses_event({"type": "response.output_text.delta", "delta": "partial"}),
+            _responses_event({
+                "type": "response.failed",
+                "response": {"error": {"message": "context length exceeded"}},
+            }),
+        ]
+        request_mock = MagicMock(status_code=200)
+        sse_mock = MagicMock(events=lambda: iter(events))
+        with patch.object(gh_copilot, "generate_copilot_headers", return_value={}), \
+             patch("notebook_intelligence.github_copilot.requests.post", return_value=request_mock), \
+             patch("notebook_intelligence.github_copilot.sseclient.SSEClient", return_value=sse_mock):
+            with pytest.raises(Exception, match="context length exceeded"):
+                gh_copilot.responses("gpt-5.3-codex", [{"role": "user", "content": "hi"}], response=chat_response)
+        assert chat_response.finished_count == 1
+
+
+class TestAggregateResponsesTerminalErrors:
+    def test_response_failed_raises_with_message(self):
+        events = [
+            _responses_event({
+                "type": "response.failed",
+                "response": {"error": {"message": "model overloaded"}},
+            }),
+        ]
+        with pytest.raises(Exception, match="model overloaded"):
+            gh_copilot._aggregate_responses_streaming(_FakeSSEClient(events))
+
+    def test_response_incomplete_without_message_falls_back_to_event_type(self):
+        events = [
+            _responses_event({"type": "response.incomplete"}),
+        ]
+        with pytest.raises(Exception, match="response.incomplete"):
+            gh_copilot._aggregate_responses_streaming(_FakeSSEClient(events))
+
+    def test_function_call_arguments_delta_stitched_in_aggregate(self):
+        events = [
+            _responses_event({
+                "type": "response.function_call_arguments.delta",
+                "item_id": "fc_1",
+                "delta": '{"a":',
+            }),
+            _responses_event({
+                "type": "response.function_call_arguments.delta",
+                "item_id": "fc_1",
+                "delta": ' 1}',
+            }),
+            _responses_event({
+                "type": "response.completed",
+                "response": {
+                    "output": [
+                        {
+                            "type": "function_call",
+                            "status": "completed",
+                            "id": "fc_1",
+                            "call_id": "call_y",
+                            "name": "do",
+                            "arguments": "",
+                        }
+                    ]
+                },
+            }),
+        ]
+        result = gh_copilot._aggregate_responses_streaming(_FakeSSEClient(events))
+        assert result["choices"][0]["message"]["tool_calls"][0]["function"]["arguments"] == '{"a": 1}'


### PR DESCRIPTION
## Summary

GitHub Copilot started surfacing Codex-family models (e.g. `gpt-5.3-codex`) in the chat-model picker, but selecting one fails with a 400: those models are served only through the OpenAI Responses API mirror at `/responses`, not `/chat/completions`. This PR adds a second code path so Codex models work without disrupting the existing chat path.

## Solution

The wiring follows codecompanion.nvim's mature Copilot/Responses adapter and OpenAI's documented Responses API shape.

- `fetch_copilot_models` now captures each entry's `supported_endpoints` field and populates a `copilot_model_endpoints` map. Models that list only `/responses` route there; everything else (including dual-listed entries during a transition) stays on `/chat/completions`. The capability-type filter relaxes to admit non-chat `capabilities.type` when `/responses` is supported, so future Codex variants that drop `type: chat` still flow through.
- A new `chat()` dispatcher picks the endpoint per `model_id` and is the single entry point the LLM provider calls. An offline fallback uses a `codex` substring heuristic so the hardcoded fallback list and air-gapped sessions still pick the right path before the live catalogue is fetched.
- A new `responses()` function translates chat-completions messages to the Responses `{input, instructions, tools}` shape, parses the typed SSE events, and returns the same `{choices: [{message: ...}]}` aggregate shape the rest of the codebase already consumes. Terminal error events (`response.failed`, `response.incomplete`, generic `error`) raise instead of producing a silent empty turn. A `function_call_arguments` delta accumulator hedges against Copilot ever shipping the terminal `arguments` empty.

The shape of `_aggregate_responses_streaming` and the streaming branch of `responses()` matches what `_aggregate_streaming_response` already produces, so the chat-sidebar consumer is endpoint-agnostic.

## Testing

- `pytest tests/ --ignore=tests/test_claude_client.py -q`: 1090 passed.
- `jlpm tsc --noEmit`: clean.
- `jlpm lint:check`: clean.
- `jlpm jest`: 281 passed.

New pytest coverage in `tests/test_github_copilot_llm_provider.py`:

- Message-to-input transform (system → `instructions`, tool calls and results to typed items).
- Tool schema flattening (chat-completions `{type, function: {...}}` → Responses `{type, name, description, parameters}`).
- SSE aggregation (text deltas, function-call extraction, malformed-event tolerance).
- Endpoint dispatch (live-catalogue lookup wins; codex substring fallback; user-set override).
- `fetch_copilot_models` endpoint-map population for responses-only, dual-listed, and non-chat-type models.
- **URL regression pin**: `chat("gpt-5.3-codex", ...)` POSTs to `/responses`; `chat("gpt-4.1", ...)` POSTs to `/chat/completions`. Without this, a future refactor that swapped the URL would still pass every transform test.
- Streaming-mode (`response is not None`) text-delta chunk emission, function-call chunk emission with `index`, arg-delta stitching when the terminal item ships empty `arguments`.
- HTTP 4xx error path: raises and streams the error markdown before `finish()`.
- Terminal error events (`response.failed` with message, `response.incomplete` falling back to event type).
- Argument-delta accumulator stitching in the aggregate path.

**End-to-end verification against live Copilot was not possible from this environment** (no Copilot Business token). The wire contract is pinned against codecompanion.nvim's reference implementation and OpenAI's documented Responses API. I would appreciate confirmation from the issue reporter (or any Copilot Business user with Codex access) that the fix resolves the 400 in their environment.

Two-round six-agent review (three `/simplify` plus three persona reviewers: API contract, distributed-systems / SDK, test architecture). Round 1 surfaced five fix-before-merge findings, all addressed; round 2 came back clean.

## Risks / follow-ups

- The Responses streaming events the implementation does not yet interpret are tracked as follow-ups:
  - `response.reasoning_summary_text.delta` (Codex is a reasoning model; mapping these to `reasoning_content` would match the gpt-5 UX in the chat sidebar).
  - `response.incomplete` could surface `incomplete_details.reason` instead of the raw event type.
  - The generic `error` event's `error.type` could feed into the error message when `message`/`code` are absent.
- The codex substring heuristic is a deliberate bridge for the hardcoded fallback list and offline sessions. If Copilot ever ships a non-Codex model with `codex` in the id, the first request 400s and users sign in to populate the live catalogue, which overrides the heuristic. Risk window is small.
- A future Codex-class model renamed without `codex` in the id (e.g. `o5-coder`) would route to `/chat/completions` and 400 until the catalogue refresh lands.
- Pre-existing `completions()` cancel-token bug (`response.finish()` without `return`) is not introduced here; the new `responses()` path handles it correctly. Follow-up to fix the legacy path.

Closes #340.