### PR TITLE
style(chat): replace expandable-content inner glow with a flat fill

### DIFF
--- a/style/base.css
+++ b/style/base.css
@@ -1561,12 +1561,17 @@ button.send-button:disabled:active:not(.send-button-stop) {
 .expandable-content-text {
   display: none;
   margin: 5px;
-  padding: 0 5px;
-  border: 1px solid var(--jp-border-color2);
-  border-radius: 5px;
+  padding: 8px 10px;
+  border-radius: 6px;
   max-height: 200px;
   overflow-y: auto;
-  box-shadow: inset 0 0 15px 15px rgb(23 23 23 / 50%);
+  background-color: var(--jp-layout-color2);
+}
+
+/* Inline code also fills with --jp-layout-color2, which now matches this box's
+   fill; recess nested code to --jp-layout-color1 so it stays distinct. */
+.expandable-content-text :not(pre) > code {
+  background-color: var(--jp-layout-color1);
 }
 
 .expandable-content .collapsed-icon {


### PR DESCRIPTION
## Summary

The collapsible **Parameters**, **reasoning/thinking**, and **Markdown-detail** boxes in the chat sidebar (all `.expandable-content-text`) used a hardcoded, non-theme-aware inset shadow:

```css
box-shadow: inset 0 0 15px 15px rgb(23 23 23 / 50%);
```

That rendered as a muddy dark gradient glow inside the box, darker at the edges than the center. This replaces it with a flat filled surface.

## Change

```css
.expandable-content-text {
  /* was: padding 0 5px; border 1px var(--jp-border-color2); border-radius 5px;
     box-shadow: inset 0 0 15px 15px rgb(23 23 23 / 50%); */
  padding: 8px 10px;
  border-radius: 6px;
  background-color: var(--jp-layout-color2);
}
```

- **Filled, no border, no shadow** (`--jp-layout-color2`), which reads as a clean raised panel in both light and dark themes and follows the existing `color2`-over-`color1` elevation convention already used elsewhere in this stylesheet.
- Padding bumped `0 5px` → `8px 10px` for breathing room.
- **Nested code recess:** inline `code` also fills with `--jp-layout-color2`, so code inside the box is recessed to `--jp-layout-color1` to stay visually distinct from the fill (otherwise inline code in a reasoning block would go flat-on-flat).

## Testing

- `jlpm lint:check` (stylelint + prettier + eslint) green. No TS/Python touched, so tsc/jest/pytest are unaffected.
- **Visual verification (Playwright):** triggered a tool call in Claude mode and confirmed the Parameters box now renders as an even, flat filled panel with the glow gone, in the running app. (Theme correctness in light is variable-driven: `--jp-layout-color2` is a slightly-darker raised surface on the light `--jp-layout-color1` background, mirroring the dark behavior.)

## Out of scope (flagging for a decision)

While auditing, I found the inline-prompt widget uses two hardcoded purple haze glows that are the same visual family but on a different component:

- `.inline-prompt-widget-floating` — `box-shadow: rgba(90 76 191 / 30%) 0 0 10px 10px;` (base.css ~1462)
- `.inline-prompt-widget-inline` — `box-shadow: rgba(90 76 191 / 25%) 0 0 4px 1px;` (~1470)

These weren't part of the approved change (which was specifically the expandable-content boxes), so I left them alone. Happy to clean those up in a follow-up if you want them gone too.