### PR TITLE
feat(claude): modernize model defaults and bound inline-completion output

### DIFF
--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -552,6 +552,17 @@ def _endpoint_identity(api_key: str = None, base_url: str = None) -> tuple:
     )
 
 
+def _model_version_key(model_id: str) -> tuple:
+    """Sort key ordering model ids by their numeric version components.
+
+    Plain lexicographic order gets version-like ids wrong —
+    ``claude-sonnet-4-6`` sorts *after* ``claude-sonnet-4-10``. Compare
+    the extracted number sequences instead ([4, 6] < [4, 10] < [5]),
+    with the id itself as a deterministic tiebreak.
+    """
+    return ([int(part) for part in re.findall(r"\d+", model_id)], model_id)
+
+
 def resolve_default_model(preferred: str, tier_prefix: str, api_key: str = None, base_url: str = None) -> str:
     """Pick a default model id, validated against the fetched model list.
 
@@ -563,20 +574,39 @@ def resolve_default_model(preferred: str, tier_prefix: str, api_key: str = None,
     (``claude-sonnet``/``claude-haiku`` prefix), then to the first
     listed model. When the cache is empty — or was fetched from a
     *different* endpoint (credentials changed, refresh still in flight)
-    — trust the constant rather than another endpoint's catalog.
+    — trust the constant rather than another endpoint's catalog, and
+    trigger a background refresh so later resolutions converge on this
+    endpoint's catalog.
     """
     models = get_claude_models()
-    if not models:
-        return preferred
-    if _claude_models_cache_endpoint != _endpoint_identity(api_key, base_url):
+    endpoint_matches = _claude_models_cache_endpoint == _endpoint_identity(api_key, base_url)
+    if not models or not endpoint_matches:
+        if not endpoint_matches and _claude_models_cache_endpoint is not None:
+            # The cache demonstrably belongs to another endpoint (the
+            # credentials changed): kick off a background refresh so
+            # subsequent resolutions see this endpoint's catalog. A
+            # never-stamped cache is left to the startup fetch that
+            # update_models_from_config already fires. The single-flight
+            # lock inside fetch_claude_models dedupes concurrent
+            # attempts; failures leave the cache as-is. Deliberately
+            # never block on the network here — this runs in model
+            # constructors on the request path, and a slow or dead
+            # custom endpoint must degrade to one possibly-failing
+            # request, not a hung chat turn.
+            threading.Thread(
+                target=fetch_claude_models,
+                kwargs={"api_key": api_key, "base_url": base_url},
+                name="nbi-claude-models-refresh",
+                daemon=True,
+            ).start()
         return preferred
     ids = [m["id"] for m in models if isinstance(m.get("id"), str)]
     if preferred in ids:
         return preferred
-    tier_matches = sorted(i for i in ids if i.startswith(tier_prefix))
+    tier_matches = sorted(
+        (i for i in ids if i.startswith(tier_prefix)), key=_model_version_key
+    )
     if tier_matches:
-        # Anthropic ids sort by recency within a tier well enough for a
-        # fallback ('claude-sonnet-5' > 'claude-sonnet-4-5').
         fallback = tier_matches[-1]
     elif ids:
         fallback = ids[0]

