### PR TITLE
fix(claude): tear down the whole process tree when a Claude turn is cancelled

### DIFF
--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -22,7 +22,7 @@ import logging
 from claude_agent_sdk import AssistantMessage, PermissionResultAllow, PermissionResultDeny, TextBlock, ToolResultBlock, ToolUseBlock, UserMessage, create_sdk_mcp_server, ClaudeAgentOptions, ClaudeSDKClient, tool
 from anthropic.types.text_block import TextBlock as AnthropicTextBlock
 
-from notebook_intelligence.util import ThreadSafeWebSocketConnector, _emit, get_jupyter_root_dir, resolve_claude_cli_path, safe_jupyter_path
+from notebook_intelligence.util import ThreadSafeWebSocketConnector, _emit, get_jupyter_root_dir, resolve_claude_cli_path, safe_jupyter_path, terminate_process_tree
 
 log = logging.getLogger(__name__)
 
@@ -848,12 +848,26 @@ class ClaudeCodeClient():
                 if nbi_request_obj is not None and nbi_request_obj.cancel_token.is_cancel_requested:
                     try:
                         process: Process = self._client._transport._process
-                        process.kill()
+                        # Tear down the whole process tree, not just the Claude CLI
+                        # child: the agent may have spawned shells, MCP servers, and
+                        # dev servers that a bare child-only kill would orphan. The
+                        # teardown (SIGTERM, grace, then SIGKILL on survivors) runs on
+                        # a background thread so this cancel returns immediately; the
+                        # reconnect on the next request spawns a fresh client and
+                        # subprocess that share no state with the dying tree.
+                        pid = process.pid if process is not None else None
+                        if pid:
+                            threading.Thread(
+                                target=terminate_process_tree,
+                                args=(pid,),
+                                name="nbi-claude-cancel-teardown",
+                                daemon=True,
+                            ).start()
 
                         self._reconnect_required = True
                         self._continue_conversation = True
                     except Exception as e:
