### PR TITLE
fix(claude): don't time out a turn while it waits on a slow tool approval

### DIFF
--- a/notebook_intelligence/api.py
+++ b/notebook_intelligence/api.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import time
 from typing import Any, Callable, Dict, Union, Optional
 from dataclasses import asdict, dataclass
 from enum import Enum
@@ -309,6 +310,24 @@ class ChatResponse:
         self._user_input_signal: SignalImpl = SignalImpl()
         self._run_ui_command_response_signal: SignalImpl = SignalImpl()
         self.participant_id = ''
+        # Cumulative wall-clock seconds spent blocked on a user reply (tool
+        # approval, plan confirm, AskUserQuestion), plus the start of any wait
+        # currently in progress. Consumers subtract this from a response
+        # timeout so a slow human approval isn't mistaken for an unresponsive
+        # agent, which previously timed out the turn and wedged the next one
+        # (issue #381).
+        self._user_input_wait_total = 0.0
+        self._user_input_wait_started = None
+
+    @property
+    def user_input_wait_seconds(self) -> float:
+        """Total time this response has spent awaiting user input, including
+        any wait still in progress."""
+        total = self._user_input_wait_total
+        started = self._user_input_wait_started
+        if started is not None:
+            total += time.time() - started
+        return total
 
     @property
     def message_id(self) -> str:
@@ -335,12 +354,19 @@ class ChatResponse:
                 resp["data"] = data['data']
 
         response.user_input_signal.connect(_on_user_input)
+        response._user_input_wait_started = time.time()
 
-        while True:
-            if resp["data"] is not None:
-                response.user_input_signal.disconnect(_on_user_input)
-                return resp["data"]
-            await asyncio.sleep(0.1)
+        try:
+            while True:
+                if resp["data"] is not None:
+                    return resp["data"]
+                await asyncio.sleep(0.1)
+        finally:
+            response.user_input_signal.disconnect(_on_user_input)
+            started = response._user_input_wait_started
+            if started is not None:
+                response._user_input_wait_total += time.time() - started
+                response._user_input_wait_started = None
 
     async def run_ui_command(self, command: str, args: dict = {}) -> None:
         raise NotImplementedError

--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -1175,6 +1175,12 @@ class ClaudeCodeClient():
 
         start_time = time.time()
         last_heartbeat = start_time
+        # Time the agent spends blocked on a tool approval (or any user input)
+        # must not count toward the response timeout: a slow human reply isn't
+        # an unresponsive agent. Without this, a long approval wait timed out
+        # the turn and left the worker mid-request, wedging later prompts
+        # (issue #381).
+        response_obj = event_args.get("response") if event_args else None
 
         try:
             while True:
@@ -1227,7 +1233,10 @@ class ClaudeCodeClient():
                         "success": False,
                         "error": "Claude agent is not running",
                     }