--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -36,8 +36,17 @@ def _extract_text_from_content(content) -> str:
 
 CLAUDE_CODE_ICON_SVG = '<svg width="1200" height="1200" viewBox="0 0 1200 1200" xmlns="http://www.w3.org/2000/svg"><g id="g314"><path id="path147" fill="#d97757" stroke="#d97757" d="M 233.959793 800.214905 L 468.644287 668.536987 L 472.590637 657.100647 L 468.644287 650.738403 L 457.208069 650.738403 L 417.986633 648.322144 L 283.892639 644.69812 L 167.597321 639.865845 L 54.926208 633.825623 L 26.577238 627.785339 L 3.3e-05 592.751709 L 2.73832 575.27533 L 26.577238 559.248352 L 60.724873 562.228149 L 136.187973 567.382629 L 249.422867 575.194763 L 331.570496 580.026978 L 453.261841 592.671082 L 472.590637 592.671082 L 475.328857 584.859009 L 468.724915 580.026978 L 463.570557 575.194763 L 346.389313 495.785217 L 219.543671 411.865906 L 153.100723 363.543762 L 117.181267 339.060425 L 99.060455 316.107361 L 91.248367 266.01355 L 123.865784 230.093994 L 167.677887 233.073853 L 178.872513 236.053772 L 223.248367 270.201477 L 318.040283 343.570496 L 441.825592 434.738342 L 459.946411 449.798706 L 467.194672 444.64447 L 468.080597 441.020203 L 459.946411 427.409485 L 392.617493 305.718323 L 320.778564 181.932983 L 288.80542 130.630859 L 280.348999 99.865845 C 277.369171 87.221436 275.194641 76.590698 275.194641 63.624268 L 312.322174 13.20813 L 332.8591 6.604126 L 382.389313 13.20813 L 403.248352 31.328979 L 434.013519 101.71814 L 483.865753 212.537048 L 561.181274 363.221497 L 583.812134 407.919434 L 595.892639 449.315491 L 600.40271 461.959839 L 608.214783 461.959839 L 608.214783 454.711609 L 614.577271 369.825623 L 626.335632 265.61084 L 637.771851 131.516846 L 641.718201 93.745117 L 660.402832 48.483276 L 697.530334 24.000122 L 726.52356 37.852417 L 750.362549 72 L 747.060486 94.067139 L 732.886047 186.201416 L 705.100708 330.52356 L 686.979919 427.167847 L 697.530334 427.167847 L 709.61084 415.087341 L 758.496704 350.174561 L 840.644348 247.490051 L 876.885925 206.738342 L 919.167847 161.71814 L 946.308838 140.29541 L 997.61084 140.29541 L 1035.38269 196.429626 L 1018.469849 254.416199 L 965.637634 321.422852 L 921.825562 378.201538 L 859.006714 462.765259 L 819.785278 530.41626 L 823.409424 535.812073 L 832.75177 534.92627 L 974.657776 504.724915 L 1051.328979 490.872559 L 1142.818848 475.167786 L 1184.214844 494.496582 L 1188.724854 514.147644 L 1172.456421 554.335693 L 1074.604126 578.496765 L 959.838989 601.449829 L 788.939636 641.879272 L 786.845764 643.409485 L 789.261841 646.389343 L 866.255127 653.637634 L 899.194702 655.409424 L 979.812134 655.409424 L 1129.932861 666.604187 L 1169.154419 692.537109 L 1192.671265 724.268677 L 1188.724854 748.429688 L 1128.322144 779.194641 L 1046.818848 759.865845 L 856.590759 714.604126 L 791.355774 698.335754 L 782.335693 698.335754 L 782.335693 703.731567 L 836.69812 756.885986 L 936.322205 846.845581 L 1061.073975 962.81897 L 1067.436279 991.490112 L 1051.409424 1014.120911 L 1034.496704 1011.704712 L 924.885986 929.234924 L 882.604126 892.107544 L 786.845764 811.48999 L 780.483276 811.48999 L 780.483276 819.946289 L 802.550415 852.241699 L 919.087341 1027.409424 L 925.127625 1081.127686 L 916.671204 1098.604126 L 886.469849 1109.154419 L 853.288696 1103.114136 L 785.073914 1007.355835 L 714.684631 899.516785 L 657.906067 802.872498 L 650.979858 806.81897 L 617.476624 1167.704834 L 601.771851 1186.147705 L 565.530212 1200 L 535.328857 1177.046997 L 519.302124 1139.919556 L 535.328857 1066.550537 L 554.657776 970.792053 L 570.362488 894.68457 L 584.536926 800.134277 L 592.993347 768.724976 L 592.429626 766.630859 L 585.503479 767.516968 L 514.22821 865.369263 L 405.825531 1011.865906 L 320.053711 1103.677979 L 299.516815 1111.812256 L 263.919525 1093.369263 L 267.221497 1060.429688 L 287.114136 1031.114136 L 405.825531 880.107361 L 477.422913 786.52356 L 523.651062 732.483276 L 523.328918 724.671265 L 520.590698 724.671265 L 205.288605 929.395935 L 149.154434 936.644409 L 124.993355 914.01355 L 127.973183 876.885986 L 139.409409 864.80542 L 234.201385 799.570435 L 233.879227 799.8927 Z"/></g></svg>'
 CLAUDE_CODE_ICON_URL = f"data:image/svg+xml;base64,{base64.b64encode(CLAUDE_CODE_ICON_SVG.encode('utf-8')).decode('utf-8')}"
-CLAUDE_DEFAULT_CHAT_MODEL = "claude-sonnet-4-5"
-CLAUDE_DEFAULT_INLINE_COMPLETION_MODEL = "claude-sonnet-4-5"
+# Fallbacks when the user hasn't picked a model. Chat wants the current
+# Sonnet-tier balance of quality and speed; autocomplete wants the fastest,
+# cheapest tier — a suggestion has to beat the user's next keystroke, and a
+# Sonnet-class model is both slower and several times the cost per token
+# for a surface that fires on every pause in typing.
+CLAUDE_DEFAULT_CHAT_MODEL = "claude-sonnet-5"
+CLAUDE_DEFAULT_INLINE_COMPLETION_MODEL = "claude-haiku-4-5"
+# Autocomplete suggestions are at most a few dozen lines; the previous
+# 10K-token ceiling let a rambling response generate for many seconds
+# before the extraction regex threw most of it away.
+CLAUDE_INLINE_COMPLETION_MAX_TOKENS = int(os.getenv("NBI_CLAUDE_INLINE_COMPLETION_MAX_TOKENS", "1024"))
 CLAUDE_CODE_CHAT_PARTICIPANT_ID = "claude-code"
 CLAUDE_CODE_MAX_BUFFER_SIZE = 20 * 1024 * 1024 # 20MB
 
@@ -547,10 +556,17 @@ def fetch_claude_models(api_key: str = None, base_url: str = None) -> list[dict]
             page = client.models.list(limit=100)
             models = []
             for model in page.data:
+                # The Models API reports the context window directly on
+                # newer SDK/service versions (max_input_tokens). Prefer it
+                # over litellm's static database, which lags new model
+                # releases and mislabels unknown ids with the 200K default.
+                context_window = getattr(model, "max_input_tokens", None)
+                if not isinstance(context_window, int) or context_window <= 0:
+                    context_window = _get_context_window(model.id)
                 models.append({
                     "id": model.id,
                     "name": model.display_name,
-                    "context_window": _get_context_window(model.id),
+                    "context_window": context_window,
                 })
             _claude_models_cache.clear()
             _claude_models_cache.extend(models)
