### PR TITLE
refactor(agent): improve notebook prompts and tool response clarity

### DIFF
--- a/notebook_intelligence/built_in_toolsets.py
+++ b/notebook_intelligence/built_in_toolsets.py
@@ -640,9 +640,17 @@ If you need to install any packages you shoud use %pip install <package_name> in
 
 If you need to detect issues in a notebook check the code cell sources and also the cell output for any problems.
 
+Choose the notebook workflow based on the task type.
+
+Default to an exploratory workflow when the task is uncertain, scientific, data-driven, or likely to require intermediate interpretation. In that mode, do not begin by building a complete notebook from start to finish. Start with a minimal notebook or a minimal extension of the current notebook, add only the next small set of code and markdown cells needed to answer the immediate question, run those cells, inspect the outputs, and then decide what to add or revise next.
+
+Use a construction workflow when the task is well-defined, narrow in scope, and largely predetermined in structure. In that mode, it is acceptable to define a fuller plan up front and proceed more linearly, while still validating outputs and revising the notebook if needed.
+
+Do not pre-write a full report, a full modeling pipeline, or dozens of cells before seeing intermediate results in exploratory or scientific tasks.
+
 After you are done making changes to the notebook, save the notebook using the save_notebook tool.
 
-First create an execution plan and show before calling any tools. The execution plan should be a list of steps that you will take. Then call the tools to execute the plan.
+Before calling any tools, first show a short execution plan. The plan should be provisional, minimal, and revisable based on what later cells reveal. Do not present the plan as a fixed end-to-end recipe when the task is exploratory or scientific.
 """
 
 NOTEBOOK_EXECUTE_INSTRUCTIONS = """
@@ -650,7 +658,14 @@ Running a notebook and executing a notebook refer to the same thing. Running a n
 
 If you create a new notebook and run it, then check for errors in the output of the cells. If there are any errors in the output, update the cell code that caused the error to fix it and rerun the cell. Repeat until there are no errors in the output of the cells.
 
