### PR TITLE
site: refresh GitHub org URL after rename to plmbr

### DIFF
--- a/404.html
+++ b/404.html
@@ -16,7 +16,7 @@ title: Page not found
       <a class="btn btn--primary" href="{{ '/' | relative_url }}">Home</a>
       <a class="btn btn--ghost" href="{{ '/install/' | relative_url }}">Install</a>
       <a class="btn btn--ghost" href="{{ '/features/' | relative_url }}">Features</a>
-      <a class="btn btn--ghost" href="https://github.com/notebook-intelligence/notebook-intelligence/issues" rel="noopener">Report an issue</a>
+      <a class="btn btn--ghost" href="https://github.com/plmbr/notebook-intelligence/issues" rel="noopener">Report an issue</a>
     </div>
   </div>
 </section>

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-# Jekyll site for notebook-intelligence.github.io.
+# Jekyll site for plmbr.dev.
 #
 # Build locally:
 #   bundle install

--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ author:
 social:
   name: Notebook Intelligence
   links:
-    - https://github.com/notebook-intelligence/notebook-intelligence
+    - https://github.com/plmbr/notebook-intelligence
     - https://twitter.com/mbektash
 
 # Default Open Graph image. Per-post overrides via front-matter `image:`.

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -19,10 +19,10 @@
       <div class="site-footer__col">
         <h4>Project</h4>
         <ul>
-          <li><a href="https://github.com/notebook-intelligence/notebook-intelligence" rel="noopener">GitHub</a></li>
-          <li><a href="https://github.com/notebook-intelligence/notebook-intelligence/issues" rel="noopener">Issues</a></li>
-          <li><a href="https://github.com/notebook-intelligence/notebook-intelligence/blob/main/CHANGELOG.md" rel="noopener">Changelog</a></li>
-          <li><a href="https://github.com/notebook-intelligence/notebook-intelligence/blob/main/CONTRIBUTING.md" rel="noopener">Contributing</a></li>
+          <li><a href="https://github.com/plmbr/notebook-intelligence" rel="noopener">GitHub</a></li>
+          <li><a href="https://github.com/plmbr/notebook-intelligence/issues" rel="noopener">Issues</a></li>
+          <li><a href="https://github.com/plmbr/notebook-intelligence/blob/main/CHANGELOG.md" rel="noopener">Changelog</a></li>
+          <li><a href="https://github.com/plmbr/notebook-intelligence/blob/main/CONTRIBUTING.md" rel="noopener">Contributing</a></li>
         </ul>
       </div>
 
@@ -31,7 +31,7 @@
         <ul>
           <li><a href="{{ '/docs/' | relative_url }}">Docs</a></li>
           <li><a href="{{ '/blog/' | relative_url }}">Blog</a></li>
-          <li><a href="https://github.com/notebook-intelligence/notebook-intelligence/blob/main/SECURITY.md" rel="noopener">Security</a></li>
+          <li><a href="https://github.com/plmbr/notebook-intelligence/blob/main/SECURITY.md" rel="noopener">Security</a></li>
           <li><a href="https://pypi.org/project/notebook-intelligence/" rel="noopener">PyPI</a></li>
         </ul>
       </div>
@@ -39,7 +39,7 @@
 
     <div class="site-footer__bottom">
       <span>© {{ site.time | date: '%Y' }} Mehmet Bektaş</span>
-      <span>Open source · <a href="https://github.com/notebook-intelligence/notebook-intelligence/blob/main/LICENSE" rel="noopener">GPL-3.0</a></span>
+      <span>Open source · <a href="https://github.com/plmbr/notebook-intelligence/blob/main/LICENSE" rel="noopener">GPL-3.0</a></span>
     </div>
   </div>
 </footer>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -18,7 +18,7 @@
 
     <div class="site-header__actions">
       {% include theme-toggle.html %}
