### PR TITLE
site: 5.0.0 release post and feature-page refresh

### DIFF
--- a/404.html
+++ b/404.html
@@ -16,7 +16,7 @@ title: Page not found
       <a class="btn btn--primary" href="{{ '/' | relative_url }}">Home</a>
       <a class="btn btn--ghost" href="{{ '/install/' | relative_url }}">Install</a>
       <a class="btn btn--ghost" href="{{ '/features/' | relative_url }}">Features</a>
-      <a class="btn btn--ghost" href="https://github.com/notebook-intelligence/notebook-intelligence/issues" rel="noopener">Report an issue</a>
+      <a class="btn btn--ghost" href="https://github.com/plmbr/notebook-intelligence/issues" rel="noopener">Report an issue</a>
     </div>
   </div>
 </section>

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-# Jekyll site for notebook-intelligence.github.io.
+# Jekyll site for plmbr.dev.
 #
 # Build locally:
 #   bundle install

--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ author:
 social:
   name: Notebook Intelligence
   links:
-    - https://github.com/notebook-intelligence/notebook-intelligence
+    - https://github.com/plmbr/notebook-intelligence
     - https://twitter.com/mbektash
 
 # Default Open Graph image. Per-post overrides via front-matter `image:`.

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -19,10 +19,10 @@
       <div class="site-footer__col">
         <h4>Project</h4>
         <ul>
-          <li><a href="https://github.com/notebook-intelligence/notebook-intelligence" rel="noopener">GitHub</a></li>
-          <li><a href="https://github.com/notebook-intelligence/notebook-intelligence/issues" rel="noopener">Issues</a></li>
-          <li><a href="https://github.com/notebook-intelligence/notebook-intelligence/blob/main/CHANGELOG.md" rel="noopener">Changelog</a></li>
-          <li><a href="https://github.com/notebook-intelligence/notebook-intelligence/blob/main/CONTRIBUTING.md" rel="noopener">Contributing</a></li>
+          <li><a href="https://github.com/plmbr/notebook-intelligence" rel="noopener">GitHub</a></li>
+          <li><a href="https://github.com/plmbr/notebook-intelligence/issues" rel="noopener">Issues</a></li>
+          <li><a href="https://github.com/plmbr/notebook-intelligence/blob/main/CHANGELOG.md" rel="noopener">Changelog</a></li>
+          <li><a href="https://github.com/plmbr/notebook-intelligence/blob/main/CONTRIBUTING.md" rel="noopener">Contributing</a></li>
         </ul>
       </div>
 
@@ -31,7 +31,7 @@
         <ul>
           <li><a href="{{ '/docs/' | relative_url }}">Docs</a></li>
           <li><a href="{{ '/blog/' | relative_url }}">Blog</a></li>
-          <li><a href="https://github.com/notebook-intelligence/notebook-intelligence/blob/main/SECURITY.md" rel="noopener">Security</a></li>
+          <li><a href="https://github.com/plmbr/notebook-intelligence/blob/main/SECURITY.md" rel="noopener">Security</a></li>
           <li><a href="https://pypi.org/project/notebook-intelligence/" rel="noopener">PyPI</a></li>
         </ul>
       </div>
@@ -39,7 +39,7 @@
 
     <div class="site-footer__bottom">
       <span>© {{ site.time | date: '%Y' }} Mehmet Bektaş</span>
-      <span>Open source · <a href="https://github.com/notebook-intelligence/notebook-intelligence/blob/main/LICENSE" rel="noopener">GPL-3.0</a></span>
+      <span>Open source · <a href="https://github.com/plmbr/notebook-intelligence/blob/main/LICENSE" rel="noopener">GPL-3.0</a></span>
     </div>
   </div>
 </footer>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -18,7 +18,7 @@
 
     <div class="site-header__actions">
       {% include theme-toggle.html %}
-      <a class="icon-btn" href="https://github.com/notebook-intelligence/notebook-intelligence" rel="noopener" aria-label="GitHub repository">
+      <a class="icon-btn" href="https://github.com/plmbr/notebook-intelligence" rel="noopener" aria-label="GitHub repository">
         <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2.02c-3.2.7-3.87-1.36-3.87-1.36-.52-1.32-1.27-1.67-1.27-1.67-1.04-.71.08-.7.08-.7 1.15.08 1.75 1.18 1.75 1.18 1.02 1.75 2.68 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.18-3.09-.12-.29-.51-1.47.11-3.06 0 0 .97-.31 3.18 1.18A11 11 0 0112 6.8c.99.01 1.99.13 2.92.39 2.21-1.49 3.18-1.18 3.18-1.18.62 1.59.23 2.77.11 3.06.74.8 1.18 1.83 1.18 3.09 0 4.43-2.69 5.4-5.25 5.69.41.35.78 1.04.78 2.1v3.11c0 .31.21.67.79.56A11.5 11.5 0 0023.5 12C23.5 5.65 18.35.5 12 .5z" />
         </svg>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,7 +6,7 @@ layout: default
   <div class="container-narrow">
     {% if page.archived %}
       <div class="stale-banner">
-        <strong>Archived post.</strong> Written {{ page.date | date: "%B %Y" }}. NBI has changed since this was written — see the <a href="{{ '/' | relative_url }}">current site</a> or the <a href="https://github.com/notebook-intelligence/notebook-intelligence/blob/main/CHANGELOG.md">changelog</a> for today's product.
+        <strong>Archived post.</strong> Written {{ page.date | date: "%B %Y" }}. NBI has changed since this was written — see the <a href="{{ '/' | relative_url }}">current site</a> or the <a href="https://github.com/plmbr/notebook-intelligence/blob/main/CHANGELOG.md">changelog</a> for today's product.
       </div>
     {% endif %}
 

--- a/_posts/2025-01-07-introducing-notebook-intelligence.markdown
+++ b/_posts/2025-01-07-introducing-notebook-intelligence.markdown
@@ -8,7 +8,7 @@ redirect_from:
   - /blog/2025/01/07/introducing-notebook-intelligence.html
   - /blog/introducing-notebook-intelligence/
 ---
