### PR TITLE
docs: document 5.0.1 changes and refresh stale references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ For each release we list user-facing changes grouped as **Added**, **Changed**, 
 
 ## [Unreleased]
 
+## [5.0.1] - 2026-05-24
+
+A patch release: one provider-compatibility fix, one chat-rendering fix, and the npm package-scope rename. No traitlet, env-var, REST route, or on-disk-format changes; no migration steps beyond the 5.0.0 note.
+
+### Changed
+
+- **GitHub Copilot Codex chat models route through the `/responses` endpoint** (#341). Codex-family models (e.g. `gpt-5.3-codex`) are served only by Copilot's OpenAI Responses API mirror and return HTTP 400 on the standard `/chat/completions` path, so selecting one in the chat-model dropdown previously failed. NBI now picks the endpoint per model from the `/models` catalog's `supported_endpoints` field (with a `codex` substring fallback for offline sessions), translates the request and streaming events to the Responses shape, and surfaces `response.failed` / `response.error` / `response.incomplete` / `error` events instead of an empty turn. No new settings; the dispatch is internal to the GitHub Copilot provider.
+- **npm package scope renamed to `@plmbr/notebook-intelligence`** (#342), following the GitHub org rename from `notebook-intelligence` to `plmbr`. The labextension is now listed as `@plmbr/notebook-intelligence` in `jupyter labextension list`; the pip package name (`notebook-intelligence`) is unchanged, so `pip install notebook-intelligence` still works.
+
+### Fixed
+
+- **AI-generated links in the chat sidebar open in a new tab instead of replacing the JupyterLab UI** (#347). Markdown links emitted by the model previously navigated the top-level document and unloaded the whole Lab session on click. External links (`http` / `https` / `mailto`) now open with `target="_blank" rel="noopener noreferrer"`; workspace-relative paths open the referenced file through JupyterLab's document manager; fragment-only links render as inert text; and disallowed schemes (`javascript:`, traversal-escaping paths, dangerous codepoints) are blocked.
+
 ## [5.0.0] - 2026-05-22
 
 5.0.0 is a major release built on top of 4.8.0, gathering a large surface of new admin policies, accessibility work across the chat sidebar / popovers / settings tabs, several security hardening passes, and three new agent-aware UI surfaces. Most existing configuration continues to work; the version bump reflects the breadth of new admin-policy / env-var surface that operators should review, plus the dependency swap from `fastmcp` to the official `mcp` SDK.
@@ -330,7 +343,8 @@ A multi-PR accessibility pass landed across most NBI surfaces. Together these ma
 - Settings UI restructured around Claude vs default mode.
 - WebSocket connection reliability improvements.
 
-[unreleased]: https://github.com/plmbr/notebook-intelligence/compare/v5.0.0...HEAD
+[unreleased]: https://github.com/plmbr/notebook-intelligence/compare/v5.0.1...HEAD
+[5.0.1]: https://github.com/plmbr/notebook-intelligence/compare/v5.0.0...v5.0.1
 [5.0.0]: https://github.com/plmbr/notebook-intelligence/compare/v4.8.0...v5.0.0
 [4.8.0]: https://github.com/plmbr/notebook-intelligence/compare/v4.7.0...v4.8.0
 [4.7.0]: https://github.com/plmbr/notebook-intelligence/compare/v4.6.0...v4.7.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ NBI has two halves:
   - `notebook_intelligence/ai_service_manager.py` — composes LLM providers, MCP, skills, and rules into the request pipeline.
   - `notebook_intelligence/llm_providers/` — provider adapters (GitHub Copilot, OpenAI-compatible, LiteLLM-compatible, Ollama).
   - `notebook_intelligence/claude.py` + `notebook_intelligence/claude_sessions.py` — Claude Code integration via [`claude-agent-sdk`](https://pypi.org/project/claude-agent-sdk/).
-  - `notebook_intelligence/mcp_manager.py` — MCP server management via [`fastmcp`](https://pypi.org/project/fastmcp/).
+  - `notebook_intelligence/mcp_manager.py`: MCP server management via the official [`mcp`](https://pypi.org/project/mcp/) SDK (replaced `fastmcp` in 5.0.0).
   - `notebook_intelligence/skill_manager.py`, `skill_github_import.py`, `skill_manifest.py`, `skill_reconciler.py`, `skillset.py` — Claude Skills storage, GitHub import, and managed-manifest reconciliation.
   - `notebook_intelligence/rule_manager.py`, `rule_injector.py`, `ruleset.py` — ruleset discovery and prompt injection.
   - `notebook_intelligence/built_in_toolsets.py` — built-in tool implementations (`nbi-notebook-edit`, `nbi-command-execute`, etc.).


### PR DESCRIPTION
## Summary

The version was bumped to 5.0.1 (commit `7d512cc`) and three PRs merged since the 5.0.0 release, but the CHANGELOG still ended at `[5.0.0]` with an empty `[Unreleased]`, and one CONTRIBUTING reference was left pointing at the removed `fastmcp` dependency. This adds the missing `[5.0.1]` CHANGELOG section and fixes the stale reference so the docs reflect the current state of the code.

## Solution

**`CHANGELOG.md`**: new `[5.0.1] - 2026-05-24` section between `[Unreleased]` and `[5.0.0]`, plus footer compare-links (`[unreleased]` repointed to `v5.0.1...HEAD`, new `[5.0.1]` line). Entries:

- **Changed**: GitHub Copilot Codex chat models route through the `/responses` endpoint (#341); npm package scope renamed to `@plmbr/notebook-intelligence` (#342).
- **Fixed**: AI-generated chat links open in a new tab instead of replacing the Lab UI (#347).

**`CONTRIBUTING.md`**: `mcp_manager.py` is now described as using the official `mcp` SDK rather than `fastmcp` (the swap shipped in 5.0.0 via #324; the module imports `mcp`, confirmed).

### Deliberately left unchanged

- `README.md` "5.0.0 migration note" link and `docs/admin-guide.md` "As of 5.0.0 ... `mcp` SDK" line: both reference 5.0.0 as correct historical fact. 5.0.1 introduces no traitlet, env-var, REST route, or on-disk-format change and no migration steps, so pointing at the 5.0.0 note remains accurate.
- The `#343` blog-URL refresh, the version-bump commit, and a lockfile lint fix are chores/docs with no user-facing surface, so they get no CHANGELOG line.

## Testing

- `prettier --check CHANGELOG.md CONTRIBUTING.md`: both pass.
- Every factual claim in the new entries was verified against the code: `gpt-5.3-codex` is the real model id (12 occurrences in the test suite); `_RESPONSES_TERMINAL_ERROR_EVENTS` contains exactly the four events listed; `mcp_manager.py` imports `mcp`; `package.json` name is `@plmbr/notebook-intelligence` while the pip name is unchanged.
- Two rounds of multi-agent review (changelog accuracy, completeness, prose/house-style, cross-doc consistency, link integrity, tone). Round 1 corrected the model id (`gpt-5-codex` → `gpt-5.3-codex`), completed the error-event list, and removed an em dash from the touched CONTRIBUTING line; round 2 came back clean.

## Risks / follow-ups

- Docs-only change; no code or behavior affected.
- The CONTRIBUTING bullet now uses a colon separator while its sibling bullets use em dashes; this is a deliberate house-style choice on the touched line, not an error.