-If you are asked to analyze a dataset, you should fist create a notebook and add the code cells and markdown cells to the notebook which are needed to analyze the dataset and run all the cells.
+When notebook execution is part of an exploratory or scientific workflow, prefer small iterative cycles:
+1. add a small number of cells (markdown cells and code cells),
+2. run them,
+3. inspect outputs and errors,
+4. revise the notebook,
+5. then continue only if the results justify the next step.
+
+If outputs suggest the notebook should be revised, stop executing linearly and return to notebook editing rather than continuing through later cells blindly.
 
 After you are done running the notebook, save the notebook using the save_notebook tool.
 """

--- a/notebook_intelligence/built_in_toolsets.py
+++ b/notebook_intelligence/built_in_toolsets.py
@@ -26,7 +26,9 @@ log = logging.getLogger(__name__)
 
 APPROX_BYTES_PER_OUTPUT_TOKEN = 4
 DEFAULT_READ_FILE_MAX_OUTPUT_TOKENS = 10_000
-READ_FILE_TRUNCATION_MARKER = "\n[output truncated]"
+READ_FILE_TRUNCATION_MARKER_TEMPLATE = (
+    "\n[output truncated within line {line} column {column}]"
+)
 
 
 def _truncate_utf8_to_byte_budget(text: str, byte_budget: int) -> str:
@@ -39,12 +41,41 @@ def _truncate_utf8_to_byte_budget(text: str, byte_budget: int) -> str:
     return encoded[:byte_budget].decode("utf-8", errors="ignore")
 
 
+def _read_position_after_content(
+    start_line: int,
+    content: str,
+) -> tuple[int, int]:
+    """Return the next unread 1-based line/column after ``content``."""
+    if not content:
+        return start_line, 1
+
+    newline_count = content.count("\n")
+    line = start_line + newline_count
+
+    last_newline = content.rfind("\n")
+    if last_newline == -1:
+        column = len(content) + 1
+    else:
+        column = len(content) - last_newline
+
+    return line, column
+
+
+def _read_file_truncation_marker(start_line: int, content: str) -> str:
+    line, column = _read_position_after_content(start_line, content)
+    return READ_FILE_TRUNCATION_MARKER_TEMPLATE.format(
+        line=line,
+        column=column,
+    )
+
+
 def _truncate_read_file_output(
     prefix: str,
     content: str,
+    start_line: int,
     max_output_tokens: int,
 ) -> str:
-    """Apply the read-file output cap using the 4 UTF-8 bytes ~= 1 token rule."""
+    """Apply the read-file output cap to prefix+content only; marker is extra."""
     byte_budget = max(0, max_output_tokens) * APPROX_BYTES_PER_OUTPUT_TOKEN
     prefix_bytes = len(prefix.encode("utf-8"))
     content_bytes = len(content.encode("utf-8"))
@@ -52,22 +83,15 @@ def _truncate_read_file_output(
     if prefix_bytes + content_bytes <= byte_budget:
         return prefix + content
 
-    marker_bytes = len(READ_FILE_TRUNCATION_MARKER.encode("utf-8"))
     if byte_budget <= prefix_bytes:
-        if byte_budget <= marker_bytes:
-            return _truncate_utf8_to_byte_budget(
-                READ_FILE_TRUNCATION_MARKER,
-                byte_budget,
-            )
-        truncated_prefix = _truncate_utf8_to_byte_budget(
-            prefix,
-            max(0, byte_budget - marker_bytes),
-        )
-        return truncated_prefix + READ_FILE_TRUNCATION_MARKER
+        truncated_prefix = _truncate_utf8_to_byte_budget(prefix, byte_budget)
+        marker = _read_file_truncation_marker(start_line, "")
+        return truncated_prefix + marker
 
-    content_budget = max(0, byte_budget - prefix_bytes - marker_bytes)
+    content_budget = byte_budget - prefix_bytes
     truncated_content = _truncate_utf8_to_byte_budget(content, content_budget)
-    return prefix + truncated_content + READ_FILE_TRUNCATION_MARKER
+    marker = _read_file_truncation_marker(start_line, truncated_content)
+    return prefix + truncated_content + marker
 
 
 @nbapi.auto_approve
@@ -450,7 +474,6 @@ async def read_file(
     file_path: str,
     start_line: int = 1,
     end_line: int = -1,
-    max_output_tokens: int = DEFAULT_READ_FILE_MAX_OUTPUT_TOKENS,
     **args,
 ) -> str:
     """Read lines from a file within jupyter_root_dir between start_line and end_line (inclusive).
