### PR TITLE
feat(chat): inline diffs, grouping, and unified tool maps for tool-call cards

### DIFF
--- a/notebook_intelligence/api.py
+++ b/notebook_intelligence/api.py
@@ -230,6 +230,8 @@ class ToolCallData(ResponseStreamData):
     title: str = ''
     kind: str = 'other'
     status: str = 'in_progress'
+    # Inline before/after edits for file-edit tools; empty/None otherwise.
+    diffs: list = None
 
     @property
     def data_type(self) -> ResponseStreamDataType:

--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -1,6 +1,7 @@
 # Copyright (c) Mehmet Bektas <mbektasgh@outlook.com>
 
 import json
+import difflib
 import os
 import sys
 import asyncio
@@ -9,7 +10,7 @@ from pathlib import Path
 from queue import Queue
 import threading
 import time
-from typing import Any
+from typing import Any, Optional
 import uuid
 import re
 from anyio.abc import Process
@@ -90,41 +91,61 @@ CLAUDE_AGENT_CLIENT_UPDATE_WAIT_TIME = float(os.getenv("NBI_CLAUDE_AGENT_CLIENT_
 CLAUDE_AGENT_CONNECT_TIMEOUT = float(os.getenv("NBI_CLAUDE_AGENT_CONNECT_TIMEOUT", "15"))
 CLAUDE_AGENT_HEARTBEAT_INTERVAL = float(os.getenv("NBI_CLAUDE_AGENT_HEARTBEAT_INTERVAL", "20"))
 
-# Human-readable labels for tool calls surfaced through the chat sidebar's
-# progress indicator. The keys are the SDK tool names — NBI's MCP tools
-# use the kebab-case @tool decorator names; Claude's built-ins keep their
-# CamelCase identifiers. Unknown names fall through `humanize_claude_tool_name`
-# to a generic kebab→sentence conversion rather than masking the raw name.
-_CLAUDE_TOOL_LABELS: dict[str, str] = {
+# Single source of truth for tool-call presentation: SDK tool name ->
+# (label, kind). `label` is the short human-readable progress label; `kind`
+# is the coarse card-icon category (read / edit / execute / other). NBI's MCP
+# tools use the kebab-case @tool decorator names; Claude's built-ins keep
+# their CamelCase identifiers. Unknown names fall through to a sentence-case
+# label and a keyword-heuristic kind rather than masking the raw name.
+_CLAUDE_TOOLS: dict[str, tuple[str, str]] = {
     # NBI's MCP toolset (defined in this file via @tool(...))
-    "create-new-notebook": "Creating notebook",
-    "rename-notebook": "Renaming notebook",
-    "add-markdown-cell": "Adding markdown cell",
-    "add-code-cell": "Adding code cell",
-    "get-number-of-cells": "Reading notebook",
-    "get-cell-type-and-source": "Reading cell",
-    "get-cell-output": "Reading cell output",
-    "set-cell-type-and-source": "Editing cell",
-    "delete-cell": "Deleting cell",
-    "insert-cell": "Inserting cell",
-    "run-cell": "Running cell",
-    "save-notebook": "Saving notebook",
-    "run-command-in-jupyter-terminal": "Running shell command",
-    "open-file-in-jupyter-ui": "Opening file",
+    "create-new-notebook": ("Creating notebook", "edit"),
+    "rename-notebook": ("Renaming notebook", "edit"),
+    "add-markdown-cell": ("Adding markdown cell", "edit"),
+    "add-code-cell": ("Adding code cell", "edit"),
+    "get-number-of-cells": ("Reading notebook", "read"),
+    "get-cell-type-and-source": ("Reading cell", "read"),
+    "get-cell-output": ("Reading cell output", "read"),
+    "set-cell-type-and-source": ("Editing cell", "edit"),
+    "delete-cell": ("Deleting cell", "edit"),
+    "insert-cell": ("Inserting cell", "edit"),
+    "run-cell": ("Running cell", "execute"),
+    "save-notebook": ("Saving notebook", "edit"),
+    "run-command-in-jupyter-terminal": ("Running shell command", "execute"),
+    "open-file-in-jupyter-ui": ("Opening file", "read"),
     # Claude's built-in toolset
-    "Bash": "Running shell command",
-    "Read": "Reading file",
-    "Write": "Writing file",
-    "Edit": "Editing file",
-    "MultiEdit": "Editing file",
-    "NotebookEdit": "Editing notebook cell",
-    "Glob": "Searching files",
-    "Grep": "Searching contents",
-    "WebFetch": "Fetching URL",
-    "WebSearch": "Searching web",
-    "Task": "Spawning subagent",
-    "TodoWrite": "Updating task list",
+    "Bash": ("Running shell command", "execute"),
+    "Read": ("Reading file", "read"),
+    "Write": ("Writing file", "edit"),
+    "Edit": ("Editing file", "edit"),
+    "MultiEdit": ("Editing file", "edit"),
+    "NotebookEdit": ("Editing notebook cell", "edit"),
+    "Glob": ("Searching files", "read"),
+    "Grep": ("Searching contents", "read"),
+    "WebFetch": ("Fetching URL", "read"),
+    "WebSearch": ("Searching web", "read"),
+    "Task": ("Spawning subagent", "other"),
+    "TodoWrite": ("Updating task list", "other"),
 }
+
+
+def _inner_tool_name(name: str) -> str:
+    """Unwrap an MCP tool name (``mcp__<server>__<tool>``) to its inner tool."""
+    if name.startswith("mcp__"):
+        parts = name.split("__")
+        if len(parts) >= 3:
+            return parts[-1]
+    return name
+
+
+def _lookup_tool(name: str) -> Optional[tuple[str, str]]:
+    """Return (label, kind) for a known tool, unwrapping MCP names; else None."""
+    if name in _CLAUDE_TOOLS:
+        return _CLAUDE_TOOLS[name]
+    inner = _inner_tool_name(name)
+    if inner != name and inner in _CLAUDE_TOOLS:
+        return _CLAUDE_TOOLS[inner]
+    return None
 
 
 def humanize_claude_tool_name(name: str) -> str:
@@ -134,73 +155,29 @@ def humanize_claude_tool_name(name: str) -> str:
     tools still surface something the user can read rather than a bare
     kebab-case identifier.
     """
-    if name in _CLAUDE_TOOL_LABELS:
-        return _CLAUDE_TOOL_LABELS[name]
-    # MCP server tools come through as `mcp__<server>__<tool>` — strip
-    # the wrapper before falling back so we don't surface protocol noise.
-    inner = name
-    if name.startswith("mcp__"):
-        parts = name.split("__")
-        if len(parts) >= 3:
-            inner = parts[-1]
-            if inner in _CLAUDE_TOOL_LABELS:
-                return _CLAUDE_TOOL_LABELS[inner]
-    pretty = inner.replace("-", " ").replace("_", " ").strip()
+    entry = _lookup_tool(name)
+    if entry is not None:
+        return entry[0]
+    pretty = _inner_tool_name(name).replace("-", " ").replace("_", " ").strip()
     if not pretty:
         return name
     return pretty[:1].upper() + pretty[1:]
-
-
-# Coarse category per tool, used only to pick a tool-call card icon.
-_CLAUDE_TOOL_KINDS: dict[str, str] = {
-    "create-new-notebook": "edit",
-    "rename-notebook": "edit",
-    "add-markdown-cell": "edit",
-    "add-code-cell": "edit",
-    "get-number-of-cells": "read",
-    "get-cell-type-and-source": "read",
-    "get-cell-output": "read",
-    "set-cell-type-and-source": "edit",
-    "delete-cell": "edit",
-    "insert-cell": "edit",
-    "run-cell": "execute",
-    "save-notebook": "edit",
-    "run-command-in-jupyter-terminal": "execute",
-    "open-file-in-jupyter-ui": "read",
-    "Bash": "execute",
-    "Read": "read",
-    "Write": "edit",
-    "Edit": "edit",
-    "MultiEdit": "edit",
-    "NotebookEdit": "edit",
-    "Glob": "read",
-    "Grep": "read",
-    "WebFetch": "read",
-    "WebSearch": "read",
-    "Task": "other",
-    "TodoWrite": "other",
-}
 
 
 def claude_tool_kind(name: str) -> str:
     """Coarse category for a tool call (``read`` / ``edit`` / ``execute`` /
     ``other``), used only to choose a card icon.
 
-    Mirrors ``humanize_claude_tool_name``: known names map directly,
-    ``mcp__server__tool`` unwraps to its inner name, and anything left over
-    falls back to a keyword heuristic so unfamiliar MCP tools still get a
-    sensible icon rather than always landing on ``other``.
+    Known names map directly (unwrapping ``mcp__server__tool``); anything left
+    over falls back to a whole-token keyword heuristic so unfamiliar MCP tools
+    still get a sensible icon rather than always landing on ``other``.
     """
-    inner = name
-    if name.startswith("mcp__"):
-        parts = name.split("__")
-        if len(parts) >= 3:
-            inner = parts[-1]
-    if inner in _CLAUDE_TOOL_KINDS:
-        return _CLAUDE_TOOL_KINDS[inner]
+    entry = _lookup_tool(name)
+    if entry is not None:
+        return entry[1]
     # Tokenize so a verb is matched as a whole word, not a substring: "widget"
     # must not read as "get", and "command" must not read as "and".
-    tokens = {t for t in re.split(r"[^a-z0-9]+", inner.lower()) if t}
+    tokens = {t for t in re.split(r"[^a-z0-9]+", _inner_tool_name(name).lower()) if t}
     if tokens & {"bash", "run", "exec", "execute", "shell", "terminal", "command"}:
         return "execute"
     if tokens & {"write", "edit", "create", "add", "insert", "delete", "remove",
@@ -210,6 +187,83 @@ def claude_tool_kind(name: str) -> str:
                  "view", "open", "show", "find"}:
         return "read"
     return "other"
+
+
+# Cap the diff lines surfaced per tool-call card so a large edit doesn't bloat
+# the transcript or the wire payload.
+_MAX_DIFF_LINES = 60
+
+
+def _diff_lines(old: str, new: str, max_lines: int = _MAX_DIFF_LINES) -> tuple[list[dict], bool]:
+    """Line-level diff of ``old`` -> ``new`` as typed lines for a card.
+
+    Returns ``(lines, truncated)``. Each line is
+    ``{"type": "add"|"remove"|"context", "content": str}``; the list is capped
+    at ``max_lines`` so a huge edit stays compact.
+    """
+    old_lines = (old or "").splitlines()
+    new_lines = (new or "").splitlines()
+    lines: list[dict] = []
+    for raw in difflib.unified_diff(old_lines, new_lines, lineterm="", n=1):
+        if raw.startswith(("---", "+++", "@@")):
+            continue
+        if raw.startswith("+"):
+            lines.append({"type": "add", "content": raw[1:]})
+        elif raw.startswith("-"):
+            lines.append({"type": "remove", "content": raw[1:]})
+        else:
+            lines.append({"type": "context", "content": raw[1:] if raw[:1] == " " else raw})
+    truncated = len(lines) > max(0, max_lines)
+    return lines[: max(0, max_lines)], truncated
+
+
+def extract_tool_diffs(name: str, tool_input: Any) -> list[dict]:
+    """Extract inline diffs from a file-edit tool's input.
+
+    Handles Claude's Edit / Write / MultiEdit (including MCP-wrapped names).
+    Returns a list of ``{"path", "lines", "truncated"}`` entries; empty for
+    tools that aren't file edits or whose input lacks the expected fields.
+    """
+    if not isinstance(tool_input, dict):
+        return []
+    inner = _inner_tool_name(name)
+    raw_diffs: list[tuple[str, str, str]] = []  # (path, old, new)
+    if inner == "Edit":
+        raw_diffs.append((
+            tool_input.get("file_path", ""),
+            tool_input.get("old_string", ""),
+            tool_input.get("new_string", ""),
+        ))
+    elif inner == "Write":
+        raw_diffs.append((
+            tool_input.get("file_path", ""),
+            "",
+            tool_input.get("content", ""),
+        ))
+    elif inner == "MultiEdit":
+        path = tool_input.get("file_path", "")
+        for edit in tool_input.get("edits", []) or []:
+            if isinstance(edit, dict):
+                raw_diffs.append((
+                    path,
+                    edit.get("old_string", ""),
+                    edit.get("new_string", ""),
+                ))
+
+    # Budget the line cap across ALL diffs in the card, not per diff, so a
+    # MultiEdit with many edits can't blow up the payload.
+    out: list[dict] = []
+    remaining = _MAX_DIFF_LINES
+    for path, old, new in raw_diffs:
+        if remaining <= 0:
+            if out:
+                out[-1]["truncated"] = True
+            break
+        lines, truncated = _diff_lines(old, new, max_lines=remaining)
+        if lines:
+            out.append({"path": path, "lines": lines, "truncated": truncated})
+            remaining -= len(lines)
+    return out
 
 
 _current_request = None
@@ -759,7 +813,7 @@ class ClaudeCodeClient():
                                 # back can re-emit the same card with a final
                                 # status. Lifetime is one query — pops entries
                                 # on completion so the dict stays bounded.
-                                in_flight_tools: dict[str, tuple[str, str]] = {}
+                                in_flight_tools: dict[str, tuple[str, str, list]] = {}
                                 async for message in client.receive_response():
                                     if request.cancel_token.is_cancel_requested:
                                         # Stop iterating once the user cancels — we'd
@@ -774,12 +828,14 @@ class ClaudeCodeClient():
                                             elif isinstance(block, ToolUseBlock):
                                                 title = humanize_claude_tool_name(block.name)
                                                 kind = claude_tool_kind(block.name)
-                                                in_flight_tools[block.id] = (title, kind)
+                                                diffs = extract_tool_diffs(block.name, block.input)
+                                                in_flight_tools[block.id] = (title, kind, diffs)
                                                 response.stream(ToolCallData(
                                                     id=block.id,
                                                     title=title,
                                                     kind=kind,
                                                     status='in_progress',
+                                                    diffs=diffs,
                                                 ))
                                     elif isinstance(message, UserMessage):
                                         if isinstance(message.content, str):
@@ -807,13 +863,14 @@ class ClaudeCodeClient():
                                                     )
                                                     if entry is None:
                                                         continue
-                                                    title, kind = entry
+                                                    title, kind, diffs = entry
                                                     status = 'failed' if block.is_error else 'completed'
                                                     response.stream(ToolCallData(
                                                         id=block.tool_use_id,
                                                         title=title,
                                                         kind=kind,
                                                         status=status,
+                                                        diffs=diffs,
                                                     ))
                                     else:
                                         pass
@@ -826,12 +883,13 @@ class ClaudeCodeClient():
                                 # 'cancelled' rather than leaving a perpetual
                                 # spinner in the transcript.
                                 if request.cancel_token.is_cancel_requested and in_flight_tools:
-                                    for tool_id, (title, kind) in in_flight_tools.items():
+                                    for tool_id, (title, kind, diffs) in in_flight_tools.items():
                                         response.stream(ToolCallData(
                                             id=tool_id,
                                             title=title,
                                             kind=kind,
                                             status='cancelled',
+                                            diffs=diffs,
                                         ))
                                     in_flight_tools.clear()
                         except Exception as e:

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -2040,7 +2040,8 @@ class WebsocketCopilotResponseEmitter(ChatResponse):
                                     "id": data.id,
                                     "title": data.title,
                                     "kind": data.kind,
-                                    "status": data.status
+                                    "status": data.status,
+                                    "diffs": data.diffs or []
                                 }
                             },
                             "content": "",

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -80,7 +80,7 @@ import { mcpServerSettingsToEnabledState } from './components/mcp-util';
 import claudeSvgStr from '../style/icons/claude.svg';
 import { AskUserQuestion } from './components/ask-user-question';
 import { ClaudeSessionPicker } from './components/claude-session-picker';
-import { ToolCallCard } from './components/tool-call-card';
+import { ToolCallGroup } from './components/tool-call-group';
 import { upsertToolCallContent } from './tool-call-stream';
 import { TourOverlay } from './tour/tour-overlay';
 import { TOUR_ANCHOR } from './tour/tour-anchors';
@@ -718,6 +718,19 @@ function ChatResponse(props: any) {
       if (item.reasoningFinished) {
         lastItem.reasoningFinished = true;
       }
+    } else if (
+      item.type === ResponseStreamDataType.ToolCall &&
+      lastItemType === ResponseStreamDataType.ToolCall
+    ) {
+      // Bundle a run of consecutive tool calls into one group item so the
+      // renderer can collapse them; ToolCallGroup unwraps content.toolCalls.
+      const lastItem = groupedContents[groupedContents.length - 1];
+      lastItem.content.toolCalls.push(structuredClone(item.content));
+    } else if (item.type === ResponseStreamDataType.ToolCall) {
+      const grouped = structuredClone(item);
+      grouped.content = { toolCalls: [structuredClone(item.content)] };
+      groupedContents.push(grouped);
+      lastItemType = item.type;
     } else {
       groupedContents.push(structuredClone(item));
       lastItemType = item.type;
@@ -955,11 +968,14 @@ function ChatResponse(props: any) {
               ) : null;
             case ResponseStreamDataType.ToolCall:
               // Unlike Progress, tool-call cards persist after the turn ends,
-              // so they render regardless of `showGenerating`. The backend
-              // re-emits each call under the same id to flip its status, and
-              // the stream handler merges by id, so one card shows here.
+              // so they render regardless of `showGenerating`. The grouping
+              // pass bundled this run's calls into content.toolCalls; the
+              // group renders a single card or a collapsible group.
               return (
-                <ToolCallCard key={`key-${index}`} toolCall={item.content} />
+                <ToolCallGroup
+                  key={`key-${index}`}
+                  toolCalls={item.content.toolCalls}
+                />
               );
             case ResponseStreamDataType.Confirmation:
               return answeredForms.get(item.id) ===

--- a/src/components/tool-call-card.tsx
+++ b/src/components/tool-call-card.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
+  VscChevronDown,
+  VscChevronRight,
   VscClose,
   VscEdit,
   VscError,
@@ -10,11 +12,22 @@ import {
   VscTools
 } from '../icons';
 
+export interface IToolCallDiffLine {
+  type: 'add' | 'remove' | 'context' | string;
+  content: string;
+}
+
+export interface IToolCallDiff {
+  path: string;
+  lines: IToolCallDiffLine[];
+  truncated?: boolean;
+}
+
 /**
  * A single agent tool call surfaced as a persistent chat card. Mirrors the
  * `ToolCallData` payload emitted by the server: it stays in the transcript
  * after the turn ends and carries its final status, unlike the transient
- * single progress line it replaces.
+ * single progress line it replaces. File-edit tools also carry inline diffs.
  */
 export interface IToolCall {
   id: string;
@@ -22,6 +35,7 @@ export interface IToolCall {
   // Coarse category, used only to pick the leading icon.
   kind: 'read' | 'edit' | 'execute' | 'other' | string;
   status: 'in_progress' | 'completed' | 'failed' | 'cancelled' | string;
+  diffs?: IToolCallDiff[];
 }
 
 const KIND_ICONS: Record<string, React.FC<any>> = {
@@ -38,8 +52,51 @@ const STATUS_LABELS: Record<string, string> = {
   cancelled: 'cancelled'
 };
 
+const GUTTER: Record<string, string> = { add: '+', remove: '-' };
+
+function ToolCallDiffView(props: { diffs: IToolCallDiff[] }): JSX.Element {
+  return (
+    <div className="nbi-tool-call-diffs">
+      {props.diffs.map((diff, i) => (
+        <div className="nbi-tool-call-diff" key={i}>
+          {diff.path ? (
+            <div className="nbi-tool-call-diff-path" title={diff.path}>
+              {diff.path}
+            </div>
+          ) : null}
+          <div className="nbi-tool-call-diff-body">
+            {diff.lines.map((line, j) => (
+              <div
+                className={`nbi-tool-call-diff-line nbi-diff-${line.type}`}
+                key={j}
+              >
+                <span className="nbi-diff-gutter" aria-hidden="true">
+                  {GUTTER[line.type] ?? ' '}
+                </span>
+                {/* The +/- gutter is decorative; give screen readers the
+                    add/remove distinction as text instead. */}
+                {line.type === 'add' || line.type === 'remove' ? (
+                  <span className="nbi-sr-only">
+                    {line.type === 'add' ? 'added ' : 'removed '}
+                  </span>
+                ) : null}
+                <span className="nbi-diff-text">{line.content}</span>
+              </div>
+            ))}
+          </div>
+          {diff.truncated ? (
+            <div className="nbi-tool-call-diff-truncated">diff truncated</div>
+          ) : null}
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export function ToolCallCard(props: { toolCall: IToolCall }): JSX.Element {
-  const { title, kind, status } = props.toolCall;
+  const { title, kind, status, diffs } = props.toolCall;
+  const [expanded, setExpanded] = useState(true);
+
   const KindIcon = KIND_ICONS[kind] ?? VscTools;
 
   let StatusIcon = VscSync;
@@ -53,18 +110,37 @@ export function ToolCallCard(props: { toolCall: IToolCall }): JSX.Element {
 
   const statusLabel = STATUS_LABELS[status] ?? status;
   const statusModifier = status.replace(/_/g, '-');
+  const hasDiffs = Array.isArray(diffs) && diffs.length > 0;
 
   return (
-    <div className={`nbi-tool-call nbi-tool-call-${statusModifier}`}>
-      <KindIcon className="nbi-tool-call-kind-icon" aria-hidden="true" />
-      <span className="nbi-tool-call-title" title={title}>
-        {title}
-      </span>
-      <StatusIcon className="nbi-tool-call-status-icon" aria-hidden="true" />
-      {/* Status reaches screen readers as text; the icons are decorative.
-          The visible title is already in the accessibility tree, so this
-          span carries only the status to avoid announcing the title twice. */}
-      <span className="nbi-sr-only">{statusLabel}</span>
+    <div className="nbi-tool-call-wrapper">
+      <div className={`nbi-tool-call nbi-tool-call-${statusModifier}`}>
+        <KindIcon className="nbi-tool-call-kind-icon" aria-hidden="true" />
+        <span className="nbi-tool-call-title" title={title}>
+          {title}
+        </span>
+        {hasDiffs ? (
+          <button
+            type="button"
+            className="nbi-tool-call-diff-toggle"
+            onClick={() => setExpanded(e => !e)}
+            aria-expanded={expanded}
+            aria-label={expanded ? 'Hide diff' : 'Show diff'}
+          >
+            {expanded ? (
+              <VscChevronDown aria-hidden="true" />
+            ) : (
+              <VscChevronRight aria-hidden="true" />
+            )}
+          </button>
+        ) : null}
+        <StatusIcon className="nbi-tool-call-status-icon" aria-hidden="true" />
+        {/* Status reaches screen readers as text; the icons are decorative.
+            The visible title is already in the accessibility tree, so this
+            span carries only the status to avoid announcing the title twice. */}
+        <span className="nbi-sr-only">{statusLabel}</span>
+      </div>
+      {hasDiffs && expanded ? <ToolCallDiffView diffs={diffs!} /> : null}
     </div>
   );
 }

--- a/src/components/tool-call-group.tsx
+++ b/src/components/tool-call-group.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import { VscChevronDown, VscChevronRight } from '../icons';
+import { IToolCall, ToolCallCard } from './tool-call-card';
+
+// Groups with more calls than this start collapsed so a tool-heavy turn (or a
+// reloaded transcript) doesn't flood the chat. A live turn mounts the group at
+// length 1, so it starts expanded and stays visible as calls stream in.
+const GROUP_COLLAPSE_THRESHOLD = 3;
+
+/**
+ * Renders a run of consecutive tool calls. A single call is shown as a bare
+ * card; multiple calls are wrapped in one collapsible group with a summary
+ * header, so consecutive agent activity reads as one unit instead of a wall
+ * of rows.
+ */
+export function ToolCallGroup(props: { toolCalls: IToolCall[] }): JSX.Element {
+  const { toolCalls } = props;
+  // Hooks must run unconditionally and in a stable order: the group's length
+  // grows as calls stream in, so call useState before any length branch.
+  // Start collapsed only for a large group whose calls are all settled --
+  // never hide a still-running or failed call (matters on transcript reload,
+  // where a group can mount already large).
+  const [expanded, setExpanded] = useState(
+    () =>
+      toolCalls.length <= GROUP_COLLAPSE_THRESHOLD ||
+      toolCalls.some(t => t.status === 'in_progress' || t.status === 'failed')
+  );
+
+  if (toolCalls.length <= 1) {
+    return toolCalls.length === 1 ? (
+      <ToolCallCard toolCall={toolCalls[0]} />
+    ) : (
+      <></>
+    );
+  }
+
+  const failed = toolCalls.filter(t => t.status === 'failed').length;
+  const summary =
+    `${toolCalls.length} tool calls` + (failed ? ` (${failed} failed)` : '');
+
+  return (
+    <div className="nbi-tool-call-group">
+      <button
+        type="button"
+        className="nbi-tool-call-group-header"
+        onClick={() => setExpanded(e => !e)}
+        aria-expanded={expanded}
+      >
+        {expanded ? (
+          <VscChevronDown aria-hidden="true" />
+        ) : (
+          <VscChevronRight aria-hidden="true" />
+        )}
+        <span className="nbi-tool-call-group-summary">{summary}</span>
+      </button>
+      {expanded ? (
+        <div className="nbi-tool-call-group-body">
+          {toolCalls.map(toolCall => (
+            <ToolCallCard key={toolCall.id} toolCall={toolCall} />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/style/base.css
+++ b/style/base.css
@@ -893,12 +893,16 @@ pre:has(.code-block-header) {
   word-break: break-word;
 }
 
+/* Semi-transparent tints rather than the solid --jp-*-color3 fills (which are
+   light pastels in BOTH themes): the tint sits over the card background so the
+   line stays readable with the theme's own (light-on-dark / dark-on-light)
+   text color instead of forcing dark text onto a pale fill. */
 .nbi-diff-add {
-  background-color: var(--jp-success-color3);
+  background-color: rgb(64 160 43 / 22%);
 }
 
 .nbi-diff-remove {
-  background-color: var(--jp-error-color3);
+  background-color: rgb(248 81 73 / 22%);
 }
 
 .nbi-diff-context {

--- a/style/base.css
+++ b/style/base.css
@@ -780,12 +780,15 @@ pre:has(.code-block-header) {
   margin-top: 2px;
 }
 
+.nbi-tool-call-wrapper {
+  margin: 2px 0;
+}
+
 .nbi-tool-call {
   display: flex;
   align-items: center;
   gap: 6px;
   padding: 3px 6px;
-  margin: 2px 0;
   border-radius: 4px;
   background-color: var(--jp-layout-color2);
   font-size: var(--jp-ui-font-size1);
@@ -835,6 +838,105 @@ pre:has(.code-block-header) {
   .nbi-tool-call-in-progress .nbi-tool-call-status-icon {
     animation: none;
   }
+}
+
+.nbi-tool-call-diff-toggle {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--jp-ui-font-color2);
+  cursor: pointer;
+}
+
+.nbi-tool-call-diffs {
+  margin: 2px 0 2px 18px;
+  padding-left: 6px;
+  border-left: 2px solid var(--jp-border-color2);
+}
+
+.nbi-tool-call-diff + .nbi-tool-call-diff {
+  margin-top: 4px;
+}
+
+.nbi-tool-call-diff-path {
+  overflow: hidden;
+  font-size: var(--jp-ui-font-size0);
+  color: var(--jp-ui-font-color2);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.nbi-tool-call-diff-body {
+  margin: 2px 0;
+  overflow-x: auto;
+  font-family: var(--jp-code-font-family);
+  font-size: var(--jp-code-font-size);
+  line-height: 1.4;
+}
+
+.nbi-tool-call-diff-line {
+  display: flex;
+}
+
+.nbi-diff-gutter {
+  flex-shrink: 0;
+  width: 1ch;
+  user-select: none;
+  text-align: center;
+}
+
+.nbi-diff-text {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.nbi-diff-add {
+  background-color: var(--jp-success-color3);
+}
+
+.nbi-diff-remove {
+  background-color: var(--jp-error-color3);
+}
+
+.nbi-diff-context {
+  color: var(--jp-ui-font-color2);
+}
+
+.nbi-tool-call-diff-truncated {
+  font-size: var(--jp-ui-font-size0);
+  font-style: italic;
+  color: var(--jp-ui-font-color2);
+}
+
+.nbi-tool-call-group {
+  margin: 2px 0;
+}
+
+.nbi-tool-call-group-header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  padding: 2px 4px;
+  border: none;
+  background: none;
+  color: var(--jp-ui-font-color2);
+  font-size: var(--jp-ui-font-size0);
+  text-align: left;
+  cursor: pointer;
+}
+
+.nbi-tool-call-group-summary {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.nbi-tool-call-group-body {
+  margin-left: 6px;
 }
 
 .user-input-autocomplete,

--- a/tests/test_claude_tool_humanizer.py
+++ b/tests/test_claude_tool_humanizer.py
@@ -19,7 +19,11 @@ at the integration level rather than here.
 """
 
 from notebook_intelligence.api import ResponseStreamDataType, ToolCallData
-from notebook_intelligence.claude import claude_tool_kind, humanize_claude_tool_name
+from notebook_intelligence.claude import (
+    claude_tool_kind,
+    extract_tool_diffs,
+    humanize_claude_tool_name,
+)
 
 
 class TestHumanizeClaudeToolName:
@@ -106,6 +110,91 @@ class TestClaudeToolKind:
     def test_unrecognized_tool_falls_back_to_other(self):
         assert claude_tool_kind("frobnicate") == "other"
         assert claude_tool_kind("") == "other"
+
+
+class TestExtractToolDiffs:
+    def test_edit_yields_remove_and_add_lines(self):
+        diffs = extract_tool_diffs(
+            "Edit",
+            {"file_path": "a.py", "old_string": "x = 1", "new_string": "x = 2"},
+        )
+        assert len(diffs) == 1
+        assert diffs[0]["path"] == "a.py"
+        types = {line["type"] for line in diffs[0]["lines"]}
+        assert "remove" in types and "add" in types
+        assert diffs[0]["truncated"] is False
+
+    def test_write_is_all_additions(self):
+        diffs = extract_tool_diffs(
+            "Write", {"file_path": "new.py", "content": "line1\nline2"}
+        )
+        assert len(diffs) == 1
+        assert [line["type"] for line in diffs[0]["lines"]] == ["add", "add"]
+        assert [line["content"] for line in diffs[0]["lines"]] == ["line1", "line2"]
+
+    def test_multiedit_yields_one_diff_per_edit(self):
+        diffs = extract_tool_diffs(
+            "MultiEdit",
+            {
+                "file_path": "a.py",
+                "edits": [
+                    {"old_string": "a", "new_string": "b"},
+                    {"old_string": "c", "new_string": "d"},
+                ],
+            },
+        )
+        assert len(diffs) == 2
+        assert all(d["path"] == "a.py" for d in diffs)
+
+    def test_mcp_wrapped_edit_is_unwrapped(self):
+        diffs = extract_tool_diffs(
+            "mcp__srv__Edit",
+            {"file_path": "a.py", "old_string": "a", "new_string": "b"},
+        )
+        assert len(diffs) == 1
+
+    def test_non_edit_tool_has_no_diffs(self):
+        assert extract_tool_diffs("Read", {"file_path": "a.py"}) == []
+        assert extract_tool_diffs("Bash", {"command": "ls"}) == []
+
+    def test_non_dict_input_is_safe(self):
+        assert extract_tool_diffs("Edit", None) == []
+        assert extract_tool_diffs("Edit", "not a dict") == []
+
+    def test_large_edit_is_truncated(self):
+        big = "\n".join(f"line {i}" for i in range(500))
+        diffs = extract_tool_diffs(
+            "Write", {"file_path": "big.py", "content": big}
+        )
+        assert diffs[0]["truncated"] is True
+        assert len(diffs[0]["lines"]) <= 60
+
+    def test_context_lines_are_classified_and_stripped(self):
+        # A change surrounded by shared lines yields context lines whose
+        # content must not keep the diff's leading marker space.
+        diffs = extract_tool_diffs(
+            "Edit",
+            {"file_path": "a.py", "old_string": "a\nx\nc", "new_string": "a\ny\nc"},
+        )
+        lines = diffs[0]["lines"]
+        context = [ln for ln in lines if ln["type"] == "context"]
+        assert context, "expected at least one context line"
+        assert all(not ln["content"].startswith(" ") for ln in context)
+        assert {"a", "c"} <= {ln["content"] for ln in context}
+
+    def test_total_diff_lines_capped_across_multiedit(self):
+        # Many edits, each large: the cap is across the whole card, not per edit.
+        big = "\n".join(f"x{i}" for i in range(100))
+        diffs = extract_tool_diffs(
+            "MultiEdit",
+            {
+                "file_path": "a.py",
+                "edits": [{"old_string": "", "new_string": big} for _ in range(5)],
+            },
+        )
+        total = sum(len(d["lines"]) for d in diffs)
+        assert total <= 60
+        assert diffs[-1]["truncated"] is True
 
 
 class TestToolCallData:

--- a/tests/ts/tool-call-card.test.tsx
+++ b/tests/ts/tool-call-card.test.tsx
@@ -1,6 +1,23 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { ToolCallCard } from '../../src/components/tool-call-card';
+
+const editToolCall = {
+  id: 'e1',
+  title: 'Editing file',
+  kind: 'edit',
+  status: 'completed',
+  diffs: [
+    {
+      path: 'src/a.py',
+      lines: [
+        { type: 'remove', content: 'x = 1' },
+        { type: 'add', content: 'x = 2' }
+      ],
+      truncated: false
+    }
+  ]
+};
 
 describe('ToolCallCard', () => {
   it('renders the title and an in-progress status', () => {
@@ -110,5 +127,54 @@ describe('ToolCallCard', () => {
     // Icons are decorative; status reaches screen readers via the sr-only text.
     expect(kindIcon).toHaveAttribute('aria-hidden', 'true');
     expect(statusIcon).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('renders an inline diff with add/remove lines and the path', () => {
+    const { container } = render(<ToolCallCard toolCall={editToolCall} />);
+    expect(screen.getByText('src/a.py')).toBeInTheDocument();
+    expect(container.querySelector('.nbi-diff-remove')).toHaveTextContent(
+      'x = 1'
+    );
+    expect(container.querySelector('.nbi-diff-add')).toHaveTextContent('x = 2');
+  });
+
+  it('collapses and expands the diff via the toggle', () => {
+    const { container } = render(<ToolCallCard toolCall={editToolCall} />);
+    // Default expanded.
+    expect(container.querySelector('.nbi-tool-call-diffs')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Hide diff' }));
+    expect(
+      container.querySelector('.nbi-tool-call-diffs')
+    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Show diff' }));
+    expect(container.querySelector('.nbi-tool-call-diffs')).toBeInTheDocument();
+  });
+
+  it('shows a truncation marker when the diff was truncated', () => {
+    render(
+      <ToolCallCard
+        toolCall={{
+          ...editToolCall,
+          diffs: [{ ...editToolCall.diffs[0], truncated: true }]
+        }}
+      />
+    );
+    expect(screen.getByText('diff truncated')).toBeInTheDocument();
+  });
+
+  it('shows no diff toggle when there are no diffs', () => {
+    render(
+      <ToolCallCard
+        toolCall={{
+          id: 'r',
+          title: 'Reading file',
+          kind: 'read',
+          status: 'completed'
+        }}
+      />
+    );
+    expect(
+      screen.queryByRole('button', { name: /diff/ })
+    ).not.toBeInTheDocument();
   });
 });

--- a/tests/ts/tool-call-group.test.tsx
+++ b/tests/ts/tool-call-group.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ToolCallGroup } from '../../src/components/tool-call-group';
+
+function calls(n: number, status = 'completed') {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `t${i}`,
+    title: `Tool ${i}`,
+    kind: 'read',
+    status
+  }));
+}
+
+describe('ToolCallGroup', () => {
+  it('renders a single call as a bare card with no group header', () => {
+    const { container } = render(<ToolCallGroup toolCalls={calls(1)} />);
+    expect(container.querySelector('.nbi-tool-call')).toBeInTheDocument();
+    expect(
+      container.querySelector('.nbi-tool-call-group-header')
+    ).not.toBeInTheDocument();
+  });
+
+  it('wraps multiple calls in a group with a count summary', () => {
+    render(<ToolCallGroup toolCalls={calls(3)} />);
+    expect(screen.getByText('3 tool calls')).toBeInTheDocument();
+  });
+
+  it('starts expanded for a small group and toggles closed', () => {
+    const { container } = render(<ToolCallGroup toolCalls={calls(3)} />);
+    expect(container.querySelectorAll('.nbi-tool-call')).toHaveLength(3);
+    fireEvent.click(screen.getByRole('button'));
+    expect(container.querySelectorAll('.nbi-tool-call')).toHaveLength(0);
+  });
+
+  it('starts collapsed for a large group (over the threshold)', () => {
+    const { container } = render(<ToolCallGroup toolCalls={calls(5)} />);
+    expect(container.querySelectorAll('.nbi-tool-call')).toHaveLength(0);
+    expect(screen.getByText('5 tool calls')).toBeInTheDocument();
+    // Expanding reveals all cards.
+    fireEvent.click(screen.getByRole('button'));
+    expect(container.querySelectorAll('.nbi-tool-call')).toHaveLength(5);
+  });
+
+  it('stays stable and expanded as the group grows from 1 across rerenders', () => {
+    // A live turn mounts the group at length 1 and grows it; useState runs
+    // before the length<=1 early return, so the hook order must stay stable
+    // (a violation would throw "rendered more/fewer hooks").
+    const { container, rerender } = render(
+      <ToolCallGroup toolCalls={calls(1)} />
+    );
+    expect(
+      container.querySelector('.nbi-tool-call-group-header')
+    ).not.toBeInTheDocument();
+
+    expect(() => {
+      rerender(<ToolCallGroup toolCalls={calls(2)} />);
+      rerender(<ToolCallGroup toolCalls={calls(4)} />);
+    }).not.toThrow();
+
+    // It became a group and, having mounted small (expanded), stays expanded
+    // even though it grew past the collapse threshold.
+    expect(
+      container.querySelector('.nbi-tool-call-group-header')
+    ).toBeInTheDocument();
+    expect(container.querySelectorAll('.nbi-tool-call')).toHaveLength(4);
+  });
+
+  it('starts expanded when a large group still has an in-progress call', () => {
+    const live = [...calls(4, 'completed'), ...calls(1, 'in_progress')].map(
+      (c, i) => ({ ...c, id: `u${i}` })
+    );
+    const { container } = render(<ToolCallGroup toolCalls={live} />);
+    // 5 calls (> threshold) would normally start collapsed, but the pending
+    // call forces it open so activity isn't hidden.
+    expect(container.querySelectorAll('.nbi-tool-call')).toHaveLength(5);
+  });
+
+  it('surfaces a failed count in the summary', () => {
+    const mixed = [
+      { id: 'a', title: 'A', kind: 'read', status: 'completed' },
+      { id: 'b', title: 'B', kind: 'read', status: 'completed' },
+      { id: 'c', title: 'C', kind: 'edit', status: 'failed' }
+    ];
+    render(<ToolCallGroup toolCalls={mixed} />);
+    expect(screen.getByText('3 tool calls (1 failed)')).toBeInTheDocument();
+  });
+});

--- a/tests/ts/tool-call-stream.test.ts
+++ b/tests/ts/tool-call-stream.test.ts
@@ -51,6 +51,44 @@ describe('upsertToolCallContent', () => {
     expect(contents.map(c => c.content.id)).toEqual(['a', 'b']);
   });
 
+  it('preserves diffs carried on the completed emission', () => {
+    // The merge replaces content wholesale, so the backend must re-emit diffs
+    // on completion; this pins that contract from the frontend side.
+    const contents: IToolCallStreamItem[] = [];
+    const diffs = [
+      {
+        path: 'a.py',
+        lines: [{ type: 'add', content: 'x = 2' }],
+        truncated: false
+      }
+    ];
+    upsertToolCallContent(
+      contents,
+      {
+        id: 'a',
+        title: 'Editing file',
+        kind: 'edit',
+        status: 'in_progress',
+        diffs
+      },
+      created
+    );
+    upsertToolCallContent(
+      contents,
+      {
+        id: 'a',
+        title: 'Editing file',
+        kind: 'edit',
+        status: 'completed',
+        diffs
+      },
+      created
+    );
+    expect(contents).toHaveLength(1);
+    expect(contents[0].content.status).toBe('completed');
+    expect(contents[0].content.diffs).toEqual(diffs);
+  });
+
   it('does not merge into a non-tool-call item that shares the id', () => {
     // A Markdown item that happens to carry a matching id must not be treated
     // as the tool call's card; the type guard prevents that.


### PR DESCRIPTION
## Summary

A follow-up to the tool-call cards (#358), bundling the three improvements that PR deferred:

1. **Inline diffs** for file-edit tools.
2. **Collapsible grouping** of consecutive tool calls.
3. **Unifying** the two tool label/kind maps into one source of truth.

All three are verified end-to-end in a real Claude-mode turn (screenshots below).

---

A single "2 tool calls" group: a completed "Reading file" card + an in-progress "Editing file" card with the inline diff.
 <img width="316" height="704" alt="improve-01-diff-and-group" src="https://github.com/user-attachments/assets/93918bcc-fce7-44c4-b21c-835243276ca9" />

---

A collapsed group (header only, cards hidden).
<img width="1400" height="900" alt="improve-02-group-collapsed" src="https://github.com/user-attachments/assets/0734c916-18ec-4aef-971e-531fd2199949" />

---

The headline shot: two groups ("4 tool calls" + "2 tool calls") with three inline diffs across config.py / greet.py / meta.py, mid-turn.
<img width="316" height="754" alt="improve-03-multi-edit-diffs" src="https://github.com/user-attachments/assets/bd44b5bb-f63d-4071-8334-f6ec8545db16" />

---

The completed state: the "2 tool calls" group with two green-check completed edit cards (diffs persist after completion) and the agent's summary.
<img width="316" height="755" alt="improve-04-completed" src="https://github.com/user-attachments/assets/b17734c9-0449-403c-a456-b07325b63b6c" />

---

The "4 tool calls" group expanded, showing 3 Reads + 1 completed Edit-with-diff, above the second group.
<img width="316" height="755" alt="improve-05-group-expanded" src="https://github.com/user-attachments/assets/61ee0439-f89d-41a2-9879-63c216d80689" />

## Inline diffs

Edit / Write / MultiEdit (and MCP-wrapped variants) now carry a before/after diff. The server computes a compact line diff with `difflib` (`extract_tool_diffs`), and the card renders it inline: red removed lines, green added lines, the file path, and a per-card collapse toggle.

- **Bounded payload:** the diff is capped at a **total** of 60 lines across the whole card (not per-edit), so a many-edit MultiEdit can't bloat the wire/transcript.
- **Persistence:** diffs are derived from the tool input at call start and re-emitted on completion, so the merge-by-id (which replaces card content wholesale) keeps them. There's a frontend test pinning that contract.
- **a11y:** the `+`/`-` gutter is decorative; screen readers get the add/remove distinction as text. Add/remove is conveyed by shape (gutter) and color, not color alone.
- **Reuse note:** this deliberately does *not* embed Monaco (`InlineDiffViewerComponent`) — a read-only CSS line-diff is the proportionate tool for a compact, static, persistent card, and avoids mounting N Monaco editors in a scrolling transcript.

## Grouping

A run of consecutive tool calls is bundled into one collapsible group with an "N tool calls" summary (and a failed count when relevant). Bundling happens in the render-time `groupedContents` pass, downstream of the id-merge, so the wire contract is unchanged.

- A group starts collapsed **only** when it is large *and* all its calls are settled, so a live turn (which mounts the group at length 1) stays visible, and a reloaded large group never hides a still-running or failed call.
- `ToolCallGroup` calls `useState` before its `length <= 1` early return so the hook order stays stable as the group grows from 1 to N during streaming (covered by a grow-from-1 rerender test).

## Unify maps

`_CLAUDE_TOOL_LABELS` and `_CLAUDE_TOOL_KINDS` (two parallel dicts with identical keysets, a drift risk) are merged into one `_CLAUDE_TOOLS` name → `(label, kind)` with shared `_inner_tool_name` / `_lookup_tool` helpers. Behavior is unchanged; the existing humanize/kind tests pass as-is.

## Testing

- **pytest:** `extract_tool_diffs` (Edit/Write/MultiEdit, mcp-unwrap, non-edit, non-dict, per-card total truncation, context-line classification + stripping); map-unify parity via the existing humanize/kind tests.
- **jest:** card diff render / collapse / truncation / no-diff; `ToolCallGroup` single-vs-group, summary, collapse threshold, **grow-from-1 hook stability**, force-expand on in-progress; `upsertToolCallContent` **preserves diffs across the merge**.
- Full gates green: `pytest` 1173, `jlpm tsc --noEmit`, `jlpm lint:check`, `jlpm jest` 351.
- **Visual verification (Playwright):** asked the agent to edit a file in Claude mode and confirmed the diff card (red/green, path, toggle) rendered inside a collapsible "2 tool calls" group; the diff persisted after the edit completed; and collapsing the group hid the cards. Screenshots: `improve-01-diff-and-group.png`, `improve-02-group-collapsed.png` (in the repo root; gh can't upload images, so drag them into this description if you'd like them inline).

## Risks / follow-ups (deferred to keep this focused)

- Extract a shared chevron-toggle component (the collapse pattern appears in both the card diff toggle and the group header).
- Extract the `groupedContents` bundling into a pure, unit-testable helper (like the prior `upsertToolCallContent` extraction).
- Emit diffs once (on the in-progress emission) and have the merge preserve them, instead of re-emitting on completion. The total cap already bounds the cost, so this is a minor optimization.
- Inline diffs currently cover Claude's Edit/Write/MultiEdit; NBI's MCP cell-edit tools (which expose only new content) could show an additions-only diff in a later pass.