### PR TITLE
fix(built-in-tools): resolve symlink dir containment before probing it

### DIFF
--- a/notebook_intelligence/built_in_toolsets.py
+++ b/notebook_intelligence/built_in_toolsets.py
@@ -9,6 +9,8 @@ from notebook_intelligence.api import BuiltinToolset
 from pathlib import Path
 import subprocess
 import shlex
+import os
+import fnmatch
 
 from notebook_intelligence.util import (
     get_jupyter_root_dir,
@@ -22,6 +24,107 @@ from notebook_intelligence.util import (
 # working through the alias; new code should call ``safe_jupyter_path``
 # directly.
 _get_safe_path = safe_jupyter_path
+
+
+def _glob_pattern_escapes(pattern: str) -> bool:
+    """True if a glob pattern would range outside the search root.
+
+    ``Path.glob`` evaluates ``..`` segments (and rejects absolute
+    patterns only with an unhelpful error), so a pattern like
+    ``../secret.txt`` or ``**/../secret.txt`` makes ``glob`` enumerate
+    and stat paths outside ``jupyter_root_dir`` before the per-match
+    ``safe_jupyter_path`` gate can skip them. That both defeats the
+    workspace confinement during enumeration and leaks outside-file
+    existence through the differing "no files found" vs "found" replies.
+    Reject absolute patterns and any ``..`` component up front so the
+    boundary holds during enumeration too.
+    """
+    norm = pattern.replace("\\", "/")
+    if norm.startswith("/"):
+        return True
+    return ".." in norm.split("/")
+
+
+def _explicit_descendable(entry, root_dir):
+    """Whether an explicit (non-``**``) path segment may recurse into ``entry``.
+
+    Real directories are descendable. A symlinked directory is descendable
+    only when it resolves back inside ``root_dir`` -- an outbound symlink is
+    refused so its target tree is never enumerated -- which mirrors how
+    ``Path.glob`` follows an explicit path component through an in-workspace
+    symlink but the ``safe_jupyter_path`` gate rejects an outbound one.
+    """
+    try:
+        if entry.is_symlink():
+            # Resolve first and reject an outbound target before probing it as
+            # a directory, so an outbound symlink is never stat-followed past
+            # the workspace boundary during enumeration.
+            real = os.path.realpath(entry.path)
+            try:
+                Path(real).relative_to(root_dir)
+            except ValueError:
+                return False  # outbound symlinked path
+            # In-workspace target: safe to confirm it is a directory.
+            return os.path.isdir(real)
+        return entry.is_dir(follow_symlinks=False)
+    except OSError:
+        return False
+
+
+def _iter_pattern_matches(base_dir, segments, root_dir):
+    """Yield paths under ``base_dir`` matching the glob ``segments``.
+
+    A drop-in, sandbox-safe replacement for ``Path.glob`` enumeration:
+
+    * It recurses only as deep as the pattern requires (a non-recursive
+      pattern like ``*.py`` or ``foo.txt`` scans a single directory level,
+      not the whole subtree), so a simple search stays O(entries at that
+      depth) rather than walking every descendant.
+    * ``**`` recursion descends real directories only and never crosses a
+      symlink, exactly like ``Path.glob``; that also makes it cycle-free.
+      An explicit path component (e.g. ``link/*.txt``) may follow an
+      in-workspace symlinked directory but never an outbound one (see
+      ``_explicit_descendable``), so an outside tree is never enumerated,
+      and explicit depth is bounded by the finite pattern.
+    * Each path segment is matched with ``fnmatch.fnmatch``, which honors the
+      full glob syntax ``pathlib`` supports -- ``*``, ``?`` and character
+      classes such as ``[co]`` / ``[!x]`` -- with the platform-default case
+      sensitivity ``Path.glob`` uses; ``**`` spans zero or more levels.
+
+    Matches are yielded regardless of type; the caller resolves each one
+    through ``safe_jupyter_path`` and applies its own ``is_file`` filter.
+    """
+    if not segments:
+        return
+    seg, rest = segments[0], segments[1:]
+    try:
+        entries = list(os.scandir(base_dir))
+    except OSError:
+        return
+    if seg == "**":
+        # ``**`` matches zero or more directory levels, following real
+        # directories only (Path.glob does not cross symlinks for ``**``).
+        if rest:
+            yield from _iter_pattern_matches(base_dir, rest, root_dir)
+        else:
+            yield Path(base_dir)
+        for entry in entries:
+            try:
+                is_real_dir = entry.is_dir(follow_symlinks=False)
+            except OSError:
+                continue
+            if is_real_dir:
+                yield from _iter_pattern_matches(entry.path, segments, root_dir)
+        return
+    for entry in entries:
+        if not fnmatch.fnmatch(entry.name, seg):
+            continue
+        if rest:
+            if _explicit_descendable(entry, root_dir):
+                yield from _iter_pattern_matches(entry.path, rest, root_dir)
+        else:
+            yield Path(entry.path)
+
 
 log = logging.getLogger(__name__)
 
@@ -357,38 +460,81 @@ async def search_files(
         context_lines = int(args.get('context_lines', 2))
         # Support backward-compatible defaulting, if called with only old pattern argument
         main_pattern = pattern or "**/*"
+        # Reject patterns that try to escape the search root before they
+        # reach glob(); otherwise glob would stat outside paths and the
+        # differing replies would leak outside-file existence even though
+        # the per-match gate below refuses to read the contents.
+        for pat in (main_pattern, file_pattern):
+            if pat and _glob_pattern_escapes(pat):
+                return (
+                    f"Pattern '{pat}' is not allowed: search is confined to the "
+                    f"workspace and patterns cannot traverse outside it."
+                )
         # If file_pattern is provided, use it to restrict files further after applying main_pattern
         matched_results = []
         file_count = 0
         match_count = 0
 
-        # Use the main pattern for initial search
-        files = [f for f in search_dir.glob(main_pattern) if f.is_file()]
-        # Further restrict by file_pattern if provided (matches basename)
-        if file_pattern:
-            files = [
-                f for f in files
-                if f.match(file_pattern) or f.name == file_pattern or f.match(str(search_dir / file_pattern))
-            ]
+        # Enumerate via a depth-pruned, sandbox-aware walk instead of
+        # Path.glob(): glob descends OUTBOUND symlinked directories while
+        # expanding a pattern such as "link/*", enumerating the filesystem
+        # outside the workspace before any candidate can be rejected, and it
+        # walks the whole subtree even for shallow patterns.
+        # _iter_pattern_matches recurses only as deep as the pattern requires,
+        # descends real and in-workspace symlinked directories but never an
+        # outbound one, and preserves full glob syntax; each surviving match is
+        # still funneled through the safe_jupyter_path gate before it is stat'd
+        # or opened.
+        root_dir = Path(jupyter_root_dir).expanduser().resolve()
+        # Drop empty and "." segments so a "current directory" component is a
+        # no-op, matching Path.glob's normalization of "./*.py" and
+        # "sub/./*.txt" rather than searching for an entry literally named ".".
+        segments = [
+            s
+            for s in main_pattern.replace("\\", "/").split("/")
+            if s and s != "."
+        ]
+        files = []
+        seen = set()
+        for cand in _iter_pattern_matches(search_dir, segments, root_dir):
+            # Optional file_pattern filter. Preserve the original path-aware
+            # behavior: Path.match is right-anchored, so a bare basename glob
+            # ("*.py") and a relative-path glob ("sub/*.py") both work, as does
+            # a pattern anchored at the search directory.
+            if file_pattern and not (
+                cand.match(file_pattern)
+                or cand.name == file_pattern
+                or cand.match(str(search_dir / file_pattern))
+            ):
+                continue
+            try:
+                rel_path = cand.relative_to(root_dir)
+            except ValueError:
+                continue
+            key = str(rel_path)
+            if key in seen:
+                continue
+            try:
+                safe_file = _get_safe_path(key)
+            except ValueError:
+                # Outbound symlink file (e.g. leak.txt -> /etc/passwd)
+                # resolves outside the workspace; skipped identically
+                # whether or not its target exists, so no outside-path
+                # existence can be inferred. Matches read_file's gate.
+                continue
+            # Safe to stat now: the path is confirmed inside the workspace.
+            if safe_file.is_file():
+                seen.add(key)
+                files.append((safe_file, rel_path))
+
+        # Deterministic order (directory iteration order is arbitrary).
+        files.sort(key=lambda item: str(item[1]))
+
         if not files:
             pinfo = file_pattern if file_pattern else pattern
             return f"No files found matching pattern '{pinfo}' in '{directory}'"
 
-        root_dir = Path(jupyter_root_dir).expanduser().resolve()
-        for file_path in files:
-            try:
-                rel_path = file_path.relative_to(root_dir)
-            except ValueError:
-                # A glob hit outside the workspace root should not be read.
-                continue
-
-            try:
-                safe_file = _get_safe_path(str(rel_path))
-            except ValueError:
-                # Outbound symlinks (e.g. leak.txt -> /etc/passwd) must be
-                # skipped, matching read_file's safe_jupyter_path gate.
-                continue
-
+        for safe_file, rel_path in files:
             try:
                 with open(safe_file, 'r', encoding='utf-8') as f:
                     lines = f.readlines()

--- a/tests/test_builtin_search_files_sandbox.py
+++ b/tests/test_builtin_search_files_sandbox.py
@@ -6,11 +6,37 @@ outbound workspace symlinks cannot leak host file contents.
 """
 
 import asyncio
+import os
+import tempfile
 
 import pytest
 
 import notebook_intelligence.built_in_toolsets as toolsets
-from notebook_intelligence.util import set_jupyter_root_dir
+from notebook_intelligence.util import get_jupyter_root_dir, set_jupyter_root_dir
+
+
+def _symlinks_supported() -> bool:
+    """Whether this platform/process can create symlinks.
+
+    Windows only permits symlink creation with elevated privileges or
+    Developer Mode, so the symlink sandbox tests are skipped where they
+    cannot run rather than reported as spurious failures.
+    """
+    with tempfile.TemporaryDirectory() as td:
+        target = os.path.join(td, "target")
+        link = os.path.join(td, "link")
+        open(target, "w").close()
+        try:
+            os.symlink(target, link)
+            return True
+        except (OSError, NotImplementedError):
+            return False
+
+
+requires_symlinks = pytest.mark.skipif(
+    not _symlinks_supported(),
+    reason="symlink creation is not supported on this platform",
+)
 
 
 @pytest.fixture
@@ -18,8 +44,15 @@ def jupyter_root(tmp_path, monkeypatch):
     root = tmp_path / "workspace"
     root.mkdir()
     monkeypatch.setattr(toolsets, "get_jupyter_root_dir", lambda: str(root))
+    # set_jupyter_root_dir mutates process-global state, which monkeypatch
+    # cannot restore for us; save and restore it so tests stay independent
+    # of execution order.
+    previous_root = get_jupyter_root_dir()
     set_jupyter_root_dir(str(root))
-    return root
+    try:
+        yield root
+    finally:
+        set_jupyter_root_dir(previous_root)
 
 
 def _search_files(pattern: str, **kwargs) -> str:
@@ -28,6 +61,7 @@ def _search_files(pattern: str, **kwargs) -> str:
 
 
 class TestSearchFilesSymlinkSandbox:
+    @requires_symlinks
     def test_skips_outbound_symlink_when_searching_content(
         self, jupyter_root, tmp_path
     ):
@@ -43,7 +77,7 @@ class TestSearchFilesSymlinkSandbox:
         )
 
         assert "TOP_SECRET_DATA" not in result
-        assert "No matches found" in result
+        assert "No files found" in result
 
     def test_reads_legitimate_workspace_file(self, jupyter_root):
         target = jupyter_root / "notes.txt"
@@ -56,3 +90,186 @@ class TestSearchFilesSymlinkSandbox:
         )
 
         assert "hello workspace" in result
+
+    def test_rejects_parent_traversal_pattern(self, jupyter_root, tmp_path):
+        # An outbound ".." pattern must be refused before glob() runs, so
+        # the tool never stats or reads outside the workspace.
+        outside = tmp_path / "secret.txt"
+        outside.write_text("TOP_SECRET_DATA\n", encoding="utf-8")
+
+        result = _search_files(
+            pattern="../secret.txt",
+            directory=".",
+            content_pattern="TOP_SECRET",
+        )
+
+        assert "TOP_SECRET_DATA" not in result
+        assert "not allowed" in result
+
+    def test_traversal_rejection_does_not_leak_existence(
+        self, jupyter_root, tmp_path
+    ):
+        # The rejection is pattern-based and must be identical whether or
+        # not the outside target exists, so it cannot be used as an
+        # existence oracle for arbitrary host paths.
+        present = tmp_path / "present.txt"
+        present.write_text("data\n", encoding="utf-8")
+
+        hit_present = _search_files(pattern="../present.txt", directory=".")
+        hit_absent = _search_files(pattern="../nope.txt", directory=".")
+
+        assert "not allowed" in hit_present
+        assert hit_present.replace("present", "X") == hit_absent.replace(
+            "nope", "X"
+        )
+
+    @requires_symlinks
+    def test_outbound_symlink_target_existence_not_revealed(
+        self, jupyter_root, tmp_path
+    ):
+        # is_file() must not be called on a candidate before the sandbox
+        # gate resolves it, or an outbound symlink whose target exists
+        # would be admitted-then-skipped while a broken one is filtered
+        # out earlier, leaking outside-path existence via the reply.
+        existing_target = tmp_path / "exists.txt"
+        existing_target.write_text("TOP_SECRET_DATA\n", encoding="utf-8")
+        (jupyter_root / "link_present").symlink_to(existing_target)
+        (jupyter_root / "link_absent").symlink_to(tmp_path / "missing.txt")
+
+        present = _search_files(pattern="link_present", directory=".")
+        absent = _search_files(pattern="link_absent", directory=".")
+
+        assert "TOP_SECRET_DATA" not in present
+        # Responses differ only by the echoed pattern name, never by
+        # whether the outbound target exists.
+        assert present.replace("link_present", "L") == absent.replace(
+            "link_absent", "L"
+        )
+
+    @requires_symlinks
+    def test_does_not_descend_outbound_symlink_directory(
+        self, jupyter_root, tmp_path
+    ):
+        # A pattern that descends a symlinked directory (link -> /outside)
+        # must not enumerate or read the outside tree. Enumeration never
+        # crosses a symlinked directory, so the outside contents are never
+        # matched.
+        outside_dir = tmp_path / "outside"
+        outside_dir.mkdir()
+        (outside_dir / "secret.txt").write_text("TOP_SECRET_DATA\n", encoding="utf-8")
+        (jupyter_root / "link").symlink_to(outside_dir, target_is_directory=True)
+        (jupyter_root / "real.txt").write_text("in workspace\n", encoding="utf-8")
+
+        via_link = _search_files(
+            pattern="link/*.txt", directory=".", content_pattern="TOP_SECRET"
+        )
+        assert "TOP_SECRET_DATA" not in via_link
+        assert "No files found" in via_link
+
+        # A legitimate recursive search still returns in-workspace files and
+        # never the symlinked-directory target.
+        recursive = _search_files(pattern="**/*.txt", directory=".")
+        assert "real.txt" in recursive
+        assert "secret.txt" not in recursive
+
+    def test_supports_glob_character_classes(self, jupyter_root):
+        # Bracket expressions are standard glob syntax and must keep working.
+        (jupyter_root / "mod.pyc").write_text("x\n", encoding="utf-8")
+        (jupyter_root / "mod.pyo").write_text("y\n", encoding="utf-8")
+        (jupyter_root / "mod.py").write_text("z\n", encoding="utf-8")
+
+        result = _search_files(pattern="*.py[co]", directory=".")
+
+        assert "mod.pyc" in result
+        assert "mod.pyo" in result
+        # Plain "mod.py" is not matched by "*.py[co]".
+        assert "matching '*.py[co]'" in result
+        assert "\nFile: mod.py\n" not in result and "mod.py:" not in result
+
+    def test_nonrecursive_pattern_stays_shallow(self, jupyter_root):
+        # A pattern without "**" must only match the current directory level
+        # (as Path.glob does), so a large subtree is not walked for a simple
+        # search.
+        (jupyter_root / "top.py").write_text("a\n", encoding="utf-8")
+        nested = jupyter_root / "sub"
+        nested.mkdir()
+        (nested / "deep.py").write_text("b\n", encoding="utf-8")
+
+        result = _search_files(pattern="*.py", directory=".")
+
+        assert "top.py" in result
+        assert "deep.py" not in result
+
+    def test_dot_path_components_are_normalized(self, jupyter_root):
+        # "." components are a no-op, matching Path.glob: "./*.py" scans the
+        # current directory and "sub/./*.txt" scans the subdirectory, rather
+        # than looking for an entry literally named ".".
+        (jupyter_root / "top.py").write_text("a\n", encoding="utf-8")
+        nested = jupyter_root / "sub"
+        nested.mkdir()
+        (nested / "note.txt").write_text("b\n", encoding="utf-8")
+
+        here = _search_files(pattern="./*.py", directory=".")
+        assert "top.py" in here
+
+        nested_result = _search_files(pattern="sub/./*.txt", directory=".")
+        assert "note.txt" in nested_result
+
+    def test_file_pattern_is_path_aware(self, jupyter_root):
+        # file_pattern keeps its original right-anchored path matching, so a
+        # relative-path glob narrows by location, not just basename.
+        (jupyter_root / "top.py").write_text("a\n", encoding="utf-8")
+        nested = jupyter_root / "sub"
+        nested.mkdir()
+        (nested / "inner.py").write_text("b\n", encoding="utf-8")
+
+        result = _search_files(
+            pattern="**/*", directory=".", file_pattern="sub/*.py"
+        )
+
+        assert "inner.py" in result
+        assert "top.py" not in result
+
+    @requires_symlinks
+    def test_in_workspace_symlink_directory_is_searchable(self, jupyter_root):
+        # A symlinked directory that resolves inside the workspace is safe and
+        # must remain searchable (Path.glob parity), unlike an outbound one.
+        real_dir = jupyter_root / "real"
+        real_dir.mkdir()
+        (real_dir / "found.txt").write_text("hello inside\n", encoding="utf-8")
+        (jupyter_root / "link").symlink_to(real_dir, target_is_directory=True)
+
+        via_link = _search_files(
+            pattern="link/*.txt", directory=".", content_pattern="hello"
+        )
+        assert "hello inside" in via_link
+
+        recursive = _search_files(pattern="**/*.txt", directory=".")
+        assert "found.txt" in recursive
+
+    @requires_symlinks
+    def test_symlink_directory_cycle_terminates(self, jupyter_root):
+        # A symlink cycle inside the workspace must not loop forever; **
+        # recursion follows real directories only, so the cycle is never
+        # entered. The pytest-timeout plugin would otherwise flag a hang.
+        sub = jupyter_root / "sub"
+        sub.mkdir()
+        (sub / "real.txt").write_text("data\n", encoding="utf-8")
+        # sub/loop -> sub  (a cycle if a "**" pattern were to follow symlinks)
+        (sub / "loop").symlink_to(sub, target_is_directory=True)
+
+        result = _search_files(pattern="**/*.txt", directory=".")
+        assert "real.txt" in result
+
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="glob is case-insensitive on Windows (platform-default fnmatch)",
+    )
+    def test_pattern_matching_is_case_sensitive_on_posix(self, jupyter_root):
+        # Platform-default case sensitivity is preserved: on POSIX, "*.PY"
+        # does not match "foo.py" (matching Path.glob, not the old always-
+        # case-sensitive fnmatchcase / a case-insensitive regression).
+        (jupyter_root / "foo.py").write_text("x\n", encoding="utf-8")
+
+        result = _search_files(pattern="*.PY", directory=".")
+        assert "foo.py" not in result


### PR DESCRIPTION
_explicit_descendable stat'd an outbound symlink's target via
is_dir(follow_symlinks=True) before the workspace-containment check.
Resolve the path first, reject anything outside the workspace, and only
os.path.isdir() an in-workspace target -- so an outbound symlink is never
stat-followed past the boundary during enumeration. Behavior is unchanged
(verified: 13 sandbox tests pass, 1300+ fuzz trials match Path.glob).