-I am thrilled to announce the release of [Notebook Intelligence](https://github.com/notebook-intelligence/notebook-intelligence){:target="_blank"} (NBI)! NBI is an AI coding assistant and extensible AI framework for JupyterLab. It uses [GitHub Copilot](https://github.com/features/copilot){:target="_blank"} under the hood and is inspired by its design principles. NBI greatly boosts the productivity of JupyterLab users with AI assistance powered by GitHub Copilot.
+I am thrilled to announce the release of [Notebook Intelligence](https://github.com/plmbr/notebook-intelligence){:target="_blank"} (NBI)! NBI is an AI coding assistant and extensible AI framework for JupyterLab. It uses [GitHub Copilot](https://github.com/features/copilot){:target="_blank"} under the hood and is inspired by its design principles. NBI greatly boosts the productivity of JupyterLab users with AI assistance powered by GitHub Copilot.
 
 ![Generate code](/notebook-intelligence/assets/images/generate-code.gif)
 
@@ -93,7 +93,7 @@ Notebook Intelligence provides APIs to let developers extend its capabilities. Y
 
 ## Try it out and share your feedback!
 
-[Notebook Intelligence](https://github.com/notebook-intelligence/notebook-intelligence){:target="_blank"} is currently in beta and designed for Python (support for more languages coming soon). Please try it out and share your feedback and any feature requests using project's [GitHub issues](https://github.com/notebook-intelligence/notebook-intelligence/issues){:target="_blank"}. User feedback from the community will shape the project's roadmap.
+[Notebook Intelligence](https://github.com/plmbr/notebook-intelligence){:target="_blank"} is currently in beta and designed for Python (support for more languages coming soon). Please try it out and share your feedback and any feature requests using project's [GitHub issues](https://github.com/plmbr/notebook-intelligence/issues){:target="_blank"}. User feedback from the community will shape the project's roadmap.
 
 ## About the Author
 

--- a/_posts/2025-02-04-building-ai-extensions-for-jupyterlab.markdown
+++ b/_posts/2025-02-04-building-ai-extensions-for-jupyterlab.markdown
@@ -9,7 +9,7 @@ redirect_from:
   - /blog/building-ai-extensions-for-jupyterlab/
 ---
 
-[Notebook Intelligence](https://github.com/notebook-intelligence/notebook-intelligence) (NBI) is an AI coding assistant and extensible AI framework for JupyterLab. For an introduction to NBI see [Introducing Notebook Intelligence blog post]({{site.baseurl}}{% post_url 2025-01-07-introducing-notebook-intelligence %}) first.
+[Notebook Intelligence](https://github.com/plmbr/notebook-intelligence) (NBI) is an AI coding assistant and extensible AI framework for JupyterLab. For an introduction to NBI see [Introducing Notebook Intelligence blog post]({{site.baseurl}}{% post_url 2025-01-07-introducing-notebook-intelligence %}) first.
 
 GitHub Copilot and other AI coding assistants generate chat responses based on publicly available knowledge and they do not have access to your workspace, tools and services. NBI provides Extension APIs to build AI extensions for JupyterLab. By extending NBI, you can build custom chat interactions and provide access to proprietary or external data, tools and services. This lets you build custom, AI powered chat experiences, natural language interface to JupyterLab and your tools.
 
@@ -261,7 +261,7 @@ async def handle_chat_request(self, request: ChatRequest, response: ChatResponse
 
 ## Try it out and share your feedback!
 
-I am looking forward to seeing the extensions built by the community. Please try the extension APIs and share your feedback using project's [GitHub issues](https://github.com/notebook-intelligence/notebook-intelligence/issues)! User feedback from the community will shape the project's roadmap.
+I am looking forward to seeing the extensions built by the community. Please try the extension APIs and share your feedback using project's [GitHub issues](https://github.com/plmbr/notebook-intelligence/issues)! User feedback from the community will shape the project's roadmap.
 
 ## About the Author
 

--- a/_posts/2025-02-05-building-ai-agents-for-jupyterlab.markdown
+++ b/_posts/2025-02-05-building-ai-agents-for-jupyterlab.markdown
@@ -9,7 +9,7 @@ redirect_from:
   - /blog/building-ai-agents-for-jupyterlab/
 ---
 
-[Notebook Intelligence](https://github.com/notebook-intelligence/notebook-intelligence) (NBI) is an AI coding assistant and extensible AI framework for JupyterLab. (*For an introduction to NBI see [Introducing Notebook Intelligence]({{site.baseurl}}{% post_url 2025-01-07-introducing-notebook-intelligence %}) and for basics of extending NBI see [Building AI Extensions for JupyterLab]({{site.baseurl}}{% post_url 2025-02-04-building-ai-extensions-for-jupyterlab %}) blog posts.*)
+[Notebook Intelligence](https://github.com/plmbr/notebook-intelligence) (NBI) is an AI coding assistant and extensible AI framework for JupyterLab. (*For an introduction to NBI see [Introducing Notebook Intelligence]({{site.baseurl}}{% post_url 2025-01-07-introducing-notebook-intelligence %}) and for basics of extending NBI see [Building AI Extensions for JupyterLab]({{site.baseurl}}{% post_url 2025-02-04-building-ai-extensions-for-jupyterlab %}) blog posts.*)
 
 GitHub Copilot and other AI coding assistants are great at generating code and answering coding related questions. But they can do a lot more than generating text and code thanks to LLM features such as tool calling and AI agents. NBI provides an extensible AI framework to integrate tool calling and AI agents into JupyterLab Copilot Chat.
 
@@ -255,7 +255,7 @@ That is all there is to create an AI Agent for JupyterLab using Notebook Intelli
 
 ## Try it out and share your feedback!
 
-I am looking forward to seeing the AI Agents built by the community. Please try the extension APIs and share your feedback using project's [GitHub issues](https://github.com/notebook-intelligence/notebook-intelligence/issues)! User feedback from the community will shape the project's roadmap.
+I am looking forward to seeing the AI Agents built by the community. Please try the extension APIs and share your feedback using project's [GitHub issues](https://github.com/plmbr/notebook-intelligence/issues)! User feedback from the community will shape the project's roadmap.
 
 ## About the Author
 

--- a/_posts/2025-03-05-support-for-any-llm-provider.markdown
+++ b/_posts/2025-03-05-support-for-any-llm-provider.markdown
@@ -9,7 +9,7 @@ redirect_from:
   - /blog/support-for-any-llm-provider/
 ---
 
-[Notebook Intelligence](https://github.com/notebook-intelligence/notebook-intelligence) (NBI) is an AI coding assistant and extensible AI framework for JupyterLab. (*For an introduction to NBI see [Introducing Notebook Intelligence]({{site.baseurl}}{% post_url 2025-01-07-introducing-notebook-intelligence %}) and for basics of extending NBI see [Building AI Extensions for JupyterLab]({{site.baseurl}}{% post_url 2025-02-04-building-ai-extensions-for-jupyterlab %}) blog posts.*)
+[Notebook Intelligence](https://github.com/plmbr/notebook-intelligence) (NBI) is an AI coding assistant and extensible AI framework for JupyterLab. (*For an introduction to NBI see [Introducing Notebook Intelligence]({{site.baseurl}}{% post_url 2025-01-07-introducing-notebook-intelligence %}) and for basics of extending NBI see [Building AI Extensions for JupyterLab]({{site.baseurl}}{% post_url 2025-02-04-building-ai-extensions-for-jupyterlab %}) blog posts.*)
 
 Notebook Intelligence now supports any LLM Provider and compatible model for chat and auto-complete. Chat model is used for Copilot Chat in the sidebar and inline chat popups that are accessible from notebook and file editors. Auto-complete model is used for providing completion suggestions as you type in a notebook or file editor (as ghost text). Your chat model and auto-complete model don't have to be from the same provider for use with NBI.
 
@@ -75,7 +75,7 @@ For building NBI extensions see [Building AI Extensions for JupyterLab]({{site.b
 
 ## Try it out and share your feedback!
 
-Please try the LLM provider and model options and share your feedback using project's [GitHub issues](https://github.com/notebook-intelligence/notebook-intelligence/issues)! User feedback from the community will shape the project's roadmap.
+Please try the LLM provider and model options and share your feedback using project's [GitHub issues](https://github.com/plmbr/notebook-intelligence/issues)! User feedback from the community will shape the project's roadmap.
 
 ## About the Author
 

--- a/_posts/2026-04-29-v4-6-0.markdown
+++ b/_posts/2026-04-29-v4-6-0.markdown
@@ -29,20 +29,20 @@ skills:
 
 Point `NBI_SKILLS_MANIFEST` at the manifest's URL or filesystem path. NBI's reconciler installs every Skill at startup and re-syncs every 24h (`NBI_SKILLS_MANIFEST_INTERVAL` overrides). Managed Skills are read-only in the UI — users can't edit, rename, or delete them, and the reconciler restores any that disappear from disk.
 
-Full reference: [docs/skills.md](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/docs/skills.md).
+Full reference: [docs/skills.md](https://github.com/plmbr/notebook-intelligence/blob/main/docs/skills.md).
 
 ## Restructured documentation
 
 The README has been rewritten with a table of contents and a concept glossary. Reference content moved out of the README and into focused docs:
 
-- [`SECURITY.md`](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/SECURITY.md) — private disclosure, threat model, supply-chain posture.
-- [`PRIVACY.md`](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/PRIVACY.md) — what NBI sends where.
-- [`docs/admin-guide.md`](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/docs/admin-guide.md) — every `NBI_*` env var and policy.
-- [`docs/rulesets.md`](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/docs/rulesets.md) — markdown-based prompt injection.
-- [`docs/skills.md`](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/docs/skills.md) — Skills authoring, importing, and the manifest reconciler.
-- [`docs/troubleshooting.md`](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/docs/troubleshooting.md) — common issues with copy-pasteable fixes.
+- [`SECURITY.md`](https://github.com/plmbr/notebook-intelligence/blob/main/SECURITY.md) — private disclosure, threat model, supply-chain posture.
+- [`PRIVACY.md`](https://github.com/plmbr/notebook-intelligence/blob/main/PRIVACY.md) — what NBI sends where.
+- [`docs/admin-guide.md`](https://github.com/plmbr/notebook-intelligence/blob/main/docs/admin-guide.md) — every `NBI_*` env var and policy.
+- [`docs/rulesets.md`](https://github.com/plmbr/notebook-intelligence/blob/main/docs/rulesets.md) — markdown-based prompt injection.
+- [`docs/skills.md`](https://github.com/plmbr/notebook-intelligence/blob/main/docs/skills.md) — Skills authoring, importing, and the manifest reconciler.
+- [`docs/troubleshooting.md`](https://github.com/plmbr/notebook-intelligence/blob/main/docs/troubleshooting.md) — common issues with copy-pasteable fixes.
 
-If you've been linking deep into the README from internal wikis, the new home for each section is documented in the [migration table at the top of the README](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/README.md).
+If you've been linking deep into the README from internal wikis, the new home for each section is documented in the [migration table at the top of the README](https://github.com/plmbr/notebook-intelligence/blob/main/README.md).
 
 ## Windows Claude mode reliability
 
@@ -69,4 +69,4 @@ Skill imports from GitHub reject tarball entries containing absolute paths or `.
 pip install --upgrade notebook-intelligence
 ```
 
-Then restart JupyterLab. Full changes in the [CHANGELOG](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/CHANGELOG.md#460--2026-04-29).
+Then restart JupyterLab. Full changes in the [CHANGELOG](https://github.com/plmbr/notebook-intelligence/blob/main/CHANGELOG.md#460--2026-04-29).

--- a/_posts/2026-05-07-v4-7-0.markdown
+++ b/_posts/2026-05-07-v4-7-0.markdown
@@ -65,7 +65,7 @@ New value-presence locks (set the env var to a value to pin it; the UI control b
 
 The `/claude-sessions` HTTP route also accepts `?scope=cwd` to filter to sessions whose recorded `cwd` matches the lab's working directory.
 
-Full env-var reference: [docs/admin-guide.md](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/docs/admin-guide.md).
+Full env-var reference: [docs/admin-guide.md](https://github.com/plmbr/notebook-intelligence/blob/main/docs/admin-guide.md).
 
 ## Internal
 
@@ -89,4 +89,4 @@ Full env-var reference: [docs/admin-guide.md](https://github.com/notebook-intell
 pip install --upgrade notebook-intelligence
 ```
 
-Then restart JupyterLab. Full changes in the [CHANGELOG](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/CHANGELOG.md#470--2026-05-07).
+Then restart JupyterLab. Full changes in the [CHANGELOG](https://github.com/plmbr/notebook-intelligence/blob/main/CHANGELOG.md#470--2026-05-07).

--- a/_posts/2026-05-12-v4-8-0.markdown
+++ b/_posts/2026-05-12-v4-8-0.markdown
@@ -67,4 +67,4 @@ Beyond the workspace scan, the `@`-mention context picker also now skips dot-pre
 pip install --upgrade notebook-intelligence
 ```
 
-Then restart JupyterLab. Full set of changes in the [v4.8.0 release notes](https://github.com/notebook-intelligence/notebook-intelligence/releases/tag/v4.8.0).
+Then restart JupyterLab. Full set of changes in the [v4.8.0 release notes](https://github.com/plmbr/notebook-intelligence/releases/tag/v4.8.0).

--- a/_posts/2026-05-22-v5-0-0.markdown
+++ b/_posts/2026-05-22-v5-0-0.markdown
@@ -1,0 +1,112 @@
+---
+layout: post
+title: "NBI 5.0.0 — three new Settings tabs, agent-aware UX, and a wide admin-policy surface"
+date: 2026-05-22 06:00:00 -0700
+permalink: /blog/v5-0-0/
+description: "Skills, Claude MCP, and Plugins each get their own Settings tab with admin policies. Five coding-agent launcher tiles. Real progress feedback. Terminal drag-drop. Wide accessibility and security passes. The official mcp SDK replaces fastmcp."
+---
+
+NBI 5.0.0 is a broad release. It promotes Skills out of the Claude-mode sub-tab into its own top-level Settings tab, adds two more (Claude MCP Servers, Claude Plugins), surfaces five coding-agent launcher tiles, hardens the chat sidebar's agent-aware UX, lands an accessibility pass across every NBI panel, swaps `fastmcp` for the official `mcp` SDK, and ships a stack of security work. Most existing config keeps working — the version bump reflects the size of the new admin-policy / env-var surface that operators will want to review.
+
+If you just want the upgrade command, jump to [Install](#install). The migration notes worth reading before upgrading are in the [release notes](https://github.com/plmbr/notebook-intelligence/blob/main/CHANGELOG.md#500---2026-05-22).
+
+## Three new Settings tabs
+
+The Settings dialog gains three top-level tabs. Each ships with an admin-policy gate.
+
+- **Skills.** Promoted from a Claude-mode sub-tab; visible in any mode, with a hint banner when Claude mode is off. New policy `NBI_SKILLS_MANAGEMENT_POLICY`. `force-off` hides the tab, 403s every `/notebook-intelligence/skills/*` route, and suppresses the managed-skills reconciler.
+- **Claude MCP Servers.** Manages the user, project, and local-scope MCP entries Claude Code reads from `~/.claude.json` and `<project>/.mcp.json`. Independent of the existing NBI MCP tab — the two never appear at the same time. New policy `NBI_CLAUDE_MCP_MANAGEMENT_POLICY`. Per-workspace toggle on/off without removing an entry. A JSON-paste path accepts Claude / Cursor / VS Code MCP config blobs.
+- **Claude Plugins.** Wraps `claude plugin` for install / uninstall / enable / disable / marketplace add. Marketplace picker shows source repo, version, and description. Per-plugin **Update** button when a newer version is available. New policies `NBI_CLAUDE_PLUGINS_MANAGEMENT_POLICY` (whole tab) and `NBI_ALLOW_GITHUB_PLUGIN_IMPORT` (marketplace sources, mirroring 4.8.0's `NBI_ALLOW_GITHUB_SKILL_IMPORT`).
+
+GitHub-sourced marketplace adds reuse the Skills `GITHUB_TOKEN` / `GH_TOKEN` / `gh auth token` precedence; tokens go through the subprocess env, never argv.
+
+## Coding-agent launcher tiles
+
+The JupyterLab launcher gains tiles for every coding-agent CLI on `PATH`:
+
+- Claude Code (no longer gated by Claude chat mode being on)
+- opencode (`NBI_OPENCODE_CLI_PATH` override)
+- Pi (`NBI_PI_CLI_PATH`)
+- GitHub Copilot CLI (`NBI_GITHUB_COPILOT_CLI_PATH`)
+- OpenAI Codex (`NBI_CODEX_CLI_PATH`)
+
+Clicking a tile opens a terminal at the file-browser's current directory. The Claude tile additionally exposes a session picker for `~/.claude/projects/` transcripts. Each tile only appears when the corresponding binary is on `PATH`.
+
+Admins can hide tiles via `disabled_coding_agent_launchers` (traitlet, list-valued). Per-pod re-enable is available via `NBI_ENABLED_CODING_AGENT_LAUNCHERS` when `allow_enabling_coding_agent_launchers_with_env` is on, so a base image can disable launchers globally and specific pods can opt back in.
+
+## Agent-aware chat UX
+
+Long Claude turns no longer feel hung. The sidebar surfaces:
+
+- An elapsed-time counter that starts on first request and updates per second.
+- A heartbeat-driven pulse with a "may be slow" copy flip after 30 seconds.
+- Inline tool-call narration as the agent works.
+- A **New chat session** button next to the gear that restarts the SDK client — same effect as typing `/clear`, without typing.
+
+A first-run **chat-sidebar tour** highlights the gear, file-attach button, chat-mode dropdown, and (when available) the Claude session history icon. Replays from the command palette via "Show NBI tour". The tour is capability-aware: steps for unavailable CLIs are skipped automatically.
+
+## Refresh open files when changed on disk
+
+When Claude (or any external process) edits a file you have open, the tab reverts to the on-disk version automatically. Tabs with unsaved local edits are skipped so your work is never clobbered. Default on; toggle in the **NBI Settings dialog → External changes**. Admin pin via `NBI_REFRESH_OPEN_FILES_ON_DISK_CHANGE_POLICY` or the matching traitlet.
+
+This closes the "Claude edited the file but my tab still shows the old version" gap that was the most visible rough edge in agent-mode notebook work.
+
+## Workspace files attach as @-mention pointers in Claude mode
+
+In Claude mode, attaching a workspace file no longer reads its contents client-side and injects them as a fenced code block. Instead the backend emits an `@<workspace-relative-path>` pointer and Claude's Read tool fetches what it needs. This unblocks three categories that the content-injection path couldn't handle:
+
+- **Images.** Previously truncated to ASCII garbage.
+- **Large files.** Previously hit the prompt-token ceiling and got silently dropped.
+- **Notebooks.** Previously serialized as raw JSON; now cell-aware, so the agent reads cells one at a time.
+
+Notebook cell-pointer prose and text-selection line ranges are preserved so deictic references ("explain this cell", "why is this broken") still have a referent.
+
+## Terminal drag-drop file attach
+
+Drop a file onto a JupyterLab terminal to insert either an `@`-mention path (for chat consumption) or a shell-escaped raw path. A per-terminal toolbar toggle switches modes; Shift inverts for one drop. New admin policy `NBI_TERMINAL_DRAG_DROP_POLICY` (`force-off` for regulated tenants). Tunables `NBI_UPLOAD_MAX_MB` (default `50`) and `NBI_UPLOAD_RETENTION_HOURS` (default `24`) govern the shared upload-staging endpoint used by both terminal drops and chat-sidebar attachments.
+
+## Settings dialog gains a Workspace section
+
+Beyond the three new tabs, the General tab grows an **External changes** section with the open-files refresh toggle described above, and a **Choose start directory** picker on each coding-agent tile (and "New Session" on the Claude resume dialog).
+
+## Accessibility pass
+
+A multi-PR accessibility pass landed across most NBI surfaces:
+
+- Keyboard navigation works end-to-end in the chat sidebar, popovers, and Settings tabs.
+- Tab order is logical, focus traps inside dialogs, Escape closes correctly.
+- Screen-reader landmarks and live regions added for streaming chat output.
+- Audited under JupyterLab's light, dark, and high-contrast themes.
+- The "open notebook" link in chat responses is keyboard-reachable (was previously click-only).
+
+## Security hardening
+
+5.0.0 ships a stack of security work. The migration-impacting items:
+
+- **Shell tool's `working_directory` is sandboxed to `jupyter_root`.** An agent-supplied absolute path or `..` traversal is rejected.
+- **Claude UI-bridge tool paths sandboxed to `jupyter_root`.** `open_file_in_jupyter_ui` and `run_command_in_jupyter_terminal` route through `safe_jupyter_path`. The Claude Agent SDK subprocess is itself rooted at `jupyter_root` via its `cwd` option.
+- **Encrypted GitHub token file enforces mode 0o600 on every save.** An out-of-band `chmod` that widens permissions is undone on the next write.
+- **Process-env secrets scrubbed from shell-tool output.** The shell tool no longer leaks `API_KEY` / `TOKEN` / `SECRET`-like env values into captured stdout/stderr returned to the model.
+- **MCP user config shape validated before persisting.** Malformed JSON-paste entries are rejected server-side.
+- **Anchor URIs in chat messages filtered against an XSS allowlist.** `javascript:`, `data:`, `vbscript:`, and tab/NEL/bidi-override codepoint smuggling are blocked at render time.
+- **Copilot WebSocket upgrades authenticated and origin-checked.** Cross-origin and unauthenticated upgrade attempts are refused. Affects any custom client hitting `WebsocketCopilotHandler` directly.
+- **GitHub Enterprise host detection hardened** for marketplace add — `git.acme.example.com` correctly routes through the GHE token / API path instead of being misclassified as public GitHub.
+- **Runtime kill switch for the managed-skills reconciler** (`POST /notebook-intelligence/skills/reconciler/stop`) provides per-pod incident response without a server restart.
+
+## fastmcp → official mcp SDK
+
+NBI now uses the official Anthropic `mcp` SDK via a thin internal shim. `fastmcp` is no longer a dependency. The swap was driven by a `python-dotenv` pin conflict between `fastmcp>=1.1.0` and `litellm==1.0.1` that blocked installs on Python 3.14, plus CVE fixes via `urllib3>=2.7.0` (CVE-2026-44431 / CVE-2026-44432).
+
+**If your image pinned `fastmcp`** because prior docs recommended it, drop the pin. **If you have downstream Python code that imported `fastmcp` transitively via NBI,** declare it as a direct dependency in your own image — the transitive path no longer exists.
+
+## Dynamic GitHub Copilot model discovery
+
+NBI now queries `https://api.githubcopilot.com/models` on each Copilot token refresh and rebuilds the chat-model dropdown from the live response. Newer Copilot chat models appear in the dropdown as soon as GitHub publishes them; the hardcoded fallback list is used only on a transient `/models` fetch failure.
+
+## Install
+
+```bash
+pip install --upgrade notebook-intelligence
+```
+
+Then restart JupyterLab. Full release notes — including the migration note for shell-tool sandboxing, the Claude session inventory move, and the WebSocket origin-check — in the [v5.0.0 CHANGELOG](https://github.com/plmbr/notebook-intelligence/blob/main/CHANGELOG.md#500---2026-05-22).

--- a/about.markdown
+++ b/about.markdown
@@ -13,4 +13,4 @@ The extension is built to be extended. Connect [Model Context Protocol](https://
 
 For administrators, NBI ships policy controls that lock specific providers, models, and endpoints via environment variables. A platform team can decide what a managed JupyterHub allows before anyone signs in — each capability has a `force-on` / `force-off` / `user-choice` triad with a matching `NBI_*_POLICY` env var.
 
-NBI is open source and BSD-licensed. It is maintained by [Mehmet Bektaş](https://github.com/mbektas) and a growing group of contributors from the Jupyter community. The codebase lives at [github.com/notebook-intelligence/notebook-intelligence](https://github.com/notebook-intelligence/notebook-intelligence).
+NBI is open source and BSD-licensed. It is maintained by [Mehmet Bektaş](https://github.com/mbektas) and a growing group of contributors from the Jupyter community. The codebase lives at [github.com/plmbr/notebook-intelligence](https://github.com/plmbr/notebook-intelligence).

--- a/admin.markdown
+++ b/admin.markdown
@@ -21,10 +21,13 @@ For string-valued settings (provider, model, endpoint) the env var sets the valu
 
 ## Policy categories
 
-- **Mode and feature flags.** `NBI_CLAUDE_MODE_POLICY`, `NBI_CLAUDE_CONTINUE_CONVERSATION_POLICY`, `NBI_CLAUDE_CODE_TOOLS_POLICY`, `NBI_CLAUDE_JUPYTER_UI_TOOLS_POLICY`, `NBI_EXPLAIN_ERROR_POLICY`, `NBI_OUTPUT_FOLLOWUP_POLICY`, `NBI_OUTPUT_TOOLBAR_POLICY`, `NBI_STORE_GITHUB_ACCESS_TOKEN_POLICY`.
+- **Mode and feature flags.** `NBI_CLAUDE_MODE_POLICY`, `NBI_CLAUDE_CONTINUE_CONVERSATION_POLICY`, `NBI_CLAUDE_CODE_TOOLS_POLICY`, `NBI_CLAUDE_JUPYTER_UI_TOOLS_POLICY`, `NBI_CLAUDE_SETTING_SOURCE_USER_POLICY`, `NBI_CLAUDE_SETTING_SOURCE_PROJECT_POLICY`, `NBI_EXPLAIN_ERROR_POLICY`, `NBI_OUTPUT_FOLLOWUP_POLICY`, `NBI_OUTPUT_TOOLBAR_POLICY`, `NBI_REFRESH_OPEN_FILES_ON_DISK_CHANGE_POLICY`, `NBI_TERMINAL_DRAG_DROP_POLICY`, `NBI_STORE_GITHUB_ACCESS_TOKEN_POLICY`.
 - **Provider locks.** `NBI_CHAT_MODEL_PROVIDER`, `NBI_CHAT_MODEL_ID`, `NBI_INLINE_COMPLETION_MODEL_PROVIDER`, `NBI_INLINE_COMPLETION_MODEL_ID`, `NBI_CLAUDE_CHAT_MODEL`, `NBI_CLAUDE_INLINE_COMPLETION_MODEL`.
 - **Anthropic endpoint pinning.** `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL` (read by the Claude SDK directly, propagated by NBI).
-- **Skills and Plugins management.** `NBI_SKILLS_MANIFEST` (org-managed YAML manifest URL or path), `NBI_SKILLS_MANIFEST_INTERVAL`, `NBI_SKILLS_MANIFEST_TOKEN`, `NBI_ALLOW_GITHUB_SKILL_IMPORT`, `NBI_CLAUDE_PLUGINS_MANAGEMENT_POLICY`.
+- **Settings tabs.** `NBI_SKILLS_MANAGEMENT_POLICY` (whole Skills tab), `NBI_CLAUDE_MCP_MANAGEMENT_POLICY` (Claude MCP Servers tab), `NBI_CLAUDE_PLUGINS_MANAGEMENT_POLICY` (Claude Plugins tab). Each `force-off` hides the tab and 403s its REST routes.
+- **Skills and Plugins management.** `NBI_SKILLS_MANIFEST` (org-managed YAML manifest URL or path), `NBI_SKILLS_MANIFEST_INTERVAL`, `NBI_SKILLS_MANIFEST_TOKEN`, `NBI_ALLOW_GITHUB_SKILL_IMPORT`, `NBI_ALLOW_GITHUB_PLUGIN_IMPORT`, `NBI_SKILL_MAX_ARCHIVE_MB`.
+- **Coding-agent launchers.** `disabled_coding_agent_launchers` (traitlet, list of `claude-code` / `opencode` / `pi` / `github-copilot-cli` / `codex`), with `allow_enabling_coding_agent_launchers_with_env` + `NBI_ENABLED_CODING_AGENT_LAUNCHERS` for per-pod re-enable.
+- **Upload staging.** `NBI_UPLOAD_MAX_MB` (default `50`), `NBI_UPLOAD_RETENTION_HOURS` (default `24`) govern the staging endpoint used by terminal drag-drop and chat-sidebar attachments.
 - **Provider gating.** `NBI_DISABLED_PROVIDERS` (comma-separated list).
 
 ## Fail-loud resolvers

--- a/admin.markdown
+++ b/admin.markdown
@@ -47,8 +47,8 @@ Set `NBI_SKILLS_MANIFEST=https://your-org/skills.yaml` (or a filesystem path). N
 
 ## Reference
 
-- [Full admin guide](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/docs/admin-guide.md) — every env var, every default, every interaction.
-- [Security policy](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/SECURITY.md) — disclosure, threat model, supply-chain posture.
-- [Privacy](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/PRIVACY.md) — what NBI sends where.
+- [Full admin guide](https://github.com/plmbr/notebook-intelligence/blob/main/docs/admin-guide.md) — every env var, every default, every interaction.
+- [Security policy](https://github.com/plmbr/notebook-intelligence/blob/main/SECURITY.md) — disclosure, threat model, supply-chain posture.
+- [Privacy](https://github.com/plmbr/notebook-intelligence/blob/main/PRIVACY.md) — what NBI sends where.
 
 <p style="margin-top: var(--space-10);"><a class="btn btn--primary" href="{{ '/install/' | relative_url }}">Install NBI</a></p>

--- a/blog/archive.markdown
+++ b/blog/archive.markdown
@@ -7,7 +7,7 @@ permalink: /blog/archive/
 
 <div class="callout callout--warn">
   <p class="callout__title">These posts are historical.</p>
-  <p>The product they describe — single-provider, Copilot-only NBI — is several major releases behind. For current information, see the <a href="{{ '/' | relative_url }}">home page</a> or the <a href="https://github.com/notebook-intelligence/notebook-intelligence/blob/main/CHANGELOG.md">CHANGELOG</a>.</p>
+  <p>The product they describe — single-provider, Copilot-only NBI — is several major releases behind. For current information, see the <a href="{{ '/' | relative_url }}">home page</a> or the <a href="https://github.com/plmbr/notebook-intelligence/blob/main/CHANGELOG.md">CHANGELOG</a>.</p>
 </div>
 
 <ul class="post-list">

--- a/docs.markdown
+++ b/docs.markdown
@@ -5,17 +5,17 @@ subtitle: The deep docs live in the repo. This page is a router.
 permalink: /docs/
 ---
 
-NBI's reference documentation is maintained alongside the code in the [main repository](https://github.com/notebook-intelligence/notebook-intelligence). Keeping one source of truth means the docs and the code can't drift.
+NBI's reference documentation is maintained alongside the code in the [main repository](https://github.com/plmbr/notebook-intelligence). Keeping one source of truth means the docs and the code can't drift.
 
 ## Reference
 
-- [README](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/README.md) — install, quick start, concept glossary.
-- [Admin guide](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/docs/admin-guide.md) — every `NBI_*` env var, every policy.
-- [Rulesets](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/docs/rulesets.md) — markdown-based prompt injection.
-- [Skills](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/docs/skills.md) — authoring, importing, and org-managed Skills.
-- [Troubleshooting](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/docs/troubleshooting.md) — common issues and fixes.
-- [CHANGELOG](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/CHANGELOG.md) — release notes.
-- [Security policy](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/SECURITY.md) — disclosure address and threat model.
-- [Privacy](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/PRIVACY.md) — what data leaves your machine.
-- [Contributing](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/CONTRIBUTING.md) — how to file a bug, propose a feature, or send a PR.
-- [Release process](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/RELEASE.md) — for maintainers.
+- [README](https://github.com/plmbr/notebook-intelligence/blob/main/README.md) — install, quick start, concept glossary.
+- [Admin guide](https://github.com/plmbr/notebook-intelligence/blob/main/docs/admin-guide.md) — every `NBI_*` env var, every policy.
+- [Rulesets](https://github.com/plmbr/notebook-intelligence/blob/main/docs/rulesets.md) — markdown-based prompt injection.
+- [Skills](https://github.com/plmbr/notebook-intelligence/blob/main/docs/skills.md) — authoring, importing, and org-managed Skills.
+- [Troubleshooting](https://github.com/plmbr/notebook-intelligence/blob/main/docs/troubleshooting.md) — common issues and fixes.
+- [CHANGELOG](https://github.com/plmbr/notebook-intelligence/blob/main/CHANGELOG.md) — release notes.
+- [Security policy](https://github.com/plmbr/notebook-intelligence/blob/main/SECURITY.md) — disclosure address and threat model.
+- [Privacy](https://github.com/plmbr/notebook-intelligence/blob/main/PRIVACY.md) — what data leaves your machine.
+- [Contributing](https://github.com/plmbr/notebook-intelligence/blob/main/CONTRIBUTING.md) — how to file a bug, propose a feature, or send a PR.
+- [Release process](https://github.com/plmbr/notebook-intelligence/blob/main/RELEASE.md) — for maintainers.

--- a/features/claude-code.markdown
+++ b/features/claude-code.markdown
@@ -9,10 +9,15 @@ NBI's deepest integration is with [Claude Code](https://docs.claude.com/en/docs/
 
 ## What you get
 
-- **Session resume.** A Claude Code tile on the JupyterLab launcher opens a picker listing every session in `~/.claude/projects/`. Resume a transcript or start a new session scoped to the file browser's current directory.
+- **Session resume.** A Claude Code tile on the JupyterLab launcher opens a picker listing every session in `~/.claude/projects/`. Resume a transcript or start a new session scoped to a directory you pick. The tile is no longer gated by Claude chat mode — it appears whenever the `claude` CLI is on `PATH`.
 - **Agent-mode notebook editing.** The agent can create notebooks, add and edit cells, run them, read the output, and fix errors without leaving the document.
+- **Real progress feedback** during long Claude turns. An elapsed-time counter, a heartbeat-driven pulse with a "may be slow" copy flip after 30 seconds, and inline tool-call narration so the sidebar reflects what the agent is doing.
+- **Open files refresh on disk change.** When Claude edits a file you have open, the tab reverts to the disk version automatically. Tabs with unsaved local edits are skipped. Toggle in **NBI Settings → External changes**.
+- **Workspace files as @-mention pointers.** Attaching a file ships an `@<path>` pointer instead of inlining contents, so images, large files, and notebooks (cell-aware) all work where the older path silently truncated them.
 - **Tools, Skills, Plugins, MCP.** Everything the standalone Claude CLI can use is available from inside JupyterLab — see [Skills &amp; Plugins]({{ '/features/skills-plugins/' | relative_url }}) and [MCP servers]({{ '/features/mcp/' | relative_url }}).
 - **Cell output actions.** Right-click a cell output for **Explain**, **Ask**, or **Troubleshoot** quick actions that open the chat with the output already attached as context.
+- **Terminal drag-drop file attach** with `@`-mention or shell-escaped raw modes. Shift inverts the mode for one drop.
+- **New chat session** button next to the gear restarts the SDK client without typing `/clear`.
 - **AGENTS.md support.** When a project root contains an `AGENTS.md`, NBI appends it under the system prompt's "Additional Guidelines" alongside the existing ruleset injection.
 
 ## Setup

--- a/features/claude-code.markdown
+++ b/features/claude-code.markdown
@@ -44,7 +44,7 @@ Or via environment variables for managed deployments — see [admin policies]({{
 ## Reference
 
 - [Claude Code documentation](https://docs.claude.com/en/docs/claude-code) (Anthropic)
-- [NBI Claude mode reference](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/README.md#claude-mode)
-- [Skills documentation](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/docs/skills.md)
+- [NBI Claude mode reference](https://github.com/plmbr/notebook-intelligence/blob/main/README.md#claude-mode)
+- [Skills documentation](https://github.com/plmbr/notebook-intelligence/blob/main/docs/skills.md)
 
 <p style="margin-top: var(--space-10);"><a class="btn btn--primary" href="{{ '/install/' | relative_url }}">Install NBI</a></p>

--- a/features/skills-plugins.markdown
+++ b/features/skills-plugins.markdown
@@ -7,19 +7,30 @@ permalink: /features/skills-plugins/
 
 ## Claude Skills
 
-A Claude Skill is a bundle of instructions, allowed tools, and helper files that an agent can invoke. NBI manages them from a Skills tab in Settings.
+A Claude Skill is a bundle of instructions, allowed tools, and helper files that an agent can invoke. As of 5.0.0, NBI's Skills tab is a top-level Settings tab visible in any mode (with a hint banner when Claude mode is off).
 
 - **Author inline.** Create a new Skill, edit its `SKILL.md` and helper files without leaving the lab.
-- **Import from GitHub.** Drop a `github.com/owner/repo/tree/main/skills/<name>` URL into the import dialog; NBI fetches the tarball, validates the bundle, and installs it under `~/.jupyter/skills/`.
-- **Org-managed manifest.** Point `NBI_SKILLS_MANIFEST` at a YAML manifest file or URL. NBI's reconciler installs every Skill in the manifest at startup and re-checks every 24h. Managed Skills are read-only in the UI — users can't edit, rename, or delete them, and the reconciler restores any that get removed.
+- **Import from GitHub.** Drop a `github.com/owner/repo/tree/main/skills/<name>` URL into the import dialog; NBI fetches the tarball, validates the bundle, and installs it under `~/.jupyter/skills/`. Optional **Track upstream** checkbox surfaces a per-skill Sync button and a panel-level "Sync tracking skills".
+- **Org-managed manifest.** Point `NBI_SKILLS_MANIFEST` at one or more YAML manifest files or URLs (comma-separated for multiple). NBI's reconciler installs every Skill at startup and re-checks every 24h. Managed Skills are read-only in the UI — users can't edit, rename, or delete them, and the reconciler restores any that get removed.
+
+## Claude MCP Servers
+
+A separate top-level tab in 5.0.0 manages the user, project, and local-scope MCP entries Claude Code reads from `~/.claude.json` and `<project>/.mcp.json`. Independent of the existing NBI MCP tab; the two never appear at the same time.
+
+- **Per-workspace enable / disable.** Toggle individual MCP entries on / off without removing them.
+- **JSON-paste path.** Paste a Claude / Cursor / VS Code MCP config blob; NBI parses, validates, and pre-fills the form.
+- **Admin policy.** `NBI_CLAUDE_MCP_MANAGEMENT_POLICY=force-off` hides the tab and 403s `/claude-mcp/*` routes.
 
 ## Claude Plugins
 
 Claude Plugins are install-and-go bundles published to marketplaces. NBI's Plugins panel wraps the `claude plugin` CLI:
 
 - **Install, uninstall, enable, disable.** From a marketplace URL or a GitHub repo.
-- **Marketplace add/remove.** Manage which marketplaces are visible to Claude.
+- **Marketplace add / remove.** Manage which marketplaces are visible to Claude.
+- **Marketplace picker.** Browse the configured marketplaces inline; entries show source repo, version, and description.
+- **Per-plugin Update button.** Surfaces when a newer version is available upstream.
 - **Project vs user scope.** Plugins installed to a project root are isolated to that workspace.
+- **Admin policies.** `NBI_CLAUDE_PLUGINS_MANAGEMENT_POLICY` for the whole tab; `NBI_ALLOW_GITHUB_PLUGIN_IMPORT` for marketplace sources resolving as GitHub URLs.
 
 ## Manifest example
 

--- a/features/skills-plugins.markdown
+++ b/features/skills-plugins.markdown
@@ -34,7 +34,7 @@ skills:
 
 ## Reference
 
-- [NBI Skills documentation](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/docs/skills.md)
+- [NBI Skills documentation](https://github.com/plmbr/notebook-intelligence/blob/main/docs/skills.md)
 - [Claude Skills SDK](https://docs.claude.com/en/docs/claude-code/skills)
 - [Claude Plugins](https://docs.claude.com/en/docs/claude-code/plugins)
 

--- a/index.markdown
+++ b/index.markdown
@@ -16,7 +16,7 @@ description: A JupyterLab extension for Claude Code, GitHub Copilot, Ollama, and
       </p>
       <div class="hero__cta">
         <a class="btn btn--primary" href="#install">Install</a>
-        <a class="btn btn--ghost" href="https://github.com/notebook-intelligence/notebook-intelligence" rel="noopener">View on GitHub</a>
+        <a class="btn btn--ghost" href="https://github.com/plmbr/notebook-intelligence" rel="noopener">View on GitHub</a>
       </div>
     </div>
     <div>

--- a/install.markdown
+++ b/install.markdown
@@ -87,7 +87,7 @@ The base URL must speak the Chat Completions API. vLLM, LiteLLM, TGI, and llama.
 If something doesn't work, check:
 
 - `jupyter server extension list` — `notebook_intelligence` should appear under "OK".
-- `jupyter labextension list` — `@notebook-intelligence/notebook-intelligence` should be listed as enabled.
+- `jupyter labextension list` — `@plmbr/notebook-intelligence` should be listed as enabled.
 - The JupyterLab terminal output where you ran `jupyter lab`. NBI logs server-side errors there.
 
-For deeper issues, see the [troubleshooting guide](https://github.com/notebook-intelligence/notebook-intelligence/blob/main/docs/troubleshooting.md) in the repo or [open an issue](https://github.com/notebook-intelligence/notebook-intelligence/issues).
+For deeper issues, see the [troubleshooting guide](https://github.com/plmbr/notebook-intelligence/blob/main/docs/troubleshooting.md) in the repo or [open an issue](https://github.com/plmbr/notebook-intelligence/issues).

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://notebook-intelligence.github.io/notebook-intelligence/sitemap.xml
+Sitemap: https://plmbr.dev/sitemap.xml


### PR DESCRIPTION
## Summary

5.0.0 shipped on 2026-05-22 but the marketing site still describes 4.8.0. This PR adds the v5.0.0 release post and pulls forward the most user-visible 5.0.0 surface into the admin and feature pages so visitors who land on plmbr.dev today see the current product, not a snapshot from two months ago.

Stacked on top of [#345](https://github.com/plmbr/notebook-intelligence/pull/345) (the org-rename URL refresh). Once #345 merges, this PR rebases cleanly onto gh-pages.

## Solution

Four file changes:

- **`_posts/2026-05-22-v5-0-0.markdown` (new).** Follows the v4-6 / v4-7 / v4-8 post template. Covers three new top-level Settings tabs (Skills, Claude MCP Servers, Claude Plugins) with admin policies, the five coding-agent launcher tiles, agent-aware chat UX (elapsed-time counter, "may be slow" pulse, tool-call narration, New chat session button), refresh-open-files-on-disk-change in the External-changes section, workspace files as @-mention pointers in Claude mode, terminal drag-drop, the accessibility pass, security hardening (shell-tool sandboxing, websocket auth, encrypted token 0o600, env scrubbing, XSS allowlist on anchors), the fastmcp -> official mcp SDK swap, and dynamic Copilot model discovery. Pinned at the canonical permalink `/blog/v5-0-0/`.

- **`admin.markdown`.** Extend the policy-categories list with the new 5.0.0 Settings-tab policies (`NBI_SKILLS_MANAGEMENT_POLICY`, `NBI_CLAUDE_MCP_MANAGEMENT_POLICY`, `NBI_CLAUDE_PLUGINS_MANAGEMENT_POLICY`), the user-toggle policies that landed in 5.0.0 (`NBI_REFRESH_OPEN_FILES_ON_DISK_CHANGE_POLICY`, `NBI_TERMINAL_DRAG_DROP_POLICY`, the Claude setting-source pair), the coding-agent launcher block-list (`disabled_coding_agent_launchers` + `NBI_ENABLED_CODING_AGENT_LAUNCHERS`), the upload-staging tunables, and the skill archive cap.

- **`features/skills-plugins.markdown`.** Mention Skills is now a top-level tab (not a Claude-mode sub-tab), the tracks-upstream import flag, multi-manifest `NBI_SKILLS_MANIFEST`, the new **Claude MCP Servers** tab with per-workspace toggle and JSON-paste path, the Claude Plugins marketplace picker and per-plugin Update button, and the admin policies on each.

- **`features/claude-code.markdown`.** Pull forward real progress feedback during long Claude turns, the open-files refresh, workspace @-mention pointers, terminal drag-drop, the New chat session button, and the fact that the launcher tile is no longer gated by Claude chat mode.

## Testing

Static-site changes. No automated tests. Verified the new post's front-matter against the v4-8 post (same fields, same permalink shape) and confirmed the four 2025 launch posts carry `archived: true` while v4-6 through v5-0 do not, so the blog index will list v5-0 alongside the recent release posts and the four 2025 posts stay in the archive.

## Risks / follow-ups

None. The post URL `/blog/v5-0-0/` doesn't collide with any existing route. Once #345 lands and this one merges, plmbr.dev will be on-message for 5.0.0.