### PR TITLE
fix(chat): keep the response message id stable so the tool-call group stops flickering

### DIFF
--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -971,9 +971,16 @@ function ChatResponse(props: any) {
               // so they render regardless of `showGenerating`. The grouping
               // pass bundled this run's calls into content.toolCalls; the
               // group renders a single card or a collapsible group.
+              //
+              // Key by the group item's own id (assigned once when the run's
+              // first call streamed in) so the group's identity follows its
+              // content, not its array position. An index key would remount the
+              // group (re-running its collapse heuristic) if anything were ever
+              // inserted ahead of it; belt-and-suspenders with the stable
+              // message key that is the primary #363 fix.
               return (
                 <ToolCallGroup
-                  key={`key-${index}`}
+                  key={item.id}
                   toolCalls={item.content.toolCalls}
                 />
               );
@@ -2929,6 +2936,12 @@ function SidebarComponent(props: any) {
       : null;
     const extractedPrompt = submitPrompt;
     const contents: IChatMessageContent[] = [];
+    // One id for this turn's response message, reused on every streamed delta.
+    // setChatMessages rebuilds the message object per delta; a fresh id each
+    // time changes its React key and remounts the whole response subtree,
+    // which re-runs ToolCallGroup's collapse heuristic and flickers the group
+    // open/closed as calls stream in (issue #363).
+    const responseMessageId = UUID.uuid4();
     const app = props.getApp();
     const additionalContext: IContextItem[] = [];
     let currentFileUsesWholeDocument = false;
@@ -3152,7 +3165,7 @@ function SidebarComponent(props: any) {
           setChatMessages([
             ...newList,
             {
-              id: UUID.uuid4(),
+              id: responseMessageId,
               date: new Date(),
               from: 'copilot',
               contents: contents,
@@ -3480,6 +3493,10 @@ function SidebarComponent(props: any) {
       }
 
       const contents: IChatMessageContent[] = [];
+      // Stable id for this turn's response message; see the matching note in
+      // handleUserInputSubmit. Reused on every delta so the message keeps one
+      // React key and the response subtree is not remounted each chunk (#363).
+      const responseMessageId = UUID.uuid4();
 
       submitCompletionRequest(request, {
         emit: async response => {
@@ -3589,11 +3606,10 @@ function SidebarComponent(props: any) {
           if (hideInChat) {
             return;
           }
-          const messageId = UUID.uuid4();
           setChatMessages([
             ...newList,
             {
-              id: messageId,
+              id: responseMessageId,
               date: new Date(),
               from: 'copilot',
               contents: contents,

--- a/tests/ts/tool-call-group.test.tsx
+++ b/tests/ts/tool-call-group.test.tsx
@@ -65,6 +65,26 @@ describe('ToolCallGroup', () => {
     expect(container.querySelectorAll('.nbi-tool-call')).toHaveLength(4);
   });
 
+  it('stays expanded when its calls settle on a persistent instance (no self-collapse)', () => {
+    // Guards the component contract the #363 fix relies on: a group that
+    // mounted expanded must not collapse itself when its calls later settle
+    // (the collapsed-default heuristic runs only at mount, never on update).
+    // The remount that actually caused the flicker is fixed in the sidebar
+    // render (stable message and group keys) and is verified live, not here --
+    // rerender keeps this same instance mounted, the post-fix steady state.
+    const live = [...calls(3, 'completed'), ...calls(1, 'in_progress')].map(
+      (c, i) => ({ ...c, id: `s${i}` })
+    );
+    const { container, rerender } = render(<ToolCallGroup toolCalls={live} />);
+    expect(container.querySelectorAll('.nbi-tool-call')).toHaveLength(4);
+
+    const settled = live.map(c => ({ ...c, status: 'completed' }));
+    rerender(<ToolCallGroup toolCalls={settled} />);
+    // 4 settled calls (> threshold) would start collapsed on a fresh mount;
+    // this instance mounted expanded and must not collapse itself.
+    expect(container.querySelectorAll('.nbi-tool-call')).toHaveLength(4);
+  });
+
   it('starts expanded when a large group still has an in-progress call', () => {
     const live = [...calls(4, 'completed'), ...calls(1, 'in_progress')].map(
       (c, i) => ({ ...c, id: `u${i}` })


### PR DESCRIPTION
## Summary

The tool-call group shown during a streaming Claude turn would expand and collapse on its own as calls arrived (#363). The group is the collapsible wrapper introduced in #360; in 5.1.0a1 it visibly flickers open and closed while the agent is still working.

## Solution

The flicker is a remount, forced from above the group. On every websocket delta both streaming handlers rebuild the assistant message object with a fresh `id: UUID.uuid4()`, and that id is the message's React key (`key={msg.id}`). A new key each delta makes React unmount and remount the entire `ChatResponse` subtree, so `ToolCallGroup` is torn down and recreated each chunk. Its collapse default is seeded by a mount-time `useState` heuristic (`length <= 3 || some call in progress`), so re-seeding it against a tool list whose length and status are still changing flips the group open and closed.

The load-bearing change is to allocate one response-message id per turn (`const responseMessageId = UUID.uuid4()`) in each streaming handler and reuse it on every delta. The message then keeps a constant key and React reconciles it in place instead of remounting, so the group's `expanded` state persists for the turn. As defense in depth, the group is now keyed by its own content id (`item.id`, the first call's stable id) rather than its array index, so its identity follows its content.

## Testing

- `jlpm tsc --noEmit`, `jlpm lint:check`, `jlpm jest` (352 passing), and `pytest` (1173 passing) all green.
- Added a unit test pinning the component contract the fix relies on: a group that mounted expanded does not collapse itself when its calls later settle past the threshold (the collapse heuristic runs only at mount). The remount itself lives in the sidebar render, so it is verified live rather than in the component unit.
- Verified live in JupyterLab by instrumenting the group's DOM node identity, its React key, and `aria-expanded` across a multi-call turn:
  - Before: the group's DOM node was replaced on essentially every delta (a fresh node each update) and `aria-expanded` flipped `true`/`false` as calls streamed in and settled.
  - After: a single stable node and a stable message key for the whole turn, `aria-expanded` stays `true` through streaming and at completion, and manual collapse/expand still works.

## Risks / follow-ups

Behavior is unchanged apart from removing the remount: messages still get unique keys, feedback/telemetry/cancellation key off unrelated ids, and the reload-collapse declutter for large settled groups is preserved. A few pre-existing items are left out of scope to keep this focused: some array children in the response map are still keyed by index (React key warnings), `groupedContents` is deep-cloned per render, and the two handlers key streamed markdown parts slightly differently. Happy to take any of these as a separate change if useful.

Closes #363