-      <a class="icon-btn" href="https://github.com/notebook-intelligence/notebook-intelligence" rel="noopener" aria-label="GitHub repository">
+      <a class="icon-btn" href="https://github.com/plmbr/notebook-intelligence" rel="noopener" aria-label="GitHub repository">
         <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.36-3.87-1.36-.52-1.32-1.27-1.67-1.27-1.67-1.04-.71.08-.7.08-.7 1.15.08 1.75 1.18 1.75 1.18 1.02 1.75 2.68 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.18-3.09-.12-.29-.51-1.47.11-3.06 0 0 .97-.31 3.18 1.18A11 11 0 0112 6.8c.99.01 1.99.13 2.92.39 2.21-1.49 3.18-1.18 3.18-1.18.62 1.59.23 2.77.11 3.06.74.8 1.18 1.83 1.18 3.09 0 4.43-2.69 5.4-5.25 5.69.41.35.78 1.04.78 2.1v3.11c0 .31.21.67.79.56A11.5 11.5 0 0023.5 12C23.5 5.65 18.35.5 12 .5z" />
         </svg>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,7 +6,7 @@ layout: default
   <div class="container-narrow">
     {% if page.archived %}
       <div class="stale-banner">
-        <strong>Archived post.</strong> Written {{ page.date | date: "%B %Y" }}. NBI has changed since this was written — see the <a href="{{ '/' | relative_url }}">current site</a> or the <a href="https://github.com/notebook-intelligence/notebook-intelligence/blob/main/CHANGELOG.md">changelog</a> for today's product.
+        <strong>Archived post.</strong> Written {{ page.date | date: "%B %Y" }}. NBI has changed since this was written — see the <a href="{{ '/' | relative_url }}">current site</a> or the <a href="https://github.com/plmbr/notebook-intelligence/blob/main/CHANGELOG.md">changelog</a> for today's product.
       </div>
     {% endif %}
 

--- a/_posts/2025-01-07-introducing-notebook-intelligence.markdown
+++ b/_posts/2025-01-07-introducing-notebook-intelligence.markdown
@@ -8,7 +8,7 @@ redirect_from:
   - /blog/2025/01/07/introducing-notebook-intelligence.html
   - /blog/introducing-notebook-intelligence/
 ---