@@ -459,8 +482,6 @@ async def read_file(
         file_path: Path to the file (relative to jupyter_root_dir)
         start_line: 1-based line number to start reading from (default = 1)
         end_line: 1-based line number to stop reading at (inclusive, default = -1 for end of file)
-        max_output_tokens: Approximate output cap. Uses 4 UTF-8 bytes ~= 1 token
-            and defaults to 10000. Truncated output ends with [output truncated].
     """
     try:
         target_file = _get_safe_path(file_path)
@@ -484,7 +505,12 @@ async def read_file(
         content_lines = lines[start_line-1:end_line]
         content = "".join(content_lines)
         prefix = f"Content of '{file_path}' (lines {start_line}-{end_line}):\n"
-        return _truncate_read_file_output(prefix, content, max_output_tokens)
+        return _truncate_read_file_output(
+            prefix,
+            content,
+            start_line,
+            DEFAULT_READ_FILE_MAX_OUTPUT_TOKENS,
+        )
     except UnicodeDecodeError:
         return f"Error: File '{file_path}' is not a text file or uses an unsupported encoding"
     except Exception as e:

--- a/notebook_intelligence/built_in_toolsets.py
+++ b/notebook_intelligence/built_in_toolsets.py
@@ -55,7 +55,9 @@ async def add_markdown_cell(source: str, **args) -> str:
     """
     response = args["response"]
     ui_cmd_response = await response.run_ui_command('notebook-intelligence:add-markdown-cell-to-active-notebook', {'source': source})
-
+    cell_index = ui_cmd_response.get("cellIndex") if isinstance(ui_cmd_response, dict) else None
+    if isinstance(cell_index, int):
+        return f"Added markdown cell at index {cell_index}"
     return "Added markdown cell to notebook"
 
 @nbapi.auto_approve
@@ -67,7 +69,9 @@ async def add_code_cell(source: str, **args) -> str:
     """
     response = args["response"]
     ui_cmd_response = await response.run_ui_command('notebook-intelligence:add-code-cell-to-active-notebook', {'source': source})
-
+    cell_index = ui_cmd_response.get("cellIndex") if isinstance(ui_cmd_response, dict) else None
+    if isinstance(cell_index, int):
+        return f"Added code cell at index {cell_index}"
     return "Added code cell to notebook"
 
 @nbapi.auto_approve

--- a/notebook_intelligence/built_in_toolsets.py
+++ b/notebook_intelligence/built_in_toolsets.py
@@ -24,6 +24,52 @@ _get_safe_path = safe_jupyter_path
 
 log = logging.getLogger(__name__)
 
+APPROX_BYTES_PER_OUTPUT_TOKEN = 4
+DEFAULT_READ_FILE_MAX_OUTPUT_TOKENS = 10_000
+READ_FILE_TRUNCATION_MARKER = "\n[output truncated]"
+
+
+def _truncate_utf8_to_byte_budget(text: str, byte_budget: int) -> str:
+    """Trim text to a UTF-8 byte budget without returning invalid Unicode."""
+    if byte_budget <= 0 or not text:
+        return ""
+    encoded = text.encode("utf-8")
+    if len(encoded) <= byte_budget:
+        return text
+    return encoded[:byte_budget].decode("utf-8", errors="ignore")
+
+
+def _truncate_read_file_output(
+    prefix: str,
+    content: str,
+    max_output_tokens: int,
+) -> str:
+    """Apply the read-file output cap using the 4 UTF-8 bytes ~= 1 token rule."""
+    byte_budget = max(0, max_output_tokens) * APPROX_BYTES_PER_OUTPUT_TOKEN
+    prefix_bytes = len(prefix.encode("utf-8"))
+    content_bytes = len(content.encode("utf-8"))
+
+    if prefix_bytes + content_bytes <= byte_budget:
+        return prefix + content
+
+    marker_bytes = len(READ_FILE_TRUNCATION_MARKER.encode("utf-8"))
+    if byte_budget <= prefix_bytes:
+        if byte_budget <= marker_bytes:
+            return _truncate_utf8_to_byte_budget(
+                READ_FILE_TRUNCATION_MARKER,
+                byte_budget,
+            )
+        truncated_prefix = _truncate_utf8_to_byte_budget(
+            prefix,
+            max(0, byte_budget - marker_bytes),
+        )
+        return truncated_prefix + READ_FILE_TRUNCATION_MARKER
+
+    content_budget = max(0, byte_budget - prefix_bytes - marker_bytes)
+    truncated_content = _truncate_utf8_to_byte_budget(content, content_budget)
+    return prefix + truncated_content + READ_FILE_TRUNCATION_MARKER
+
+
 @nbapi.auto_approve
 @nbapi.tool
 async def create_new_notebook(**args) -> str:
@@ -400,13 +446,21 @@ async def list_files(
         return f"Error listing files: {str(e)}"
 
 @nbapi.tool
-async def read_file(file_path: str, start_line: int = 1, end_line: int = -1, **args) -> str:
+async def read_file(
+    file_path: str,
+    start_line: int = 1,
+    end_line: int = -1,
+    max_output_tokens: int = DEFAULT_READ_FILE_MAX_OUTPUT_TOKENS,
+    **args,
+) -> str:
     """Read lines from a file within jupyter_root_dir between start_line and end_line (inclusive).
     
     Args:
         file_path: Path to the file (relative to jupyter_root_dir)
         start_line: 1-based line number to start reading from (default = 1)
         end_line: 1-based line number to stop reading at (inclusive, default = -1 for end of file)
+        max_output_tokens: Approximate output cap. Uses 4 UTF-8 bytes ~= 1 token
+            and defaults to 10000. Truncated output ends with [output truncated].
     """
     try:
         target_file = _get_safe_path(file_path)
@@ -429,7 +483,8 @@ async def read_file(file_path: str, start_line: int = 1, end_line: int = -1, **a
         # Slice lines based on user input (start_line and end_line are 1-based and inclusive)
         content_lines = lines[start_line-1:end_line]
         content = "".join(content_lines)
-        return f"Content of '{file_path}' (lines {start_line}-{end_line}):\n{content}"
+        prefix = f"Content of '{file_path}' (lines {start_line}-{end_line}):\n"
+        return _truncate_read_file_output(prefix, content, max_output_tokens)
     except UnicodeDecodeError:
         return f"Error: File '{file_path}' is not a text file or uses an unsupported encoding"
     except Exception as e:

--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -995,7 +995,9 @@ async def add_markdown_cell(args) -> str:
     """
     response = get_current_response()
     ui_cmd_response = await response.run_ui_command('notebook-intelligence:add-markdown-cell-to-active-notebook', {'source': args['source']})
-
+    cell_index = ui_cmd_response.get("cellIndex") if isinstance(ui_cmd_response, dict) else None
+    if isinstance(cell_index, int):
+        return tool_text_response(f"Added markdown cell at index {cell_index}")
     return tool_text_response(f"Added markdown cell to notebook")
 
 @tool("add-code-cell", "Adds a code cell to the notebook.", {"source": str})
@@ -1006,7 +1008,9 @@ async def add_code_cell(args) -> str:
     """
     response = get_current_response()
     ui_cmd_response = await response.run_ui_command('notebook-intelligence:add-code-cell-to-active-notebook', {'source': args['source']})
-
+    cell_index = ui_cmd_response.get("cellIndex") if isinstance(ui_cmd_response, dict) else None
+    if isinstance(cell_index, int):
+        return tool_text_response(f"Added code cell at index {cell_index}")
     return tool_text_response(f"Added code cell to notebook")
 
 @tool("get-number-of-cells", "Gets the number of cells in the notebook.", {})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1734,7 +1734,7 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
           source: args.source as string
         });
 
-        return true;
+        return { cellIndex: newCellIndex };
       }
     });
 
@@ -1755,7 +1755,7 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
           source: args.source as string
         });
 
-        return true;
+        return { cellIndex: newCellIndex };
       }
     });
 

--- a/tests/test_builtin_file_read.py
+++ b/tests/test_builtin_file_read.py
@@ -1,6 +1,7 @@
 """Regression tests for the built-in file read tool output cap."""
 
 import asyncio
+import re
 
 import pytest
 
@@ -21,7 +22,27 @@ def _read_file(file_path: str, **kwargs) -> str:
     return asyncio.run(tool(file_path=file_path, **kwargs))
 
 
+def _parse_truncation_marker(result: str) -> tuple[int, int]:
+    match = re.search(
+        r"\[output truncated within line (\d+) column (\d+)\]$",
+        result,
+    )
+    assert match is not None
+    return int(match.group(1)), int(match.group(2))
+
+
+def _visible_content(result: str) -> str:
+    return result.split(":\n", 1)[1].rsplit(
+        "\n[output truncated within line ",
+        1,
+    )[0]
+
+
 class TestReadFileOutputCap:
+    def test_public_schema_hides_max_output_tokens(self):
+        properties = toolsets.read_file.schema["function"]["parameters"]["properties"]
+        assert "max_output_tokens" not in properties
+
     def test_small_file_is_returned_verbatim(self, jupyter_root):
         target = jupyter_root / "small.txt"
         target.write_text("hello\nworld\n", encoding="utf-8")
@@ -36,24 +57,70 @@ class TestReadFileOutputCap:
         target.write_text("a" * 40_500, encoding="utf-8")
 
         result = _read_file("huge.txt")
+        line, column = _parse_truncation_marker(result)
+        visible = _visible_content(result)
+        prefix = "Content of 'huge.txt' (lines 1-1):\n"
 
         assert result.startswith("Content of 'huge.txt' (lines 1-1):\n")
-        assert result.endswith("[output truncated]")
+        assert line == 1
+        assert column == len(visible) + 1
         assert "a" * 40_500 not in result
-        assert len(result.encode("utf-8")) <= 40_000
+        assert len((prefix + visible).encode("utf-8")) <= 40_000
 
-    def test_multibyte_utf8_content_respects_byte_budget(self, jupyter_root):
-        target = jupyter_root / "multibyte.txt"
-        target.write_text("你🙂" * 20, encoding="utf-8")
+    def test_marker_is_appended_beyond_prefix_plus_content_budget(self, jupyter_root):
+        target = jupyter_root / "budget.txt"
+        target.write_text("a" * 50_000, encoding="utf-8")
 
-        result = _read_file("multibyte.txt", max_output_tokens=16)
+        result = _read_file("budget.txt")
+        line, column = _parse_truncation_marker(result)
+        visible = _visible_content(result)
+        prefix = "Content of 'budget.txt' (lines 1-1):\n"
+        marker = f"\n[output truncated within line {line} column {column}]"
 
-        assert result.endswith("[output truncated]")
-        assert len(result.encode("utf-8")) <= 64
-        visible = result.split(":\n", 1)[1].removesuffix("\n[output truncated]")
-        assert visible
-        for ch in visible:
-            assert ch in {"你", "🙂"}
+        assert visible == "a" * (40_000 - len(prefix.encode("utf-8")))
+        assert column == len(visible) + 1
+        assert len((prefix + visible).encode("utf-8")) == 40_000
+        assert len(result.encode("utf-8")) == 40_000 + len(marker.encode("utf-8"))
+
+    def test_multibyte_utf8_content_keeps_maximum_prefix_within_budget(
+        self,
+        jupyter_root,
+    ):
+        target = jupyter_root / "emoji.txt"
+        target.write_text("🙂" * 20_000, encoding="utf-8")
+
+        result = _read_file("emoji.txt")
+        line, column = _parse_truncation_marker(result)
+        visible = _visible_content(result)
+        prefix = "Content of 'emoji.txt' (lines 1-1):\n"
+        content_budget = 40_000 - len(prefix.encode("utf-8"))
+        expected_count = content_budget // len("🙂".encode("utf-8"))
+
+        assert len((prefix + visible).encode("utf-8")) <= 40_000
+        assert visible == "🙂" * expected_count
+        assert line == 1
+        assert column == expected_count + 1
+
+    def test_truncation_marker_tracks_line_and_column_across_newlines(
+        self,
+        jupyter_root,
+    ):
+        target = jupyter_root / "many-lines.txt"
+        line_text = "123456789\n"
+        target.write_text(line_text * 20_000, encoding="utf-8")
+        start_line = 10
+
+        result = _read_file("many-lines.txt", start_line=start_line)
+        line, column = _parse_truncation_marker(result)
+        visible = _visible_content(result)
+        prefix = "Content of 'many-lines.txt' (lines 10-20000):\n"
+        content_budget = 40_000 - len(prefix.encode("utf-8"))
+        full_lines, remainder = divmod(content_budget, len(line_text))
+        expected_line = start_line + full_lines
+        expected_column = 1 if remainder == 0 else remainder + 1
+
+        assert visible == (line_text * full_lines) + line_text[:remainder]
+        assert (line, column) == (expected_line, expected_column)
 
     def test_non_utf8_file_returns_encoding_error(self, jupyter_root):
         target = jupyter_root / "latin1.bin"
@@ -62,4 +129,4 @@ class TestReadFileOutputCap:
         result = _read_file("latin1.bin")
 
         assert "is not a text file or uses an unsupported encoding" in result
-        assert "[output truncated]" not in result
+        assert "[output truncated within line " not in result

--- a/tests/test_builtin_file_read.py
+++ b/tests/test_builtin_file_read.py
@@ -1,0 +1,65 @@
+"""Regression tests for the built-in file read tool output cap."""
+
+import asyncio
+
+import pytest
+
+import notebook_intelligence.built_in_toolsets as toolsets
+from notebook_intelligence import util as util_mod
+
+
+@pytest.fixture
+def jupyter_root(tmp_path, monkeypatch):
+    root = tmp_path / "workspace"
+    root.mkdir()
+    monkeypatch.setattr(util_mod, "_jupyter_root_dir", str(root))
+    return root
+
+
+def _read_file(file_path: str, **kwargs) -> str:
+    tool = toolsets.read_file._tool_function
+    return asyncio.run(tool(file_path=file_path, **kwargs))
+
+
+class TestReadFileOutputCap:
+    def test_small_file_is_returned_verbatim(self, jupyter_root):
+        target = jupyter_root / "small.txt"
+        target.write_text("hello\nworld\n", encoding="utf-8")
+
+        result = _read_file("small.txt")
+
+        assert result == "Content of 'small.txt' (lines 1-2):\nhello\nworld\n"
+        assert "[output truncated]" not in result
+
+    def test_oversize_output_is_truncated_with_marker(self, jupyter_root):
+        target = jupyter_root / "huge.txt"
+        target.write_text("a" * 40_500, encoding="utf-8")
+
+        result = _read_file("huge.txt")
+
+        assert result.startswith("Content of 'huge.txt' (lines 1-1):\n")
+        assert result.endswith("[output truncated]")
+        assert "a" * 40_500 not in result
+        assert len(result.encode("utf-8")) <= 40_000
+
+    def test_multibyte_utf8_content_respects_byte_budget(self, jupyter_root):
+        target = jupyter_root / "multibyte.txt"
+        target.write_text("你🙂" * 20, encoding="utf-8")
+
+        result = _read_file("multibyte.txt", max_output_tokens=16)
+
+        assert result.endswith("[output truncated]")
+        assert len(result.encode("utf-8")) <= 64
+        visible = result.split(":\n", 1)[1].removesuffix("\n[output truncated]")
+        assert visible
+        for ch in visible:
+            assert ch in {"你", "🙂"}
+
+    def test_non_utf8_file_returns_encoding_error(self, jupyter_root):
+        target = jupyter_root / "latin1.bin"
+        target.write_bytes(b"\xff\xfe\xfd\xfc")
+
+        result = _read_file("latin1.bin")
+
+        assert "is not a text file or uses an unsupported encoding" in result
+        assert "[output truncated]" not in result


### PR DESCRIPTION
## Summary

This PR combines three related improvements to notebook-agent behavior and tool response clarity.

  1. Prompt instruction refinement for notebook editing/execution workflows.
  2. Changes `add-code-cell` and `add-markdown-cell` to return the inserted `cellIndex` when available, improving traceability in iterative notebook editing.
  3. Adds UTF-8-safe output truncation to `read_file` so large file reads stay within an output budget, with regression tests covering truncation, multibyte content, and non-text files.

## Motivation
1. In a data analysis and modeling task, the agent followed the prompt by first stating a high-level goal and then proceeding to generate the entire notebook implementation in one pass. For exploratory notebook work, this is not a reasonable default behavior. The notebook instructions should instead encourage incremental analysis, intermediate validation, and task-adaptive planning rather than upfront full-pipeline code generation.

2. `add-cell` tool actions previously returned generic success responses, which made it harder to reference newly inserted cells in subsequent steps. Returning the inserted cellIndex improves traceability for iterative notebook workflows.

3. `read_file` could emit overly large outputs, which is risky for tool usability and model context management.



## What changed

  - Updated NOTEBOOK_EDIT_INSTRUCTIONS to clarify when to prefer exploratory workflows vs. construction workflows.
  - Updated NOTEBOOK_EXECUTE_INSTRUCTIONS to encourage smaller, iterative execution cycles for exploratory/scientific tasks.
  - Updated notebook `add_code_cell` and `add_markdown_cell` responses to return `{ cellIndex }` when the UI command provides it.
  - Updated Python tool wrappers and Claude tool handlers to surface the inserted cell index in tool responses.
  - Added `max_output_tokens` to `read_file`, with UTF-8-safe truncation and an `[output truncated]` marker.
  - Added regression tests for:
    - normal small-file reads
    - oversized output truncation
    - multibyte UTF-8 content
    - non-UTF-8 files
