### PR TITLE
style(chat): custom Claude spinner verbs from ~/.claude/settings.json

### DIFF
--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -423,6 +423,20 @@ def _scrub_credentials_for_wire(claude_settings: dict, string_overrides: dict) -
     return result
 
 
+def _read_claude_spinner_verbs():
+    import json
+    settings_path = os.path.join(
+        os.environ.get('CLAUDE_CONFIG_DIR') or os.path.join(os.path.expanduser('~'), '.claude'),
+        'settings.json'
+    )
+    try:
+        with open(settings_path) as f:
+            data = json.load(f)
+        return data.get('spinnerVerbs') or None
+    except Exception:
+        return None
+
+
 class GetCapabilitiesHandler(APIHandler):
     disabled_tools = []
     allow_enabling_tools_with_env = False
@@ -524,6 +538,7 @@ class GetCapabilitiesHandler(APIHandler):
             "claude_settings": _scrub_credentials_for_wire(
                 nbi_config.claude_settings, self.string_overrides
             ),
+            "spinner_verbs": _read_claude_spinner_verbs(),
             "claude_models": ai_service_manager.claude_models,
             # Drive launcher-tile visibility (issues #183, #260). Each flag
             # gates one tile under the "Coding Agent" category. Detection is

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -11,7 +11,7 @@ import os
 import shutil
 import tempfile
 import time
-from typing import Union
+from typing import Optional, Union
 import uuid
 import threading
 import logging
@@ -423,8 +423,7 @@ def _scrub_credentials_for_wire(claude_settings: dict, string_overrides: dict) -
     return result
 
 