-I am thrilled to announce the release of [Notebook Intelligence](https://github.com/notebook-intelligence/notebook-intelligence){:target="_blank"} (NBI)! NBI is an AI coding assistant and extensible AI framework for JupyterLab. It uses [GitHub Copilot](https://github.com/features/copilot){:target="_blank"} under the hood and is inspired by its design principles. NBI greatly boosts the productivity of JupyterLab users with AI assistance powered by GitHub Copilot.
+I am thrilled to announce the release of [Notebook Intelligence](https://github.com/plmbr/notebook-intelligence){:target="_blank"} (NBI)! NBI is an AI coding assistant and extensible AI framework for JupyterLab. It uses [GitHub Copilot](https://github.com/features/copilot){:target="_blank"} under the hood and is inspired by its design principles. NBI greatly boosts the productivity of JupyterLab users with AI assistance powered by GitHub Copilot.
 
 ![Generate code](/notebook-intelligence/assets/images/generate-code.gif)
 
@@ -93,7 +93,7 @@ Notebook Intelligence provides APIs to let developers extend its capabilities. Y
 
 ## Try it out and share your feedback!
 
-[Notebook Intelligence](https://github.com/notebook-intelligence/notebook-intelligence){:target="_blank"} is currently in beta and designed for Python (support for more languages coming soon). Please try it out and share your feedback and any feature requests using project's [GitHub issues](https://github.com/notebook-intelligence/notebook-intelligence/issues){:target="_blank"}. User feedback from the community will shape the project's roadmap.
+[Notebook Intelligence](https://github.com/plmbr/notebook-intelligence){:target="_blank"} is currently in beta and designed for Python (support for more languages coming soon). Please try it out and share your feedback and any feature requests using project's [GitHub issues](https://github.com/plmbr/notebook-intelligence/issues){:target="_blank"}. User feedback from the community will shape the project's roadmap.
 
 ## About the Author
 

--- a/_posts/2025-02-04-building-ai-extensions-for-jupyterlab.markdown
+++ b/_posts/2025-02-04-building-ai-extensions-for-jupyterlab.markdown
@@ -9,7 +9,7 @@ redirect_from:
   - /blog/building-ai-extensions-for-jupyterlab/
 ---
 
-[Notebook Intelligence](https://github.com/notebook-intelligence/notebook-intelligence) (NBI) is an AI coding assistant and extensible AI framework for JupyterLab. For an introduction to NBI see [Introducing Notebook Intelligence blog post]({{site.baseurl}}{% post_url 2025-01-07-introducing-notebook-intelligence %}) first.
+[Notebook Intelligence](https://github.com/plmbr/notebook-intelligence) (NBI) is an AI coding assistant and extensible AI framework for JupyterLab. For an introduction to NBI see [Introducing Notebook Intelligence blog post]({{site.baseurl}}{% post_url 2025-01-07-introducing-notebook-intelligence %}) first.
 
 GitHub Copilot and other AI coding assistants generate chat responses based on publicly available knowledge and they do not have access to your workspace, tools and services. NBI provides Extension APIs to build AI extensions for JupyterLab. By extending NBI, you can build custom chat interactions and provide access to proprietary or external data, tools and services. This lets you build custom, AI powered chat experiences, natural language interface to JupyterLab and your tools.
 
@@ -261,7 +261,7 @@ async def handle_chat_request(self, request: ChatRequest, response: ChatResponse
 
 ## Try it out and share your feedback!
 
-I am looking forward to seeing the extensions built by the community. Please try the extension APIs and share your feedback using project's [GitHub issues](https://github.com/notebook-intelligence/notebook-intelligence/issues)! User feedback from the community will shape the project's roadmap.
+I am looking forward to seeing the extensions built by the community. Please try the extension APIs and share your feedback using project's [GitHub issues](https://github.com/plmbr/notebook-intelligence/issues)! User feedback from the community will shape the project's roadmap.
 
 ## About the Author
 

--- a/_posts/2025-02-05-building-ai-agents-for-jupyterlab.markdown
+++ b/_posts/2025-02-05-building-ai-agents-for-jupyterlab.markdown
@@ -9,7 +9,7 @@ redirect_from:
   - /blog/building-ai-agents-for-jupyterlab/
 ---
 
-[Notebook Intelligence](https://github.com/notebook-intelligence/notebook-intelligence) (NBI) is an AI coding assistant and extensible AI framework for JupyterLab. (*For an introduction to NBI see [Introducing Notebook Intelligence]({{site.baseurl}}{% post_url 2025-01-07-introducing-notebook-intelligence %}) and for basics of extending NBI see [Building AI Extensions for JupyterLab]({{site.baseurl}}{% post_url 2025-02-04-building-ai-extensions-for-jupyterlab %}) blog posts.*)
+[Notebook Intelligence](https://github.com/plmbr/notebook-intelligence) (NBI) is an AI coding assistant and extensible AI framework for JupyterLab. (*For an introduction to NBI see [Introducing Notebook Intelligence]({{site.baseurl}}{% post_url 2025-01-07-introducing-notebook-intelligence %}) and for basics of extending NBI see [Building AI Extensions for JupyterLab]({{site.baseurl}}{% post_url 2025-02-04-building-ai-extensions-for-jupyterlab %}) blog posts.*)
 
 GitHub Copilot and other AI coding assistants are great at generating code and answering coding related questions. But they can do a lot more than generating text and code thanks to LLM features such as tool calling and AI agents. NBI provides an extensible AI framework to integrate tool calling and AI agents into JupyterLab Copilot Chat.
 
@@ -255,7 +255,7 @@ That is all there is to create an AI Agent for JupyterLab using Notebook Intelli
 
 ## Try it out and share your feedback!
 
-I am looking forward to seeing the AI Agents built by the community. Please try the extension APIs and share your feedback using project's [GitHub issues](https://github.com/notebook-intelligence/notebook-intelligence/issues)! User feedback from the community will shape the project's roadmap.
+I am looking forward to seeing the AI Agents built by the community. Please try the extension APIs and share your feedback using project's [GitHub issues](https://github.com/plmbr/notebook-intelligence/issues)! User feedback from the community will shape the project's roadmap.
 
 ## About the Author
 

--- a/_posts/2025-03-05-support-for-any-llm-provider.markdown
+++ b/_posts/2025-03-05-support-for-any-llm-provider.markdown
@@ -9,7 +9,7 @@ redirect_from:
   - /blog/support-for-any-llm-provider/
 ---
 
-[Notebook Intelligence](https://github.com/notebook-intelligence/notebook-intelligence) (NBI) is an AI coding assistant and extensible AI framework for JupyterLab. (*For an introduction to NBI see [Introducing Notebook Intelligence]({{site.baseurl}}{% post_url 2025-01-07-introducing-notebook-intelligence %}) and for basics of extending NBI see [Building AI Extensions for JupyterLab]({{site.baseurl}}{% post_url 2025-02-04-building-ai-extensions-for-jupyterlab %}) blog posts.*)
+[Notebook Intelligence](https://github.com/plmbr/notebook-intelligence) (NBI) is an AI coding assistant and extensible AI framework for JupyterLab. (*For an introduction to NBI see [Introducing Notebook Intelligence]({{site.baseurl}}{% post_url 2025-01-07-introducing-notebook-intelligence %}) and for basics of extending NBI see [Building AI Extensions for JupyterLab]({{site.baseurl}}{% post_url 2025-02-04-building-ai-extensions-for-jupyterlab %}) blog posts.*)
 
 Notebook Intelligence now supports any LLM Provider and compatible model for chat and auto-complete. Chat model is used for Copilot Chat in the sidebar and inline chat popups that are accessible from notebook and file editors. Auto-complete model is used for providing completion suggestions as you type in a notebook or file editor (as ghost text). Your chat model and auto-complete model don't have to be from the same provider for use with NBI.
 
@@ -75,7 +75,7 @@ For building NBI extensions see [Building AI Extensions for JupyterLab]({{site.b
 
 ## Try it out and share your feedback!
 
-Please try the LLM provider and model options and share your feedback using project's [GitHub issues](https://github.com/notebook-intelligence/notebook-intelligence/issues)! User feedback from the community will shape the project's roadmap.
+Please try the LLM provider and model options and share your feedback using project's [GitHub issues](https://github.com/plmbr/notebook-intelligence/issues)! User feedback from the community will shape the project's roadmap.
 
 ## About the Author
 

--- a/_posts/2026-04-29-v4-6-0.markdown
+++ b/_posts/2026-04-29-v4-6-0.markdown
@@ -29,20 +29,20 @@ skills:
 
 Point `NBI_SKILLS_MANIFEST` at the manifest's URL or filesystem path. NBI's reconciler installs every Skill at startup and re-syncs every 24h (`NBI_SKILLS_MANIFEST_INTERVAL` overrides). Managed Skills are read-only in the UI — users can't edit, rename, or delete them, and the reconciler restores any that disappear from disk.
 
-Full reference: [docs/skills.md](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/docs/skills.md).
+Full reference: [docs/skills.md](https://github.com/plmbr/notebook-intelligence/blob/main/docs/skills.md).
 
 ## Restructured documentation
 
 The README has been rewritten with a table of contents and a concept glossary. Reference content moved out of the README and into focused docs:
 
-- [`SECURITY.md`](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/SECURITY.md) — private disclosure, threat model, supply-chain posture.
-- [`PRIVACY.md`](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/PRIVACY.md) — what NBI sends where.
-- [`docs/admin-guide.md`](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/docs/admin-guide.md) — every `NBI_*` env var and policy.
-- [`docs/rulesets.md`](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/docs/rulesets.md) — markdown-based prompt injection.
-- [`docs/skills.md`](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/docs/skills.md) — Skills authoring, importing, and the manifest reconciler.
-- [`docs/troubleshooting.md`](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/docs/troubleshooting.md) — common issues with copy-pasteable fixes.
+- [`SECURITY.md`](https://github.com/plmbr/notebook-intelligence/blob/main/SECURITY.md) — private disclosure, threat model, supply-chain posture.
+- [`PRIVACY.md`](https://github.com/plmbr/notebook-intelligence/blob/main/PRIVACY.md) — what NBI sends where.
+- [`docs/admin-guide.md`](https://github.com/plmbr/notebook-intelligence/blob/main/docs/admin-guide.md) — every `NBI_*` env var and policy.
+- [`docs/rulesets.md`](https://github.com/plmbr/notebook-intelligence/blob/main/docs/rulesets.md) — markdown-based prompt injection.
+- [`docs/skills.md`](https://github.com/plmbr/notebook-intelligence/blob/main/docs/skills.md) — Skills authoring, importing, and the manifest reconciler.
+- [`docs/troubleshooting.md`](https://github.com/plmbr/notebook-intelligence/blob/main/docs/troubleshooting.md) — common issues with copy-pasteable fixes.
 
-If you've been linking deep into the README from internal wikis, the new home for each section is documented in the [migration table at the top of the README](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/README.md).
+If you've been linking deep into the README from internal wikis, the new home for each section is documented in the [migration table at the top of the README](https://github.com/plmbr/notebook-intelligence/blob/main/README.md).
 
 ## Windows Claude mode reliability
 
@@ -69,4 +69,4 @@ Skill imports from GitHub reject tarball entries containing absolute paths or `.
 pip install --upgrade notebook-intelligence
 ```
 
-Then restart JupyterLab. Full changes in the [CHANGELOG](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/CHANGELOG.md#460--2026-04-29).
+Then restart JupyterLab. Full changes in the [CHANGELOG](https://github.com/plmbr/notebook-intelligence/blob/main/CHANGELOG.md#460--2026-04-29).

--- a/_posts/2026-05-07-v4-7-0.markdown
+++ b/_posts/2026-05-07-v4-7-0.markdown
@@ -65,7 +65,7 @@ New value-presence locks (set the env var to a value to pin it; the UI control b
 
 The `/claude-sessions` HTTP route also accepts `?scope=cwd` to filter to sessions whose recorded `cwd` matches the lab's working directory.
 
-Full env-var reference: [docs/admin-guide.md](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/docs/admin-guide.md).
+Full env-var reference: [docs/admin-guide.md](https://github.com/plmbr/notebook-intelligence/blob/main/docs/admin-guide.md).
 
 ## Internal
 
@@ -89,4 +89,4 @@ Full env-var reference: [docs/admin-guide.md](https://github.com/notebook-intell
 pip install --upgrade notebook-intelligence
 ```
 
-Then restart JupyterLab. Full changes in the [CHANGELOG](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/CHANGELOG.md#470--2026-05-07).
+Then restart JupyterLab. Full changes in the [CHANGELOG](https://github.com/plmbr/notebook-intelligence/blob/main/CHANGELOG.md#470--2026-05-07).

--- a/_posts/2026-05-12-v4-8-0.markdown
+++ b/_posts/2026-05-12-v4-8-0.markdown
@@ -67,4 +67,4 @@ Beyond the workspace scan, the `@`-mention context picker also now skips dot-pre
 pip install --upgrade notebook-intelligence
 ```
 
-Then restart JupyterLab. Full set of changes in the [v4.8.0 release notes](https://github.com/notebook-intelligence/notebook-intelligence/releases/tag/v4.8.0).
+Then restart JupyterLab. Full set of changes in the [v4.8.0 release notes](https://github.com/plmbr/notebook-intelligence/releases/tag/v4.8.0).

--- a/about.markdown
+++ b/about.markdown
@@ -13,4 +13,4 @@ The extension is built to be extended. Connect [Model Context Protocol](https://
 
 For administrators, NBI ships policy controls that lock specific providers, models, and endpoints via environment variables. A platform team can decide what a managed JupyterHub allows before anyone signs in — each capability has a `force-on` / `force-off` / `user-choice` triad with a matching `NBI_*_POLICY` env var.
 
-NBI is open source and BSD-licensed. It is maintained by [Mehmet Bektaş](https://github.com/mbektas) and a growing group of contributors from the Jupyter community. The codebase lives at [github.com/notebook-intelligence/notebook-intelligence](https://github.com/notebook-intelligence/notebook-intelligence).
+NBI is open source and BSD-licensed. It is maintained by [Mehmet Bektaş](https://github.com/mbektas) and a growing group of contributors from the Jupyter community. The codebase lives at [github.com/plmbr/notebook-intelligence](https://github.com/plmbr/notebook-intelligence).

--- a/admin.markdown
+++ b/admin.markdown
@@ -47,8 +47,8 @@ Set `NBI_SKILLS_MANIFEST=https://your-org/skills.yaml` (or a filesystem path). N
 
 ## Reference
 
-- [Full admin guide](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/docs/admin-guide.md) — every env var, every default, every interaction.
-- [Security policy](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/SECURITY.md) — disclosure, threat model, supply-chain posture.
-- [Privacy](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/PRIVACY.md) — what NBI sends where.
+- [Full admin guide](https://github.com/plmbr/notebook-intelligence/blob/main/docs/admin-guide.md) — every env var, every default, every interaction.
+- [Security policy](https://github.com/plmbr/notebook-intelligence/blob/main/SECURITY.md) — disclosure, threat model, supply-chain posture.
+- [Privacy](https://github.com/plmbr/notebook-intelligence/blob/main/PRIVACY.md) — what NBI sends where.
 
 <p style="margin-top: var(--space-10);"><a class="btn btn--primary" href="{{ '/install/' | relative_url }}">Install NBI</a></p>

--- a/blog/archive.markdown
+++ b/blog/archive.markdown
@@ -7,7 +7,7 @@ permalink: /blog/archive/
 
 <div class="callout callout--warn">
   <p class="callout__title">These posts are historical.</p>
-  <p>The product they describe — single-provider, Copilot-only NBI — is several major releases behind. For current information, see the <a href="{{ '/' | relative_url }}">home page</a> or the <a href="https://github.com/notebook-intelligence/notebook-intelligence/blob/main/CHANGELOG.md">CHANGELOG</a>.</p>
+  <p>The product they describe — single-provider, Copilot-only NBI — is several major releases behind. For current information, see the <a href="{{ '/' | relative_url }}">home page</a> or the <a href="https://github.com/plmbr/notebook-intelligence/blob/main/CHANGELOG.md">CHANGELOG</a>.</p>
 </div>
 
 <ul class="post-list">

--- a/docs.markdown
+++ b/docs.markdown
@@ -5,17 +5,17 @@ subtitle: The deep docs live in the repo. This page is a router.
 permalink: /docs/
 ---
 
-NBI's reference documentation is maintained alongside the code in the [main repository](https://github.com/notebook-intelligence/notebook-intelligence). Keeping one source of truth means the docs and the code can't drift.
+NBI's reference documentation is maintained alongside the code in the [main repository](https://github.com/plmbr/notebook-intelligence). Keeping one source of truth means the docs and the code can't drift.
 
 ## Reference
 
-- [README](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/README.md) — install, quick start, concept glossary.
-- [Admin guide](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/docs/admin-guide.md) — every `NBI_*` env var, every policy.
-- [Rulesets](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/docs/rulesets.md) — markdown-based prompt injection.
-- [Skills](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/docs/skills.md) — authoring, importing, and org-managed Skills.
-- [Troubleshooting](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/docs/troubleshooting.md) — common issues and fixes.
-- [CHANGELOG](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/CHANGELOG.md) — release notes.
-- [Security policy](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/SECURITY.md) — disclosure address and threat model.
-- [Privacy](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/PRIVACY.md) — what data leaves your machine.
-- [Contributing](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/CONTRIBUTING.md) — how to file a bug, propose a feature, or send a PR.
-- [Release process](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/RELEASE.md) — for maintainers.
+- [README](https://github.com/plmbr/notebook-intelligence/blob/main/README.md) — install, quick start, concept glossary.
+- [Admin guide](https://github.com/plmbr/notebook-intelligence/blob/main/docs/admin-guide.md) — every `NBI_*` env var, every policy.
+- [Rulesets](https://github.com/plmbr/notebook-intelligence/blob/main/docs/rulesets.md) — markdown-based prompt injection.
+- [Skills](https://github.com/plmbr/notebook-intelligence/blob/main/docs/skills.md) — authoring, importing, and org-managed Skills.
+- [Troubleshooting](https://github.com/plmbr/notebook-intelligence/blob/main/docs/troubleshooting.md) — common issues and fixes.
+- [CHANGELOG](https://github.com/plmbr/notebook-intelligence/blob/main/CHANGELOG.md) — release notes.
+- [Security policy](https://github.com/plmbr/notebook-intelligence/blob/main/SECURITY.md) — disclosure address and threat model.
+- [Privacy](https://github.com/plmbr/notebook-intelligence/blob/main/PRIVACY.md) — what data leaves your machine.
+- [Contributing](https://github.com/plmbr/notebook-intelligence/blob/main/CONTRIBUTING.md) — how to file a bug, propose a feature, or send a PR.
+- [Release process](https://github.com/plmbr/notebook-intelligence/blob/main/RELEASE.md) — for maintainers.

--- a/features/claude-code.markdown
+++ b/features/claude-code.markdown
@@ -44,7 +44,7 @@ Or via environment variables for managed deployments — see [admin policies]({{
 ## Reference
 
 - [Claude Code documentation](https://docs.claude.com/en/docs/claude-code) (Anthropic)
-- [NBI Claude mode reference](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/README.md#claude-mode)
-- [Skills documentation](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/docs/skills.md)
+- [NBI Claude mode reference](https://github.com/plmbr/notebook-intelligence/blob/main/README.md#claude-mode)
+- [Skills documentation](https://github.com/plmbr/notebook-intelligence/blob/main/docs/skills.md)
 
 <p style="margin-top: var(--space-10);"><a class="btn btn--primary" href="{{ '/install/' | relative_url }}">Install NBI</a></p>

--- a/features/skills-plugins.markdown
+++ b/features/skills-plugins.markdown
@@ -34,7 +34,7 @@ skills:
 
 ## Reference
 
-- [NBI Skills documentation](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/docs/skills.md)
+- [NBI Skills documentation](https://github.com/plmbr/notebook-intelligence/blob/main/docs/skills.md)
 - [Claude Skills SDK](https://docs.claude.com/en/docs/claude-code/skills)
 - [Claude Plugins](https://docs.claude.com/en/docs/claude-code/plugins)
 

--- a/index.markdown
+++ b/index.markdown
@@ -16,7 +16,7 @@ description: A JupyterLab extension for Claude Code, GitHub Copilot, Ollama, and
       </p>
       <div class="hero__cta">
         <a class="btn btn--primary" href="#install">Install</a>
-        <a class="btn btn--ghost" href="https://github.com/notebook-intelligence/notebook-intelligence" rel="noopener">View on GitHub</a>
+        <a class="btn btn--ghost" href="https://github.com/plmbr/notebook-intelligence" rel="noopener">View on GitHub</a>
       </div>
     </div>
     <div>

--- a/install.markdown
+++ b/install.markdown
@@ -87,7 +87,7 @@ The base URL must speak the Chat Completions API. vLLM, LiteLLM, TGI, and llama.
 If something doesn't work, check:
 
 - `jupyter server extension list` — `notebook_intelligence` should appear under "OK".
-- `jupyter labextension list` — `@notebook-intelligence/notebook-intelligence` should be listed as enabled.
+- `jupyter labextension list` — `@plmbr/notebook-intelligence` should be listed as enabled.
 - The JupyterLab terminal output where you ran `jupyter lab`. NBI logs server-side errors there.
 
-For deeper issues, see the [troubleshooting guide](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/docs/troubleshooting.md) in the repo or [open an issue](https://github.com/notebook-intelligence/notebook-intelligence/issues).
+For deeper issues, see the [troubleshooting guide](https://github.com/plmbr/notebook-intelligence/blob/main/docs/troubleshooting.md) in the repo or [open an issue](https://github.com/plmbr/notebook-intelligence/issues).

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://notebook-intelligence.github.io/notebook-intelligence/sitemap.xml
+Sitemap: https://plmbr.dev/sitemap.xml


### PR DESCRIPTION
## Summary

The org renamed from `notebook-intelligence` to `plmbr`, and the npm scope renamed from `@notebook-intelligence/notebook-intelligence` to `@plmbr/notebook-intelligence` (#342). GitHub redirects the old URLs, but every page on plmbr.dev still rendered with the pre-rename org name in headers, footers, layouts, posts, and content pages, and the install checklist still pointed at the old npm scope.

## Solution

22 files updated:

- **Site chrome.** `_config.yml` social link, `_includes/footer.html` (GitHub / Issues / Changelog / Contributing / Security / License links), `_includes/header.html` GitHub icon, `_layouts/post.html` archived-post changelog link.
- **Pages.** `404.html`, `index.markdown`, `about.markdown`, `admin.markdown`, `docs.markdown`, `install.markdown` (GitHub URLs + npm scope checklist line), `features/claude-code.markdown`, `features/skills-plugins.markdown`, `blog/archive.markdown`.
- **Posts.** All four 2025 launch posts and the v4.6 / v4.7 / v4.8 release posts had inline GitHub links updated.
- **Crawler signals.** `robots.txt` sitemap URL.
- **Build comment.** `Gemfile` header comment updated from `notebook-intelligence.github.io` to `plmbr.dev`.

Scope intentionally excludes `_config.yml`'s `url` / `baseurl` / `domain` block and the `CNAME` file — both already updated in the recent domain-cutover commits.

## Testing

Verified each file with `grep -n "notebook-intelligence/notebook-intelligence"` post-edit returns empty.

## Risks / follow-ups

- Live-site smoke check after merge: hit `plmbr.dev/` and inspect the header / footer / a sample post body to confirm all GitHub links point at `github.com/plmbr/notebook-intelligence`.