@@ -702,7 +718,7 @@ class ClaudeCodeInlineCompletionModel(InlineCompletionModel):
 
         message = self._client.messages.create(
             model=self._model_id,
-            max_tokens=10000,
+            max_tokens=CLAUDE_INLINE_COMPLETION_MAX_TOKENS,
             system=f"""You are a code completion assistant. Your task is to generate intelligent autocomplete suggestions for the code at the cursor position for given language and active file type. This is not an interactive session, don't ask for clarifying questions, always generate a suggestion. Don't include any explanations for your response, just generate the code. Don't return any thinking or reasoning, just generate the code. You are given a code snippet with a prefix and a suffix. You need to generate a suggestion for the code that fits best in place of <CURSOR/>. You should return only the code that fits best in place of <CURSOR/>. You should provide multiline code if needed. Enclose the code in triple backticks, just return the code in language. You should not return any other text, just the code. DO NOT INCLUDE THE PREFIX OR SUFFIX IN THE RESPONSE. .ipynb files are Jupyter notebook files and for notebook files, you generate suggestions for a cell within the notebook. A cell can be a code cell with code or a markdown cell with markdown text. If the language is markdown, only return markdown text. If you need to install a Python package within a notebook cell code (for .ipynb files), use %pip install <package_name> instead of !pip install <package_name>. Follow the tags very carefully for proper spacing and indentations.""",
             messages=[
                 {"role": "user", "content": f"""Generate a single suggestion that fits best in place of cursor. The code is below in between <CODE> tags and <CURSOR/> is the placeholder for the code to be filled in. Current language is {language} and the active file is {filename}.

--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -532,6 +532,12 @@ def model_info_from_id(model_id: str) -> dict:
 # another doomed thread, hammering api.anthropic.com in parallel when the
 # api_key is missing or wrong.
 _claude_models_cache: list[dict] = []
+# Identity of the endpoint the cache was fetched from — (api_key,
+# base_url) after credential normalization. The cache is only
+# authoritative for that endpoint: a user can switch to a custom
+# base_url whose catalog differs, and resolving a default against
+# another endpoint's model list would send it an id it doesn't serve.
+_claude_models_cache_endpoint: Optional[tuple] = None
 _claude_models_fetch_lock = threading.Lock()
 
 def get_claude_models() -> list[dict]:
@@ -539,20 +545,30 @@ def get_claude_models() -> list[dict]:
     return _claude_models_cache
 
 
-def resolve_default_model(preferred: str, tier_prefix: str) -> str:
+def _endpoint_identity(api_key: str = None, base_url: str = None) -> tuple:
+    return (
+        _normalize_anthropic_credential(api_key),
+        _normalize_anthropic_credential(base_url),
+    )
+
+
+def resolve_default_model(preferred: str, tier_prefix: str, api_key: str = None, base_url: str = None) -> str:
     """Pick a default model id, validated against the fetched model list.
 
     The ``CLAUDE_DEFAULT_*`` constants name current first-party aliases,
     but a custom ``base_url`` can front an endpoint that serves a
-    different catalog. When the model cache has entries, prefer the
-    constant only if the endpoint actually lists it; otherwise fall back
-    to the newest id in the same tier (``claude-sonnet``/``claude-haiku``
-    prefix), then to the first listed model. An empty cache (fetch not
-    yet run, or failed) trusts the constant — first-party endpoints
-    always serve it.
+    different catalog. When the model cache holds this endpoint's
+    catalog, prefer the constant only if the endpoint actually lists it;
+    otherwise fall back to the newest id in the same tier
+    (``claude-sonnet``/``claude-haiku`` prefix), then to the first
+    listed model. When the cache is empty — or was fetched from a
+    *different* endpoint (credentials changed, refresh still in flight)
+    — trust the constant rather than another endpoint's catalog.
     """
     models = get_claude_models()
     if not models:
+        return preferred
+    if _claude_models_cache_endpoint != _endpoint_identity(api_key, base_url):
         return preferred
     ids = [m["id"] for m in models if isinstance(m.get("id"), str)]
     if preferred in ids:
@@ -637,8 +653,10 @@ def fetch_claude_models(api_key: str = None, base_url: str = None) -> list[dict]
                     "name": model.display_name,
                     "context_window": context_window,
                 })
+            global _claude_models_cache_endpoint
             _claude_models_cache.clear()
             _claude_models_cache.extend(models)
+            _claude_models_cache_endpoint = _endpoint_identity(api_key, base_url)
             log.info(f"Fetched {len(models)} Claude models: {[m['id'] + ' (' + m['name'] + ')' for m in models]}")
             return models
         except Exception as e:
@@ -651,7 +669,7 @@ class ClaudeChatModel(ChatModel):
     def __init__(self, model_id: str, api_key: str = None, base_url: str = None):
         super().__init__(provider=None)
         if model_id == "":
-            model_id = resolve_default_model(CLAUDE_DEFAULT_CHAT_MODEL, "claude-sonnet")
+            model_id = resolve_default_model(CLAUDE_DEFAULT_CHAT_MODEL, "claude-sonnet", api_key, base_url)
 
         model_info = model_info_from_id(model_id)
         self._model_id = model_id
@@ -735,7 +753,7 @@ class ClaudeCodeInlineCompletionModel(InlineCompletionModel):
     def __init__(self, model_id: str, api_key: str = None, base_url: str = None):
         super().__init__(provider=None)
         if model_id == "":
-            model_id = resolve_default_model(CLAUDE_DEFAULT_INLINE_COMPLETION_MODEL, "claude-haiku")
+            model_id = resolve_default_model(CLAUDE_DEFAULT_INLINE_COMPLETION_MODEL, "claude-haiku", api_key, base_url)
 
         model_info = model_info_from_id(model_id)
         self._model_id = model_id

--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -538,6 +538,41 @@ def get_claude_models() -> list[dict]:
     """Return the cached list of available Claude models."""
     return _claude_models_cache
 
+
+def resolve_default_model(preferred: str, tier_prefix: str) -> str:
+    """Pick a default model id, validated against the fetched model list.
+
+    The ``CLAUDE_DEFAULT_*`` constants name current first-party aliases,
+    but a custom ``base_url`` can front an endpoint that serves a
+    different catalog. When the model cache has entries, prefer the
+    constant only if the endpoint actually lists it; otherwise fall back
+    to the newest id in the same tier (``claude-sonnet``/``claude-haiku``
+    prefix), then to the first listed model. An empty cache (fetch not
+    yet run, or failed) trusts the constant — first-party endpoints
+    always serve it.
+    """
+    models = get_claude_models()
+    if not models:
+        return preferred
+    ids = [m["id"] for m in models if isinstance(m.get("id"), str)]
+    if preferred in ids:
+        return preferred
+    tier_matches = sorted(i for i in ids if i.startswith(tier_prefix))
+    if tier_matches:
+        # Anthropic ids sort by recency within a tier well enough for a
+        # fallback ('claude-sonnet-5' > 'claude-sonnet-4-5').
+        fallback = tier_matches[-1]
+    elif ids:
+        fallback = ids[0]
+    else:
+        return preferred
+    log.info(
+        "Default model %r is not served by the configured endpoint; using %r",
+        preferred, fallback,
+    )
+    return fallback
+
+
 def _get_context_window(model_id: str) -> int:
     """Get context window size for a model using litellm's model database."""
     try:
@@ -616,7 +651,7 @@ class ClaudeChatModel(ChatModel):
     def __init__(self, model_id: str, api_key: str = None, base_url: str = None):
         super().__init__(provider=None)
         if model_id == "":
-            model_id = CLAUDE_DEFAULT_CHAT_MODEL
+            model_id = resolve_default_model(CLAUDE_DEFAULT_CHAT_MODEL, "claude-sonnet")
 
         model_info = model_info_from_id(model_id)
         self._model_id = model_id
@@ -700,7 +735,7 @@ class ClaudeCodeInlineCompletionModel(InlineCompletionModel):
     def __init__(self, model_id: str, api_key: str = None, base_url: str = None):
         super().__init__(provider=None)
         if model_id == "":
-            model_id = CLAUDE_DEFAULT_INLINE_COMPLETION_MODEL
+            model_id = resolve_default_model(CLAUDE_DEFAULT_INLINE_COMPLETION_MODEL, "claude-haiku")
 
         model_info = model_info_from_id(model_id)
         self._model_id = model_id

--- a/notebook_intelligence/claude.py
+++ b/notebook_intelligence/claude.py
@@ -43,10 +43,44 @@ CLAUDE_CODE_ICON_URL = f"data:image/svg+xml;base64,{base64.b64encode(CLAUDE_CODE
 # for a surface that fires on every pause in typing.
 CLAUDE_DEFAULT_CHAT_MODEL = "claude-sonnet-5"
 CLAUDE_DEFAULT_INLINE_COMPLETION_MODEL = "claude-haiku-4-5"
+def _bounded_int_env(name: str, default: int, minimum: int, maximum: int) -> int:
+    """Parse an int env var defensively and clamp it to a sane range.
+
+    This runs at import time: a malformed value must degrade to the
+    default with a warning, not raise ``ValueError`` and block the
+    backend from starting. Out-of-range values are clamped so an
+    operator typo (``0``, ``-5``, ``10000``) can't produce failing API
+    requests or restore the unbounded behavior the cap exists to
+    prevent.
+    """
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        log.warning(
+            "Invalid %s=%r (expected an integer); using default %d",
+            name, raw, default,
+        )
+        return default
+    clamped = max(minimum, min(maximum, value))
+    if clamped != value:
+        log.warning(
+            "%s=%d is outside the supported range [%d, %d]; clamping to %d",
+            name, value, minimum, maximum, clamped,
+        )
+    return clamped
+
+
 # Autocomplete suggestions are at most a few dozen lines; the previous
 # 10K-token ceiling let a rambling response generate for many seconds
-# before the extraction regex threw most of it away.
-CLAUDE_INLINE_COMPLETION_MAX_TOKENS = int(os.getenv("NBI_CLAUDE_INLINE_COMPLETION_MAX_TOKENS", "1024"))
+# before the extraction regex threw most of it away. The override is
+# clamped to [1, 4096] so it can't reintroduce that behavior or produce
+# a max_tokens value the API rejects.
+CLAUDE_INLINE_COMPLETION_MAX_TOKENS = _bounded_int_env(
+    "NBI_CLAUDE_INLINE_COMPLETION_MAX_TOKENS", 1024, 1, 4096
+)
 CLAUDE_CODE_CHAT_PARTICIPANT_ID = "claude-code"
 CLAUDE_CODE_MAX_BUFFER_SIZE = 20 * 1024 * 1024 # 20MB
 

--- a/tests/test_claude_models.py
+++ b/tests/test_claude_models.py
@@ -355,10 +355,14 @@ class TestResolveDefaultModel:
             [{"id": "endpoint-a-only-model", "name": "A", "context_window": 128000}],
             base_url="https://endpoint-a.example.com",
         )
-        resolved = resolve_default_model(
-            "claude-sonnet-5", "claude-sonnet",
-            base_url="https://endpoint-b.example.com",
-        )
+        # The stale-cache path spawns a background catalog refresh;
+        # patch it so the test doesn't leak a real network thread that
+        # holds the single-flight lock into later tests.
+        with patch("notebook_intelligence.claude.threading.Thread"):
+            resolved = resolve_default_model(
+                "claude-sonnet-5", "claude-sonnet",
+                base_url="https://endpoint-b.example.com",
+            )
         assert resolved == "claude-sonnet-5"
 
     def test_credential_normalization_applies_to_identity(self):
@@ -405,3 +409,84 @@ class TestResolveDefaultModel:
         assert claude_module._claude_models_cache_endpoint == (
             "key-a", "https://a.example.com"
         )
+
+
+class TestResolveDefaultModelRefreshAndOrdering:
+    def _fill_cache(self, models, api_key=None, base_url=None):
+        import notebook_intelligence.claude as claude_module
+        claude_module._claude_models_cache.extend(models)
+        claude_module._claude_models_cache_endpoint = (
+            claude_module._endpoint_identity(api_key, base_url)
+        )
+
+    def test_foreign_endpoint_triggers_background_refresh(self):
+        from notebook_intelligence.claude import resolve_default_model
+        self._fill_cache(
+            [{"id": "endpoint-a-model", "name": "A", "context_window": 128000}],
+            base_url="https://endpoint-a.example.com",
+        )
+        with patch("notebook_intelligence.claude.threading.Thread") as mock_thread:
+            resolved = resolve_default_model(
+                "claude-sonnet-5", "claude-sonnet",
+                base_url="https://endpoint-b.example.com",
+            )
+        assert resolved == "claude-sonnet-5"
+        mock_thread.assert_called_once()
+        kwargs = mock_thread.call_args.kwargs
+        assert kwargs["kwargs"] == {
+            "api_key": None, "base_url": "https://endpoint-b.example.com"
+        }
+        mock_thread.return_value.start.assert_called_once()
+
+    def test_matching_endpoint_triggers_no_refresh(self):
+        from notebook_intelligence.claude import resolve_default_model
+        self._fill_cache(
+            [{"id": "claude-sonnet-5", "name": "S", "context_window": 1000000}]
+        )
+        with patch("notebook_intelligence.claude.threading.Thread") as mock_thread:
+            resolve_default_model("claude-sonnet-5", "claude-sonnet")
+        mock_thread.assert_not_called()
+
+    def test_empty_cache_with_matching_identity_triggers_no_refresh(self):
+        import notebook_intelligence.claude as claude_module
+        from notebook_intelligence.claude import resolve_default_model
+        claude_module._claude_models_cache_endpoint = (
+            claude_module._endpoint_identity(None, None)
+        )
+        with patch("notebook_intelligence.claude.threading.Thread") as mock_thread:
+            resolved = resolve_default_model("claude-sonnet-5", "claude-sonnet")
+        assert resolved == "claude-sonnet-5"
+        mock_thread.assert_not_called()
+
+    def test_never_stamped_cache_triggers_no_refresh(self):
+        # Nothing fetched yet at all (marker is None): the startup fetch
+        # that update_models_from_config fires owns that case. Spawning
+        # here too would make every model constructor a network call in
+        # fresh processes (and in tests).
+        from notebook_intelligence.claude import resolve_default_model
+        with patch("notebook_intelligence.claude.threading.Thread") as mock_thread:
+            resolved = resolve_default_model(
+                "claude-haiku-4-5", "claude-haiku", api_key="test-key"
+            )
+        assert resolved == "claude-haiku-4-5"
+        mock_thread.assert_not_called()
+
+    def test_tier_fallback_orders_versions_numerically(self):
+        # Lexicographic order would pick 4-6 over 4-10; numeric version
+        # comparison must pick 4-10 (and a bare 5 over both).
+        from notebook_intelligence.claude import resolve_default_model
+        self._fill_cache([
+            {"id": "claude-sonnet-4-10", "name": "S", "context_window": 200000},
+            {"id": "claude-sonnet-4-6", "name": "S", "context_window": 200000},
+        ])
+        assert resolve_default_model("claude-sonnet-9", "claude-sonnet") == "claude-sonnet-4-10"
+
+    def test_bare_major_version_beats_dated_snapshot(self):
+        from notebook_intelligence.claude import _model_version_key
+        ordered = sorted(
+            ["claude-sonnet-4-5-20250929", "claude-sonnet-5", "claude-sonnet-4-10"],
+            key=_model_version_key,
+        )
+        assert ordered == [
+            "claude-sonnet-4-5-20250929", "claude-sonnet-4-10", "claude-sonnet-5"
+        ]

--- a/tests/test_claude_models.py
+++ b/tests/test_claude_models.py
@@ -175,3 +175,90 @@ class TestFetchClaudeModels:
         mock_anthropic_cls.assert_called_once_with(
             api_key=None, base_url=None, default_headers=ANY
         )
+
+
+class TestModelDefaults:
+    """Pin the fallback model choices. Chat falls back to the current
+    Sonnet tier; autocomplete falls back to the fastest/cheapest tier —
+    a suggestion has to beat the user's next keystroke, and it fires on
+    every pause in typing."""
+
+    def test_default_chat_model_is_current_sonnet(self):
+        from notebook_intelligence.claude import CLAUDE_DEFAULT_CHAT_MODEL
+        assert CLAUDE_DEFAULT_CHAT_MODEL == "claude-sonnet-5"
+
+    def test_default_inline_completion_model_is_haiku(self):
+        from notebook_intelligence.claude import CLAUDE_DEFAULT_INLINE_COMPLETION_MODEL
+        assert CLAUDE_DEFAULT_INLINE_COMPLETION_MODEL == "claude-haiku-4-5"
+
+    def test_inline_completion_max_tokens_is_bounded(self):
+        # Autocomplete output is a few dozen lines at most; the old
+        # 10K-token ceiling let a rambling response generate for many
+        # seconds before extraction threw most of it away.
+        from notebook_intelligence.claude import CLAUDE_INLINE_COMPLETION_MAX_TOKENS
+        assert 0 < CLAUDE_INLINE_COMPLETION_MAX_TOKENS <= 4096
+
+    @patch("anthropic.Anthropic")
+    def test_inline_completion_request_uses_bounded_max_tokens(self, mock_anthropic_cls):
+        from notebook_intelligence.claude import (
+            CLAUDE_INLINE_COMPLETION_MAX_TOKENS,
+            ClaudeCodeInlineCompletionModel,
+        )
+
+        mock_message = Mock()
+        mock_message.content = []
+        mock_anthropic_cls.return_value.messages.create.return_value = mock_message
+
+        model = ClaudeCodeInlineCompletionModel("", api_key="test-key")
+        assert model.id == "claude-haiku-4-5"
+
+        cancel_token = Mock()
+        cancel_token.is_cancel_requested = False
+        model.inline_completions("prefix", "suffix", "python", "nb.ipynb", None, cancel_token)
+
+        kwargs = mock_anthropic_cls.return_value.messages.create.call_args.kwargs
+        assert kwargs["max_tokens"] == CLAUDE_INLINE_COMPLETION_MAX_TOKENS
+        assert kwargs["model"] == "claude-haiku-4-5"
+
+
+class TestFetchClaudeModelsContextWindow:
+    def _make_mock_model(self, model_id, display_name, max_input_tokens=None):
+        m = Mock()
+        m.id = model_id
+        m.display_name = display_name
+        m.max_input_tokens = max_input_tokens
+        return m
+
+    @patch("notebook_intelligence.claude._get_context_window", return_value=150000)
+    @patch("anthropic.Anthropic")
+    def test_prefers_models_api_context_window(self, mock_anthropic_cls, mock_ctx_window):
+        """When the Models API reports max_input_tokens, litellm's static
+        database (which lags new releases) must not be consulted."""
+        from notebook_intelligence.claude import fetch_claude_models
+
+        mock_page = Mock()
+        mock_page.data = [
+            self._make_mock_model("claude-sonnet-5", "Claude Sonnet 5", max_input_tokens=1000000)
+        ]
+        mock_anthropic_cls.return_value.models.list.return_value = mock_page
+
+        result = fetch_claude_models(api_key="test-key")
+
+        assert result[0]["context_window"] == 1000000
+        mock_ctx_window.assert_not_called()
+
+    @patch("notebook_intelligence.claude._get_context_window", return_value=150000)
+    @patch("anthropic.Anthropic")
+    def test_falls_back_to_litellm_when_api_omits_window(self, mock_anthropic_cls, mock_ctx_window):
+        from notebook_intelligence.claude import fetch_claude_models
+
+        mock_page = Mock()
+        mock_page.data = [
+            self._make_mock_model("claude-sonnet-4-6", "Claude Sonnet 4.6", max_input_tokens=None)
+        ]
+        mock_anthropic_cls.return_value.models.list.return_value = mock_page
+
+        result = fetch_claude_models(api_key="test-key")
+
+        assert result[0]["context_window"] == 150000
+        mock_ctx_window.assert_called_once_with("claude-sonnet-4-6")

--- a/tests/test_claude_models.py
+++ b/tests/test_claude_models.py
@@ -7,11 +7,13 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def clear_cache():
-    """Clear the model cache before and after each test."""
-    from notebook_intelligence.claude import _claude_models_cache
-    _claude_models_cache.clear()
+    """Clear the model cache (and its endpoint marker) around each test."""
+    import notebook_intelligence.claude as claude_module
+    claude_module._claude_models_cache.clear()
+    claude_module._claude_models_cache_endpoint = None
     yield
-    _claude_models_cache.clear()
+    claude_module._claude_models_cache.clear()
+    claude_module._claude_models_cache_endpoint = None
 
 
 class TestGetClaudeModels:
@@ -305,24 +307,32 @@ class TestBoundedIntEnv:
 class TestResolveDefaultModel:
     """Defaults are validated against the fetched model list so a custom
     base_url that serves a different catalog never gets a model id it
-    doesn't recognize. An empty cache trusts the constant — first-party
-    endpoints always serve the current aliases."""
+    doesn't recognize. The cache is only authoritative for the endpoint
+    it was fetched from; an empty or foreign-endpoint cache trusts the
+    constant — first-party endpoints always serve the current aliases."""
+
+    def _fill_cache(self, models, api_key=None, base_url=None):
+        import notebook_intelligence.claude as claude_module
+        claude_module._claude_models_cache.extend(models)
+        claude_module._claude_models_cache_endpoint = (
+            claude_module._endpoint_identity(api_key, base_url)
+        )
 
     def test_empty_cache_trusts_the_constant(self):
         from notebook_intelligence.claude import resolve_default_model
         assert resolve_default_model("claude-sonnet-5", "claude-sonnet") == "claude-sonnet-5"
 
     def test_preferred_id_used_when_endpoint_lists_it(self):
-        from notebook_intelligence.claude import resolve_default_model, _claude_models_cache
-        _claude_models_cache.extend([
+        from notebook_intelligence.claude import resolve_default_model
+        self._fill_cache([
             {"id": "claude-sonnet-5", "name": "Claude Sonnet 5", "context_window": 1000000},
             {"id": "claude-haiku-4-5", "name": "Claude Haiku 4.5", "context_window": 200000},
         ])
         assert resolve_default_model("claude-sonnet-5", "claude-sonnet") == "claude-sonnet-5"
 
     def test_falls_back_to_newest_same_tier_model(self):
-        from notebook_intelligence.claude import resolve_default_model, _claude_models_cache
-        _claude_models_cache.extend([
+        from notebook_intelligence.claude import resolve_default_model
+        self._fill_cache([
             {"id": "claude-sonnet-4-5", "name": "Claude Sonnet 4.5", "context_window": 200000},
             {"id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6", "context_window": 200000},
             {"id": "claude-haiku-4-5", "name": "Claude Haiku 4.5", "context_window": 200000},
@@ -330,18 +340,68 @@ class TestResolveDefaultModel:
         assert resolve_default_model("claude-sonnet-5", "claude-sonnet") == "claude-sonnet-4-6"
 
     def test_falls_back_to_first_listed_model_without_tier_match(self):
-        from notebook_intelligence.claude import resolve_default_model, _claude_models_cache
-        _claude_models_cache.extend([
+        from notebook_intelligence.claude import resolve_default_model
+        self._fill_cache([
             {"id": "custom-proxy-model", "name": "Proxy", "context_window": 128000},
         ])
         assert resolve_default_model("claude-haiku-4-5", "claude-haiku") == "custom-proxy-model"
 
+    def test_cache_from_another_endpoint_is_not_authoritative(self):
+        # Endpoint A's catalog must not pick the default for endpoint B:
+        # the id might not be served there at all. The constant is the
+        # safer bet until B's own fetch lands.
+        from notebook_intelligence.claude import resolve_default_model
+        self._fill_cache(
+            [{"id": "endpoint-a-only-model", "name": "A", "context_window": 128000}],
+            base_url="https://endpoint-a.example.com",
+        )
+        resolved = resolve_default_model(
+            "claude-sonnet-5", "claude-sonnet",
+            base_url="https://endpoint-b.example.com",
+        )
+        assert resolved == "claude-sonnet-5"
+
+    def test_credential_normalization_applies_to_identity(self):
+        # '' and None are the same identity (settings-panel empty fields
+        # save as ''), so a cache fetched with no explicit credentials is
+        # authoritative for a constructor called with empty strings.
+        from notebook_intelligence.claude import resolve_default_model
+        self._fill_cache(
+            [{"id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6", "context_window": 200000}],
+            api_key=None, base_url=None,
+        )
+        resolved = resolve_default_model(
+            "claude-sonnet-5", "claude-sonnet", api_key="", base_url="  ",
+        )
+        assert resolved == "claude-sonnet-4-6"
+
     def test_chat_model_constructor_resolves_against_cache(self):
         from unittest.mock import patch as _patch
-        from notebook_intelligence.claude import ClaudeChatModel, _claude_models_cache
-        _claude_models_cache.extend([
-            {"id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6", "context_window": 200000},
-        ])
+        from notebook_intelligence.claude import ClaudeChatModel
+        self._fill_cache(
+            [{"id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6", "context_window": 200000}],
+            api_key="test-key",
+        )
         with _patch("anthropic.Anthropic"):
             model = ClaudeChatModel("", api_key="test-key")
         assert model.id == "claude-sonnet-4-6"
+
+    @patch("notebook_intelligence.claude._get_context_window", return_value=200000)
+    @patch("anthropic.Anthropic")
+    def test_fetch_stamps_the_endpoint_identity(self, mock_anthropic_cls, mock_ctx_window):
+        import notebook_intelligence.claude as claude_module
+        from notebook_intelligence.claude import fetch_claude_models
+
+        mock_model = Mock()
+        mock_model.id = "claude-sonnet-4-6"
+        mock_model.display_name = "Claude Sonnet 4.6"
+        mock_model.max_input_tokens = None
+        mock_page = Mock()
+        mock_page.data = [mock_model]
+        mock_anthropic_cls.return_value.models.list.return_value = mock_page
+
+        fetch_claude_models(api_key="key-a", base_url="https://a.example.com")
+
+        assert claude_module._claude_models_cache_endpoint == (
+            "key-a", "https://a.example.com"
+        )

--- a/tests/test_claude_models.py
+++ b/tests/test_claude_models.py
@@ -262,3 +262,41 @@ class TestFetchClaudeModelsContextWindow:
 
         assert result[0]["context_window"] == 150000
         mock_ctx_window.assert_called_once_with("claude-sonnet-4-6")
+
+
+class TestBoundedIntEnv:
+    """NBI_CLAUDE_INLINE_COMPLETION_MAX_TOKENS is parsed at import time —
+    malformed values must degrade to the default (never raise and block
+    startup), and out-of-range values are clamped so an operator typo
+    can't restore unbounded autocomplete output or break API requests."""
+
+    def _parse(self, monkeypatch, raw):
+        from notebook_intelligence.claude import _bounded_int_env
+        if raw is None:
+            monkeypatch.delenv('NBI_TEST_INT', raising=False)
+        else:
+            monkeypatch.setenv('NBI_TEST_INT', raw)
+        return _bounded_int_env('NBI_TEST_INT', 1024, 1, 4096)
+
+    def test_unset_returns_default(self, monkeypatch):
+        assert self._parse(monkeypatch, None) == 1024
+
+    def test_valid_value_parsed(self, monkeypatch):
+        assert self._parse(monkeypatch, '2048') == 2048
+
+    def test_empty_string_returns_default(self, monkeypatch):
+        assert self._parse(monkeypatch, '  ') == 1024
+
+    def test_malformed_value_returns_default(self, monkeypatch):
+        assert self._parse(monkeypatch, '1k') == 1024
+
+    def test_too_high_is_clamped_to_maximum(self, monkeypatch):
+        # 10000 would restore the old unbounded behavior the cap prevents.
+        assert self._parse(monkeypatch, '10000') == 4096
+
+    def test_zero_is_clamped_to_minimum(self, monkeypatch):
+        # max_tokens=0 would fail the Anthropic request outright.
+        assert self._parse(monkeypatch, '0') == 1
+
+    def test_negative_is_clamped_to_minimum(self, monkeypatch):
+        assert self._parse(monkeypatch, '-5') == 1

--- a/tests/test_claude_models.py
+++ b/tests/test_claude_models.py
@@ -300,3 +300,48 @@ class TestBoundedIntEnv:
 
     def test_negative_is_clamped_to_minimum(self, monkeypatch):
         assert self._parse(monkeypatch, '-5') == 1
+
+
+class TestResolveDefaultModel:
+    """Defaults are validated against the fetched model list so a custom
+    base_url that serves a different catalog never gets a model id it
+    doesn't recognize. An empty cache trusts the constant — first-party
+    endpoints always serve the current aliases."""
+
+    def test_empty_cache_trusts_the_constant(self):
+        from notebook_intelligence.claude import resolve_default_model
+        assert resolve_default_model("claude-sonnet-5", "claude-sonnet") == "claude-sonnet-5"
+
+    def test_preferred_id_used_when_endpoint_lists_it(self):
+        from notebook_intelligence.claude import resolve_default_model, _claude_models_cache
+        _claude_models_cache.extend([
+            {"id": "claude-sonnet-5", "name": "Claude Sonnet 5", "context_window": 1000000},
+            {"id": "claude-haiku-4-5", "name": "Claude Haiku 4.5", "context_window": 200000},
+        ])
+        assert resolve_default_model("claude-sonnet-5", "claude-sonnet") == "claude-sonnet-5"
+
+    def test_falls_back_to_newest_same_tier_model(self):
+        from notebook_intelligence.claude import resolve_default_model, _claude_models_cache
+        _claude_models_cache.extend([
+            {"id": "claude-sonnet-4-5", "name": "Claude Sonnet 4.5", "context_window": 200000},
+            {"id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6", "context_window": 200000},
+            {"id": "claude-haiku-4-5", "name": "Claude Haiku 4.5", "context_window": 200000},
+        ])
+        assert resolve_default_model("claude-sonnet-5", "claude-sonnet") == "claude-sonnet-4-6"
+
+    def test_falls_back_to_first_listed_model_without_tier_match(self):
+        from notebook_intelligence.claude import resolve_default_model, _claude_models_cache
+        _claude_models_cache.extend([
+            {"id": "custom-proxy-model", "name": "Proxy", "context_window": 128000},
+        ])
+        assert resolve_default_model("claude-haiku-4-5", "claude-haiku") == "custom-proxy-model"
+
+    def test_chat_model_constructor_resolves_against_cache(self):
+        from unittest.mock import patch as _patch
+        from notebook_intelligence.claude import ClaudeChatModel, _claude_models_cache
+        _claude_models_cache.extend([
+            {"id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6", "context_window": 200000},
+        ])
+        with _patch("anthropic.Anthropic"):
+            model = ClaudeChatModel("", api_key="test-key")
+        assert model.id == "claude-sonnet-4-6"


### PR DESCRIPTION
## Changes
- **Chat default** moves `claude-sonnet-4-5` → `claude-sonnet-5` (current Sonnet tier).
- **Inline completion default** moves to `claude-haiku-4-5`: a suggestion has to beat the user's next keystroke and fires on every pause in typing, so the fastest/cheapest tier is the right default.
- **Inline completion `max_tokens`** capped at 1024 (was 10000), overridable via `NBI_CLAUDE_INLINE_COMPLETION_MAX_TOKENS` and clamped to `[1, 4096]`. The old ceiling let a rambling response generate for many seconds before the extraction regex threw most of it away.
- **`resolve_default_model`** validates the default id against the fetched catalog: if the endpoint doesn't list the preferred alias, it falls back to the newest id in the same tier (numeric version-aware sort, so `claude-sonnet-4-6 < claude-sonnet-5`), then to the first listed model. The cache is scoped to the endpoint it was fetched from, and a credentials change triggers a non-blocking background refresh (never blocks a chat turn).
- **`fetch_claude_models`** prefers the Models API's `max_input_tokens` (validated as a positive int) over litellm's static database, which lags new model releases; litellm remains the fallback.
- Unit tests pinning the defaults, the bounded request, endpoint-scoped caching, version-aware fallback, and the context-window preference.

## Testing
Full Python suite passes. Manually verified against the live first-party Anthropic API:
- Catalog fetch returns 10 models with context windows from `max_input_tokens`.
- Chat default resolves to `claude-sonnet-5` (matched verbatim).
- Version-aware fallback: a bogus `claude-sonnet-99` resolves to `claude-sonnet-5` (newest in tier), not a lexicographic pick.
- Inline completions drive in-notebook ghost-completions on the Haiku default; the `max_tokens` clamp holds end-to-end.

### Note on a benign startup log
The Models API lists Haiku only under its **dated** id (`claude-haiku-4-5-20251001`), not the rolling `claude-haiku-4-5` alias it uses for Sonnet. The inline default therefore isn't matched verbatim and the fallback resolves it to the dated snapshot — the same model, correct outcome. Expected side effect: this INFO line prints on every startup and is **not** an error:

```
Default model 'claude-haiku-4-5' is not served by the configured endpoint; using 'claude-haiku-4-5-20251001'
```

The constant is intentionally left as the rolling alias — resolving it via the fallback is exactly what this change is for.