-                if time.time() - start_time > CLAUDE_AGENT_CLIENT_RESPONSE_TIMEOUT:
+                elapsed = time.time() - start_time
+                if response_obj is not None:
+                    elapsed -= response_obj.user_input_wait_seconds
+                if elapsed > CLAUDE_AGENT_CLIENT_RESPONSE_TIMEOUT:
                     return {
                         "data": None,
                         "success": False,

--- a/notebook_intelligence/extension.py
+++ b/notebook_intelligence/extension.py
@@ -2632,11 +2632,21 @@ class WebsocketCopilotHandler(WebSocketMixin, websocket.WebSocketHandler, Jupyte
             handlers.cancel_token.cancel_request()
  
     def on_close(self):
-        # Drop any handler entries whose worker threads outlive the
-        # websocket connection. The thread wrapper would clean these up
-        # on its own once the coro returns, but a long-running request
-        # left in-flight at disconnect would otherwise pin its emitter
-        # and cancel token for the lifetime of the worker.
+        # Cancel any requests still in flight at disconnect, then drop their
+        # handlers. Clearing alone isn't enough: a turn parked on a tool
+        # approval no longer self-resolves via the response timeout (the
+        # approval wait is excluded from it, #381), so without an explicit
+        # cancel its worker thread and the Claude subprocess would spin until
+        # the server restarts. Cancelling makes the poll loop tear the
+        # subprocess down and return.
+        # Snapshot first: a worker thread finishing its request pops its own
+        # entry (see _run_request_thread), which would otherwise raise
+        # "dictionary changed size during iteration" here on the IOLoop thread.
+        for handlers in list(self._messageCallbackHandlers.values()):
+            try:
+                handlers.cancel_token.cancel_request()
+            except Exception as e:
+                log.warning(f"Error cancelling in-flight request on close: {e}")
         self._messageCallbackHandlers.clear()
 
     async def handle_inline_completions(prefix, suffix, language, filename, response_emitter, cancel_token):

--- a/tests/test_user_input_wait.py
+++ b/tests/test_user_input_wait.py
@@ -1,0 +1,79 @@
+"""Regression coverage for the user-input wait accounting on ChatResponse.
+
+#381: a tool approval that the user takes a long time to confirm used to
+count toward the Claude response timeout, so a slow human reply timed out the
+turn and left the worker mid-request, wedging the next prompt. ChatResponse now
+tracks the time it spends blocked on user input so the timeout can exclude it.
+"""
+
+import asyncio
+import time
+
+from notebook_intelligence.api import ChatResponse
+
+
+class _Response(ChatResponse):
+    @property
+    def message_id(self) -> str:
+        return "msg-1"
+
+    def stream(self, data, finish: bool = False) -> None:
+        pass
+
+    def finish(self) -> None:
+        pass
+
+
+class TestUserInputWaitSeconds:
+    def test_starts_at_zero(self):
+        assert _Response().user_input_wait_seconds == 0.0
+
+    def test_counts_a_wait_in_progress(self):
+        resp = _Response()
+        resp._user_input_wait_started = time.time() - 5
+        assert resp.user_input_wait_seconds >= 5
+
+    def test_accumulates_completed_waits(self):
+        resp = _Response()
+        resp._user_input_wait_total = 12.0
+        # No wait in progress -> just the accumulated total.
+        assert resp.user_input_wait_seconds == 12.0
+        # A wait in progress adds on top of the accumulated total.
+        resp._user_input_wait_started = time.time() - 3
+        assert resp.user_input_wait_seconds >= 15
+
+
+class TestWaitForChatUserInput:
+    def _drive(self, confirmed_after: float):
+        resp = _Response()
+
+        async def run():
+            task = asyncio.create_task(
+                ChatResponse.wait_for_chat_user_input(resp, "cb-1")
+            )
+            await asyncio.sleep(confirmed_after)
+            resp.on_user_input({"callback_id": "cb-1", "data": {"confirmed": True}})
+            return await task
+
+        result = asyncio.run(run())
+        return resp, result
+
+    def test_records_wait_time_and_clears_in_progress(self):
+        resp, result = self._drive(0.25)
+        assert result == {"confirmed": True}
+        # The wait was accounted for ...
+        assert resp.user_input_wait_seconds >= 0.2
+        # ... and is no longer in progress, so the value is now stable.
+        assert resp._user_input_wait_started is None
+        first = resp.user_input_wait_seconds
+        time.sleep(0.05)
+        assert resp.user_input_wait_seconds == first
+
+    def test_disconnects_listener_after_answer(self):
+        resp, _ = self._drive(0.05)
+        # The wait's listener was removed (the finally disconnect), so no
+        # dangling subscription survives the answer. This fails if the
+        # disconnect ever regresses out of the finally.
+        assert resp.user_input_signal._listeners == []
+        # A late, unmatched input must not raise.
+        resp.on_user_input({"callback_id": "cb-1", "data": {"confirmed": False}})

--- a/tests/test_ws_callback_handler_leak.py
+++ b/tests/test_ws_callback_handler_leak.py
@@ -8,9 +8,11 @@ entry keyed by messageId and nothing ever removed them. Across a long
 chat session this leaked one response emitter + cancel token per turn.
 
 Fix: the worker thread is wrapped in `_run_request_thread`, which pops
-the entry once the request coroutine returns. `on_close` clears the
-whole dict so requests still in flight at disconnect don't pin their
-state for the worker's lifetime.
+the entry once the request coroutine returns. `on_close` cancels any
+requests still in flight at disconnect and clears the whole dict so they
+don't pin their state for the worker's lifetime. The cancel matters since
+a turn parked on a tool approval no longer self-resolves via the response
+timeout (#381).
 """
 
 import asyncio
@@ -117,6 +119,41 @@ class TestOnCloseClearsHandlers:
 
         h.on_close()
 
+        assert h._messageCallbackHandlers == {}
+
+    def test_on_close_cancels_in_flight_requests(self):
+        # A turn parked on a tool approval no longer times out on its own
+        # (#381), so on_close must actively cancel in-flight requests; the
+        # poll loop then tears down the worker and Claude subprocess.
+        h = _make_handler()
+        tokens = []
+        for i in range(3):
+            token = MagicMock()
+            tokens.append(token)
+            h._messageCallbackHandlers[f"m{i}"] = MessageCallbackHandlers(
+                MagicMock(), token
+            )
+
+        h.on_close()
+
+        for token in tokens:
+            token.cancel_request.assert_called_once_with()
+        assert h._messageCallbackHandlers == {}
+
+    def test_on_close_continues_if_a_cancel_raises(self):
+        # One bad cancel_token must not prevent the others from cancelling or
+        # the dict from clearing.
+        h = _make_handler()
+        bad = MagicMock()
+        bad.cancel_request.side_effect = RuntimeError("boom")
+        good = MagicMock()
+        h._messageCallbackHandlers["bad"] = MessageCallbackHandlers(MagicMock(), bad)
+        h._messageCallbackHandlers["good"] = MessageCallbackHandlers(MagicMock(), good)
+
+        h.on_close()
+
+        bad.cancel_request.assert_called_once_with()
+        good.cancel_request.assert_called_once_with()
         assert h._messageCallbackHandlers == {}
 
     def test_on_close_is_idempotent(self):


### PR DESCRIPTION
## Summary

Approving a tool after a long wait (around 30 minutes) threw a "Claude agent response timeout" error, and subsequent prompts then got stuck. The root cause: the response timeout (`CLAUDE_AGENT_CLIENT_RESPONSE_TIMEOUT`, default 1800s) counted the time the agent spent legitimately blocked on the user's tool approval, so a slow human reply timed out the turn while the worker was still mid-request awaiting the approval. The orphaned request then wedged the next prompt.

## Solution

Exclude user-wait time from the response timeout. `ChatResponse` now tracks the wall-clock time it spends blocked on user input (every tool approval, plan confirm, and AskUserQuestion funnels through `wait_for_chat_user_input`), and `_send_claude_agent_request` subtracts that from the timeout window. A slow human reply no longer looks like an unresponsive agent, while the timeout still fires for a genuine post-approval hang.

Cancel in-flight requests on `on_close`. Because a parked approval no longer self-resolves via the timeout, an abandoned turn (the user closes the tab) would otherwise spin its worker thread and the Claude subprocess forever; cancelling makes the poll loop tear the subprocess down. The handler dict is snapshotted before iterating so a worker popping its own entry at the same instant can't raise mid-iteration.

`wait_for_chat_user_input` now disconnects its listener in a `finally`, fixing a latent subscription leak on a cancelled turn.

## Testing

Unit tests cover the new `ChatResponse` wait accounting (starts at zero, counts an in-progress wait, accumulates completed waits, clears in-progress on answer, disconnects the listener) and the `on_close` cancellation (cancels each in-flight token, continues if one cancel raises, clears the dict). Full suite green: 1235 passed plus the 57-test Claude client suite.

Verified live in a running JupyterLab with a lowered timeout so a "long wait" is fast to reproduce: an approval held about 7x past the timeout did not error, completed on approval, and the next prompt responded normally (both symptoms fixed). Separately, closing the tab mid-approval fired `on_close` and tore the subprocess down within a poll cycle, so an abandoned approval no longer leaks; ungraceful drops are covered by Tornado's websocket ping timeout firing `on_close`.

## Risks / follow-ups

The accounting assumes a single in-flight approval at a time, which holds because the Claude SDK serializes tool permission prompts; worth a note near `wait_for_chat_user_input` if that ever changes. The timing uses wall-clock `time.time()` rather than a monotonic clock, so a system clock adjustment mid-wait could skew the window slightly; cosmetic, optional to switch to a monotonic source.

Closes #381.