-                        log.error(f"Error occurred while setting current request and response to None: {str(e)}")
+                        log.error(f"Error tearing down Claude subprocess on cancel: {str(e)}")
                     if self._reconnect_required:
                         self._mark_as_disconnected()
                     return {

--- a/notebook_intelligence/util.py
+++ b/notebook_intelligence/util.py
@@ -2,9 +2,12 @@
 
 import os
 import base64
+import logging
 import re
 import shutil
+import signal
 import subprocess
+import time
 from pathlib import Path
 from typing import Optional, Set
 from cryptography.hazmat.primitives import hashes
@@ -12,6 +15,13 @@ from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from cryptography.fernet import Fernet
 import asyncio
 from tornado import ioloop
+
+try:
+    import psutil
+except ImportError:  # psutil is optional; we degrade to a single-process kill
+    psutil = None
+
+log = logging.getLogger(__name__)
 
 _jupyter_root_dir: str = None
 _enabled_tools: Set[str] = None
@@ -121,6 +131,100 @@ def invalidate_cli_cache(name: Optional[str] = None) -> None:
         _cached_cli_paths.clear()
     else:
         _cached_cli_paths.pop(name, None)
+
+
+# Seconds to wait after SIGTERM before escalating to SIGKILL during teardown.
+_TEARDOWN_GRACE_SECONDS = 3.0
+
+
+def _signal_proc(proc, *, force: bool) -> None:
+    """Signal one psutil process, swallowing the races that are expected here."""
+    try:
+        proc.kill() if force else proc.terminate()
+    except psutil.NoSuchProcess:
+        pass
+    except psutil.AccessDenied as e:
+        log.warning("No permission to signal pid %s during teardown: %s", proc.pid, e)
+
+
+def terminate_process_tree(
+    pid: Optional[int], grace_seconds: float = _TEARDOWN_GRACE_SECONDS
+) -> None:
+    """Terminate ``pid`` and every descendant, gracefully then forcefully.
+
+    Sends SIGTERM to the whole tree, waits up to ``grace_seconds`` for exits,
+    then SIGKILLs any survivors. This tears down an agent subprocess along with
+    everything it spawned (shells, MCP servers, dev servers) that a bare
+    child-only kill would orphan.
+
+    Signals are sent per-PID, never to a process group: the agent subprocess is
+    spawned inside this server's own process group, so a group signal would also
+    hit the Jupyter server. Safe to call with a missing or already-dead pid.
+    Without psutil only ``pid`` itself is terminated (descendants can't be
+    discovered), which still adds a graceful step over a bare SIGKILL.
+
+    Never raises: this is run fire-and-forget from a background thread, so any
+    unexpected failure is logged rather than propagated.
+    """
+    if not pid or pid <= 0:
+        return
+
+    if psutil is None:
+        _terminate_pid_without_psutil(pid, grace_seconds)
+        return
+
+    try:
+        try:
+            parent = psutil.Process(pid)
+        except psutil.NoSuchProcess:
+            return
+
+        # Snapshot descendants before signalling: once the parent dies its
+        # children are reparented to init and the tree linkage is lost.
+        try:
+            procs = parent.children(recursive=True)
+        except psutil.NoSuchProcess:
+            procs = []
+        procs.append(parent)
+
+        for proc in procs:
+            _signal_proc(proc, force=False)
+
+        _, alive = psutil.wait_procs(procs, timeout=max(0.0, grace_seconds))
+        for proc in alive:
+            _signal_proc(proc, force=True)
+        if alive:
+            psutil.wait_procs(alive, timeout=max(0.0, grace_seconds))
+    except Exception:
+        log.exception("Failed to terminate process tree for pid %s", pid)
+
+
+def _terminate_pid_without_psutil(pid: int, grace_seconds: float) -> None:
+    """Graceful kill of a single pid for the rare environment without psutil.
+
+    Cannot discover descendants, so this only improves on a bare SIGKILL by
+    adding a SIGTERM grace period; grandchildren may still be orphaned. This
+    path is POSIX-shaped: on Windows ``os.kill`` routes any signal through
+    TerminateProcess, so the SIGTERM grace and the SIGKILL escalation collapse
+    into a single hard kill (still terminates ``pid``, just not gracefully).
+    """
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except (ProcessLookupError, OSError):
+        return
+    deadline = time.monotonic() + max(0.0, grace_seconds)
+    while time.monotonic() < deadline:
+        try:
+            os.kill(pid, 0)  # probe: raises once the process is gone
+        except OSError:
+            return
+        time.sleep(0.05)
+    sigkill = getattr(signal, "SIGKILL", None)  # absent on Windows
+    if sigkill is not None:
+        try:
+            os.kill(pid, sigkill)
+        except (ProcessLookupError, OSError):
+            pass
 
 
 def resolve_github_token() -> Optional[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,12 @@ dependencies = [
     "mcp>=1.27.0",
     "claude-agent-sdk",
     "anthropic>=0.22.1",
+    # Used to tear down an agent subprocess and its descendants (shells, MCP
+    # servers, dev servers) on cancel; see util.terminate_process_tree. Already
+    # present transitively via jupyterlab -> ipykernel, but the cancel teardown
+    # depends on it for first-class behavior, so the contract is made explicit.
+    # >=5.7 matches ipykernel's floor and covers the API used.
+    "psutil>=5.7",
     # Transitive lower bounds for known CVEs whose parents don't pin
     # tightly enough on their own.
     "mistune>=3.2.1",  # CVE-2026-33441

--- a/tests/test_process_tree_teardown.py
+++ b/tests/test_process_tree_teardown.py
@@ -1,0 +1,189 @@
+"""Tests for util.terminate_process_tree.
+
+These spawn real process trees and assert the whole tree is reaped, that a
+SIGTERM-ignoring process is escalated to SIGKILL, and that the no-psutil
+fallback still works. psutil is used by the tests themselves to inspect and
+clean up processes (it is a declared test dependency).
+"""
+
+import os
+import signal
+import subprocess
+import sys
+import time
+
+import psutil
+import pytest
+
+import notebook_intelligence.util as util
+
+# A child that ignores SIGTERM, so only SIGKILL can stop it. It prints a line
+# once the handler is installed so the test can wait for readiness rather than
+# racing a fixed sleep.
+IGNORE_TERM_SRC = (
+    "import signal, time, sys\n"
+    "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+    "print('ready', flush=True)\n"
+    "time.sleep(120)\n"
+)
+
+# A parent that spawns N long-sleeping children and then sleeps itself.
+PARENT_SRC = (
+    "import subprocess, sys, time\n"
+    "kids = [subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(120)'])"
+    " for _ in range({n})]\n"
+    "time.sleep(120)\n"
+)
+
+# A three-level tree: parent -> child -> grandchild. Exercises the recursive
+# descendant discovery (a grandchild a non-recursive walk would miss).
+GRANDPARENT_SRC = (
+    "import subprocess, sys, time\n"
+    "subprocess.Popen([sys.executable, '-c',\n"
+    "    'import subprocess, sys, time;'\n"
+    "    'subprocess.Popen([sys.executable, \"-c\", \"import time; time.sleep(120)\"]);'\n"
+    "    'time.sleep(120)'])\n"
+    "time.sleep(120)\n"
+)
+
+
+def _alive(pid: int) -> bool:
+    """True if pid exists and is not a reaped/zombie corpse."""
+    try:
+        return psutil.Process(pid).status() != psutil.STATUS_ZOMBIE
+    except psutil.NoSuchProcess:
+        return False
+
+
+def _assert_dead(pid: int, timeout: float = 3.0) -> None:
+    """Poll until pid is gone/zombie. SIGKILL delivery is asynchronous, so a
+    process can still read as RUNNING for a moment after the signal is sent."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _alive(pid):
+            return
+        time.sleep(0.05)
+    assert not _alive(pid), f"pid {pid} survived teardown"
+
+
+@pytest.fixture
+def spawn():
+    """Spawn-and-track helper that force-cleans any survivors after each test."""
+    procs = []
+
+    def _spawn(src, **kwargs):
+        p = subprocess.Popen([sys.executable, "-c", src], **kwargs)
+        procs.append(p)
+        return p
+
+    yield _spawn
+
+    for p in procs:
+        try:
+            tree = psutil.Process(p.pid).children(recursive=True)
+        except psutil.NoSuchProcess:
+            tree = []
+        for proc in tree:
+            try:
+                proc.kill()
+            except psutil.Error:
+                pass
+        try:
+            p.kill()
+        except OSError:
+            pass
+        try:
+            p.wait(timeout=2)
+        except Exception:
+            pass
+
+
+def _wait_for_children(parent_pid, n, timeout=5.0):
+    parent = psutil.Process(parent_pid)
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        kids = parent.children(recursive=True)
+        if len(kids) >= n:
+            return kids
+        time.sleep(0.05)
+    return parent.children(recursive=True)
+
+
+class TestTerminateProcessTree:
+    def test_terminates_parent_and_all_descendants(self, spawn):
+        p = spawn(PARENT_SRC.format(n=3))
+        kids = _wait_for_children(p.pid, 3)
+        assert len(kids) >= 3, "child processes did not start"
+        pids = [p.pid] + [k.pid for k in kids]
+
+        util.terminate_process_tree(p.pid, grace_seconds=3.0)
+
+        for pid in pids:
+            _assert_dead(pid)
+
+    def test_terminates_deep_tree_including_grandchildren(self, spawn):
+        p = spawn(GRANDPARENT_SRC)
+        # parent -> child -> grandchild, so at least two descendants exist.
+        descendants = _wait_for_children(p.pid, 2)
+        assert len(descendants) >= 2, "deep tree did not start"
+        # Capture every pid up front: once the parent dies the tree linkage is
+        # gone, so an orphaned grandchild could not be rediscovered by walking.
+        pids = [p.pid] + [d.pid for d in descendants]
+
+        try:
+            util.terminate_process_tree(p.pid, grace_seconds=3.0)
+            for pid in pids:
+                _assert_dead(pid)
+        finally:
+            # Guarantee no real process leaks even if an assertion above fails.
+            for pid in pids:
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                except OSError:
+                    pass
+
+    def test_escalates_to_sigkill_when_sigterm_ignored(self, spawn):
+        p = spawn(IGNORE_TERM_SRC, stdout=subprocess.PIPE, text=True)
+        assert p.stdout.readline().strip() == "ready"
+        assert _alive(p.pid)
+
+        start = time.monotonic()
+        util.terminate_process_tree(p.pid, grace_seconds=1.0)
+        elapsed = time.monotonic() - start
+
+        _assert_dead(p.pid)
+        # It must have waited out the grace window before forcing the kill,
+        # proving the escalation path (not just a lucky SIGTERM) ran.
+        assert elapsed >= 1.0
+
+    def test_missing_pid_is_noop(self, spawn):
+        p = spawn("pass")
+        p.wait()
+        # Already exited (and reaped); must not raise.
+        util.terminate_process_tree(p.pid, grace_seconds=0.5)
+
+    def test_none_and_invalid_pids_are_noops(self):
+        util.terminate_process_tree(None)
+        util.terminate_process_tree(0)
+        util.terminate_process_tree(-5)
+
+
+class TestNoPsutilFallback:
+    def test_fallback_terminates_process(self, spawn, monkeypatch):
+        monkeypatch.setattr(util, "psutil", None)
+        p = spawn("import time; time.sleep(120)")
+        time.sleep(0.2)
+        assert _alive(p.pid)
+
+        util.terminate_process_tree(p.pid, grace_seconds=1.0)
+
+        _assert_dead(p.pid)
+
+    def test_fallback_escalates_to_sigkill(self, spawn, monkeypatch):
+        monkeypatch.setattr(util, "psutil", None)
+        p = spawn(IGNORE_TERM_SRC, stdout=subprocess.PIPE, text=True)
+        assert p.stdout.readline().strip() == "ready"
+
+        util.terminate_process_tree(p.pid, grace_seconds=1.0)
+
+        _assert_dead(p.pid)


### PR DESCRIPTION
## Summary

Cancelling an in-flight Claude turn only killed the direct `claude` CLI child. Anything the agent had spawned (shells, MCP servers, dev servers) was reparented to init and leaked, accumulating across cancels and restarts. This makes cancel tear down the whole process tree the agent created, gracefully then forcefully.

The cancel path previously did a bare child-only `process.kill()` (an instant SIGKILL of just the CLI):

```python
process = self._client._transport._process
process.kill()
```

## Solution

`claude-agent-sdk` spawns the CLI via `anyio.open_process(...)` with **no** `start_new_session`, so the child runs inside this server's own process group. A process-group kill (`killpg`) would therefore also signal the Jupyter server, so that approach is off the table.

Instead, a new `util.terminate_process_tree(pid, grace_seconds)`:

- enumerates the child plus all descendants via `psutil` (snapshotting the tree **before** signalling, since once the parent dies its children reparent and the linkage is lost),
- sends SIGTERM to the whole set, waits a grace period, then SIGKILLs any survivors,
- signals **per-PID, never a process group**, so it can never reach the server,
- is safe on a missing/already-dead pid, and never raises (failures are logged, since it runs fire-and-forget).

The cancel handler reads the child pid and runs the teardown on a background daemon thread, so cancel still returns immediately; the reconnect on the next request spawns a fresh client and subprocess that share no state with the dying tree.

`psutil` is promoted from a test-only to a runtime dependency. It is already present transitively via `jupyterlab -> ipykernel`, but the teardown depends on it for full-tree behavior, so the contract is made explicit. A graceful single-process fallback covers environments without it.

## Testing

New `tests/test_process_tree_teardown.py` spawns **real** process trees and asserts:

- the whole tree is reaped, including a **depth-3 grandchild** (which actually exercises recursive descendant discovery, not just direct children),
- a SIGTERM-ignoring child is escalated to SIGKILL after the grace window,
- missing / `None` / invalid pids are no-ops,
- the no-psutil fallback (psutil monkeypatched to `None`) still terminates the target and escalates.

Tests use readiness-via-stdout (not fixed sleeps), zombie-aware liveness, and a force-clean fixture; verified stable across repeated runs with no leaked processes. Full gates green: `pytest` 1100 passed, `jlpm tsc --noEmit`, `jlpm lint:check`, `jlpm jest` (328) all clean.

## Risks / follow-ups

- **Scope:** this is the independently-shippable, low-risk core of the cancel-teardown improvement. Reconciling in-flight tool-call state and pending permission prompts on cancel is deliberately left out (it depends on other in-flight work) and can follow separately.
- **Daemonized grandchildren:** a descendant that double-forks into its own session before the snapshot escapes a per-PID tree walk (as it would any non-`killpg` approach). The common targets (shells, MCP servers, foreground dev servers) stay in the subtree and are caught.
- **Possible follow-ups, not included to keep this focused:** sending SIGINT before SIGTERM to the parent CLI for a cleaner transcript flush on resume; cleaning up the worker thread that is left parked after a cancel (a pre-existing condition, not introduced here).