-def _read_claude_spinner_verbs():
-    import json
+def _read_claude_spinner_verbs() -> Optional[dict]:
     settings_path = os.path.join(
         os.environ.get('CLAUDE_CONFIG_DIR') or os.path.join(os.path.expanduser('~'), '.claude'),
         'settings.json'
@@ -432,7 +431,16 @@ def _read_claude_spinner_verbs():
     try:
         with open(settings_path) as f:
             data = json.load(f)
-        return data.get('spinnerVerbs') or None
+        sv = data.get('spinnerVerbs')
+        if (
+            isinstance(sv, dict)
+            and sv.get('mode') == 'replace'
+            and isinstance(sv.get('verbs'), list)
+            and sv['verbs']
+            and all(isinstance(v, str) for v in sv['verbs'])
+        ):
+            return sv
+        return None
     except Exception:
         return None
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -388,6 +388,10 @@ export class NBIConfig {
     return this.capabilities.claude_settings;
   }
 
+  get spinnerVerbs(): { mode: string; verbs: string[] } | null {
+    return this.capabilities.spinner_verbs ?? null;
+  }
+
   get claudeModels(): IClaudeModelInfo[] {
     return (this.capabilities.claude_models ?? []).map(claudeModelFromWire);
   }

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -522,6 +522,80 @@ function ChatResponseHTMLFrame(props: any) {
 // Memoize ChatResponse for performance
 function ChatResponse(props: any) {
   const [renderCount, setRenderCount] = useState(0);
+  const shuffledOrder = useRef<number[]>([]);
+  const shufflePos = useRef(0);
+
+  const _spinnerVerbs = NBIAPI.config.isInClaudeCodeMode
+    ? (NBIAPI.config.spinnerVerbs ?? null)
+    : null;
+  const hasCustomVerbs =
+    _spinnerVerbs?.mode === 'replace' &&
+    Array.isArray(_spinnerVerbs.verbs) &&
+    _spinnerVerbs.verbs.length > 0;
+
+  // Fisher-Yates shuffle. When `avoidFirst` is set, swap it out of
+  // position 0 so the new first verb is never the same as the last shown
+  // (prevents an identical repeat at the wrap point between passes).
+  const shuffleVerbs = (verbs: any[], avoidFirst?: number): number[] => {
+    const order = verbs.map((_, i) => i);
+    for (let i = order.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [order[i], order[j]] = [order[j], order[i]];
+    }
+    if (avoidFirst !== undefined && order[0] === avoidFirst && order.length > 1) {
+      [order[0], order[1]] = [order[1], order[0]];
+    }
+    return order;
+  };
+
+  // Initialize the shuffle synchronously in useState so the correct verb
+  // is shown on the very first paint. A useEffect-based init fires after
+  // paint and causes a single-frame flash of verbs[0] before correcting.
+  const [verbIndex, setVerbIndex] = useState(() => {
+    const sv = NBIAPI.config.isInClaudeCodeMode
+      ? (NBIAPI.config.spinnerVerbs ?? null)
+      : null;
+    if (!sv || sv.mode !== 'replace' || !Array.isArray(sv.verbs) || sv.verbs.length === 0) {
+      return 0;
+    }
+    const order = shuffleVerbs(sv.verbs);
+    shuffledOrder.current = order;
+    shufflePos.current = 0;
+    return order[0];
+  });
+
+  useEffect(() => {
+    if (!props.showGenerating || !hasCustomVerbs) return;
+
+    const verbs = _spinnerVerbs!.verbs;
+
+    // Shuffle already initialized by useState on mount. Only re-initialize
+    // if hasCustomVerbs just became true after a capabilities refresh
+    // (shuffledOrder would be empty because the lazy init found no verbs).
+    if (shuffledOrder.current.length === 0) {
+      shuffledOrder.current = shuffleVerbs(verbs);
+      shufflePos.current = 0;
+      setVerbIndex(shuffledOrder.current[0]);
+    }
+
+    let id: ReturnType<typeof setTimeout>;
+    const scheduleNext = () => {
+      const delay = 4000 + Math.random() * 3000;
+      id = setTimeout(() => {
+        shufflePos.current++;
+        if (shufflePos.current >= shuffledOrder.current.length) {
+          const lastShown = shuffledOrder.current[shuffledOrder.current.length - 1];
+          shuffledOrder.current = shuffleVerbs(verbs, lastShown);
+          shufflePos.current = 0;
+        }
+        setVerbIndex(shuffledOrder.current[shufflePos.current]);
+        scheduleNext();
+      }, delay);
+    };
+    scheduleNext();
+    return () => clearTimeout(id);
+  }, [props.showGenerating, hasCustomVerbs]);
+
   const msg: IChatMessage = props.message;
   const timestamp = msg.date.toLocaleTimeString('en-US', { hour12: false });
 
@@ -712,17 +786,29 @@ function ChatResponse(props: any) {
               }`}
               aria-hidden="true"
             />
+            <div className="generating-label" aria-hidden="true">
+              {props.isStalled
+                ? 'Still working, server may be slow'
+                : hasCustomVerbs
+                  ? _spinnerVerbs!.verbs[verbIndex]
+                  : 'Generating'}
+              {props.showGenerating && props.elapsedSeconds > 0
+                ? ` (${formatElapsedSeconds(props.elapsedSeconds)})`
+                : ''}
+            </div>
+            {/* aria-live region contains only the verb — no elapsed suffix —
+                so screen readers announce only on verb changes, not on every
+                elapsed-seconds tick. */}
             <div
-              className="generating-label"
+              className="nbi-sr-only"
               aria-live="polite"
               aria-atomic="true"
             >
               {props.isStalled
                 ? 'Still working, server may be slow'
-                : 'Generating'}
-              {props.showGenerating && props.elapsedSeconds > 0
-                ? ` (${formatElapsedSeconds(props.elapsedSeconds)})`
-                : ''}
+                : hasCustomVerbs
+                  ? _spinnerVerbs!.verbs[verbIndex]
+                  : 'Generating'}
             </div>
           </div>
         </div>

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -542,7 +542,11 @@ function ChatResponse(props: any) {
       const j = Math.floor(Math.random() * (i + 1));
       [order[i], order[j]] = [order[j], order[i]];
     }
-    if (avoidFirst !== undefined && order[0] === avoidFirst && order.length > 1) {
+    if (
+      avoidFirst !== undefined &&
+      order[0] === avoidFirst &&
+      order.length > 1
+    ) {
       [order[0], order[1]] = [order[1], order[0]];
     }
     return order;
@@ -555,7 +559,12 @@ function ChatResponse(props: any) {
     const sv = NBIAPI.config.isInClaudeCodeMode
       ? (NBIAPI.config.spinnerVerbs ?? null)
       : null;
-    if (!sv || sv.mode !== 'replace' || !Array.isArray(sv.verbs) || sv.verbs.length === 0) {
+    if (
+      !sv ||
+      sv.mode !== 'replace' ||
+      !Array.isArray(sv.verbs) ||
+      sv.verbs.length === 0
+    ) {
       return 0;
     }
     const order = shuffleVerbs(sv.verbs);
@@ -565,7 +574,9 @@ function ChatResponse(props: any) {
   });
 
   useEffect(() => {
-    if (!props.showGenerating || !hasCustomVerbs) return;
+    if (!props.showGenerating || !hasCustomVerbs) {
+      return;
+    }
 
     const verbs = _spinnerVerbs!.verbs;
 
@@ -584,7 +595,8 @@ function ChatResponse(props: any) {
       id = setTimeout(() => {
         shufflePos.current++;
         if (shufflePos.current >= shuffledOrder.current.length) {
-          const lastShown = shuffledOrder.current[shuffledOrder.current.length - 1];
+          const lastShown =
+            shuffledOrder.current[shuffledOrder.current.length - 1];
           shuffledOrder.current = shuffleVerbs(verbs, lastShown);
           shufflePos.current = 0;
         }
@@ -799,11 +811,7 @@ function ChatResponse(props: any) {
             {/* aria-live region contains only the verb — no elapsed suffix —
                 so screen readers announce only on verb changes, not on every
                 elapsed-seconds tick. */}
-            <div
-              className="nbi-sr-only"
-              aria-live="polite"
-              aria-atomic="true"
-            >
+            <div className="nbi-sr-only" aria-live="polite" aria-atomic="true">
               {props.isStalled
                 ? 'Still working, server may be slow'
                 : hasCustomVerbs


### PR DESCRIPTION
## Summary

- Reads `spinnerVerbs.verbs` from `~/.claude/settings.json` and cycles them in the generating label when Claude Mode is active, replacing the static "Generating" text
- Fisher-Yates shuffle with random 4–7s delay per verb; no immediate repeats across shuffle passes
- Separates visible label (`aria-hidden`) from a hidden `aria-live` div containing only the verb, so screen readers announce on verb changes only — not on every elapsed-seconds tick

## Settings shape consumed

```json
{
  "spinnerVerbs": {
    "mode": "replace",
    "verbs": ["Doing Pull Ups", "Caffeinating", "Kwisatz-haderaching"]
  }
}
```

`mode: "replace"` is the only supported mode. Falls back to `"Generating"` if Claude Mode is off, verbs are absent, or the file can't be read.

## Test plan

- [x] Enable Claude Mode, ensure `~/.claude/settings.json` has `spinnerVerbs.verbs`
- [x] Send a chat message — verify custom verbs appear and cycle with varied timing
- [x] Verify cycling resumes from a randomized verb on each new request (no mid-sequence start)
- [x] Disable Claude Mode — verify fallback to `"Generating"`
- [x] Remove `spinnerVerbs` from settings — verify fallback to `"Generating"`
- [x] Screen reader: verify announcements fire on verb change only, not every second

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evidence:
<img width="494" height="241" alt="image" src="https://github.com/user-attachments/assets/1fdc20fa-87a0-46ce-82fe-5ae053a04118" />
