### PR TITLE
docs: document the duplicate-sidebar-icon issue from the scope rename (#367)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ For each release we list user-facing changes grouped as **Added**, **Changed**, 
 
 5.1.0 builds on 5.0.x with a focus on Claude-mode agent visibility. Tool calls the agent runs now render as persistent status cards with inline diffs and collapsible grouping, the generating indicator can cycle custom verbs, and cancelling a turn tears down the whole process tree the agent spawned instead of leaking it. It also adds two opt-in security guardrails (an MCP stdio-command allowlist and a default-token-password check on shared filesystems) and an always-visible mode for chat feedback. No traitlet, env-var, REST route, or on-disk-format renames or removals; every new admin surface is opt-in and listed below.
 
+### Upgrade note
+
+If you installed NBI before the 5.0 npm-scope rename (from `@notebook-intelligence/notebook-intelligence` to `@plmbr/notebook-intelligence`) and now see **two Notebook Intelligence icons** in the sidebar, an old labextension is lingering alongside the new one and JupyterLab is loading both. Run `jupyter labextension list`; if both scopes show as enabled, remove the stale `@notebook-intelligence` labextension directory. See [Two Notebook Intelligence icons in the sidebar](docs/troubleshooting.md#two-notebook-intelligence-icons-in-the-sidebar) (#367).
+
 ### Added
 
 - **Claude agent tool calls render as persistent status cards** (#358). Each tool the agent runs in Claude mode appears as its own card showing a kind icon (read / edit / execute / other), a humanized label, and a live status (in progress, completed, failed, cancelled) that stays on screen after the turn ends instead of scrolling away as transient progress text. Built-in and `mcp__<server>__<tool>` names map to friendly labels, with a sentence-case fallback for unknown tools.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -20,6 +20,25 @@ pip install --force-reinstall notebook-intelligence   # if the labextension is m
 
 The chat sidebar appears as a left-rail icon in the JupyterLab UI. Click it to open the panel.
 
+## "Two Notebook Intelligence icons in the sidebar"
+
+Seeing two NBI sidebar tabs with the same sparkle icon means two copies of the labextension are loaded at once. This happens after upgrading across the package rename: the labextension was renamed from `@notebook-intelligence/notebook-intelligence` to `@plmbr/notebook-intelligence` in the 5.0 line, and an upgrade installs the new one but can leave the old one behind. JupyterLab then loads both, and each registers its own sidebar tab.
+
+Confirm it:
+
+```bash
+jupyter labextension list
+```
+
+If both `@notebook-intelligence/notebook-intelligence` and `@plmbr/notebook-intelligence` are listed as enabled, the first is the stale duplicate. Remove its directory (its path is shown in the list), checking both your environment prefix and the per-user location:
+
+```bash
+rm -rf <prefix>/share/jupyter/labextensions/@notebook-intelligence
+rm -rf ~/.local/share/jupyter/labextensions/@notebook-intelligence
+```
+
+Restart JupyterLab and hard-refresh the browser; only `@plmbr/notebook-intelligence` should remain. If you would rather not delete files, `jupyter labextension disable @notebook-intelligence/notebook-intelligence` stops JupyterLab from loading the old extension reversibly. Note that `pip uninstall` does not remove the stale directory on its own, because the old labextension is no longer tracked by the current package.
+
 ## "GitHub login window doesn't open" or Copilot login does nothing
 
 NBI uses GitHub's device-flow login. The server extension prints the URL and one-time code to the JupyterLab terminal. Look there first.


### PR DESCRIPTION
## Summary

Documents the "two Notebook Intelligence sidebar icons" issue (#367). Upgrading across the 5.0 npm-scope rename (from `@notebook-intelligence/notebook-intelligence` to `@plmbr/notebook-intelligence`) can leave the old labextension installed next to the new one. The two have distinct plugin ids, so JupyterLab loads both federated extensions and each registers its own sidebar tab, producing the duplicate icon.

## Changes

- **`docs/troubleshooting.md`**: a new "Two Notebook Intelligence icons in the sidebar" entry with the confirm step (`jupyter labextension list`) and the fix (remove the stale `@notebook-intelligence` labextension directory, checking both the env prefix and the per-user location), plus a reversible `jupyter labextension disable` alternative.
- **`CHANGELOG.md`**: a short "Upgrade note" in the 5.1.0 entry pointing at the troubleshooting section.

This is a docs-only change; there is no code fix, since the duplicate is an environmental leftover from the rename rather than an extension bug.

## Notes

- A companion callout in the 5.1.0 release blog post is in #366 (gh-pages).
- This was originally pushed onto the already-merged #365 branch by mistake; this PR re-bases it onto current `main`.

Refs #367
