### PR TITLE
docs(readme): refresh blog URLs after org rename to plmbr

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ NBI reloads open document tabs when their files change on disk, so edits an AI a
 
 ## Configuration
 
-Configure your provider, model, and API key from NBI Settings — the gear icon in the chat panel, the `/settings` chat command, or the JupyterLab command palette. For background, see the [provider blog post](https://notebook-intelligence.github.io/notebook-intelligence/blog/2025/03/05/support-for-any-llm-provider.html).
+Configure your provider, model, and API key from NBI Settings — the gear icon in the chat panel, the `/settings` chat command, or the JupyterLab command palette. For background, see the [provider blog post](https://plmbr.dev/blog/archive/support-for-any-llm-provider/).
 
 <img src="media/provider-list.png" alt="Settings dialog" width=500 />
 
@@ -398,10 +398,10 @@ The feedback fires an in-process `telemetry` event. Nothing leaves the process b
 
 ## Further reading
 
-- [Introducing Notebook Intelligence!](https://notebook-intelligence.github.io/notebook-intelligence/blog/2025/01/08/introducing-notebook-intelligence.html)
-- [Building AI Extensions for JupyterLab](https://notebook-intelligence.github.io/notebook-intelligence/blog/2025/02/05/building-ai-extensions-for-jupyterlab.html)
-- [Building AI Agents for JupyterLab](https://notebook-intelligence.github.io/notebook-intelligence/blog/2025/02/09/building-ai-agents-for-jupyterlab.html)
-- [Notebook Intelligence now supports any LLM Provider and AI Model!](https://notebook-intelligence.github.io/notebook-intelligence/blog/2025/03/05/support-for-any-llm-provider.html)
+- [Introducing Notebook Intelligence!](https://plmbr.dev/blog/archive/introducing-notebook-intelligence/)
+- [Building AI Extensions for JupyterLab](https://plmbr.dev/blog/archive/building-ai-extensions-for-jupyterlab/)
+- [Building AI Agents for JupyterLab](https://plmbr.dev/blog/archive/building-ai-agents-for-jupyterlab/)
+- [Notebook Intelligence now supports any LLM Provider and AI Model!](https://plmbr.dev/blog/archive/support-for-any-llm-provider/)
 
 ## Roadmap
 


### PR DESCRIPTION
## Summary

The blog moved from `notebook-intelligence.github.io/notebook-intelligence` to `plmbr.dev` with a new `/blog/archive/<slug>/` permalink shape as part of the recent org rename. The README's five direct links still pointed at the old URL, which serves via redirect today but won't survive any future GitHub Pages cleanup and gives readers an extra hop.

## Solution

Updated all five blog references in `README.md` to use the live canonical URL.

| Title | Old | New |
| - | - | - |
| Provider blog post (Configuration section) | `notebook-intelligence.github.io/.../blog/2025/03/05/support-for-any-llm-provider.html` | `plmbr.dev/blog/archive/support-for-any-llm-provider/` |
| Introducing Notebook Intelligence | `.../blog/2025/01/08/...` | `plmbr.dev/blog/archive/introducing-notebook-intelligence/` |
| Building AI Extensions for JupyterLab | `.../blog/2025/02/05/...` | `plmbr.dev/blog/archive/building-ai-extensions-for-jupyterlab/` |
| Building AI Agents for JupyterLab | `.../blog/2025/02/09/...` | `plmbr.dev/blog/archive/building-ai-agents-for-jupyterlab/` |
| Provider support post (Further reading) | `.../blog/2025/03/05/...` | `plmbr.dev/blog/archive/support-for-any-llm-provider/` |

All four target URLs return HTTP 200, and the `/blog/archive/<slug>/` shape matches what the site's archive page declares as the canonical for each post.

## Testing

No automated tests for static docs. Verified each replacement URL with `curl -sI` and confirmed it matches the `<link rel="canonical">` Jekyll renders.

## Risks / follow-ups

None. The gh-pages branch still has stale references in headers/footers/posts/configs; I'll send that as a separate PR against `gh-pages` rather than mixing branches here.